### PR TITLE
chore: add `task ci` for local CI parity, plus versioned pre-push hook

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,12 +11,28 @@ git clone https://github.com/MudwoodLabs/pyrxd.git
 cd pyrxd
 python3 -m venv .venv
 source .venv/bin/activate
-pip install -e ".[dev]"
-pytest -q
+poetry install --sync     # installs all groups (dev + test) — matches CI exactly
+poetry run task test      # full pytest suite, ~45 seconds
 ```
+
+If you don't have Poetry installed, `pip install -e ".[dev]"` works for
+basic development but won't pull in the full `test` group (pytest-cov,
+hypothesis, pytest-mock). Use Poetry to match the exact CI environment.
 
 The full test suite runs in under a minute on a modern laptop. If
 something is slow, that's a regression — please flag it.
+
+### Recommended: install the pre-push hook
+
+Run `task ci` (the full local-CI matrix) automatically before every push:
+
+```bash
+./scripts/install-git-hooks.sh
+```
+
+This catches the same failures CI catches, locally, in ~1-2 minutes —
+much faster than the push-fail-fix-push loop. Bypass for a specific push
+with `git push --no-verify`.
 
 ## Sign your commits (DCO)
 
@@ -71,16 +87,44 @@ runs both ruff hooks plus bandit and detect-secrets. Install hooks with
 
 ## Testing your changes
 
-Before opening a PR:
+Before opening a PR, run the full local CI matrix:
+
+```bash
+poetry run task ci  # runs everything CI runs (~3-5 min)
+```
+
+This is the canonical "is my PR likely to pass CI" check. Mirrors
+`.github/workflows/{lint,ci}.yml` exactly. If `task ci` passes locally,
+PR CI will almost always pass too.
+
+For faster iteration during a work session, run the individual tasks:
 
 ```bash
 poetry run task test                 # full pytest suite
 poetry run task lint                 # ruff check + bandit security scan
-poetry run task format               # ruff format src tests examples
-poetry run mypy src/pyrxd/security/  # type checker (security module is strict-typed)
+poetry run task format-check         # ruff format --check (no rewrites)
+poetry run task format               # ruff format src tests examples (does rewrite)
+poetry run task typecheck            # mypy on src/pyrxd/security/
+poetry run task coverage-security    # security module coverage (must be 100%)
+poetry run task coverage-overall     # overall coverage (must be ≥85%)
 ```
 
-CI runs the same checks; local feedback is faster.
+### Pre-push hook
+
+To run `task ci` automatically before every `git push`, install the
+versioned pre-push hook:
+
+```bash
+./scripts/install-git-hooks.sh
+```
+
+This symlinks `scripts/git-hooks/pre-push` into `.git/hooks/pre-push`, so
+every `git push` runs `task ci` first. Bypass for a specific push with
+`git push --no-verify` (e.g. for WIP branches you're sharing for review).
+
+The hook is **strongly recommended** if you push to PRs frequently —
+catching CI failures locally takes 3-5 minutes; finding out via a failed
+PR check takes 4-6 minutes plus another full CI run after fixing.
 
 ## Commit message style
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,7 +50,15 @@ include = [
 # before pushing.
 lint = "ruff check src tests examples && bandit -r src/ -c pyproject.toml --quiet"
 format = "ruff format src tests examples"
+format-check = "ruff format --check src tests examples"
 test = "pytest"
+typecheck = "mypy src/pyrxd/security/"
+coverage-security = 'pytest tests/security/ -o "addopts=" --cov=pyrxd.security --cov-fail-under=100'
+coverage-overall = 'pytest tests/ -o "addopts=" --cov=pyrxd --cov-fail-under=85'
+# `task ci` runs the full set of checks GitHub Actions runs (.github/workflows/{lint,ci}.yml).
+# Run before pushing to avoid the push-fail-fix-push loop. ~3-5 min.
+# For a faster pre-commit pass, just run `task lint && task format-check && task test`.
+ci = "task lint && task format-check && task test && task coverage-security && task coverage-overall && task typecheck"
 docs = "sphinx-build -b html docs docs/_build/html"
 docs-clean = "rm -rf docs/_build"
 docs-serve = "sphinx-autobuild docs docs/_build/html --open-browser"

--- a/scripts/git-hooks/pre-push
+++ b/scripts/git-hooks/pre-push
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+# Pre-push hook: run the full CI matrix locally before push.
+#
+# Mirrors .github/workflows/{lint,ci}.yml via the `ci` task in pyproject.toml.
+# This is the versioned source of truth — the actual hook lives at
+# .git/hooks/pre-push (per-clone), installed by scripts/install-git-hooks.sh.
+#
+# Bypass with `git push --no-verify` for emergencies (e.g. work-in-progress
+# branch pushes for backup or sharing). Don't bypass before a PR merges.
+
+set -euo pipefail
+
+say()  { printf '\n\033[1;36m== %s ==\033[0m\n' "$*"; }
+ok()   { printf '  \033[1;32mOK\033[0m %s\n' "$*"; }
+fail() { printf '  \033[1;31mFAIL\033[0m %s\n' "$*"; exit 1; }
+
+# Make sure we're using the project's Python environment so `task` resolves.
+if ! command -v task >/dev/null 2>&1; then
+  fail "task not found on PATH — activate the project venv (source .venv/bin/activate) and re-run, or install dev deps with: pip install -e .[dev]"
+fi
+
+say "Running local CI parity (task ci)"
+echo "  This runs lint + format-check + tests + coverage + typecheck."
+echo "  Bypass with \`git push --no-verify\` if you need to push WIP."
+echo
+
+if task ci; then
+  ok "pre-push: all CI checks passed locally"
+else
+  fail "pre-push: local CI failed — fix before pushing (or --no-verify for WIP)"
+fi

--- a/scripts/install-git-hooks.sh
+++ b/scripts/install-git-hooks.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+# Install pyrxd's versioned git hooks into your local .git/hooks/.
+#
+# Run once after cloning. Idempotent: re-running overwrites symlinks/copies
+# with the latest versions from scripts/git-hooks/.
+#
+# Hooks installed:
+#   pre-push  — runs the full local-CI matrix (`task ci`) before every push
+#               so PR CI rarely catches anything you didn't already see locally.
+#               Bypass per-push with `git push --no-verify`.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+HOOK_SRC_DIR="${REPO_ROOT}/scripts/git-hooks"
+HOOK_DST_DIR="${REPO_ROOT}/.git/hooks"
+
+say()  { printf '\n\033[1;36m== %s ==\033[0m\n' "$*"; }
+ok()   { printf '  \033[1;32mOK\033[0m %s\n' "$*"; }
+warn() { printf '  \033[1;33mWARN\033[0m %s\n' "$*"; }
+fail() { printf '  \033[1;31mFAIL\033[0m %s\n' "$*"; exit 1; }
+
+if [[ ! -d "${HOOK_DST_DIR}" ]]; then
+  fail "${HOOK_DST_DIR} does not exist — are you inside the pyrxd git repo?"
+fi
+
+if [[ ! -d "${HOOK_SRC_DIR}" ]]; then
+  fail "${HOOK_SRC_DIR} does not exist — this script must be run from the pyrxd repo root"
+fi
+
+say "Installing git hooks"
+
+for src in "${HOOK_SRC_DIR}"/*; do
+  name="$(basename "${src}")"
+  dst="${HOOK_DST_DIR}/${name}"
+
+  # Symlink rather than copy, so future updates to scripts/git-hooks/
+  # take effect without re-running this installer. Falls back to copy if
+  # symlinks aren't supported (e.g. Windows without dev-mode enabled).
+  if ln -sf "${src}" "${dst}" 2>/dev/null; then
+    chmod +x "${dst}"
+    ok "${name} -> symlink to scripts/git-hooks/${name}"
+  else
+    cp "${src}" "${dst}"
+    chmod +x "${dst}"
+    warn "${name} -> copied (symlink unsupported); re-run this script after future updates"
+  fi
+done
+
+say "Done. Hooks installed."
+echo
+echo "To bypass a hook for a single push: git push --no-verify"
+echo "To uninstall: rm .git/hooks/<hook-name>"


### PR DESCRIPTION
## Summary

CI-fail-then-fix cycles are slow: a failed PR check costs ~4 min for the test job to fail + another ~4 min to re-run after pushing the fix. The local equivalent runs in ~1.5 min and catches the same failures.

This change makes the local-CI workflow trivially accessible:

```bash
poetry run task ci    # mirrors .github/workflows/{lint,ci}.yml exactly
```

`task ci` chains: lint, format-check, test, coverage-security (must be 100%), coverage-overall (must be ≥85%), typecheck. Same checks, same order, same failure conditions as GitHub Actions.

## What's added

**New tasks in `pyproject.toml`** (`[tool.taskipy.tasks]`):
- `ci` — the umbrella that runs everything CI runs
- `format-check` — `ruff format --check` (the missing piece that bit PR #14)
- `typecheck` — `mypy src/pyrxd/security/`
- `coverage-security` — security module ≥100% coverage check
- `coverage-overall` — overall ≥85% coverage check

Existing tasks (`lint`, `test`, `format`, `docs*`) unchanged.

**Versioned pre-push hook** in `scripts/git-hooks/pre-push`:
- Runs `task ci` automatically before every `git push`
- Bypassed per-push via `git push --no-verify` (for WIP/sharing)
- Errors clearly if `task` isn't on PATH (suggests venv activation)

**Installer script** at `scripts/install-git-hooks.sh`:
- Symlinks `scripts/git-hooks/*` into `.git/hooks/` (so future hook updates don't require re-running)
- Falls back to copy if symlinks unsupported (Windows without dev mode)
- Idempotent

**CONTRIBUTING.md updates**:
- Recommended setup uses `poetry install --sync` (matches CI exactly; the previous `pip install -e .[dev]` instruction misses the `test` group, which contains pytest-cov, hypothesis, pytest-mock — anyone following old instructions would hit `task ci` failures)
- New tasks documented
- Pre-push hook installation instructions

## Why this matters

PR #14 (the BIP44 derivation path fix) caught two failures in CI that would have been caught locally if `ruff format --check` and the full test suite had been run before push:

1. `ruff format --check` (the formatter, distinct from `ruff check` the linter) — caught locally only after CI failed
2. Four CLI tests with hardcoded path strings that needed updating — same story

Both took an additional commit + CI cycle to fix. With `task ci` available and the pre-push hook installed, this class of failure is caught before push.

## Test plan

- [x] `task ci` passes locally end-to-end in 1m34s on this branch (2178 tests pass, 86.26% overall coverage, 100% security coverage, mypy clean)
- [x] Pre-push hook actually triggers on push (this PR's push tested it — `task ci` ran, passed, push proceeded)
- [x] `scripts/install-git-hooks.sh` correctly symlinks the hook and reports OK
- [x] All shell scripts pass `bash -n` syntax check
- [x] All component tasks (`lint`, `format-check`, `test`, etc.) work standalone

## Notes

- The pre-push hook is **opt-in** via `scripts/install-git-hooks.sh`. Not installed automatically, so existing contributors aren't surprised
- Bypassing via `--no-verify` is documented for emergency cases
- Local CI takes ~1.5 min; CI takes ~4 min for the slow test job. The local hook adds latency but eliminates the push-fail-fix-push cycle
- Caveat: `task ci` depends on test-group dependencies (pytest-cov, hypothesis, pytest-mock) being installed. The CONTRIBUTING change recommends `poetry install --sync` which gets these. Anyone using `pip install -e .[dev]` from old instructions will need to also install the test group manually or switch to Poetry