### PR TITLE
docs: add seed-phrase quick-start and mnemonic_to_key example

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,43 @@ priv = PrivateKey("L1aW4aubDFB7yfras2S1mN3bqg9nwySY8nkoLmJebSLD5BWv3ENZ")
 # See examples/ for full flows.
 ```
 
+### From a BIP39 seed phrase
+
+If you already have a 12/24-word mnemonic (e.g. created by `pyrxd wallet
+new` or restored from another Radiant wallet), `HdWallet.from_mnemonic`
+gives you a full HD wallet at the correct Radiant BIP44 path
+(`m/44'/236'/<account>'`).
+
+> Radiant uses BIP44 coin type **236**, not 0 (Bitcoin). Examples written
+> for Bitcoin libraries will derive the wrong addresses — make sure any
+> derivation path you use is `m/44'/236'/...`.
+
+```python
+from pyrxd.hd import HdWallet
+
+wallet = HdWallet.from_mnemonic("word1 word2 ... word12")
+addr = wallet.next_receive_address()
+print(f"first receive address: {addr}")
+```
+
+For a one-off private key at a specific path (the equivalent of the
+short `mnemonic + bip32utils` snippet some users start from), use the
+lower-level helpers directly:
+
+```python
+from pyrxd.hd import bip44_derive_xprv_from_mnemonic
+
+# Default path is m/44'/236'/0' — the Radiant account 0 key.
+xprv = bip44_derive_xprv_from_mnemonic("word1 word2 ... word12")
+child = xprv.ckd(0).ckd(0)  # m/44'/236'/0'/0/0  (external chain, index 0)
+priv = child.private_key()
+print(f"WIF:     {priv.wif()}")
+print(f"address: {priv.public_key().address()}")
+```
+
+See [`examples/mnemonic_to_key.py`](examples/mnemonic_to_key.py) for a
+runnable version of both flows.
+
 ### Mint a Glyph NFT
 
 ```python

--- a/examples/mnemonic_to_key.py
+++ b/examples/mnemonic_to_key.py
@@ -1,0 +1,84 @@
+#!/usr/bin/env python3
+"""Derive Radiant keys and addresses from a BIP39 mnemonic.
+
+Two flows are demonstrated, in order of how most users will want to
+approach the problem:
+
+1. ``HdWallet.from_mnemonic`` — the high-level path. Returns a full HD
+   wallet at the correct Radiant BIP44 path (``m/44'/236'/0'``) with
+   address tracking, gap-limit discovery, and optional encrypted
+   persistence. This is the recommended entry point.
+
+2. ``bip44_derive_xprv_from_mnemonic`` — the low-level path. Returns
+   the account xprv so you can derive a single private key at a
+   specific child index. Useful when you only want one key, or when
+   migrating code from another library that exposed the seed-to-key
+   primitives directly.
+
+Radiant note
+------------
+Radiant uses BIP44 coin type **236**, not 0 (Bitcoin). Code copied
+from Bitcoin examples that hardcodes ``m/44'/0'/0'/0/0`` will derive
+the wrong addresses. Both helpers here use the correct Radiant path
+by default.
+
+Usage
+-----
+    # Use the demo mnemonic baked into this script:
+    python examples/mnemonic_to_key.py
+
+    # Or supply your own (do NOT share a real mnemonic on the command line
+    # in production — this is for local testing only):
+    MNEMONIC="word1 word2 ... word12" python examples/mnemonic_to_key.py
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
+
+from pyrxd.hd import HdWallet, bip44_derive_xprv_from_mnemonic
+
+# A well-known BIP39 test vector mnemonic. NEVER use this for real funds —
+# the seed and every key derived from it are public. It is here purely so
+# the example runs without configuration.
+DEMO_MNEMONIC = "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about"
+
+
+def high_level(mnemonic: str) -> None:
+    """Build a full HD wallet from the mnemonic."""
+    print("=== HdWallet.from_mnemonic ===")
+    wallet = HdWallet.from_mnemonic(mnemonic)
+    print(f"first receive address: {wallet.next_receive_address()}")
+    # next_receive_address keeps returning the same address until it is
+    # marked used (after a refresh against the network finds history).
+    print(f"same again (unused):   {wallet.next_receive_address()}")
+    print()
+
+
+def low_level(mnemonic: str) -> None:
+    """Derive a single private key at m/44'/236'/0'/0/0."""
+    print("=== bip44_derive_xprv_from_mnemonic ===")
+    # Default path is m/44'/236'/0' (Radiant account 0).
+    account_xprv = bip44_derive_xprv_from_mnemonic(mnemonic)
+    # External chain (change=0), first address (index=0).
+    child = account_xprv.ckd(0).ckd(0)
+    priv = child.private_key()
+    print(f"path:    m/44'/236'/0'/0/0")
+    print(f"WIF:     {priv.wif()}")
+    print(f"address: {priv.public_key().address()}")
+    print()
+
+
+def main() -> None:
+    mnemonic = os.environ.get("MNEMONIC", DEMO_MNEMONIC)
+    if mnemonic == DEMO_MNEMONIC:
+        print("Using the public BIP39 test-vector mnemonic. Do not send funds to these addresses.\n")
+    high_level(mnemonic)
+    low_level(mnemonic)
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/mnemonic_to_key.py
+++ b/examples/mnemonic_to_key.py
@@ -66,7 +66,7 @@ def low_level(mnemonic: str) -> None:
     # External chain (change=0), first address (index=0).
     child = account_xprv.ckd(0).ckd(0)
     priv = child.private_key()
-    print(f"path:    m/44'/236'/0'/0/0")
+    print("path:    m/44'/236'/0'/0/0")
     print(f"WIF:     {priv.wif()}")
     print(f"address: {priv.public_key().address()}")
     print()


### PR DESCRIPTION
## Summary
- Adds a **From a BIP39 seed phrase** subsection to the README quick start showing both the high-level (`HdWallet.from_mnemonic`) and low-level (`bip44_derive_xprv_from_mnemonic`) flows.
- Adds [`examples/mnemonic_to_key.py`](examples/mnemonic_to_key.py) — a runnable script that demonstrates both flows against the public BIP39 test-vector mnemonic.
- Explicit callout that Radiant uses BIP44 coin type **236**, not Bitcoin's 0.

No library code changes.

## Context
A community member asked how to derive a Radiant key from a seed phrase and shared an example using `mnemonic` + `bip32utils` against `m/44'/0'/0'/0/0` — Bitcoin's path. Following that snippet would silently derive Bitcoin addresses that no Radiant wallet will ever see funds at.

The helpers already exist in pyrxd at the correct path; this PR just makes them discoverable.

## Verification
Ran the example end-to-end:

\`\`\`
$ python examples/mnemonic_to_key.py
Using the public BIP39 test-vector mnemonic. Do not send funds to these addresses.

=== HdWallet.from_mnemonic ===
first receive address: 1K6LZdwpKT5XkEZo2T2kW197aMXYbYMc4f
same again (unused):   1K6LZdwpKT5XkEZo2T2kW197aMXYbYMc4f

=== bip44_derive_xprv_from_mnemonic ===
path:    m/44'/236'/0'/0/0
WIF:     KxU83MzcLXP1WJtoFJXMDMcN3z5ykAa9xLdFTDY5XpV4e6Zit9BA
address: 1K6LZdwpKT5XkEZo2T2kW197aMXYbYMc4f
\`\`\`

Both flows produce the same address at `m/44'/236'/0'/0/0`, as expected.

## Test plan
- [x] Example runs from a clean checkout
- [x] High-level and low-level flows produce identical first-address output
- [x] README renders correctly on GitHub
- [x] Reviewer sanity-check on the BIP44 coin-type callout wording