### PR TITLE
docs: establish docs/solutions/ + add private-link guardrail

### DIFF
--- a/docs/solutions/design-decisions/expert-panel-pivot-before-coding.md
+++ b/docs/solutions/design-decisions/expert-panel-pivot-before-coding.md
@@ -1,0 +1,151 @@
+---
+title: Pre-implementation expert panel pivot — CLI scanner deprioritized in favor of ecosystem catalyst role
+date: 2026-05-03
+problem_type: design_decision
+component: design-process
+symptoms:
+  - About to commit engineering effort to a CLI tool that takes BIP39 mnemonics as input, framed internally as "highest-leverage near-term tool"
+  - No expert review had been run on the security surface of "paste your mnemonic into a CLI" as a normalized user workflow
+  - Plan assumed pyrxd should be the tool provider rather than the ecosystem catalyst, without testing that assumption
+  - No reference case study consulted from analogous UTXO-fork migrations (Avian from Ravencoin) before settling on the primitive
+  - Roadmap framed scanner as Phase 1 of a 3-phase tool chain, locking in the primitive before validating it
+severity: high
+status: solved
+related_prs: []
+tags:
+  - design-decisions
+  - process-patterns
+  - pre-implementation-review
+  - expert-panel
+  - security-surface
+  - ecosystem-strategy
+  - red-team
+  - mnemonic-handling
+  - radiant-migration
+  - avian-case-study
+---
+
+## Root Cause Analysis
+
+The original plan failed not because any individual technical decision was wrong, but because the *primitive itself* — a standalone CLI that accepts a mnemonic to scan for funds — was a category error invisible from any single reviewer's vantage point. From the protocol angle it was sound (correct derivation paths, valid ElectrumX queries). From the CLI-ergonomics angle it was sound (clear command surface, silent prompt for secrets). From the cryptography angle it was sound (correct BIP44 derivation). Each domain expert, evaluating within their own lane, would have approved a hardened version of the design. The structural defect — that shipping the tool *normalizes the behavior of pasting a seed phrase into an arbitrarily-named CLI to recover funds*, creating a phishing template that adversaries can clone within hours — only becomes visible when you stack an adversarial perspective and an ecosystem-positioning perspective on top of the technical ones. Single-discipline review is good at hardening a primitive; it is structurally incapable of asking whether the primitive should exist.
+
+The deeper pattern is that "reasonable-looking next step" is the most dangerous failure mode in early-stage projects, because it consumes real engineering budget on something that passes every local sanity check while quietly committing the project to a posture (in this case: "the upstream library is the place users go to recover funds") that is much harder to reverse than to avoid. The cost of *not* running a multi-perspective review is asymmetric: skipping it saves a day; discovering the wrong primitive after two weeks of implementation costs the implementation, the social capital of walking it back, and any users harmed by the v1 that shipped before the rethink.
+
+## Solution
+
+The pattern: **for any design decision that will commit non-trivial engineering effort AND has an irreversible-ish dimension (security posture, public API shape, ecosystem positioning, user-facing defaults), run a structured pre-implementation brainstorm panel before writing code.** The cost is roughly one day; the upside is catching wrong-primitive errors while they are still free to fix.
+
+**When to trigger a panel.** Run one when *any* of these are true:
+
+- The work is estimated at more than a few days and touches a security-sensitive surface (key material, auth, payments, PII).
+- The output will be publicly distributed under a name that confers authority (the project's own package, a "reference" implementation, anything users will trust on sight).
+- The decision sets a *posture* — establishes who does what in the ecosystem, what behavior gets normalized, what becomes the default — not just an implementation detail.
+- The plan "feels obvious" but no one has stress-tested it from outside the implementer's frame. Obviousness is a warning sign, not a green light.
+
+Hardening reviews (single-discipline, after the primitive is chosen) do not substitute. The panel must precede implementation.
+
+**Which experts to spin up.** The minimum viable panel is six to eight perspectives chosen so that *no single discipline can dominate*. For most software decisions, cover:
+
+1. **Domain/protocol expert** — does the technical core actually work?
+2. **UX or human-factors expert** — what will users actually do with this, including the wrong things?
+3. **Security researcher** — what surfaces does this expose?
+4. **Implementation-discipline expert** (CLI, API, data, whichever applies) — is the shape idiomatic and ergonomic?
+5. **Correctness specialist** (cryptographer, type theorist, formal-methods person — domain-dependent) — are the invariants right?
+6. **Ecosystem/strategic reviewer** — what posture does shipping this commit us to? What does it normalize?
+7. **Adversarial red team** — *non-negotiable.* Their job is to assume the design ships as-specified and describe the attack within the first week. This is the role most likely to surface wrong-primitive errors, because adversaries don't care about your design intent — they care about what the artifact enables.
+8. *(Optional but high-value)* **A practitioner who shipped the analogous thing in a comparable project** — independent real-world confirmation is worth more than any number of hypothetical reviews.
+
+Spin them up in parallel, not serially, and have each one write their review without seeing the others' first. Parallelism prevents anchoring; the value of the panel is in the *independence* of the perspectives.
+
+**How to read the results — pivot vs. harden.** After collecting all reviews, classify each concern:
+
+- **Local concerns** (one or two reviewers raise issue X, others don't see it) → almost always a *harden* signal. Fix the specific issue and proceed.
+- **Convergent concerns** (three or more reviewers from different disciplines independently arrive at the same structural objection, often phrased differently) → strong *pivot* signal. The primitive itself is likely wrong. Convergence across disciplines is the diagnostic, because each discipline reaches it via its own reasoning path; that they end up in the same place is evidence the issue is structural, not stylistic.
+- **Adversarial-critical findings** (the red team identifies an attack that is cheap, fast, and pays for itself with one victim) → automatic *pivot or kill* signal regardless of how many other reviewers raised it. One reviewer is enough here, because the asymmetry is the point.
+- **Independent external confirmation** (a practitioner who has actually shipped the analogous thing reports the same conclusion the panel reached) → treat as decisive. Two independent paths to the same finding — internal panel and external precedent — is much stronger evidence than either alone, and should override the sunk-cost pull toward the original plan.
+
+**The decision rule.** If the panel produces convergent structural objections OR a critical adversarial finding OR independent external confirmation that the plan is misframed: stop, redesign the primitive, do not try to harden your way out of it. If the panel produces only local concerns: incorporate the fixes and proceed to implementation. The hardest discipline is honoring a pivot signal *before* any code is written, when the sunk cost is only the panel itself — which is precisely when the pivot is cheapest and most valuable.
+
+**What to preserve from a pivoted plan.** The technical sub-decisions surfaced during the panel (edge cases, failure semantics, correctness invariants) usually remain valid as guidance for whatever the redesigned primitive turns out to be, or for downstream implementers. Capture them as a public artifact even if the original plan dies; the brainstorm's value extends past the specific decision it killed.
+
+## Concrete instance: the Radiant migration tool pivot
+
+This pattern was applied to a real decision. The shape of the actual case, as evidence the pattern works:
+
+**The original plan.** Build `pyrxd wallet check-historical-paths` (or `pyrxd migrate scan`) — a CLI command that takes a BIP39 mnemonic via silent prompt, derives addresses at coin types 0, 236, 512 (the historical Radiant derivation paths), queries ElectrumX for balances, and reports a table. Phase 1 scan-only (1-2 days estimated). Phase 2 plain-RXD sweep (3-5 days). Phase 3 Glyph-aware sweep (~2 weeks). This was framed as "the highest-leverage near-term tool" and was about to become the next coding work session.
+
+**The panel.** Six experts plus an adversarial red team plus one community member with direct production experience. Spun up in parallel. Reviewed independently.
+
+**The convergent findings.** All seven inputs landed at the same structural objection from different angles:
+
+> Red team CRITICAL: "this command's whole reason for existing is to normalize 'paste your mnemonic into a CLI to find your money.' Build it carefully or scammers will own it within a quarter."
+>
+> Strategic reviewer: "Be useful before being authoritative. Reference implementations earn the title by being forkable and quotable, not by being installed."
+>
+> UX expert: "Users will run this with their seed on a machine that already has malware — that's often *why* their funds moved unexpectedly and they're scanning."
+>
+> Avian community input: "We shipped this exact migration recently (Ravencoin's coin type 175 → Avian's 921). Our playbook: dual-path support inside each wallet, no separate CLI tool."
+
+**The red team's day-1 attack scenario.** Within 6 hours of release, attacker publishes `radiant-recovery-tool` on PyPI — a 200-line wrapper around pyrxd that exfiltrates mnemonics. Costs attacker $5 in Reddit ads. Conservative estimate: 5-20 victims in week one. Attack pays for itself with one funded victim. PyPI takedowns take 3-10 days.
+
+**The pivot.** The plan changed before any code was written:
+
+| Old plan | New plan |
+|---|---|
+| pyrxd ships a 3-phase CLI tool | pyrxd's role becomes ecosystem catalyst, not tool provider |
+| Tool takes mnemonic input | No mnemonic-handling tool ships from pyrxd |
+| pyrxd is the migration destination | Wallets (Photonic, Electron-Radiant, Orbital) implement dual-path support inside their existing UIs |
+| Standalone scanner is the artifact | Test vectors + migration playbook + reference helper code are the artifacts |
+
+**What was preserved.** The technical decisions from the panel (gap-limit handling, scripthash queries, partial-failure semantics, ElectrumX hardening) remained valid as guidance for the wallet-side implementations. They are documented in the conversation history and can be extracted as a design doc if needed when wallet maintainers ask "how should we implement this?"
+
+**Cost of the pivot.** One day of panel reviews. Zero lines of code thrown away. Compare to the alternative: 1-2 weeks building Phase 1, then either deprecating it after launch or shipping a tool that the red team predicted scammers would clone within a quarter.
+
+## Prevention Strategies
+
+- **Run a brainstorm panel BEFORE writing significant code.** For any non-trivial feature — and especially anything touching keys, mnemonics, signing, money, or other irreversible operations — convene a multi-expert panel as a gate, not a retrospective. The cost (calendar time + agent invocations) is almost always less than the cost of building the wrong primitive and then having to deprecate it.
+- **Always include an adversarial reviewer.** For security-adjacent tooling, a red-team seat is mandatory, not optional. The author cannot see the attack patterns the author created. Specifically charter the red-teamer to assume malicious actors will exploit the *existence* of the tool (typosquats, wrappers, social-engineering normalization), not just bugs in it.
+- **Search adjacent ecosystems for the analogous migration/feature.** Before assuming you're solving a novel problem, spend an hour finding the closest prior art (here: Avian's 175 → 921 migration). If a community member surfaces such a parallel, treat their input as load-bearing, not anecdotal.
+- **Treat convergent concerns as signal, not noise.** When experts approaching from different angles (UX, crypto, protocol, ecosystem) independently land on the same concern, that's the moment to pivot — not the moment to harden the existing design against each objection.
+- **Explicitly separate "I have a plan" from "I have validated the primitive."** Add a checklist item to every design doc: *"Have I confirmed this is the right primitive, or only that this primitive is internally consistent?"* The gap between those two is invisible until you name it.
+- **Budget the panel into the project plan.** If panels are scheduled, they happen. If they're "nice to have when there's time," they happen after the code is written, when pivoting is expensive.
+
+## Detection Methods
+
+- **The "highest-leverage near-term tool" framing is a tripwire.** If a piece of work is that important, it deserves a panel review before implementation. High leverage cuts both ways — wrong primitives at high leverage cause proportional damage.
+- **The "this is the next concrete work session" moment.** When work is well-defined enough to start coding, that is precisely the moment to verify the primitive is correct. Imminent implementation is the last cheap pivot point.
+- **You cannot name an analogous project that solved this.** That's a signal to look harder, not a signal you're innovating. Genuinely novel primitives in mature domains (wallets, crypto, key management) are rare; first check that you're not reinventing a known anti-pattern.
+- **Multi-phase scope ("Phase 1 → Phase 2 → Phase 3").** Each phase typically has different trust properties. Phase 1 being safe says nothing about Phase 2. If the rationale for Phase 1 depends on Phase 2 existing, that's coupling you should make explicit.
+- **You catch yourself defending the design.** Phrases like "but it's just Phase 1," "it's read-only," "it can't lose money," or "the user has to opt in" are signs you're discounting concerns rather than addressing them. Write the objection down verbatim and respond to it on its own terms.
+- **The design's whole purpose is to normalize a behavior you'd otherwise warn users against.** If the tool exists to teach users to do the dangerous thing safely, ask whether it should exist at all.
+
+## Anti-patterns to Avoid
+
+- **Don't run panels as confirmation theater.** A panel that isn't allowed to overturn the decision isn't a panel — it's a sign-off ritual. Commit in advance to honoring a pivot recommendation.
+- **Don't skip adversarial review because the tool "can't lose money."** Read-only tools normalize behaviors (paste mnemonic into CLI) that downstream malicious clones absolutely can weaponize. The attack surface is the *category*, not the binary.
+- **Don't dismiss cross-ecosystem input as "different ecosystem."** Migration playbooks, wallet UX patterns, and attacker behavior transfer far more than they differ. Someone who shipped the analogous thing has paid tuition you haven't.
+- **Don't bundle multi-phase plans where later phases have materially different trust properties.** Design Phase 1 assuming Phase 2 may never ship — or may never be safe to ship. If Phase 1 only makes sense as a stepping stone, the stepping stone may be the wrong primitive.
+- **Don't assume the obvious tool is the right primitive.** The wrong primitive often looks obvious precisely because it's the first thing that comes to mind. "Obvious" is a hypothesis, not a conclusion.
+- **Don't run the panel after writing code.** Sunk cost makes pivots dramatically harder, and the panel's findings get framed as "what to fix" rather than "what to reconsider." Panel first, code second.
+
+## Related Documentation
+
+**Public research:**
+- [docs/research/wallet-derivation-paths.md](../../research/wallet-derivation-paths.md) — The ecosystem fragmentation research that motivated the project requiring expert review. Includes methodology notes on verification discipline.
+
+**Adjacent process docs in this repo:**
+- [docs/scope-decision-2026-04-30.md](../../scope-decision-2026-04-30.md) — Earlier scope decision (pyrxd stays narrow). Demonstrates the repo's pattern for scope questions.
+- [docs/threat-model.md](../../threat-model.md) — Security review and threat modeling; complements the adversarial review discipline this pattern formalizes.
+- [docs/red-team-checklist.md](../../red-team-checklist.md) — Red team review checklist; the adversarial review discipline this pattern relies on.
+
+**Solution docs in this category:**
+- (none other yet) — this is the first entry in `docs/solutions/design-decisions/`.
+- [docs/solutions/integration-issues/local-ci-parity-via-task-ci-and-pre-push-hook.md](../integration-issues/local-ci-parity-via-task-ci-and-pre-push-hook.md) — First solution doc overall (in `integration-issues`). Different problem class but template for the `docs/solutions/` structure.
+
+**Recent related work:**
+- **PR #14** ([fix/bip44-coin-type-512](https://github.com/MudwoodLabs/pyrxd/pull/14)) — Merged. Default BIP44 path switched from `m/44'/236'/0'` to `m/44'/512'/0'` (Radiant's SLIP-0044 spec-correct value). The technical groundwork that made the migration question worth thinking through carefully.
+- **PR #15** ([chore/local-ci-parity](https://github.com/MudwoodLabs/pyrxd/pull/15)) — Merged. Added `task ci` aggregate command + versioned pre-push hook + installer.
+
+**External community input:**
+- **Avian migration precedent** (Discord, May 2026) — Community member with direct production experience of Avian's coin type 175 → 921 migration provided the playbook that independently confirmed the panel's findings: dual-path support inside each wallet, no separate CLI tool.
+- **TheArtofSatoshi acknowledgment** (Discord, May 2026) — Active glyph-miner contributor confirmed the underlying spec direction is correct ("having the same as Bitcoin was super lazy but we are here now") and that migration is "a big breaking change."

--- a/docs/solutions/integration-issues/local-ci-parity-via-task-ci-and-pre-push-hook.md
+++ b/docs/solutions/integration-issues/local-ci-parity-via-task-ci-and-pre-push-hook.md
@@ -1,0 +1,194 @@
+---
+title: Local CI parity prevents push-fail-fix-push churn on pre-push hook
+date: 2026-05-03
+problem_type: workflow_issue
+component: ci-cd-tooling
+symptoms:
+  - Remote CI rejected push due to ruff format --check formatting nits not caught by local ruff check hook
+  - Remote pytest failed 4 CLI tests with stale m/44'/236'/... path expectations because local test runs were scoped to HD tests only
+  - Developers discovered failures only after push, forcing fix-and-force-push cycles on PR #14
+severity: medium
+status: solved
+related_prs:
+  - https://github.com/MudwoodLabs/pyrxd/pull/14
+  - https://github.com/MudwoodLabs/pyrxd/pull/15
+tags:
+  - pre-push-hook
+  - taskipy
+  - local-ci-parity
+  - ruff-format
+  - pytest
+  - poetry
+  - contributor-workflow
+---
+
+## Root Cause Analysis
+
+The pre-push hook and the `task lint` shortcut were a strict subset of what GitHub Actions executed. Local checks ran `ruff check` and `bandit`, but CI additionally enforced `ruff format --check`, `mypy src/pyrxd/security/`, the full `pytest` suite, a 100% coverage floor on `pyrxd.security`, and an 85% coverage floor on the package overall. Because none of those four gates were reachable through a single local command, contributors could push a branch that passed every check they knew to run and still watch CI fail — exactly what happened on PR #14. The drift was silent: nothing in the repo flagged that the local and remote check sets had diverged, so the gap only surfaced when CI rejected work that "looked clean" locally.
+
+A second, subtler cause compounded the first. `CONTRIBUTING.md` instructed new contributors to bootstrap with `pip install -e ".[dev]"`, which installs only the `dev` dependency group. The `test` group — containing `pytest-cov`, `pytest-mock`, `hypothesis`, and `pytest-github-actions-annotate-failures` — was omitted, so even a contributor who tried to run the full CI command set locally would hit cryptic `ModuleNotFoundError` failures rather than a real signal. The fix had to address both halves: a single local command that mirrors CI exactly, and a setup path that actually installs the dependencies that command needs.
+
+## Solution
+
+PR #15 closed the gap with three coordinated changes: a `task ci` aggregate that mirrors the CI workflows one-for-one, a versioned pre-push hook that runs it, and a corrected setup instruction so the hook's dependencies are actually present.
+
+### 1. New tasks in `pyproject.toml`
+
+The missing checks are added as named tasks, then composed into a single `task ci` that runs the same set GitHub Actions runs.
+
+```toml
+[tool.taskipy.tasks]
+# ... existing tasks ...
+format-check = "ruff format --check src tests examples"
+typecheck = "mypy src/pyrxd/security/"
+coverage-security = 'pytest tests/security/ -o "addopts=" --cov=pyrxd.security --cov-fail-under=100'
+coverage-overall = 'pytest tests/ -o "addopts=" --cov=pyrxd --cov-fail-under=85'
+# `task ci` runs the full set of checks GitHub Actions runs (.github/workflows/{lint,ci}.yml).
+ci = "task lint && task format-check && task test && task coverage-security && task coverage-overall && task typecheck"
+```
+
+The `-o "addopts="` override on the coverage tasks clears any default `addopts` so the explicit `--cov` flags are not double-applied or shadowed by repo-wide pytest configuration.
+
+### 2. Versioned pre-push hook at `scripts/git-hooks/pre-push`
+
+The hook lives in the repo (so it's reviewable and updatable) and delegates entirely to `task ci`, keeping a single source of truth for what "ready to push" means.
+
+```bash
+#!/usr/bin/env bash
+set -euo pipefail
+
+if ! command -v task >/dev/null 2>&1; then
+  echo "task not found on PATH — activate the project venv (source .venv/bin/activate) and re-run, or install dev deps with: pip install -e .[dev]"
+  exit 1
+fi
+
+if task ci; then
+  echo "pre-push: all CI checks passed locally"
+else
+  echo "pre-push: local CI failed — fix before pushing (or --no-verify for WIP)"
+  exit 1
+fi
+```
+
+### 3. Installer at `scripts/install-git-hooks.sh`
+
+Git won't track `.git/hooks/` directly, so an installer symlinks the versioned hooks into place. Symlinking (rather than copying) means future hook updates take effect without re-running the installer.
+
+```bash
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+HOOK_SRC_DIR="${REPO_ROOT}/scripts/git-hooks"
+HOOK_DST_DIR="${REPO_ROOT}/.git/hooks"
+
+for src in "${HOOK_SRC_DIR}"/*; do
+  name="$(basename "${src}")"
+  dst="${HOOK_DST_DIR}/${name}"
+  # Symlink so future updates take effect without re-running installer
+  if ln -sf "${src}" "${dst}" 2>/dev/null; then
+    chmod +x "${dst}"
+  else
+    cp "${src}" "${dst}"
+    chmod +x "${dst}"
+  fi
+done
+```
+
+### 4. `CONTRIBUTING.md` setup fix
+
+The bootstrap instruction is changed so the dependencies `task ci` needs are actually installed.
+
+Before:
+
+```bash
+pip install -e ".[dev]"
+```
+
+After:
+
+```bash
+poetry install --sync     # installs all groups (dev + test) — matches CI exactly
+```
+
+`poetry install --sync` installs both the `dev` and `test` groups, matching the environment CI builds. Without this, `task ci` would fail on the coverage tasks with `ModuleNotFoundError: No module named 'pytest_cov'` and similar.
+
+### Contributor workflow
+
+After cloning:
+
+```bash
+poetry install --sync
+./scripts/install-git-hooks.sh    # one-time hook install
+```
+
+Before any push (automatic once the hook is installed):
+
+```bash
+poetry run task ci
+```
+
+### Validation
+
+End-to-end run on the PR #15 branch:
+
+- `task ci` completed in 1m34s
+- 2178 tests passed, 3 skipped
+- 86.26% overall coverage (>=85% required)
+- 100% `pyrxd.security` coverage (required)
+- mypy reported "no issues found in 5 source files"
+
+The pre-push hook fired on the actual push, found nothing new because `task ci` had already been run, and PR #15 went green in CI on the first attempt.
+
+## Prevention Strategies
+
+- **Run `task ci` before every push.** This is the canonical local mirror of `.github/workflows/{lint,ci}.yml`. If it passes locally, CI will pass; if it fails, fix it before pushing. Treat `task ci` as the source of truth for "ready to push."
+- **Install the pre-push hook once per clone.** Run `./scripts/install-git-hooks.sh` after cloning and after the hook version bumps. The hook runs `task ci` automatically so you cannot accidentally push a broken commit during routine work.
+- **Use `poetry install --sync` for dev setup.** Do not use `pip install -e .[dev]` — it silently skips the `test` Poetry group, so your environment will be missing test-only dependencies and you will get green local runs that diverge from CI. `--sync` also prunes stale packages so your env matches `poetry.lock` exactly.
+- **When changing a constant referenced in tests, run the full suite.** Constants like the BIP-44 coin type (`m/44'/512'/...`), key prefixes, network IDs, and fee schedules are typically referenced as literal strings across many test files. Run `poetry run pytest` (no path argument) — not `pytest tests/test_hd_wallet.py` — whenever you touch a shared constant.
+- **Keep `pyproject.toml` tasks in lockstep with `.github/workflows/*.yml`.** When you add or modify a CI step (new linter, new check, new pytest flag), update the corresponding task in the same PR. Treat the workflow file and the task definition as a paired edit.
+- **Run both halves of ruff.** Local checks must include `ruff check` (lint) AND `ruff format --check` (formatter). `task ci` already does both — don't substitute partial commands.
+
+## Detection Methods
+
+- **The pre-push hook is the primary early-detection mechanism.** It catches local-CI parity issues before they ever reach GitHub Actions. Hook output should match CI output line-for-line.
+- **CI parity audit script.** Add a small CI job (or pre-commit check) that asserts `task ci` invokes the same commands as the workflow files. A simple diff of the command list catches drift like "we added `mypy` to CI but forgot to add it to `task ci`."
+- **Watch the workflow vs. task last-modified gap.** If `.github/workflows/ci.yml` was edited more recently than `pyproject.toml`'s `[tool.taskipy.tasks]` block (or vice-versa), that's a signal of drift worth investigating.
+- **Run `poetry run pytest --collect-only | wc -l` before and after refactors.** If the number of collected tests changes unexpectedly, you may be running a narrower set than CI.
+- **Search for literal constant values, not just symbol names.** Before merging a constant change, `rg "44'/236'"` (or whatever the old value was) across the entire repo — including `tests/`, `docs/`, and example files — to find every hardcoded usage.
+
+## Anti-patterns to Avoid
+
+- **Don't claim "tests passed" after a scoped run.** `pytest tests/test_hd_wallet.py tests/test_hd.py tests/test_keys.py` is a partial signal, not a green light. Only a full `task ci` (or unscoped `pytest`) justifies pushing.
+- **Don't rely on `ruff check` alone.** It does not catch formatting issues that `ruff format --check` would catch. They are separate tools with separate rule sets.
+- **Don't bypass the pre-push hook with `--no-verify`** except for genuine WIP branches you are sharing for review-only purposes. Never bypass when pushing to a PR branch you intend to merge.
+- **Don't add a CI workflow step without updating the matching task.** A CI-only check creates a permanent local-CI drift trap for the next contributor.
+- **Don't use `pip install -e .[dev]` in this repo.** It misses the `test` group and produces an environment that lies to you about test status.
+- **Don't trust "works on my machine."** The only equivalent of "what CI will say" is `task ci`. Anything less is speculation.
+- **Don't change a coin-type, prefix, or wire-format constant in isolation** — these values are baked into test fixtures and example outputs across the repo. Treat constant changes as cross-cutting refactors that demand a full-suite verification.
+
+## Related Documentation
+
+**In-repo:**
+- [CONTRIBUTING.md](../../../CONTRIBUTING.md) — Comprehensive guide including "Recommended: install the pre-push hook" section, full development setup, testing instructions, and code style expectations
+- [scripts/git-hooks/pre-push](../../../scripts/git-hooks/pre-push) — Versioned pre-push hook source that mirrors CI workflows and describes bypass mechanism
+- [scripts/install-git-hooks.sh](../../../scripts/install-git-hooks.sh) — Installer script for symlinking/copying git hooks
+- [.github/workflows/ci.yml](../../../.github/workflows/ci.yml) — GitHub Actions CI job that defines the test matrix and coverage requirements (100% security module, 85% overall)
+- [.github/workflows/lint.yml](../../../.github/workflows/lint.yml) — GitHub Actions lint job with ruff check and format steps
+- [docs/pre-commit-config.md](../../pre-commit-config.md) — Documents the pre-commit framework (auto-formatting, linting, secret detection); predates the pre-push hook work
+- [docs/developer.md](../../developer.md) — Stub developer guide
+- [docs/pyproject.md](../../pyproject.md) — Explains pyproject.toml as config file for build/lint/test/publish
+
+**Recent related PRs/commits:**
+- #15 (commit `bed9c82`) — "chore: add `task ci` for local CI parity, plus versioned pre-push hook" — the solution commit itself
+- #14 (commit `808155c`) — "fix(hd): switch BIP44 coin type from 236 (BSV) to 512" — exposed the gap that motivated #15 (missing format-check in local workflow)
+- commit `8adeb27` — "chore(lint): include bandit in `task lint` so CI failures fail locally first" — earlier attempt at parity, predates the full solution
+
+**Cross-references:**
+- `pyproject.toml` `[tool.taskipy.tasks].ci` chains the full CI matrix
+- `CONTRIBUTING.md` "Recommended: install the pre-push hook" section recommends running `./scripts/install-git-hooks.sh` and explains bypass with `--no-verify`
+- `CONTRIBUTING.md` "Testing your changes" section documents individual task commands and notes that `task ci` must pass before PR
+- `scripts/git-hooks/pre-push` explicitly states it "Mirrors .github/workflows/{lint,ci}.yml exactly"
+
+**Existing solution docs in this category:**
+- (none) — this is the first structured solution doc in `docs/solutions/`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,10 +55,15 @@ test = "pytest"
 typecheck = "mypy src/pyrxd/security/"
 coverage-security = 'pytest tests/security/ -o "addopts=" --cov=pyrxd.security --cov-fail-under=100'
 coverage-overall = 'pytest tests/ -o "addopts=" --cov=pyrxd --cov-fail-under=85'
-# `task ci` runs the full set of checks GitHub Actions runs (.github/workflows/{lint,ci}.yml).
-# Run before pushing to avoid the push-fail-fix-push loop. ~3-5 min.
+# `task check-private-links` ensures tracked docs (and staged additions) don't
+# link to gitignored paths. Catches leaks where a public doc references a
+# private design doc — broken links + leaked filenames in commit history.
+check-private-links = "python3 scripts/check-no-private-links.py"
+# `task ci` runs the full set of checks GitHub Actions runs (.github/workflows/{lint,ci}.yml)
+# plus local-only guardrails (private-link check). Run before pushing to avoid
+# the push-fail-fix-push loop. ~3-5 min.
 # For a faster pre-commit pass, just run `task lint && task format-check && task test`.
-ci = "task lint && task format-check && task test && task coverage-security && task coverage-overall && task typecheck"
+ci = "task lint && task format-check && task test && task coverage-security && task coverage-overall && task typecheck && task check-private-links"
 docs = "sphinx-build -b html docs docs/_build/html"
 docs-clean = "rm -rf docs/_build"
 docs-serve = "sphinx-autobuild docs docs/_build/html --open-browser"

--- a/scripts/check-no-private-links.py
+++ b/scripts/check-no-private-links.py
@@ -1,0 +1,258 @@
+#!/usr/bin/env python3
+"""Check that tracked markdown/rst files don't link to gitignored paths.
+
+Catches the failure mode where AI-generated documentation (or careless
+manual edits) reference files in private directories like ``docs/design/``.
+Such links would be broken in any clone of the repo and leak the
+existence of private files via the link text.
+
+Usage
+-----
+    scripts/check-no-private-links.py            # check all tracked files
+    scripts/check-no-private-links.py --verbose  # show what's being checked
+
+Exit codes
+----------
+    0  no leaks found (or no tracked files to check)
+    1  one or more tracked files link to a gitignored path
+    2  invocation error (not in a git repo, dependencies missing, etc.)
+
+Design notes
+------------
+- "Tracked" = appears in ``git ls-files`` (index or working tree)
+- "Private path" = matches a ``.gitignore`` rule, verified via
+  ``git check-ignore``
+- We deliberately use ``git check-ignore`` rather than re-implementing
+  gitignore semantics so the rules stay aligned with ``.gitignore``
+  automatically
+- We only inspect markdown (``.md``) and reStructuredText (``.rst``)
+  files. Source code links to private paths are an unrelated concern
+  and would surface differently
+- Links are extracted with a deliberately simple regex; this catches
+  ``[text](path)`` and bare ``](path)`` forms. URLs (``http://``,
+  ``https://``, ``mailto:``) are skipped — only relative/absolute
+  filesystem paths are checked
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+# Match markdown link targets: the part inside parentheses of [text](target).
+# Also matches inline reference-style: [text]: target (rare, but harmless to scan).
+_MARKDOWN_LINK_RE = re.compile(r"\]\(([^)\s]+)(?:\s+\"[^\"]*\")?\)")
+_REFERENCE_LINK_RE = re.compile(r"^\s*\[[^\]]+\]:\s+(\S+)", re.MULTILINE)
+
+# Match RST hyperlinks: `text <target>`_ and .. _name: target
+_RST_INLINE_RE = re.compile(r"`[^`]+\s+<([^>]+)>`_")
+_RST_TARGET_RE = re.compile(r"^\.\.\s+_[^:]+:\s+(\S+)", re.MULTILINE)
+
+
+def git_ls_files(repo_root: Path) -> list[Path]:
+    """Return files that are tracked OR staged (would be in a push).
+
+    Combines:
+    - ``git ls-files`` — already-tracked files
+    - ``git diff --cached --name-only --diff-filter=A`` — staged additions
+      that aren't yet tracked (the pre-push hook needs to see these
+      before they reach the remote)
+
+    Deliberately excludes purely untracked files (not staged) — those
+    won't be in any push, so leaking from them isn't a publication risk.
+    """
+    tracked = subprocess.run(
+        ["git", "-C", str(repo_root), "ls-files"],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    # Include staged additions (files that will be committed but aren't
+    # yet in the index from a previous commit).
+    staged_adds = subprocess.run(
+        ["git", "-C", str(repo_root), "diff", "--cached", "--name-only", "--diff-filter=A"],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+
+    paths: set[Path] = set()
+    for line in tracked.stdout.splitlines():
+        if line:
+            paths.add(Path(line))
+    for line in staged_adds.stdout.splitlines():
+        if line:
+            paths.add(Path(line))
+    return sorted(paths)
+
+
+def is_doc_file(path: Path) -> bool:
+    """True if the path is a markdown or RST file we should scan."""
+    return path.suffix in (".md", ".rst")
+
+
+def extract_links(content: str, suffix: str) -> list[str]:
+    """Extract link targets from doc content. Returns the raw target strings."""
+    links: list[str] = []
+    if suffix == ".md":
+        links.extend(_MARKDOWN_LINK_RE.findall(content))
+        links.extend(_REFERENCE_LINK_RE.findall(content))
+    elif suffix == ".rst":
+        links.extend(_RST_INLINE_RE.findall(content))
+        links.extend(_RST_TARGET_RE.findall(content))
+    return links
+
+
+def looks_like_url(target: str) -> bool:
+    """Skip http/https/mailto/data/git URLs — only filesystem paths matter."""
+    return target.startswith(("http://", "https://", "mailto:", "data:", "git@", "ftp://"))
+
+
+def looks_like_anchor(target: str) -> bool:
+    """Skip pure in-page anchors like #section-name."""
+    return target.startswith("#")
+
+
+def resolve_link(source_file: Path, target: str, repo_root: Path) -> Path | None:
+    """Resolve a link target to a path relative to repo_root. None if it can't be resolved."""
+    # Strip any trailing #anchor or ?query
+    target = target.split("#", 1)[0].split("?", 1)[0]
+    if not target:
+        return None
+
+    if target.startswith("/"):
+        # Absolute paths are interpreted as repo-root-relative
+        candidate = repo_root / target.lstrip("/")
+    else:
+        # Relative to the directory containing the source file
+        candidate = (repo_root / source_file).parent / target
+
+    try:
+        # Resolve symlinks and ".." but stay within filesystem reality
+        resolved = candidate.resolve()
+    except (OSError, RuntimeError):
+        return None
+
+    try:
+        return resolved.relative_to(repo_root.resolve())
+    except ValueError:
+        # Outside repo — not our concern
+        return None
+
+
+def check_ignored(repo_root: Path, paths: list[Path]) -> set[Path]:
+    """Return the subset of paths that match .gitignore (i.e., are private)."""
+    if not paths:
+        return set()
+
+    # git check-ignore exits 0 if a path is ignored, 1 if not, 128 on error.
+    # Pass paths via stdin to handle large lists and unusual filenames.
+    result = subprocess.run(
+        ["git", "-C", str(repo_root), "check-ignore", "--stdin"],
+        input="\n".join(str(p) for p in paths),
+        capture_output=True,
+        text=True,
+        check=False,  # exit 1 is normal (means "no ignored files in input")
+    )
+    if result.returncode not in (0, 1):
+        raise RuntimeError(
+            f"git check-ignore failed with exit code {result.returncode}: {result.stderr}"
+        )
+    return {Path(line) for line in result.stdout.splitlines() if line}
+
+
+def find_repo_root() -> Path:
+    """Find the repo root by asking git."""
+    try:
+        result = subprocess.run(
+            ["git", "rev-parse", "--show-toplevel"],
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+        return Path(result.stdout.strip())
+    except (subprocess.CalledProcessError, FileNotFoundError) as exc:
+        print(f"error: not in a git repo (or git not found): {exc}", file=sys.stderr)
+        sys.exit(2)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Check that tracked docs don't link to gitignored paths.",
+    )
+    parser.add_argument(
+        "--verbose",
+        "-v",
+        action="store_true",
+        help="show progress while scanning",
+    )
+    args = parser.parse_args()
+
+    repo_root = find_repo_root()
+    tracked = git_ls_files(repo_root)
+    docs = [p for p in tracked if is_doc_file(p)]
+
+    if args.verbose:
+        print(f"Scanning {len(docs)} tracked doc files for private-path links...")
+
+    leaks: list[tuple[Path, str, Path]] = []  # (source_file, raw_target, resolved_path)
+
+    for doc in docs:
+        full_path = repo_root / doc
+        try:
+            content = full_path.read_text(encoding="utf-8")
+        except (OSError, UnicodeDecodeError) as exc:
+            if args.verbose:
+                print(f"  skip {doc}: {exc}")
+            continue
+
+        targets = extract_links(content, doc.suffix)
+        if not targets:
+            continue
+
+        # Resolve each target and collect non-URL filesystem paths
+        candidates: list[tuple[str, Path]] = []
+        for target in targets:
+            if looks_like_url(target) or looks_like_anchor(target):
+                continue
+            resolved = resolve_link(doc, target, repo_root)
+            if resolved is not None:
+                candidates.append((target, resolved))
+
+        if not candidates:
+            continue
+
+        # Check which resolved paths are gitignored
+        unique_paths = list({path for _, path in candidates})
+        ignored = check_ignored(repo_root, unique_paths)
+
+        for raw_target, resolved in candidates:
+            if resolved in ignored:
+                leaks.append((doc, raw_target, resolved))
+
+    if leaks:
+        print("error: tracked docs link to gitignored (private) paths:", file=sys.stderr)
+        print("", file=sys.stderr)
+        for source, target, resolved in leaks:
+            print(f"  {source}", file=sys.stderr)
+            print(f"    link target: {target}", file=sys.stderr)
+            print(f"    resolves to: {resolved} (gitignored)", file=sys.stderr)
+            print("", file=sys.stderr)
+        print(
+            "Public docs (anything tracked by git) must not link to private paths.\n"
+            "Either move the target out of the gitignored directory, or remove the\n"
+            "link. See docs/CONTRIBUTING.md for the docs-publication convention.",
+            file=sys.stderr,
+        )
+        return 1
+
+    if args.verbose:
+        print(f"OK — {len(docs)} tracked doc files, no leaks to private paths.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

Establishes the \`docs/solutions/\` convention with the first two entries, plus adds a mechanical guardrail (\`scripts/check-no-private-links.py\` wired into \`task ci\`) to prevent solution docs from accidentally referencing gitignored paths.

## What's in this PR

### Two new solution docs

**\`docs/solutions/integration-issues/local-ci-parity-via-task-ci-and-pre-push-hook.md\`**

Documents the \`task ci\` + versioned pre-push hook solution shipped in PR #15. Captures the specific lessons:
- \`ruff format --check\` vs \`ruff check\` (different tools, both required)
- \`poetry install --sync\` vs \`pip install -e .[dev]\` (the latter misses the test dependency group)
- Pattern: keep local task definitions in lockstep with \`.github/workflows/*.yml\`

**\`docs/solutions/design-decisions/expert-panel-pivot-before-coding.md\`**

Documents the process pattern of running a multi-perspective expert review before committing engineering effort to non-trivial features. Generalized from a real authoring case where the panel surfaced a wrong-primitive concern that hardening would not have caught. Includes the 'pivot vs harden' decision rule and a checklist of when to trigger a panel.

### The guardrail

**\`scripts/check-no-private-links.py\`**

Scans tracked-or-staged markdown/RST files for links pointing to gitignored paths. Catches the failure mode where a public doc references a private \`docs/design/*\` file — broken links plus leaked filenames in commit history.

**\`pyproject.toml\`**

Two new tasks:
- \`task check-private-links\` — runs the checker
- \`task ci\` — now includes \`check-private-links\` after \`typecheck\`

The pre-push hook (which runs \`task ci\`) now catches private-path leaks before they reach the remote.

## Why this guardrail exists

During authoring of the second solution doc, an earlier draft cited six private \`docs/design/*\` files that would have:
1. Left broken links in the public repo
2. Leaked the existence of private project filenames via commit history
3. Revealed private project context through link descriptions

The leakage was caught on review (after a question from the user about whether guardrails existed). The checker would have caught it mechanically; now it does going forward.

## Test plan

- [x] \`scripts/check-no-private-links.py\` written with three test scenarios verified:
  - Clean repo state → exit 0 ✓
  - Staged solution docs (clean content) → exit 0 ✓
  - Deliberate test leak in staged file → exit 1 with helpful error ✓
- [x] Full \`task ci\` passes locally (2178 tests, 86% coverage, mypy clean, no link leaks)
- [x] Pre-push hook ran \`task ci\` during this push and passed
- [x] Both solution docs audited for private-content references — both clean

## Methodology note

This PR was authored with AI assistance. Verification of the guardrail's correctness (does it catch the failure mode it claims to catch?) was done by deliberately introducing test leaks and confirming they're flagged.