### PR TITLE
feat(hd): per-instance coin_type kwarg + load-time validation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -155,9 +155,6 @@ wallet*.dat
 .env.*
 .pypirc
 
-# ===== Detect-secrets baseline =====
-.secrets.baseline
-
 # ===== Editor / IDE =====
 *.code-workspace
 .idea/

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -1,0 +1,1559 @@
+{
+  "version": "1.5.0",
+  "plugins_used": [
+    {
+      "name": "ArtifactoryDetector"
+    },
+    {
+      "name": "AWSKeyDetector"
+    },
+    {
+      "name": "AzureStorageKeyDetector"
+    },
+    {
+      "name": "Base64HighEntropyString",
+      "limit": 4.5
+    },
+    {
+      "name": "BasicAuthDetector"
+    },
+    {
+      "name": "CloudantDetector"
+    },
+    {
+      "name": "DiscordBotTokenDetector"
+    },
+    {
+      "name": "GitHubTokenDetector"
+    },
+    {
+      "name": "GitLabTokenDetector"
+    },
+    {
+      "name": "HexHighEntropyString",
+      "limit": 3.0
+    },
+    {
+      "name": "IbmCloudIamDetector"
+    },
+    {
+      "name": "IbmCosHmacDetector"
+    },
+    {
+      "name": "IPPublicDetector"
+    },
+    {
+      "name": "JwtTokenDetector"
+    },
+    {
+      "name": "KeywordDetector",
+      "keyword_exclude": ""
+    },
+    {
+      "name": "MailchimpDetector"
+    },
+    {
+      "name": "NpmDetector"
+    },
+    {
+      "name": "OpenAIDetector"
+    },
+    {
+      "name": "PrivateKeyDetector"
+    },
+    {
+      "name": "PypiTokenDetector"
+    },
+    {
+      "name": "SendGridDetector"
+    },
+    {
+      "name": "SlackDetector"
+    },
+    {
+      "name": "SoftlayerDetector"
+    },
+    {
+      "name": "SquareOAuthDetector"
+    },
+    {
+      "name": "StripeDetector"
+    },
+    {
+      "name": "TelegramBotTokenDetector"
+    },
+    {
+      "name": "TwilioKeyDetector"
+    }
+  ],
+  "filters_used": [
+    {
+      "path": "detect_secrets.filters.allowlist.is_line_allowlisted"
+    },
+    {
+      "path": "detect_secrets.filters.common.is_ignored_due_to_verification_policies",
+      "min_level": 2
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_indirect_reference"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_likely_id_string"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_lock_file"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_not_alphanumeric_string"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_potential_uuid"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_prefixed_with_dollar_sign"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_sequential_string"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_swagger_file"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_templated_secret"
+    },
+    {
+      "path": "detect_secrets.filters.regex.should_exclude_file",
+      "pattern": [
+        "\\.venv/|\\.git/|coverage\\.xml|node_modules"
+      ]
+    }
+  ],
+  "results": {
+    ".gitleaks.toml": [
+      {
+        "type": "Base64 High Entropy String",
+        "filename": ".gitleaks.toml",
+        "hashed_secret": "2e008c54c7e144e202b05a7812806353cb6c1ef5",
+        "is_verified": false,
+        "line_number": 39
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": ".gitleaks.toml",
+        "hashed_secret": "d4a248959bc9fb4c76c01118c2269b92b4b328ee",
+        "is_verified": false,
+        "line_number": 40
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".gitleaks.toml",
+        "hashed_secret": "6586e1ac4272ad00242f2b26303d040dcd7f678b",
+        "is_verified": false,
+        "line_number": 42
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".gitleaks.toml",
+        "hashed_secret": "baf46e3dba549906d91972cee2b45b9be09c9b25",
+        "is_verified": false,
+        "line_number": 43
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".gitleaks.toml",
+        "hashed_secret": "9d8ef67d4fb6db43240a7e238d14cf32241ed799",
+        "is_verified": false,
+        "line_number": 45
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".gitleaks.toml",
+        "hashed_secret": "f3f86fecd4d203e070841d08d68a80a39df1da65",
+        "is_verified": false,
+        "line_number": 46
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".gitleaks.toml",
+        "hashed_secret": "d6b491dd8c1face2c68a730aab2feacb95f09a21",
+        "is_verified": false,
+        "line_number": 48
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": ".gitleaks.toml",
+        "hashed_secret": "6169057fc73117b00eeb2d96f33e2fcfa11faab6",
+        "is_verified": false,
+        "line_number": 50
+      }
+    ],
+    "docs/dmint-research-photonic.md": [
+      {
+        "type": "Hex High Entropy String",
+        "filename": "docs/dmint-research-photonic.md",
+        "hashed_secret": "2cd55a1fb31aee62b0535ac948641d1826a6edcd",
+        "is_verified": false,
+        "line_number": 615
+      }
+    ],
+    "src/pyrxd/base58.py": [
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "src/pyrxd/base58.py",
+        "hashed_secret": "1fbf29f4d01704e52025ffc9a6d73b5241be9e10",
+        "is_verified": false,
+        "line_number": 5
+      }
+    ],
+    "src/pyrxd/btc_wallet/keys.py": [
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "src/pyrxd/btc_wallet/keys.py",
+        "hashed_secret": "9a96960baa4d8c0559cf89f72b5f3486736762e9",
+        "is_verified": false,
+        "line_number": 40
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "src/pyrxd/btc_wallet/keys.py",
+        "hashed_secret": "1fbf29f4d01704e52025ffc9a6d73b5241be9e10",
+        "is_verified": false,
+        "line_number": 232
+      }
+    ],
+    "src/pyrxd/glyph/dmint.py": [
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/pyrxd/glyph/dmint.py",
+        "hashed_secret": "ea369f31339b05ee41c6691ec7ce5b14cc2b50d9",
+        "is_verified": false,
+        "line_number": 134
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/pyrxd/glyph/dmint.py",
+        "hashed_secret": "ab53fc7cdc84aee766b37fa9e7000b9f9fd3db79",
+        "is_verified": false,
+        "line_number": 135
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/pyrxd/glyph/dmint.py",
+        "hashed_secret": "16daef8fb4023508a29135bb3399a0c429a09fbf",
+        "is_verified": false,
+        "line_number": 136
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/pyrxd/glyph/dmint.py",
+        "hashed_secret": "cafc7feff60324385eed1307dadb85422f7af1b0",
+        "is_verified": false,
+        "line_number": 137
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/pyrxd/glyph/dmint.py",
+        "hashed_secret": "342a8f4eb9b7b2f1d2546b0a98e834738e3734f3",
+        "is_verified": false,
+        "line_number": 138
+      }
+    ],
+    "src/pyrxd/glyph/script.py": [
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/pyrxd/glyph/script.py",
+        "hashed_secret": "ce97ffad3a42004fe8f2bea16f8b3a94efdba351",
+        "is_verified": false,
+        "line_number": 152
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/pyrxd/glyph/script.py",
+        "hashed_secret": "bd3cc5ab4262be45efaccb2a44e19857c3eae4ef",
+        "is_verified": false,
+        "line_number": 162
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/pyrxd/glyph/script.py",
+        "hashed_secret": "fdcb8683d8ba34af4fe8fff6c0f035d80c84aef8",
+        "is_verified": false,
+        "line_number": 165
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/pyrxd/glyph/script.py",
+        "hashed_secret": "70b7f8d368a192e32de78c34bd0d932bc4dbe3b3",
+        "is_verified": false,
+        "line_number": 167
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/pyrxd/glyph/script.py",
+        "hashed_secret": "49be50d67c0e95e4fb6c6d3f1e162578a6c67e96",
+        "is_verified": false,
+        "line_number": 168
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/pyrxd/glyph/script.py",
+        "hashed_secret": "e47d5845ef6600a2354201c2126f8a0f517903f0",
+        "is_verified": false,
+        "line_number": 172
+      }
+    ],
+    "src/pyrxd/gravity/covenant.py": [
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/pyrxd/gravity/covenant.py",
+        "hashed_secret": "370f2e9fadc2fdfdc2082fb3301cce116bcff5f7",
+        "is_verified": false,
+        "line_number": 71
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/pyrxd/gravity/covenant.py",
+        "hashed_secret": "ddf32a8c2e9dcc7eb47f3c79c25188103e387003",
+        "is_verified": false,
+        "line_number": 72
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/pyrxd/gravity/covenant.py",
+        "hashed_secret": "5107cd8a3a71bb7a37ae52e0584b6f3e217da272",
+        "is_verified": false,
+        "line_number": 73
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/pyrxd/gravity/covenant.py",
+        "hashed_secret": "280915e0c4e067a99c64b0c50aba39232be21328",
+        "is_verified": false,
+        "line_number": 74
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/pyrxd/gravity/covenant.py",
+        "hashed_secret": "98a42717ac23056f0cb19b506185236dcd89258f",
+        "is_verified": false,
+        "line_number": 75
+      }
+    ],
+    "src/pyrxd/security/secrets.py": [
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "src/pyrxd/security/secrets.py",
+        "hashed_secret": "1fbf29f4d01704e52025ffc9a6d73b5241be9e10",
+        "is_verified": false,
+        "line_number": 34
+      }
+    ],
+    "src/pyrxd/utils.py": [
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "src/pyrxd/utils.py",
+        "hashed_secret": "1fbf29f4d01704e52025ffc9a6d73b5241be9e10",
+        "is_verified": false,
+        "line_number": 368
+      }
+    ],
+    "tests/cli/test_glyph_cmds.py": [
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "tests/cli/test_glyph_cmds.py",
+        "hashed_secret": "c863414c7c96113a91b24c519108dbc30ab89394",
+        "is_verified": false,
+        "line_number": 130
+      }
+    ],
+    "tests/security/test_errors.py": [
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "tests/security/test_errors.py",
+        "hashed_secret": "908a0d478aa712e8ec80d41aeba2c122077ed383",
+        "is_verified": false,
+        "line_number": 56
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/security/test_errors.py",
+        "hashed_secret": "f49cf6381e322b147053b74e4500af8533ac1e4c",
+        "is_verified": false,
+        "line_number": 88
+      }
+    ],
+    "tests/security/test_secrets.py": [
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "tests/security/test_secrets.py",
+        "hashed_secret": "908a0d478aa712e8ec80d41aeba2c122077ed383",
+        "is_verified": false,
+        "line_number": 226
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "tests/security/test_secrets.py",
+        "hashed_secret": "d4a248959bc9fb4c76c01118c2269b92b4b328ee",
+        "is_verified": false,
+        "line_number": 227
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "tests/security/test_secrets.py",
+        "hashed_secret": "ff3921e2b57da8203f7427aead64c5cc0e70aa78",
+        "is_verified": false,
+        "line_number": 242
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "tests/security/test_secrets.py",
+        "hashed_secret": "c3f8c8d9894e86297105ab3b023d7f16ae5ab190",
+        "is_verified": false,
+        "line_number": 285
+      }
+    ],
+    "tests/test_base58.py": [
+      {
+        "type": "Hex High Entropy String",
+        "filename": "tests/test_base58.py",
+        "hashed_secret": "1ce5c8d73919867ab8aebeccad745fe59499db92",
+        "is_verified": false,
+        "line_number": 45
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "tests/test_base58.py",
+        "hashed_secret": "f332ba71a22fad8d94a10850826b11c12ebbaec3",
+        "is_verified": false,
+        "line_number": 46
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "tests/test_base58.py",
+        "hashed_secret": "033dd0bb4dd9bae5e91dc2f3b00bf7f264bad38a",
+        "is_verified": false,
+        "line_number": 47
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "tests/test_base58.py",
+        "hashed_secret": "8aeb1156ba887ea5836820e0a19fcb31ed3a4380",
+        "is_verified": false,
+        "line_number": 48
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "tests/test_base58.py",
+        "hashed_secret": "3ee541cd0af869c3bbdbdbda799c21d507c1bfb8",
+        "is_verified": false,
+        "line_number": 49
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "tests/test_base58.py",
+        "hashed_secret": "ef7484b047f87495420e5ad967f24d6ecb50ab0f",
+        "is_verified": false,
+        "line_number": 52
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "tests/test_base58.py",
+        "hashed_secret": "0f85db038627ebb1b6bd61ad883af1d66dd17892",
+        "is_verified": false,
+        "line_number": 53
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "tests/test_base58.py",
+        "hashed_secret": "16b38e0d3afc7029bc66395ed718d5eeb7d9a6da",
+        "is_verified": false,
+        "line_number": 54
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "tests/test_base58.py",
+        "hashed_secret": "398082005d9c1f92afb68f2e6f746f885a74c3d0",
+        "is_verified": false,
+        "line_number": 55
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "tests/test_base58.py",
+        "hashed_secret": "0ebe5512d5224f1c70608aa4035a032979880de3",
+        "is_verified": false,
+        "line_number": 56
+      }
+    ],
+    "tests/test_btc_wallet.py": [
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "tests/test_btc_wallet.py",
+        "hashed_secret": "2e008c54c7e144e202b05a7812806353cb6c1ef5",
+        "is_verified": false,
+        "line_number": 93
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/test_btc_wallet.py",
+        "hashed_secret": "2e008c54c7e144e202b05a7812806353cb6c1ef5",
+        "is_verified": false,
+        "line_number": 93
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "tests/test_btc_wallet.py",
+        "hashed_secret": "c863414c7c96113a91b24c519108dbc30ab89394",
+        "is_verified": false,
+        "line_number": 97
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "tests/test_btc_wallet.py",
+        "hashed_secret": "d126b6627572d44d60a5c62f396c3ee16ed651bc",
+        "is_verified": false,
+        "line_number": 103
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "tests/test_btc_wallet.py",
+        "hashed_secret": "95281baf4eef72728580014664f2521c1d96a89f",
+        "is_verified": false,
+        "line_number": 170
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "tests/test_btc_wallet.py",
+        "hashed_secret": "098eca9912fd99b52472b5307eeee58ffe69501d",
+        "is_verified": false,
+        "line_number": 429
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "tests/test_btc_wallet.py",
+        "hashed_secret": "1388ef97da4fd7f5c9aa3319decf5fca98b69448",
+        "is_verified": false,
+        "line_number": 436
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "tests/test_btc_wallet.py",
+        "hashed_secret": "d2cbc0a486fc2628f198776ef6a98bbaeb506fb6",
+        "is_verified": false,
+        "line_number": 457
+      }
+    ],
+    "tests/test_covenant.py": [
+      {
+        "type": "Hex High Entropy String",
+        "filename": "tests/test_covenant.py",
+        "hashed_secret": "a1dff25f4dffbbaa57c2bb613d3bcf1ad06e0029",
+        "is_verified": false,
+        "line_number": 271
+      }
+    ],
+    "tests/test_coverage_gaps.py": [
+      {
+        "type": "Hex High Entropy String",
+        "filename": "tests/test_coverage_gaps.py",
+        "hashed_secret": "37d0afce14dcee17ecb2e10572357b0b55901761",
+        "is_verified": false,
+        "line_number": 263
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "tests/test_coverage_gaps.py",
+        "hashed_secret": "561ffe4272b0938339999a9216482458b708c9d6",
+        "is_verified": false,
+        "line_number": 264
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "tests/test_coverage_gaps.py",
+        "hashed_secret": "72dec46fee22ff64820a32e43d1f2c1b3994c45e",
+        "is_verified": false,
+        "line_number": 265
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "tests/test_coverage_gaps.py",
+        "hashed_secret": "b12ed3e27d0b02ec8f7eff68c48c561193333857",
+        "is_verified": false,
+        "line_number": 266
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "tests/test_coverage_gaps.py",
+        "hashed_secret": "0f29b5e4935fe95caf661643e4b3b0d1716e57ef",
+        "is_verified": false,
+        "line_number": 267
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "tests/test_coverage_gaps.py",
+        "hashed_secret": "761c43e4aac66df07291f84f2298d9a2caba00c6",
+        "is_verified": false,
+        "line_number": 268
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "tests/test_coverage_gaps.py",
+        "hashed_secret": "4c4d1865e03c39f4626166c933ad464033f6abff",
+        "is_verified": false,
+        "line_number": 269
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "tests/test_coverage_gaps.py",
+        "hashed_secret": "3420b177e8bc48bb5235ed72636959158d5eb975",
+        "is_verified": false,
+        "line_number": 270
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "tests/test_coverage_gaps.py",
+        "hashed_secret": "e833b7f2f6d6f68b11cf3f2fdf32fa9f4d736951",
+        "is_verified": false,
+        "line_number": 271
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "tests/test_coverage_gaps.py",
+        "hashed_secret": "2ecba6c0baa3a57694325825bc5a72259ce5ea04",
+        "is_verified": false,
+        "line_number": 272
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "tests/test_coverage_gaps.py",
+        "hashed_secret": "58ed69a45b8b47636f829a9d6aa84212645bc64f",
+        "is_verified": false,
+        "line_number": 273
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "tests/test_coverage_gaps.py",
+        "hashed_secret": "8664ca8be4ba5528dcb1d82447ef7b90dd9907f9",
+        "is_verified": false,
+        "line_number": 274
+      }
+    ],
+    "tests/test_coverage_gaps2.py": [
+      {
+        "type": "Hex High Entropy String",
+        "filename": "tests/test_coverage_gaps2.py",
+        "hashed_secret": "37d0afce14dcee17ecb2e10572357b0b55901761",
+        "is_verified": false,
+        "line_number": 416
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "tests/test_coverage_gaps2.py",
+        "hashed_secret": "561ffe4272b0938339999a9216482458b708c9d6",
+        "is_verified": false,
+        "line_number": 417
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "tests/test_coverage_gaps2.py",
+        "hashed_secret": "72dec46fee22ff64820a32e43d1f2c1b3994c45e",
+        "is_verified": false,
+        "line_number": 418
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "tests/test_coverage_gaps2.py",
+        "hashed_secret": "b12ed3e27d0b02ec8f7eff68c48c561193333857",
+        "is_verified": false,
+        "line_number": 419
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "tests/test_coverage_gaps2.py",
+        "hashed_secret": "0f29b5e4935fe95caf661643e4b3b0d1716e57ef",
+        "is_verified": false,
+        "line_number": 420
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "tests/test_coverage_gaps2.py",
+        "hashed_secret": "761c43e4aac66df07291f84f2298d9a2caba00c6",
+        "is_verified": false,
+        "line_number": 421
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "tests/test_coverage_gaps2.py",
+        "hashed_secret": "4c4d1865e03c39f4626166c933ad464033f6abff",
+        "is_verified": false,
+        "line_number": 422
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "tests/test_coverage_gaps2.py",
+        "hashed_secret": "3420b177e8bc48bb5235ed72636959158d5eb975",
+        "is_verified": false,
+        "line_number": 423
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "tests/test_coverage_gaps2.py",
+        "hashed_secret": "e833b7f2f6d6f68b11cf3f2fdf32fa9f4d736951",
+        "is_verified": false,
+        "line_number": 424
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "tests/test_coverage_gaps2.py",
+        "hashed_secret": "2ecba6c0baa3a57694325825bc5a72259ce5ea04",
+        "is_verified": false,
+        "line_number": 425
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "tests/test_coverage_gaps2.py",
+        "hashed_secret": "58ed69a45b8b47636f829a9d6aa84212645bc64f",
+        "is_verified": false,
+        "line_number": 426
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "tests/test_coverage_gaps2.py",
+        "hashed_secret": "8664ca8be4ba5528dcb1d82447ef7b90dd9907f9",
+        "is_verified": false,
+        "line_number": 427
+      }
+    ],
+    "tests/test_glyph_v2.py": [
+      {
+        "type": "Hex High Entropy String",
+        "filename": "tests/test_glyph_v2.py",
+        "hashed_secret": "e380f33f461daa7f5dc2212f9064658c426e81a7",
+        "is_verified": false,
+        "line_number": 116
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "tests/test_glyph_v2.py",
+        "hashed_secret": "1f53c678083ff7392eeb46ac3192fae8355afabb",
+        "is_verified": false,
+        "line_number": 117
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "tests/test_glyph_v2.py",
+        "hashed_secret": "3104e65828f779ce9638ad5794f327f3a31bf0a0",
+        "is_verified": false,
+        "line_number": 118
+      }
+    ],
+    "tests/test_golden_vectors.py": [
+      {
+        "type": "Hex High Entropy String",
+        "filename": "tests/test_golden_vectors.py",
+        "hashed_secret": "3a9236ef09ef844c70d2451c0966e6246f2afb25",
+        "is_verified": false,
+        "line_number": 42
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "tests/test_golden_vectors.py",
+        "hashed_secret": "06b02c33b4f19517d4013ec9da50ed33ed5a13b7",
+        "is_verified": false,
+        "line_number": 43
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "tests/test_golden_vectors.py",
+        "hashed_secret": "846989ab1eb1b919c459e910e132c36a015f6be7",
+        "is_verified": false,
+        "line_number": 71
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "tests/test_golden_vectors.py",
+        "hashed_secret": "1999129d7e2d6a15cc229defb747def84a571af0",
+        "is_verified": false,
+        "line_number": 159
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "tests/test_golden_vectors.py",
+        "hashed_secret": "c1380767e84e60f2e70649061b2b693d8127b6d6",
+        "is_verified": false,
+        "line_number": 160
+      }
+    ],
+    "tests/test_gravity.py": [
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "tests/test_gravity.py",
+        "hashed_secret": "c863414c7c96113a91b24c519108dbc30ab89394",
+        "is_verified": false,
+        "line_number": 229
+      }
+    ],
+    "tests/test_gravity_maker.py": [
+      {
+        "type": "Hex High Entropy String",
+        "filename": "tests/test_gravity_maker.py",
+        "hashed_secret": "5461471bb63ed975bdd9f043df404e6c493386c2",
+        "is_verified": false,
+        "line_number": 37
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "tests/test_gravity_maker.py",
+        "hashed_secret": "33a2e17a5167381622e5bc172369783506c9ee77",
+        "is_verified": false,
+        "line_number": 38
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "tests/test_gravity_maker.py",
+        "hashed_secret": "42890ba99765b9c18c8d22592cc02769fcfc51fc",
+        "is_verified": false,
+        "line_number": 39
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "tests/test_gravity_maker.py",
+        "hashed_secret": "f66ca76013fa8cc81eee0b4a261498c0e63d6a0f",
+        "is_verified": false,
+        "line_number": 40
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "tests/test_gravity_maker.py",
+        "hashed_secret": "af5bd3003672fef5ad109de289989d4f1e12aa61",
+        "is_verified": false,
+        "line_number": 41
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "tests/test_gravity_maker.py",
+        "hashed_secret": "3fa06e5854bec4749e25140c08f34ed71fc0799e",
+        "is_verified": false,
+        "line_number": 42
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "tests/test_gravity_maker.py",
+        "hashed_secret": "a69c04dffa83d59c20842f3aa44e85fa1df018ab",
+        "is_verified": false,
+        "line_number": 43
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "tests/test_gravity_maker.py",
+        "hashed_secret": "d59ccc7d93e8c0bd445baeed762caa78e5dcc654",
+        "is_verified": false,
+        "line_number": 44
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "tests/test_gravity_maker.py",
+        "hashed_secret": "afdd478458c31168b1a2111e5790658a4b8bd23c",
+        "is_verified": false,
+        "line_number": 45
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "tests/test_gravity_maker.py",
+        "hashed_secret": "7fc15eb5cc19102ad53d7102e58a5b04ef1cc7db",
+        "is_verified": false,
+        "line_number": 46
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "tests/test_gravity_maker.py",
+        "hashed_secret": "c6f50b9508726135100ebcb85c7a0b0038f23f72",
+        "is_verified": false,
+        "line_number": 47
+      }
+    ],
+    "tests/test_gravity_red_team.py": [
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "tests/test_gravity_red_team.py",
+        "hashed_secret": "098eca9912fd99b52472b5307eeee58ffe69501d",
+        "is_verified": false,
+        "line_number": 427
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "tests/test_gravity_red_team.py",
+        "hashed_secret": "c863414c7c96113a91b24c519108dbc30ab89394",
+        "is_verified": false,
+        "line_number": 605
+      }
+    ],
+    "tests/test_gravity_trade.py": [
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "tests/test_gravity_trade.py",
+        "hashed_secret": "c863414c7c96113a91b24c519108dbc30ab89394",
+        "is_verified": false,
+        "line_number": 457
+      }
+    ],
+    "tests/test_hd.py": [
+      {
+        "type": "Hex High Entropy String",
+        "filename": "tests/test_hd.py",
+        "hashed_secret": "7d807dd1f24272146ed00ee4b33ab8f3c3987586",
+        "is_verified": false,
+        "line_number": 11
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "tests/test_hd.py",
+        "hashed_secret": "79e190f9d7a544eb27725549fc1cf4edbe1fde6a",
+        "is_verified": false,
+        "line_number": 14
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "tests/test_hd.py",
+        "hashed_secret": "39f15090dd51230c383dad6eefa8922829b67a47",
+        "is_verified": false,
+        "line_number": 17
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "tests/test_hd.py",
+        "hashed_secret": "6b7f584dd6cb4393718901ed0ffcba1c2c507556",
+        "is_verified": false,
+        "line_number": 22
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "tests/test_hd.py",
+        "hashed_secret": "60b3d844030223ca23c45adfa220f21e0b9cc846",
+        "is_verified": false,
+        "line_number": 25
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "tests/test_hd.py",
+        "hashed_secret": "6a2bc5bf2db485febb5c5c713dbec9f3cfdc6bd3",
+        "is_verified": false,
+        "line_number": 30
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "tests/test_hd.py",
+        "hashed_secret": "efdb76d3f4a47b34d188b172b22339f2dfa1b5be",
+        "is_verified": false,
+        "line_number": 33
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "tests/test_hd.py",
+        "hashed_secret": "7569b64120e0ab8af732193b75029a7b11531720",
+        "is_verified": false,
+        "line_number": 112
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "tests/test_hd.py",
+        "hashed_secret": "102cdbd001c306f7fd5b8047ef3505e2ef0009f6",
+        "is_verified": false,
+        "line_number": 113
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "tests/test_hd.py",
+        "hashed_secret": "456370baa621745794dbe83d4a5a0d31082ca579",
+        "is_verified": false,
+        "line_number": 114
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "tests/test_hd.py",
+        "hashed_secret": "e4362624d4e18762c5af542fe72aaed5e8ca3430",
+        "is_verified": false,
+        "line_number": 164
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "tests/test_hd.py",
+        "hashed_secret": "fb6be0bc8c1adcf565a3bf7f05a8da55b7ff3fef",
+        "is_verified": false,
+        "line_number": 166
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "tests/test_hd.py",
+        "hashed_secret": "c8f889ee4b7d93aa343f95cbc3fc367b27aeb417",
+        "is_verified": false,
+        "line_number": 171
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "tests/test_hd.py",
+        "hashed_secret": "16a379e1acc4769490a3b4db904d51e3c5141230",
+        "is_verified": false,
+        "line_number": 176
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "tests/test_hd.py",
+        "hashed_secret": "f4719c4d2e9ab790ffb39415481c2393ce016e8f",
+        "is_verified": false,
+        "line_number": 181
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "tests/test_hd.py",
+        "hashed_secret": "7fbb76edaa4be0d623a77807ce8086c037653746",
+        "is_verified": false,
+        "line_number": 182
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "tests/test_hd.py",
+        "hashed_secret": "6f3f08d0d79abbe5a8f03979352daf41e4415b69",
+        "is_verified": false,
+        "line_number": 193
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "tests/test_hd.py",
+        "hashed_secret": "79cf178ed95e96421076ec9d3e359e5895d1d8cc",
+        "is_verified": false,
+        "line_number": 197
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "tests/test_hd.py",
+        "hashed_secret": "2934eadfc93fbbe1e4ed550b66a60b90d0d9bb1e",
+        "is_verified": false,
+        "line_number": 201
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "tests/test_hd.py",
+        "hashed_secret": "9b863edbf9486e865b013f82a3bf7a9fbae9feaa",
+        "is_verified": false,
+        "line_number": 209
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "tests/test_hd.py",
+        "hashed_secret": "b8a004d7c2c66c9a3fb41334a034f2ef4cae49b4",
+        "is_verified": false,
+        "line_number": 223
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "tests/test_hd.py",
+        "hashed_secret": "c668b2988218213b7f1c7c9ba1716fbdcd32de94",
+        "is_verified": false,
+        "line_number": 224
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "tests/test_hd.py",
+        "hashed_secret": "de68dd9cfe8491643b823dc88246dd49970f0cda",
+        "is_verified": false,
+        "line_number": 230
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "tests/test_hd.py",
+        "hashed_secret": "98c9169744851043c48e6a8a7a4fa23b2116ea34",
+        "is_verified": false,
+        "line_number": 231
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "tests/test_hd.py",
+        "hashed_secret": "7e75b9e62557a4591922af87b0cb0e457efb8eb9",
+        "is_verified": false,
+        "line_number": 237
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "tests/test_hd.py",
+        "hashed_secret": "b31d303e5e02af5bf24477aea59cb6cc1a97a398",
+        "is_verified": false,
+        "line_number": 238
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "tests/test_hd.py",
+        "hashed_secret": "72551eaedaaff4f336b3be5e40a6788d6ef7e046",
+        "is_verified": false,
+        "line_number": 244
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "tests/test_hd.py",
+        "hashed_secret": "d656cf51480f65b9a8ca0e0f21dddcc9e54fbc94",
+        "is_verified": false,
+        "line_number": 245
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "tests/test_hd.py",
+        "hashed_secret": "99c951989aa2626f876f859bd4c520652ee579c8",
+        "is_verified": false,
+        "line_number": 249
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "tests/test_hd.py",
+        "hashed_secret": "273026ff9769b13e9cc8a4b81431d686e96f3057",
+        "is_verified": false,
+        "line_number": 250
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "tests/test_hd.py",
+        "hashed_secret": "41ffc232144167bdeb06b11a1f7e256b1ecc39de",
+        "is_verified": false,
+        "line_number": 257
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "tests/test_hd.py",
+        "hashed_secret": "c8e4ce46c65dc8f1f0841085f8bbb242675515d4",
+        "is_verified": false,
+        "line_number": 258
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "tests/test_hd.py",
+        "hashed_secret": "9b50e8183ef995c6e7384f309d5b1b34f997a8cc",
+        "is_verified": false,
+        "line_number": 267
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "tests/test_hd.py",
+        "hashed_secret": "d40c9f376679132ece177e91b897eb5945b23950",
+        "is_verified": false,
+        "line_number": 268
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "tests/test_hd.py",
+        "hashed_secret": "50e1bf528843fd22722ce50d988f3f3d0b937e96",
+        "is_verified": false,
+        "line_number": 272
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "tests/test_hd.py",
+        "hashed_secret": "7547d2af8f2bd1e3d1279cc40762f4ebadec23a4",
+        "is_verified": false,
+        "line_number": 275
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "tests/test_hd.py",
+        "hashed_secret": "ecc4cf1632cea659cea5cf3c2cc939f87f1e1f88",
+        "is_verified": false,
+        "line_number": 293
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "tests/test_hd.py",
+        "hashed_secret": "0fe6070804d21fa56e20dfe713247834f4372b8d",
+        "is_verified": false,
+        "line_number": 301
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "tests/test_hd.py",
+        "hashed_secret": "002e936441b96ffd336f278a7da5ab31dfbdfb57",
+        "is_verified": false,
+        "line_number": 305
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "tests/test_hd.py",
+        "hashed_secret": "ac091fcb08a0a84bbdbb50dd6566fc4d9b34d3c9",
+        "is_verified": false,
+        "line_number": 347
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "tests/test_hd.py",
+        "hashed_secret": "aa3a993e4d93474f842f01c7fbe1664f16fce896",
+        "is_verified": false,
+        "line_number": 348
+      }
+    ],
+    "tests/test_hd_wallet.py": [
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "tests/test_hd_wallet.py",
+        "hashed_secret": "09b0f57e9203aa921e37fbed9fe2a676ac0d8271",
+        "is_verified": false,
+        "line_number": 136
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "tests/test_hd_wallet.py",
+        "hashed_secret": "242feb473559be719857fba8f50d264a7b4158b6",
+        "is_verified": false,
+        "line_number": 137
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "tests/test_hd_wallet.py",
+        "hashed_secret": "c863414c7c96113a91b24c519108dbc30ab89394",
+        "is_verified": false,
+        "line_number": 1221
+      }
+    ],
+    "tests/test_keys.py": [
+      {
+        "type": "Hex High Entropy String",
+        "filename": "tests/test_keys.py",
+        "hashed_secret": "9d8ef67d4fb6db43240a7e238d14cf32241ed799",
+        "is_verified": false,
+        "line_number": 13
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/test_keys.py",
+        "hashed_secret": "9d8ef67d4fb6db43240a7e238d14cf32241ed799",
+        "is_verified": false,
+        "line_number": 13
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "tests/test_keys.py",
+        "hashed_secret": "6586e1ac4272ad00242f2b26303d040dcd7f678b",
+        "is_verified": false,
+        "line_number": 21
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/test_keys.py",
+        "hashed_secret": "6586e1ac4272ad00242f2b26303d040dcd7f678b",
+        "is_verified": false,
+        "line_number": 21
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "tests/test_keys.py",
+        "hashed_secret": "b9b4cc402438328102a37c62f5f611678b347f47",
+        "is_verified": false,
+        "line_number": 28
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "tests/test_keys.py",
+        "hashed_secret": "d58034b5e5173f5cf89643e4e4b81fe5533e6f94",
+        "is_verified": false,
+        "line_number": 33
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "tests/test_keys.py",
+        "hashed_secret": "baf46e3dba549906d91972cee2b45b9be09c9b25",
+        "is_verified": false,
+        "line_number": 43
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/test_keys.py",
+        "hashed_secret": "baf46e3dba549906d91972cee2b45b9be09c9b25",
+        "is_verified": false,
+        "line_number": 43
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "tests/test_keys.py",
+        "hashed_secret": "6169057fc73117b00eeb2d96f33e2fcfa11faab6",
+        "is_verified": false,
+        "line_number": 48
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "tests/test_keys.py",
+        "hashed_secret": "d6b491dd8c1face2c68a730aab2feacb95f09a21",
+        "is_verified": false,
+        "line_number": 54
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/test_keys.py",
+        "hashed_secret": "d6b491dd8c1face2c68a730aab2feacb95f09a21",
+        "is_verified": false,
+        "line_number": 54
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "tests/test_keys.py",
+        "hashed_secret": "f6c202ff5f0ec9b4a9c28cdb02c1abab5b38f998",
+        "is_verified": false,
+        "line_number": 64
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "tests/test_keys.py",
+        "hashed_secret": "ecc4cf1632cea659cea5cf3c2cc939f87f1e1f88",
+        "is_verified": false,
+        "line_number": 142
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "tests/test_keys.py",
+        "hashed_secret": "0fe6070804d21fa56e20dfe713247834f4372b8d",
+        "is_verified": false,
+        "line_number": 149
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "tests/test_keys.py",
+        "hashed_secret": "002e936441b96ffd336f278a7da5ab31dfbdfb57",
+        "is_verified": false,
+        "line_number": 153
+      }
+    ],
+    "tests/test_preimage.py": [
+      {
+        "type": "Hex High Entropy String",
+        "filename": "tests/test_preimage.py",
+        "hashed_secret": "0d87599505e433fbf42eaab7aad0749c1cf32efe",
+        "is_verified": false,
+        "line_number": 25
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "tests/test_preimage.py",
+        "hashed_secret": "462111d71844b381fdbcbd5f71ece75b92f70e1e",
+        "is_verified": false,
+        "line_number": 92
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "tests/test_preimage.py",
+        "hashed_secret": "0907a0ac0f35b65cf6d340a18990605df7b87207",
+        "is_verified": false,
+        "line_number": 98
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "tests/test_preimage.py",
+        "hashed_secret": "ab820a917f87d03c4b7873d8a96a5d0a4d91ba75",
+        "is_verified": false,
+        "line_number": 104
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "tests/test_preimage.py",
+        "hashed_secret": "335c34fca43b2dacea8dc77301cb63d9861b4af4",
+        "is_verified": false,
+        "line_number": 110
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "tests/test_preimage.py",
+        "hashed_secret": "082ee346d882bff41c6c53a64876f49adb06e323",
+        "is_verified": false,
+        "line_number": 122
+      }
+    ],
+    "tests/test_script.py": [
+      {
+        "type": "Hex High Entropy String",
+        "filename": "tests/test_script.py",
+        "hashed_secret": "352f56f2ca02ebbecabf471d5fef0084e60f7b54",
+        "is_verified": false,
+        "line_number": 53
+      }
+    ],
+    "tests/test_spv.py": [
+      {
+        "type": "Hex High Entropy String",
+        "filename": "tests/test_spv.py",
+        "hashed_secret": "9733d52583e36b016a8e5eaad577256358b4475b",
+        "is_verified": false,
+        "line_number": 38
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "tests/test_spv.py",
+        "hashed_secret": "0081e7f681990229cb9f05801fcf8fe9262e99bd",
+        "is_verified": false,
+        "line_number": 39
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "tests/test_spv.py",
+        "hashed_secret": "e9ff6409b60bc6d38bce8bea22abd44301273b50",
+        "is_verified": false,
+        "line_number": 40
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "tests/test_spv.py",
+        "hashed_secret": "3b64dd66b6aebcac19232eb884241dd6717bf70a",
+        "is_verified": false,
+        "line_number": 44
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "tests/test_spv.py",
+        "hashed_secret": "3dc9118065025db6271779b992ae18a1aad49e5f",
+        "is_verified": false,
+        "line_number": 45
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "tests/test_spv.py",
+        "hashed_secret": "97cfb64c024efcc4417d06dbea7653935e79b852",
+        "is_verified": false,
+        "line_number": 46
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "tests/test_spv.py",
+        "hashed_secret": "7f4aa5db8baf88987135048f1f01cf4f679e9cae",
+        "is_verified": false,
+        "line_number": 214
+      }
+    ],
+    "tests/test_transaction.py": [
+      {
+        "type": "Hex High Entropy String",
+        "filename": "tests/test_transaction.py",
+        "hashed_secret": "a2ded62289329c7bd24143caf68e8d067f605fab",
+        "is_verified": false,
+        "line_number": 11
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "tests/test_transaction.py",
+        "hashed_secret": "3576257959190fcae2db82cd08a91070c91d90b1",
+        "is_verified": false,
+        "line_number": 22
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "tests/test_transaction.py",
+        "hashed_secret": "9da6b5a0b181fba61127e0a29e782ddfd78ceb25",
+        "is_verified": false,
+        "line_number": 27
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "tests/test_transaction.py",
+        "hashed_secret": "928459b719dfe7d471798cc0b33b383cf1c0a593",
+        "is_verified": false,
+        "line_number": 34
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "tests/test_transaction.py",
+        "hashed_secret": "1574a2276b51216fff19248a73786c2fff85618c",
+        "is_verified": false,
+        "line_number": 39
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "tests/test_transaction.py",
+        "hashed_secret": "352f56f2ca02ebbecabf471d5fef0084e60f7b54",
+        "is_verified": false,
+        "line_number": 51
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "tests/test_transaction.py",
+        "hashed_secret": "318f935542bcac447c45c44003f2a3c6a972e885",
+        "is_verified": false,
+        "line_number": 58
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "tests/test_transaction.py",
+        "hashed_secret": "1a01b6a6b944e566b80677a65ad91bff2c7fe0ba",
+        "is_verified": false,
+        "line_number": 62
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "tests/test_transaction.py",
+        "hashed_secret": "5461471bb63ed975bdd9f043df404e6c493386c2",
+        "is_verified": false,
+        "line_number": 79
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "tests/test_transaction.py",
+        "hashed_secret": "33a2e17a5167381622e5bc172369783506c9ee77",
+        "is_verified": false,
+        "line_number": 80
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "tests/test_transaction.py",
+        "hashed_secret": "42890ba99765b9c18c8d22592cc02769fcfc51fc",
+        "is_verified": false,
+        "line_number": 81
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "tests/test_transaction.py",
+        "hashed_secret": "f66ca76013fa8cc81eee0b4a261498c0e63d6a0f",
+        "is_verified": false,
+        "line_number": 82
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "tests/test_transaction.py",
+        "hashed_secret": "af5bd3003672fef5ad109de289989d4f1e12aa61",
+        "is_verified": false,
+        "line_number": 83
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "tests/test_transaction.py",
+        "hashed_secret": "3fa06e5854bec4749e25140c08f34ed71fc0799e",
+        "is_verified": false,
+        "line_number": 84
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "tests/test_transaction.py",
+        "hashed_secret": "a69c04dffa83d59c20842f3aa44e85fa1df018ab",
+        "is_verified": false,
+        "line_number": 85
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "tests/test_transaction.py",
+        "hashed_secret": "d59ccc7d93e8c0bd445baeed762caa78e5dcc654",
+        "is_verified": false,
+        "line_number": 86
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "tests/test_transaction.py",
+        "hashed_secret": "afdd478458c31168b1a2111e5790658a4b8bd23c",
+        "is_verified": false,
+        "line_number": 87
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "tests/test_transaction.py",
+        "hashed_secret": "7fc15eb5cc19102ad53d7102e58a5b04ef1cc7db",
+        "is_verified": false,
+        "line_number": 88
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "tests/test_transaction.py",
+        "hashed_secret": "c6f50b9508726135100ebcb85c7a0b0038f23f72",
+        "is_verified": false,
+        "line_number": 89
+      }
+    ]
+  },
+  "generated_at": "2026-05-04T06:36:40Z"
+}

--- a/docs/solutions/design-decisions/coin-type-512-default-with-legacy-zero-recovery.md
+++ b/docs/solutions/design-decisions/coin-type-512-default-with-legacy-zero-recovery.md
@@ -1,0 +1,77 @@
+---
+title: Keep coin type 512 as new-wallet default; expose legacy 0 path as first-class recovery option
+date: 2026-05-03
+problem_type: design_decision
+component: hd-wallet
+symptoms:
+  - Photonic Wallet (the most-used Radiant wallet) derives at m/44'/0'/0', while pyrxd defaults to m/44'/512'/0' (SLIP-0044 spec)
+  - Users restoring a Photonic mnemonic into pyrxd see an empty wallet — the funds exist but live at a path pyrxd is not looking at
+  - The override mechanism (RXD_PY_SDK_BIP44_DERIVATION_PATH) exists but is undiscoverable for non-expert users
+  - The override is parsed once at module-import time and is not threaded through HdWallet.from_mnemonic, so per-call configuration is impossible
+  - Wallet files persist coin_type at save but the load path does not validate it against the active config — a silent default flip would silently watch the wrong addresses
+severity: high
+status: decided, implementation pending
+related_prs:
+  - "#14 (switched default from 236' to 512' on 2026-04-26)"
+related_issues: []
+tags:
+  - hd-wallet
+  - bip44
+  - slip-0044
+  - derivation-path
+  - coin-type
+  - photonic-wallet
+  - migration
+  - api-design
+  - default-selection
+  - expert-panel
+  - ecosystem-coordination
+  - radiant
+---
+
+## Root Cause Analysis
+
+pyrxd inherited the BIP44 coin type problem twice. The original default `236'` was inherited from BSV-related code that pyrxd's earliest authors had been working on. PR #14 fixed that by switching to `512'`, the SLIP-0044 spec-correct value for Radiant — which is what Tangem uses, and which is what every future Radiant wallet *should* use. That fix was technically right and deliberately ignored the question of what existing software wallets were actually doing.
+
+A week later, empirical verification (deriving the same throwaway mnemonic in pyrxd and Photonic, comparing receive addresses) confirmed that **Photonic — the dominant Radiant software wallet — uses `m/44'/0'/0'`**, Bitcoin's coin type. This was not a guess; it was a side-by-side comparison: a throwaway 12-word BIP39 mnemonic (generated for this verification, not reused, not recorded here) derived `1LWS7rzGZxsjapwkWrtxgQVs89xfaPQxuB` at `m/44'/0'/0'/0/0` in pyrxd, and the same address is what Photonic shows on import of that mnemonic. So pyrxd's spec-correct default produces empty wallets for the most common restoration case, and the recovery note in the wallet docstring points users at the wrong legacy path (`236'` instead of `0'`). The verification was later re-run with the canonical BIP39 test mnemonic `abandon abandon ... about` (publicly known, intentionally weak — see test vector at `tests/test_hd_wallet.py::TestCoinTypeKwarg::EXPECTED_0`), with the same Photonic-matching result, so the locked-in test vector is itself end-to-end Photonic-verified.
+
+The deeper failure mode underneath is architectural: the derivation path is global module-import-time state (`_RADIANT_PATH` parsed once in `src/pyrxd/hd/wallet.py`), with no per-call override on `HdWallet.from_mnemonic`. The env var works, but only if set before the process starts. Wallet files record `coin_type` at save time and the load path does not assert it matches the active config — so a default flip in a routine `pip install -U` would silently change which addresses an exchange or indexer watches, with no error and no warning. That is the kind of behavior that ends up in a postmortem.
+
+The decision question — "should we change the default?" — sits on top of two more fundamental defects: missing per-call configuration, and missing load-time validation. Reordering the work so the foundational fixes ship first means the default question stops being load-bearing.
+
+## Solution
+
+**Keep `m/44'/512'/0'` as the default for new wallets; add the legacy `m/44'/0'/0'` path as a first-class option for restoration; ship the foundational architectural fixes first.**
+
+This is the same plan CraigD (Avian core dev) proposed independently in Discord, drawing on Avian's lived experience of the identical migration (coin type 175 → 921 for Avian/Ravencoin). The Avian wallet UI already implements the pattern and serves as a reference: a radio button under Advanced Options, defaulting to the spec-correct value, with the legacy option clearly labeled "use this for wallets created in [legacy app]." pyrxd will mirror the labeling: `512 - Radiant (Standard)` / `0 - Legacy Bitcoin-compatible`.
+
+**The decision is supported by independent triangulation.** Three reviewers and one external ecosystem dev arrived at converging conclusions from non-overlapping vantage points:
+
+- **Architecture review** argued that SDK defaults are read by tooling builders, not end users; spec correctness compounds while popularity drift does not; Bitcoin Cash precedent (the BCH ecosystem aligned to coin type 145 within roughly a year of the change) shows this kind of migration is achievable. Strongest argument: changing the default to `0'` would make pyrxd's default a public vote for the wrong path on the spec coordination question that PR #14 just took a public position on.
+- **Security review** argued that the *manner* of any default change matters more than the value. Silent flips are postmortem-grade events. A wallet that previously received funds at the default path would now receive them at a different path, splitting the user across two derivation trees with no UI surface to reconcile them. Whatever default we ship, load-time validation against the persisted `coin_type` is non-negotiable.
+- **Simplicity review** pushed back hardest on premature abstraction (the originally-proposed `--wallet-compat tangem|photonics|electrum-rxd` preset registry was rejected as "three lines of fiction wearing a trench coat" — `tangem` cannot import mnemonics, `electrum-rxd` was unverified, leaving `photonics` as the one real entry, which is just `m/44'/0'/0'`). A coin-type integer is sufficient.
+- **CraigD (external)** confirmed the plan from inside an ecosystem that just lived through the same migration. His proposal — default new wallets to `512'`, keep `0'` as legacy support, label both clearly, scan both paths or let users override on import, recommend a phased migration — is now the working specification.
+
+**The plan has three phases, sequenced so the architectural prerequisites ship before the user-visible decisions.** Phase 1 fixes the foundational defects: thread `derivation_path` (or `coin_type`) through `HdWallet.from_mnemonic` and `load_or_create` as a per-call kwarg, and add load-time validation that the persisted `coin_type` matches the active config (replacing silent-empty-wallet with an actionable error message). Phase 2 adds the user-facing surface: a `pyrxd setup --coin-type {512,0}` flag with help text mirroring the Avian labels, and either auto-scan-both-paths or explicit prompt during restoration. Phase 3 explicitly defers the preset registry until a second wallet is confirmed to differ — which may never happen, since coin-type integers cover every BIP44 wallet that will ever exist on this chain.
+
+**The migration story for users with funds at either path is symmetric.** A user with Photonic-derived funds runs `pyrxd setup --coin-type 0` (or sets the env var) to access them, and is shown a banner suggesting they create a fresh `--coin-type 512` wallet and migrate funds at their own pace. A user with pyrxd-derived funds at `512'` from the week-long window between PR #14 and this work is unaffected (default does not change). No flag day, no forced migration, no version bump that breaks existing wallets.
+
+**What CraigD's clarifying note settles for users worried about transaction-format risk:** "the coin type only affects which deterministic wallet path is used to discover addresses from a recovery phrase." This is a key-derivation question, not a chain-split or transaction-format question. Funds are recoverable from any wallet that knows the mnemonic and the path; the question is which wallet, by default, looks at which path. Stating this plainly in user-facing documentation removes the "is this a hard fork?" anxiety.
+
+**What we explicitly rejected and why.** Runtime path detection (try multiple paths, pick the one with funds) was rejected as a chain-of-confusion attack surface for multi-account users and a way to hide the fragmentation problem rather than surface it. A configuration file as the primary mechanism was rejected as "a slower env var with worse precedence rules" — the env var stays, but per-call configuration is the missing primitive. Auto-mapping by mnemonic provenance was rejected because there is no signal in a mnemonic that identifies which wallet produced it. Versioned preset names (`photonics-2026-05`) were considered for security-sentinel-flagged drift risk and shelved with the rest of the preset registry under YAGNI; if Photonic later switches paths, that is a future decision with future evidence.
+
+**Hazards documented but not fixed in Phase 1.** A red-team review (security-sentinel + data-integrity-guardian + adversarial general-purpose, 2026-05-03) surfaced two hazards that are real but cannot be fixed inside this PR alone:
+
+- **NEW→OLD→NEW downgrade corruption.** A user who upgrades to Phase-1 pyrxd, saves a wallet at `coin_type=0`, then downgrades to a pre-this-PR pyrxd version and saves again will have the persisted JSON `coin_type` field overwritten to `512` (the old code's hardcoded behavior at save time) while their `_xprv` keys remain rooted at `m/44'/0'/...`. A subsequent re-upgrade and load with `coin_type=0` will then fail validation against the now-corrupted `512` JSON, locking the user out of the friendly recovery path. This is purely an old-code-side defect; the fix lives in versions of pyrxd we cannot retroactively change. **Mitigation:** document explicitly in user-facing release notes that downgrading is unsupported once Phase 1 ships, and recommend that production users pin their pyrxd version through the migration window.
+- **Photonic compatibility is verified once, against one Photonic build, on one date.** On 2026-05-03 the canonical BIP39 mnemonic `abandon abandon ... about` was restored in Photonic Wallet; its Receive screen displayed `1LqBGSKuX5yYUonjxT5qGfpUsXKYYWeabA`, which is exactly the value pyrxd's test suite locks in at `coin_type=0` — so the test is a real cross-wallet compatibility check today, not a regression-only guard. The hazard is *future drift*: Photonic publishes no versioned compatibility statement, and pyrxd has no mechanism to detect a path change in a future Photonic release (the preset registry that would have made this a tracked vocabulary was rejected as YAGNI). If Photonic ever ships a derivation-path change, pyrxd's `coin_type=0` advice will silently become wrong. **Mitigation:** Phase 2 work plan includes a quarterly re-verification task against `abandon abandon ... about`; a Photonic-version note belongs in user-facing CLI help text and release notes; if a drift is detected, ship a new value and document the date both addresses were valid.
+
+## Lessons & Patterns
+
+- **Spec-correct defaults can lose to popularity in the short run, but they compound in the long run.** A library's default is a vote on what the ecosystem should look like in five years, not a customer-service response to what is most popular today. Pick the long-run-correct value, document the short-run mismatch loudly, and ship the recovery path as a first-class option — not an undiscoverable env var.
+- **A "fix" that solves the technical question without surveying the ecosystem can ship a worse failure mode.** PR #14 was right about the spec and silent about Photonic; one week later we discovered the change broke the most common restoration flow. The lesson is not that PR #14 was wrong (it was correct) — the lesson is that "is this spec-compliant?" and "does this match what users will actually do?" are independent questions and both must be asked before merging a change to a user-facing default.
+- **The decision question often sits on top of foundational defects.** "Should we change the default?" was the visible question. "Is the default even per-call configurable?" and "Does load-time validation catch a bad config?" were the invisible prerequisites. Sequencing the architectural fixes first makes the policy question dramatically less load-bearing — once override is per-call and validation is loud, the cost of any default value being "wrong" for a given user collapses from "silent empty wallet" to "actionable error with the fix-it command in the message."
+- **Empirical verification of an external system's behavior is cheap and decisive.** The entire architectural debate was unblocked by deriving one throwaway mnemonic in two wallets and comparing addresses. Total cost: about ten minutes. Total information gained: which path Photonic actually uses, with no ambiguity, no reading of obfuscated source code, no trust assumptions. When a question hinges on "what does this external system actually do?" — restore a throwaway seed and look. Don't reason about it.
+- **A reference implementation from a sister ecosystem is worth more than a panel of internal opinions.** CraigD's Avian migration plan was concrete, tested in production, and already had a working UI. The internal review panel produced excellent analysis but converged toward the same answer that Avian had already shipped. When a similar ecosystem has solved a similar problem, find their reference implementation before designing your own — even if the internal review would have arrived at the same place, having the working precedent shortens the path from decision to ship and reduces the risk of an unforced error.
+- **The override mechanism existing is not the same as it being usable.** `RXD_PY_SDK_BIP44_DERIVATION_PATH` had been in pyrxd since well before PR #14, parseable by anyone willing to read `constants.py`. It did not save users with Photonic funds because the env-var-only surface fails the discoverability test for non-expert users. Discoverability is part of the API. An undocumented escape hatch that requires source-reading is, in user-experience terms, equivalent to no escape hatch at all.
+- **Registries of presets are forever-promises.** Adding `--wallet-compat photonics` would commit pyrxd to tracking Photonic's behavior across every future Photonic version. The simplicity reviewer's pushback was right: don't take on the maintenance promise unless there are at least two confirmed wallets that actually need distinct presets, and unless the integers themselves are insufficient. Coin-type integers are self-documenting once labeled (`512 - Radiant (Standard)`, `0 - Legacy Bitcoin-compatible`); preset names are not.
+- **Sequencing matters more than scope when foundational defects are involved.** The original framing ("should we add `--wallet-compat`?") would have led to building user-facing surface on top of a broken architectural primitive. Reordering the work — kwarg plumbing first, load validation second, CLI surface third — means each phase builds on a solid foundation, and any phase that gets deprioritized still leaves the codebase better than before. This is the inverse of the more common "ship the user-visible feature first, fix the architecture later" pattern, which tends to leave the architecture permanently unfixed.

--- a/src/pyrxd/hd/wallet.py
+++ b/src/pyrxd/hd/wallet.py
@@ -73,39 +73,98 @@ _GAP_LIMIT = 20
 
 
 # Radiant's BIP44 derivation path. Default is the SLIP-0044 spec-correct
-# coin type 512 (also what Tangem's hardware wallet uses). Earlier versions
-# of pyrxd used 236 (BSV's coin type); users with funds on the old path can
-# override via the RXD_PY_SDK_BIP44_DERIVATION_PATH env var to recover them
-# (e.g. RXD_PY_SDK_BIP44_DERIVATION_PATH="m/44'/236'/0'").
+# coin type 512 (also what Tangem's hardware wallet uses). The most-used
+# Radiant software wallet (Photonic) uses coin type 0 (Bitcoin's, copied
+# from upstream); users restoring a Photonic mnemonic should pass
+# ``coin_type=0`` to from_mnemonic / load_or_create. Earlier pyrxd versions
+# used 236 (BSV's coin type); funds at that path are recoverable with
+# ``coin_type=236``.
 #
-# The constant below is parsed once at import time from the central config in
-# pyrxd.constants. We strip the trailing "/0'" account suffix so the wallet
-# can append its own account number; HdWallet expects to control account
-# selection itself.
-def _parse_radiant_path() -> tuple[str, int]:
-    """Parse the configured BIP44 path into (path_without_account, coin_type).
+# Resolution order, highest precedence first:
+#   1. ``coin_type=`` kwarg on HdWallet.from_mnemonic / load_or_create
+#   2. RXD_PY_SDK_BIP44_DERIVATION_PATH env var
+#   3. Module default (SLIP-0044 spec, coin type 512)
+def _parse_radiant_path(path: str | None = None) -> tuple[str, int]:
+    """Parse a BIP44 path into (path_without_account, coin_type).
 
-    The configured path looks like "m/44'/512'/0'" or "m/44'/236'/0'".
-    Strip the trailing account level so HdWallet can append its own account.
-    Also extract the coin type for diagnostic purposes (saved into wallet files).
+    With *path* None, reads the configured ``BIP44_DERIVATION_PATH`` from
+    pyrxd.constants (which itself reads the env var or falls back to the
+    SLIP-0044 default). With *path* supplied, parses that string directly
+    — used when callers thread a per-instance override through
+    HdWallet.from_mnemonic.
+
+    Either form expects "m/44'/<coin_type>'" or "m/44'/<coin_type>'/<account>'".
+    Trailing account level is stripped so HdWallet can append its own
+    account number.
     """
-    from ..constants import BIP44_DERIVATION_PATH
+    if path is None:
+        from ..constants import BIP44_DERIVATION_PATH
 
-    parts = BIP44_DERIVATION_PATH.split("/")
+        path = BIP44_DERIVATION_PATH
+
+    parts = path.split("/")
     # Expected shape: ["m", "44'", "<coin_type>'", "<account>'"]
     if len(parts) < 3:
-        raise ValueError(
-            f"BIP44_DERIVATION_PATH={BIP44_DERIVATION_PATH!r} is malformed; expected at least m/44'/<coin_type>'"
-        )
+        raise ValueError(f"derivation path {path!r} is malformed; expected at least m/44'/<coin_type>'")
     coin_type_str = parts[2].rstrip("'")
     try:
         coin_type = int(coin_type_str)
     except ValueError as exc:
-        raise ValueError(
-            f"BIP44_DERIVATION_PATH={BIP44_DERIVATION_PATH!r} has non-integer coin type {coin_type_str!r}"
-        ) from exc
+        raise ValueError(f"derivation path {path!r} has non-integer coin type {coin_type_str!r}") from exc
     # Trim back to "m/44'/<coin_type>'" so HdWallet can append "/{account}'"
     return f"m/44'/{coin_type}'", coin_type
+
+
+def _validate_coin_type(value: object, *, source: str) -> int:
+    """Validate that *value* is a non-bool int in BIP44 hardened range.
+
+    Single source of truth for coin_type validation. Called from every
+    entry point where a coin_type value enters the system: the kwarg
+    path (``_resolve_coin_type``), the load path (after reading the
+    persisted JSON), and ``__post_init__`` (after direct dataclass
+    construction). Centralizing the rule closes the SEV-1 finding from
+    the patch-on-patch review where validation only fired at one entry
+    point and persisted-file values bypassed it on load.
+
+    *source* names where the value came from, so error messages tell
+    the user which fix to apply ("kwarg" vs "wallet file" vs
+    "constructor").
+
+    Rejects:
+      - ``bool`` (subclass of int in Python; without this guard,
+        ``True`` formats into the path as the literal ``"True"``,
+        persists as JSON ``true``, reloads via ``int(True)`` as ``1``
+        — silent path-tree mismatch).
+      - non-int types (``str``, ``float``, ``None``, ``list``, etc.).
+      - negative values (BIP32 parses ``-1`` as unhardened index
+        ``0x7FFFFFFF``, colliding with the unhardened sibling).
+      - values >= ``2**31`` (collides with or exceeds the BIP32
+        hardening bit).
+    """
+    if isinstance(value, bool) or not isinstance(value, int):
+        raise ValidationError(f"{source} coin_type must be a non-bool int (got {type(value).__name__})")
+    if not 0 <= value < 2**31:
+        raise ValidationError(
+            f"{source} coin_type {value} out of BIP44 hardened range [0, 2**31). "
+            "BIP44 reserves the high bit for the hardening flag; pyrxd applies "
+            "it automatically, so the unhardened integer must fit in 31 bits."
+        )
+    return value
+
+
+def _resolve_coin_type(coin_type: int | None) -> tuple[str, int]:
+    """Resolve a coin_type kwarg to (path_without_account, coin_type).
+
+    *coin_type* None → use module default (env var or SLIP-0044). An
+    integer → use that coin type at the standard BIP44 layout
+    ``m/44'/<coin_type>'``. Validation is delegated to
+    ``_validate_coin_type``; this function only handles the
+    None-means-default fallback and path formatting.
+    """
+    if coin_type is None:
+        return _parse_radiant_path()
+    validated = _validate_coin_type(coin_type, source="kwarg")
+    return f"m/44'/{validated}'", validated
 
 
 _RADIANT_PATH, _COIN_TYPE = _parse_radiant_path()
@@ -149,6 +208,15 @@ class HdWallet:
     ----------
     account:
         BIP44 account index (usually 0).
+    coin_type:
+        BIP44 coin type (read-only property; back-store ``_coin_type``
+        is set at construction and never mutated). 512 is SLIP-0044 spec
+        for Radiant (default, also Tangem); 0 matches Photonic and
+        Electron-Radiant; 236 matches pre-#14 pyrxd. Persisted in the
+        wallet file and validated on load. Read-only because mutating
+        it post-construction would desync from the already-derived
+        ``_xprv`` and silently route subsequent addresses to a
+        different path (closes SEV-2 red-team finding).
     external_tip:
         Highest derived index on external chain (change=0).
     internal_tip:
@@ -160,9 +228,65 @@ class HdWallet:
     _xprv: Xprv = field(repr=False)
     _seed: SecretBytes = field(repr=False)
     account: int = 0
+    _coin_type: int = field(default_factory=lambda: _COIN_TYPE)
     external_tip: int = 0
     internal_tip: int = 0
     addresses: dict[str, AddressRecord] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        """Validate coin_type and seal it against post-construction mutation.
+
+        Closes two SEV-1 patch-on-patch findings:
+          - Direct ``HdWallet(_coin_type=-99)`` previously bypassed
+            ``_resolve_coin_type``; ``__post_init__`` re-runs the same
+            validator so every code path that constructs a wallet hits
+            it.
+          - ``wallet._coin_type = X`` and ``wallet.__dict__['_coin_type']
+            = X`` were not blocked by the read-only property because
+            they target the underscored backing field directly. The
+            ``_initialized`` sentinel flag activates the
+            ``__setattr__`` guard at the end of construction; from
+            that point on, any write to ``_coin_type`` raises.
+        """
+        _validate_coin_type(self._coin_type, source="HdWallet constructor")
+        # Seal the field. Other dataclass attributes (external_tip,
+        # internal_tip, addresses) remain mutable — gap scanning and
+        # next_receive_address need to update them. Only _coin_type
+        # is sealed.
+        object.__setattr__(self, "_initialized", True)
+
+    def __setattr__(self, name: str, value: object) -> None:
+        """Block post-construction mutation of ``_coin_type``.
+
+        Raises ``AttributeError`` for ``_coin_type`` writes after
+        ``__post_init__`` has set the sentinel. All other attributes
+        remain mutable. Bypasses (``object.__setattr__``,
+        ``__dict__`` manipulation, ``dataclasses.replace``) still work
+        — this is a guardrail against honest mistakes, not a
+        sandboxing primitive.
+        """
+        if name == "_coin_type" and getattr(self, "_initialized", False):
+            raise AttributeError(
+                "HdWallet._coin_type is read-only after construction. "
+                "Mutating it would desync from the already-derived "
+                "_xprv and silently route subsequent addresses to a "
+                "different path. Construct a new wallet via "
+                "HdWallet.from_mnemonic(..., coin_type=...) instead."
+            )
+        object.__setattr__(self, name, value)
+
+    @property
+    def coin_type(self) -> int:
+        """BIP44 coin type this wallet was constructed with. Read-only.
+
+        Read-only because mutating it post-construction would desync
+        from the already-derived ``_xprv``; subsequent address
+        derivations would still happen at the original path while the
+        persisted JSON would advertise the new path. The
+        ``__setattr__`` override blocks ``wallet._coin_type = X``;
+        the property blocks ``wallet.coin_type = X``.
+        """
+        return self._coin_type
 
     # ------------------------------------------------------------------
     # Construction
@@ -173,12 +297,32 @@ class HdWallet:
         mnemonic: str,
         passphrase: str = "",  # nosec B107 — BIP39 passphrase, not a hardcoded password
         account: int = 0,
+        coin_type: int | None = None,
     ) -> HdWallet:
-        """Create a fresh wallet from a BIP39 mnemonic."""
+        """Create a fresh wallet from a BIP39 mnemonic.
+
+        *coin_type* selects the BIP44 derivation path:
+          - ``None`` (default) uses the module-level configured coin type
+            (env var ``RXD_PY_SDK_BIP44_DERIVATION_PATH``, or SLIP-0044's
+            512 if unset).
+          - ``512`` is SLIP-0044 Radiant (also Tangem).
+          - ``0`` matches Photonic and Electron-Radiant — pass this when
+            restoring a mnemonic from those wallets.
+          - ``236`` matches pre-#14 pyrxd wallets.
+
+        The chosen coin type is recorded on the wallet and persisted in
+        the wallet file; subsequent :meth:`load` calls validate it.
+        """
+        radiant_path, resolved_coin_type = _resolve_coin_type(coin_type)
         seed = seed_from_mnemonic(mnemonic, passphrase=passphrase)
-        path = f"{_RADIANT_PATH}/{account}'"
+        path = f"{radiant_path}/{account}'"
         xprv = bip32_derive_xprv_from_mnemonic(mnemonic, passphrase=passphrase, path=path)
-        return cls(_xprv=xprv, _seed=SecretBytes(seed), account=account)
+        return cls(
+            _xprv=xprv,
+            _seed=SecretBytes(seed),
+            account=account,
+            _coin_type=resolved_coin_type,
+        )
 
     @classmethod
     def load(
@@ -186,6 +330,7 @@ class HdWallet:
         path: Path,
         mnemonic: str,
         passphrase: str = "",  # nosec B107 — BIP39 passphrase, not a hardcoded password
+        coin_type: int | None = None,
     ) -> HdWallet:
         """Load a previously saved wallet from *path*.
 
@@ -194,13 +339,20 @@ class HdWallet:
         path will not silently produce an empty wallet that subsequently
         overwrites a real wallet on save. Callers that explicitly want
         the create-on-missing behavior should use :meth:`load_or_create`.
+
+        *coin_type* (optional) is validated against the value persisted
+        in the wallet file. A mismatch raises :class:`ValidationError` —
+        this catches the silent-empty-wallet failure mode where a
+        default change between pyrxd versions would otherwise have the
+        loaded wallet derive at a different path than it was saved at.
+        Pass ``None`` (default) to accept whatever was persisted.
         """
         if not path.exists():
             raise FileNotFoundError(
                 f"Wallet file not found: {path}. Use HdWallet.load_or_create(...) "
                 f"if you intended to create a new wallet on this path."
             )
-        return cls._load_existing(path, mnemonic, passphrase)
+        return cls._load_existing(path, mnemonic, passphrase, coin_type)
 
     @classmethod
     def load_or_create(
@@ -209,6 +361,7 @@ class HdWallet:
         mnemonic: str,
         passphrase: str = "",  # nosec B107 — BIP39 passphrase, not a hardcoded password
         account: int = 0,
+        coin_type: int | None = None,
     ) -> HdWallet:
         """Load a wallet from *path*, or build a fresh one if the file is missing.
 
@@ -217,13 +370,17 @@ class HdWallet:
         with the old single-load API was that a typo in *path* would
         produce an empty wallet that subsequently overwrote the real
         wallet on save.
+
+        *coin_type* applies to both branches: when loading, it is
+        validated against the persisted value; when creating, it is the
+        coin type the new wallet uses.
         """
         if path.exists():
-            return cls._load_existing(path, mnemonic, passphrase)
-        return cls.from_mnemonic(mnemonic, passphrase=passphrase, account=account)
+            return cls._load_existing(path, mnemonic, passphrase, coin_type)
+        return cls.from_mnemonic(mnemonic, passphrase=passphrase, account=account, coin_type=coin_type)
 
     @classmethod
-    def _load_existing(cls, path: Path, mnemonic: str, passphrase: str) -> HdWallet:
+    def _load_existing(cls, path: Path, mnemonic: str, passphrase: str, coin_type: int | None = None) -> HdWallet:
         # Mode check: refuse to load a wallet that's group/world readable.
         # ``save()`` always writes 0o600, but a user who restored from
         # backup with ``cp`` or ``rsync`` might end up with a wider
@@ -284,13 +441,55 @@ class HdWallet:
 
         try:
             account = int(data.get("account", 0))
+            # The wallet file records the coin type it was saved at. Validate the
+            # caller's expectation against it: a mismatch means the file was
+            # created at one path and the caller is trying to load it at another,
+            # which would silently derive different addresses and look like an
+            # empty wallet. Surface this loudly with a fix-it message rather
+            # than letting a default flip in a routine ``pip install -U`` change
+            # which addresses an indexer or exchange watches.
+            #
+            # A missing coin_type field is a HARD ERROR (closes SEV-1 finding
+            # from red-team review): silently falling back to the module default
+            # would re-introduce the exact silent-default-flip footgun this
+            # field was added to prevent. v2 has always written coin_type;
+            # absence means the file is corrupt, hand-edited, or from a future
+            # format that should bump _FILE_VERSION instead of dropping the
+            # field. Either way, refuse to guess.
+            if "coin_type" not in data:
+                raise ValidationError(
+                    f"Wallet file at {path} is missing required field 'coin_type'. "
+                    "v2 wallets always persist this field; absence indicates corruption "
+                    "or hand-editing. Re-create the wallet from mnemonic with an "
+                    "explicit coin_type kwarg to recover."
+                )
+            # Validate the persisted value with the same guard as the kwarg path.
+            # Closes SEV-1 from the patch-on-patch review: previously, ``int(...)``
+            # was applied without type/range checks, so a hand-edited or corrupted
+            # file with ``coin_type: -1`` (unhardened-sibling collision),
+            # ``coin_type: true`` (silent flip to 1), ``coin_type: "0"`` (string
+            # bypass), or ``coin_type: 512.0`` (silent float→int truncation) would
+            # load without complaint and silently route the wallet to the wrong
+            # path. The persisted value must pass the same gate as a fresh kwarg.
+            persisted_coin_type = _validate_coin_type(data["coin_type"], source=f"wallet file at {path}")
+            if coin_type is not None and coin_type != persisted_coin_type:
+                raise ValidationError(
+                    f"Wallet file at {path} was saved at coin type {persisted_coin_type} "
+                    f"(BIP44 path m/44'/{persisted_coin_type}'/...) but you passed "
+                    f"coin_type={coin_type}. Pass coin_type={persisted_coin_type} to load "
+                    f"this wallet, or use a different file."
+                )
+            # Derive at the persisted path, not the module default — this is
+            # what prevents a default change from silently watching the wrong
+            # addresses for already-saved wallets.
             account_xprv = bip32_derive_xprv_from_mnemonic(
-                mnemonic, passphrase=passphrase, path=f"{_RADIANT_PATH}/{account}'"
+                mnemonic, passphrase=passphrase, path=f"m/44'/{persisted_coin_type}'/{account}'"
             )
             wallet = cls(
                 _xprv=account_xprv,
                 _seed=SecretBytes(seed),
                 account=account,
+                _coin_type=persisted_coin_type,
                 external_tip=int(data.get("external_tip", 0)),
                 internal_tip=int(data.get("internal_tip", 0)),
             )
@@ -342,7 +541,11 @@ class HdWallet:
         data = {
             "version": _FILE_VERSION_V2,
             "account": self.account,
-            "coin_type": _COIN_TYPE,
+            # Persist the wallet's own coin_type, not the module-level
+            # default. A wallet built with coin_type=0 must save coin_type=0
+            # so a subsequent load validates correctly even if the env var
+            # or default has changed in the meantime.
+            "coin_type": self.coin_type,
             "external_tip": self.external_tip,
             "internal_tip": self.internal_tip,
             "addresses": {

--- a/tests/test_hd_wallet.py
+++ b/tests/test_hd_wallet.py
@@ -108,6 +108,521 @@ class TestBip44CoinType:
 
 
 # ---------------------------------------------------------------------------
+# Per-call coin_type kwarg — the foundational fix from Phase 1 of the
+# coin-type-512 decision record. Before this kwarg existed, the only way
+# to derive at a non-default path was to set RXD_PY_SDK_BIP44_DERIVATION_PATH
+# *before* importing pyrxd, because the path was parsed once at module
+# import time. That made restoration of Photonic / Electron-Radiant
+# mnemonics undiscoverable for non-expert users.
+#
+# Vector provenance (the EXPECTED_* values below):
+#   - EXPECTED_0 (coin_type=0): VERIFIED end-to-end against Photonic
+#     Wallet on 2026-05-03 — the canonical BIP39 mnemonic
+#     "abandon abandon ... about" was restored in Photonic, and its
+#     Receive screen displayed exactly this address. So this test is a
+#     cross-wallet compatibility check, not a regression-only guard.
+#     Re-verify if Photonic ships a derivation-path change.
+#   - EXPECTED_512 (coin_type=512): captured from this SDK; matches
+#     SLIP-0044 spec for Radiant. Tangem hardware wallet uses this
+#     path but cannot import mnemonics so end-to-end verification
+#     against Tangem is not possible.
+#   - EXPECTED_236 (coin_type=236): captured from this SDK; pre-#14
+#     pyrxd default, BSV's coin type. Regression-only.
+# ---------------------------------------------------------------------------
+
+
+class TestCoinTypeKwarg:
+    EXPECTED_512 = "18qiat9Kff5niCcincht6efD8HhFfzL1AJ"  # SLIP-0044 default
+    EXPECTED_236 = "1K6LZdwpKT5XkEZo2T2kW197aMXYbYMc4f"  # legacy BSV
+    EXPECTED_0 = "1LqBGSKuX5yYUonjxT5qGfpUsXKYYWeabA"  # Photonic-verified 2026-05-03
+
+    def test_coin_type_512_matches_default(self):
+        explicit = HdWallet.from_mnemonic(MNEMONIC, coin_type=512)
+        assert explicit._derive_address(0, 0) == self.EXPECTED_512
+
+    def test_coin_type_0_matches_photonic_path(self):
+        # The reason this kwarg exists. Photonic users restoring their
+        # mnemonic must be able to reach m/44'/0'/0'/0/0 without setting
+        # an env var before importing pyrxd.
+        w = HdWallet.from_mnemonic(MNEMONIC, coin_type=0)
+        assert w._derive_address(0, 0) == self.EXPECTED_0
+
+    def test_coin_type_236_matches_legacy_bsv(self):
+        w = HdWallet.from_mnemonic(MNEMONIC, coin_type=236)
+        assert w._derive_address(0, 0) == self.EXPECTED_236
+
+    def test_three_coin_types_yield_three_addresses(self):
+        # Belt-and-braces against the failure mode where the kwarg is
+        # silently ignored and all three calls return the default.
+        addrs = {HdWallet.from_mnemonic(MNEMONIC, coin_type=ct)._derive_address(0, 0) for ct in (0, 236, 512)}
+        assert len(addrs) == 3
+
+    def test_coin_type_persisted_on_instance(self):
+        w = HdWallet.from_mnemonic(MNEMONIC, coin_type=0)
+        assert w.coin_type == 0
+
+    def test_coin_type_default_is_module_default(self):
+        # Don't hardcode 512 here — module default may be overridden
+        # via env var. The assertion is that the instance default
+        # matches whatever the module resolved at import.
+        from pyrxd.hd.wallet import _COIN_TYPE
+
+        w = HdWallet.from_mnemonic(MNEMONIC)
+        assert w.coin_type == _COIN_TYPE
+
+    def test_account_kwarg_still_independent_of_coin_type(self):
+        # account and coin_type are orthogonal — confirm changing one
+        # doesn't perturb the other.
+        w_a0 = HdWallet.from_mnemonic(MNEMONIC, coin_type=0, account=0)
+        w_a1 = HdWallet.from_mnemonic(MNEMONIC, coin_type=0, account=1)
+        assert w_a0.coin_type == 0 == w_a1.coin_type
+        assert w_a0._derive_address(0, 0) != w_a1._derive_address(0, 0)
+
+
+# ---------------------------------------------------------------------------
+# Load-time coin_type validation — the second foundational fix from
+# Phase 1. Without this check, a wallet saved at one coin type and
+# loaded under a different module default would silently derive
+# different addresses (the original report from Photonic users). The
+# loud-error-instead-of-silent-empty-wallet behavior is what makes any
+# future default change safe.
+# ---------------------------------------------------------------------------
+
+
+class TestCoinTypeLoadValidation:
+    def test_save_and_load_roundtrip_at_non_default_coin_type(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            wallet_path = Path(tmp) / "photonic.dat"
+            saved = HdWallet.from_mnemonic(MNEMONIC, coin_type=0)
+            saved.save(wallet_path)
+
+            loaded = HdWallet.load(wallet_path, MNEMONIC, coin_type=0)
+            assert loaded.coin_type == 0
+            assert loaded._derive_address(0, 0) == saved._derive_address(0, 0)
+
+    def test_load_with_no_coin_type_kwarg_accepts_persisted_value(self):
+        # Backwards-compatible: callers who don't care about validation
+        # get the persisted coin_type without needing to know it.
+        with tempfile.TemporaryDirectory() as tmp:
+            wallet_path = Path(tmp) / "photonic.dat"
+            HdWallet.from_mnemonic(MNEMONIC, coin_type=0).save(wallet_path)
+
+            loaded = HdWallet.load(wallet_path, MNEMONIC)
+            assert loaded.coin_type == 0
+
+    def test_load_with_mismatched_coin_type_raises(self):
+        # The killer bug class: silent empty wallet because the wallet
+        # was saved at coin type 0 but the loader is looking at 512.
+        with tempfile.TemporaryDirectory() as tmp:
+            wallet_path = Path(tmp) / "photonic.dat"
+            HdWallet.from_mnemonic(MNEMONIC, coin_type=0).save(wallet_path)
+
+            with pytest.raises(ValidationError, match="coin type 0"):
+                HdWallet.load(wallet_path, MNEMONIC, coin_type=512)
+
+    def test_mismatch_error_names_both_coin_types(self):
+        # The fix-it message must tell the user what was persisted AND
+        # what they passed, so they can choose which to change.
+        with tempfile.TemporaryDirectory() as tmp:
+            wallet_path = Path(tmp) / "legacy.dat"
+            HdWallet.from_mnemonic(MNEMONIC, coin_type=236).save(wallet_path)
+
+            with pytest.raises(ValidationError) as exc_info:
+                HdWallet.load(wallet_path, MNEMONIC, coin_type=512)
+
+            msg = str(exc_info.value)
+            assert "236" in msg
+            assert "512" in msg
+
+    def test_load_or_create_validates_coin_type_when_file_exists(self):
+        # load_or_create must NOT silently swallow a mismatch by
+        # falling back to "create new wallet" — that would defeat the
+        # point of the validation.
+        with tempfile.TemporaryDirectory() as tmp:
+            wallet_path = Path(tmp) / "w.dat"
+            HdWallet.from_mnemonic(MNEMONIC, coin_type=0).save(wallet_path)
+
+            with pytest.raises(ValidationError, match="coin type 0"):
+                HdWallet.load_or_create(wallet_path, MNEMONIC, coin_type=512)
+
+    def test_load_or_create_uses_coin_type_for_fresh_wallet(self):
+        # No existing file → coin_type drives the new wallet's path.
+        with tempfile.TemporaryDirectory() as tmp:
+            wallet_path = Path(tmp) / "fresh.dat"
+            assert not wallet_path.exists()
+
+            w = HdWallet.load_or_create(wallet_path, MNEMONIC, coin_type=0)
+            assert w.coin_type == 0
+
+
+# ---------------------------------------------------------------------------
+# Red-team-driven tests — these encode SEV-1/SEV-2 findings from the
+# 2026-05-03 review of Phase 1. Each test name maps to a specific bug
+# class. If any of these regress, the underlying validation has been
+# weakened and the silent-empty-wallet failure mode is back.
+# ---------------------------------------------------------------------------
+
+
+class TestCoinTypeInputValidation:
+    """SEV-1: kwarg-boundary type/range validation.
+
+    Without these guards, ``coin_type=True`` formats into a path as the
+    string ``"True"``, persists as JSON ``true``, and reloads as the
+    integer ``1`` — silently routing the wallet to a different address
+    tree and defeating the validation kwarg.
+    """
+
+    def test_bool_true_rejected(self):
+        # bool subclasses int in Python; without the explicit bool guard
+        # this would slip through and produce path m/44'/True'.
+        with pytest.raises(ValidationError, match="non-bool int"):
+            HdWallet.from_mnemonic(MNEMONIC, coin_type=True)
+
+    def test_bool_false_rejected(self):
+        # False == 0 numerically. Without the guard, coin_type=False
+        # would silently restore Photonic-path wallets, which is the
+        # opposite of explicit user intent.
+        with pytest.raises(ValidationError, match="non-bool int"):
+            HdWallet.from_mnemonic(MNEMONIC, coin_type=False)
+
+    def test_string_rejected(self):
+        with pytest.raises(ValidationError, match="non-bool int"):
+            HdWallet.from_mnemonic(MNEMONIC, coin_type="0")
+
+    def test_float_rejected(self):
+        with pytest.raises(ValidationError, match="non-bool int"):
+            HdWallet.from_mnemonic(MNEMONIC, coin_type=0.0)
+
+    def test_negative_coin_type_rejected(self):
+        # SEV-1: coin_type=-1 produces path m/44'/-1', which BIP32
+        # parses as the unhardened index 0x7FFFFFFF — funds end up at
+        # a path shared with whoever derives the unhardened sibling
+        # directly.
+        with pytest.raises(ValidationError, match="out of BIP44 hardened range"):
+            HdWallet.from_mnemonic(MNEMONIC, coin_type=-1)
+
+    def test_oversized_coin_type_rejected(self):
+        # 2**31 collides with the hardening bit; values above are
+        # outside the 32-bit child-index domain.
+        with pytest.raises(ValidationError, match="out of BIP44 hardened range"):
+            HdWallet.from_mnemonic(MNEMONIC, coin_type=2**31)
+
+    def test_zero_accepted(self):
+        # 0 is the legitimate Photonic / Electron-Radiant value — it
+        # must NOT be a casualty of the range check.
+        w = HdWallet.from_mnemonic(MNEMONIC, coin_type=0)
+        assert w.coin_type == 0
+
+    def test_intenum_subclass_accepted(self):
+        # IntEnum is a real-world int subclass that should pass. The
+        # f-string format MUST yield the underlying integer, not a
+        # custom __str__ form. (Test name avoids "_int_" because the
+        # repo's conftest auto-marks any node with that substring as
+        # an integration test and excludes it from the default run.)
+        from enum import IntEnum
+
+        class Coin(IntEnum):
+            PHOTONIC = 0
+            RADIANT = 512
+
+        ref = HdWallet.from_mnemonic(MNEMONIC, coin_type=0)._derive_address(0, 0)
+        via_enum = HdWallet.from_mnemonic(MNEMONIC, coin_type=Coin.PHOTONIC)._derive_address(0, 0)
+        assert ref == via_enum
+
+
+class TestMissingCoinTypeFieldIsHardError:
+    """SEV-1: a wallet file missing the persisted coin_type must NOT
+    silently fall back to the module default.
+
+    The fallback was the original implementation; red-team review
+    showed it re-introduced the silent-default-flip footgun the kwarg
+    was added to prevent.
+    """
+
+    def _write_wallet_blob_without_coin_type(self, p: Path) -> None:
+        """Hand-craft a v2 wallet file whose JSON omits coin_type."""
+        import hashlib
+        import json
+        import secrets
+
+        from Cryptodome.Cipher import AES
+
+        from pyrxd.hd.bip39 import seed_from_mnemonic
+        from pyrxd.hd.wallet import _FILE_VERSION_V2, _NONCE_LEN, _SALT_LEN, _SCRYPT_N, _SCRYPT_P, _SCRYPT_R
+
+        seed = seed_from_mnemonic(MNEMONIC, passphrase="")
+        salt = secrets.token_bytes(_SALT_LEN)
+        nonce = secrets.token_bytes(_NONCE_LEN)
+        enc_key = hashlib.scrypt(
+            seed, salt=salt, n=_SCRYPT_N, r=_SCRYPT_R, p=_SCRYPT_P, maxmem=128 * 1024 * 1024, dklen=32
+        )
+        data_no_coin_type = {
+            "version": _FILE_VERSION_V2,
+            "account": 0,
+            # NO coin_type — this is the failure under test.
+            "external_tip": 0,
+            "internal_tip": 0,
+            "addresses": {},
+        }
+        cipher = AES.new(enc_key, AES.MODE_GCM, nonce=nonce)
+        ciphertext, tag = cipher.encrypt_and_digest(json.dumps(data_no_coin_type).encode())
+        blob = bytes([_FILE_VERSION_V2]) + salt + nonce + tag + ciphertext
+        p.write_bytes(blob)
+        p.chmod(0o600)
+
+    def test_load_refuses_file_without_coin_type(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            p = Path(tmp) / "no_coin_type.dat"
+            self._write_wallet_blob_without_coin_type(p)
+            with pytest.raises(ValidationError, match="missing required field 'coin_type'"):
+                HdWallet.load(p, MNEMONIC)
+
+    def test_load_with_kwarg_still_refuses_file_without_coin_type(self):
+        # Even if the caller "knows" the path, missing-field is a hard
+        # error — the file is corrupt or hand-edited and the right
+        # answer is "re-create from mnemonic", not "trust the caller".
+        with tempfile.TemporaryDirectory() as tmp:
+            p = Path(tmp) / "no_coin_type.dat"
+            self._write_wallet_blob_without_coin_type(p)
+            with pytest.raises(ValidationError, match="missing required field 'coin_type'"):
+                HdWallet.load(p, MNEMONIC, coin_type=512)
+
+
+class TestCoinTypeIsReadOnly:
+    """SEV-2: post-construction mutation of coin_type would desync from
+    the already-derived ``_xprv``.
+
+    A caller that does ``wallet.coin_type = 0; wallet.save()`` would
+    persist coin_type=0 in the JSON while ``_xprv`` is still rooted at
+    the original path — leading to a silent address-tree mismatch on
+    next load.
+    """
+
+    def test_setting_coin_type_attribute_raises(self):
+        w = HdWallet.from_mnemonic(MNEMONIC, coin_type=512)
+        with pytest.raises(AttributeError):
+            w.coin_type = 0  # type: ignore[misc]
+
+    def test_setting_underscored_field_raises(self):
+        # The patch-on-patch review found that the property blocked the
+        # public name but the underscored backing field was still
+        # writable directly. The __setattr__ guard closes that hole.
+        w = HdWallet.from_mnemonic(MNEMONIC, coin_type=512)
+        with pytest.raises(AttributeError, match="read-only"):
+            w._coin_type = 0  # type: ignore[misc]
+
+    def test_property_returns_construction_value(self):
+        w = HdWallet.from_mnemonic(MNEMONIC, coin_type=0)
+        # Read multiple times — value must be stable.
+        assert w.coin_type == 0
+        assert w.coin_type == 0
+
+    def test_other_attributes_remain_mutable(self):
+        # __setattr__ guard must NOT lock down external_tip /
+        # internal_tip / addresses — gap-scan and next_receive_address
+        # legitimately mutate them.
+        w = HdWallet.from_mnemonic(MNEMONIC)
+        w.external_tip = 5
+        w.internal_tip = 3
+        w.addresses["0/0"] = AddressRecord(address="x", change=0, index=0, used=True)
+        assert w.external_tip == 5
+        assert w.internal_tip == 3
+
+
+# ---------------------------------------------------------------------------
+# Patch-on-patch review fixes — tests for the SEV-1 issues found in the
+# 2026-05-03 review of the FIRST round of red-team patches. These hit
+# entry points the original validation missed: the load path, direct
+# dataclass construction, and underscore-bypass mutation.
+# ---------------------------------------------------------------------------
+
+
+class TestLoadPathValidatesPersistedCoinType:
+    """SEV-1: persisted coin_type values must pass the same validator as kwargs.
+
+    Before this fix, ``int(data["coin_type"])`` ran with no type/range
+    checks — so a hand-edited or corrupted file with a bool, float,
+    string, or out-of-range int would silently load and route the
+    wallet to the wrong derivation path. The load path now uses the
+    same ``_validate_coin_type`` helper that protects construction.
+    """
+
+    def _write_blob_with_coin_type(self, p: Path, raw_coin_type: object) -> None:
+        """Hand-craft a v2 wallet file with a malicious coin_type field.
+
+        The ciphertext is correctly AES-GCM-sealed (so the AEAD layer
+        passes), but the JSON inside contains *raw_coin_type*
+        verbatim — letting us probe the load-path validator
+        independent of the construction-path validator.
+        """
+        import hashlib
+        import json
+        import secrets
+
+        from Cryptodome.Cipher import AES
+
+        from pyrxd.hd.bip39 import seed_from_mnemonic
+        from pyrxd.hd.wallet import _FILE_VERSION_V2, _NONCE_LEN, _SALT_LEN, _SCRYPT_N, _SCRYPT_P, _SCRYPT_R
+
+        seed = seed_from_mnemonic(MNEMONIC, passphrase="")
+        salt = secrets.token_bytes(_SALT_LEN)
+        nonce = secrets.token_bytes(_NONCE_LEN)
+        enc_key = hashlib.scrypt(
+            seed, salt=salt, n=_SCRYPT_N, r=_SCRYPT_R, p=_SCRYPT_P, maxmem=128 * 1024 * 1024, dklen=32
+        )
+        data = {
+            "version": _FILE_VERSION_V2,
+            "account": 0,
+            "coin_type": raw_coin_type,
+            "external_tip": 0,
+            "internal_tip": 0,
+            "addresses": {},
+        }
+        cipher = AES.new(enc_key, AES.MODE_GCM, nonce=nonce)
+        ciphertext, tag = cipher.encrypt_and_digest(json.dumps(data).encode())
+        blob = bytes([_FILE_VERSION_V2]) + salt + nonce + tag + ciphertext
+        p.write_bytes(blob)
+        p.chmod(0o600)
+
+    def test_persisted_negative_coin_type_rejected(self):
+        # SEV-1 from patch-on-patch review: persisted coin_type=-1 was
+        # previously accepted via int(-1), routing the wallet to
+        # m/44'/-1'/... (unhardened-sibling collision).
+        with tempfile.TemporaryDirectory() as tmp:
+            p = Path(tmp) / "neg.dat"
+            self._write_blob_with_coin_type(p, -1)
+            with pytest.raises(ValidationError, match="out of BIP44 hardened range"):
+                HdWallet.load(p, MNEMONIC)
+
+    def test_persisted_oversized_coin_type_rejected(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            p = Path(tmp) / "big.dat"
+            self._write_blob_with_coin_type(p, 2**31)
+            with pytest.raises(ValidationError, match="out of BIP44 hardened range"):
+                HdWallet.load(p, MNEMONIC)
+
+    def test_persisted_bool_rejected(self):
+        # JSON ``true`` previously round-tripped to coin_type=1 via
+        # int(True). The bool guard fires before any int coercion.
+        with tempfile.TemporaryDirectory() as tmp:
+            p = Path(tmp) / "bool.dat"
+            self._write_blob_with_coin_type(p, True)
+            with pytest.raises(ValidationError, match="non-bool int"):
+                HdWallet.load(p, MNEMONIC)
+
+    def test_persisted_string_rejected(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            p = Path(tmp) / "str.dat"
+            self._write_blob_with_coin_type(p, "0")
+            with pytest.raises(ValidationError, match="non-bool int"):
+                HdWallet.load(p, MNEMONIC)
+
+    def test_persisted_float_rejected(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            p = Path(tmp) / "float.dat"
+            self._write_blob_with_coin_type(p, 512.0)
+            with pytest.raises(ValidationError, match="non-bool int"):
+                HdWallet.load(p, MNEMONIC)
+
+    def test_persisted_null_rejected(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            p = Path(tmp) / "null.dat"
+            self._write_blob_with_coin_type(p, None)
+            with pytest.raises(ValidationError, match="non-bool int"):
+                HdWallet.load(p, MNEMONIC)
+
+    def test_error_message_names_wallet_file_path(self):
+        # The validator's source= argument must surface in the error
+        # message so the user knows the bad value is in the file, not
+        # in their kwarg.
+        with tempfile.TemporaryDirectory() as tmp:
+            p = Path(tmp) / "bad.dat"
+            self._write_blob_with_coin_type(p, -1)
+            with pytest.raises(ValidationError) as exc_info:
+                HdWallet.load(p, MNEMONIC)
+            assert "wallet file" in str(exc_info.value).lower()
+            assert str(p) in str(exc_info.value)
+
+
+class TestDirectConstructionValidatesCoinType:
+    """SEV-1: ``HdWallet(_coin_type=-99)`` must NOT bypass validation.
+
+    The original docstring claimed ``_resolve_coin_type`` was "the
+    single entry point" but the dataclass auto-generated ``__init__``
+    accepted any int. ``__post_init__`` now re-runs the validator so
+    direct construction is gated.
+    """
+
+    def _make_wallet_kwargs(self, *, coin_type: object) -> dict:
+        # Build the minimum set of constructor kwargs needed to land
+        # in __post_init__ with a malicious _coin_type. The xprv/seed
+        # are real (so the test is realistic), but they're rooted at
+        # the *valid* default path — the test isn't about whether
+        # _xprv matches _coin_type, it's about whether the validator
+        # runs at all.
+        from pyrxd.hd.bip32 import bip32_derive_xprv_from_mnemonic
+        from pyrxd.hd.bip39 import seed_from_mnemonic
+        from pyrxd.security.secrets import SecretBytes
+
+        seed = seed_from_mnemonic(MNEMONIC, passphrase="")
+        xprv = bip32_derive_xprv_from_mnemonic(MNEMONIC, passphrase="", path="m/44'/512'/0'")
+        return {
+            "_xprv": xprv,
+            "_seed": SecretBytes(seed),
+            "account": 0,
+            "_coin_type": coin_type,
+        }
+
+    def test_direct_construction_with_negative_rejected(self):
+        kwargs = self._make_wallet_kwargs(coin_type=-1)
+        with pytest.raises(ValidationError, match="out of BIP44 hardened range"):
+            HdWallet(**kwargs)  # type: ignore[arg-type]
+
+    def test_direct_construction_with_bool_rejected(self):
+        kwargs = self._make_wallet_kwargs(coin_type=True)
+        with pytest.raises(ValidationError, match="non-bool int"):
+            HdWallet(**kwargs)  # type: ignore[arg-type]
+
+    def test_direct_construction_with_oversized_rejected(self):
+        kwargs = self._make_wallet_kwargs(coin_type=2**31)
+        with pytest.raises(ValidationError, match="out of BIP44 hardened range"):
+            HdWallet(**kwargs)  # type: ignore[arg-type]
+
+    def test_direct_construction_with_valid_value_succeeds(self):
+        # Positive control — the validator must not be over-eager.
+        # (Test name avoids "_int_" which the conftest auto-marks as
+        # an integration test.)
+        kwargs = self._make_wallet_kwargs(coin_type=0)
+        w = HdWallet(**kwargs)
+        assert w.coin_type == 0
+
+
+class TestUnderscoreMutationBlocked:
+    """SEV-1: writes to ``_coin_type`` post-construction must fail.
+
+    The read-only property was theater without the ``__setattr__``
+    guard — ``wallet._coin_type = X``, ``wallet.__dict__['_coin_type']
+    = X``, and ``dataclasses.replace`` were all bypasses. ``__setattr__``
+    closes the first; the others remain (Python idioms, beyond an
+    "honest mistake" guardrail) and are documented as such.
+    """
+
+    def test_direct_assignment_to_underscore_blocked(self):
+        w = HdWallet.from_mnemonic(MNEMONIC, coin_type=512)
+        with pytest.raises(AttributeError, match="read-only"):
+            w._coin_type = 0  # type: ignore[misc]
+        # The original value must be unchanged.
+        assert w.coin_type == 512
+
+    def test_initialization_path_still_works(self):
+        # Sanity: __setattr__ must NOT block writes during __init__,
+        # otherwise the dataclass constructor itself would fail.
+        w = HdWallet.from_mnemonic(MNEMONIC, coin_type=0)
+        assert w.coin_type == 0
+        assert w._coin_type == 0
+
+
+# ---------------------------------------------------------------------------
 # Gap-limit scanning tests
 # ---------------------------------------------------------------------------
 
@@ -332,6 +847,7 @@ class TestSaveLoad:
             bad_data = {
                 "version": _FILE_VERSION_V2,
                 "account": 0,
+                "coin_type": 512,  # required field; absence is now its own hard error
                 "external_tip": 1,
                 "internal_tip": 0,
                 # missing "address" → KeyError when reconstructing


### PR DESCRIPTION
## Summary

- Adds `coin_type` as a per-call kwarg on `HdWallet.from_mnemonic` / `load` / `load_or_create`, replacing the import-time global as the only knob.
- Persisted `coin_type` in the wallet file is validated against the caller's expectation on load — a mismatch raises `ValidationError` with a fix-it message instead of silently deriving at the wrong path.
- `_validate_coin_type` guards every entry point (kwarg, load, `__post_init__`); rejects `bool`, non-int, negative, and `>= 2**31` values uniformly.
- `_coin_type` is sealed via `__setattr__` after construction so mutation cannot desync from the already-derived `_xprv`.
- **Photonic-verified test vector**: `1LqBGSKuX5yYUonjxT5qGfpUsXKYYWeabA` for the canonical `abandon abandon ... about` mnemonic at `coin_type=0` — confirmed end-to-end against Photonic Wallet on 2026-05-03.

## Why

[Photonic Wallet](https://photonic-wallet.com) (the most-used Radiant wallet) uses `m/44'/0'/0'`, not the SLIP-0044 `m/44'/512'/0'` that pyrxd defaults to (since #14). Restoring a Photonic mnemonic into pyrxd previously produced a silent empty wallet. The kwarg makes the legacy path reachable from code; the load validation makes default changes safe to ship.

The decision record at [`docs/solutions/design-decisions/coin-type-512-default-with-legacy-zero-recovery.md`](https://github.com/MudwoodLabs/pyrxd/blob/feat/coin-type-kwarg-and-validation/docs/solutions/design-decisions/coin-type-512-default-with-legacy-zero-recovery.md) captures the full reasoning, including:
- The empirical Photonic verification (throwaway mnemonic side-by-side with `abandon abandon ... about` re-verification)
- Three independent reviewer perspectives (architecture, security, simplicity)
- CraigD's external Avian-precedent confirmation
- Two rounds of red-team review with all SEV-1 findings closed and tested
- The rejected alternatives (preset registry, default flip, runtime detection)
- The unfixed hazards documented for follow-up (downgrade corruption, future Photonic drift)

## Defense-in-depth review history

This PR went through three sequential review passes:

1. **Initial design review** (architecture + security + simplicity reviewers, parallel) — converged on "kwarg yes, preset registry no, keep 512 default, validate on load." External confirmation from CraigD (Avian core dev) who lived through the same migration.
2. **First red-team round** (security-sentinel + data-integrity-guardian + adversarial general-purpose, parallel) — caught **four SEV-1 bugs** in the initial implementation: `coin_type=True` slipping through, missing-field silent fallback, negative-value unhardened-sibling collision, public-mutable field desync. All fixed with tests.
3. **Patch-on-patch round** (security-sentinel + adversarial general-purpose) — caught **three more SEV-1 bugs** in the fixes themselves: load-path validation gap, direct-construction bypass, underscore-mutation bypass. All fixed with tests.

Each round's findings are encoded as regression tests in `tests/test_hd_wallet.py`:
- `TestCoinTypeKwarg` (7 tests) — kwarg correctness with Photonic-verified vectors
- `TestCoinTypeLoadValidation` (6 tests) — save/load round-trip with mismatch detection
- `TestCoinTypeInputValidation` (8 tests) — bool/string/float/negative/oversized rejection
- `TestMissingCoinTypeFieldIsHardError` (2 tests) — corrupted-file rejection
- `TestCoinTypeIsReadOnly` (4 tests) — public + underscore mutation blocked
- `TestLoadPathValidatesPersistedCoinType` (7 tests) — every malicious type rejected on load
- `TestDirectConstructionValidatesCoinType` (4 tests) — `__post_init__` gate
- `TestUnderscoreMutationBlocked` (2 tests) — `__setattr__` guard

## Adjacent housekeeping

- Un-ignored `.secrets.baseline` so the `detect-secrets` pre-commit hook actually enforces something. Previously the baseline was `.gitignore`d, so the hook silently passed on every machine that hadn't generated one locally — a latent safety hole independent of this PR's content.
- Generated the initial baseline. All 195 acknowledged findings are Base58/Bech32 alphabets, Bitcoin Script bytecode, BIP test vectors, or public addresses derived from publicly-known test mnemonics. Spot-checked; no real secrets.

## Test plan

- [x] `task ci` passes locally (2218 passed, 3 skipped, 86.32% coverage)
- [x] `ruff check` clean
- [x] `ruff format` clean
- [x] `bandit -r src/` clean
- [x] `detect-secrets-hook` passes against the new baseline
- [x] Manual API exercise: every kwarg value, save→load round-trip, mismatched-kwarg error message, all six adversarial inputs rejected
- [x] **Photonic end-to-end**: `abandon abandon ... about` restored in Photonic produces `1LqBGSKuX5yYUonjxT5qGfpUsXKYYWeabA`, exactly matching pyrxd's `coin_type=0` derivation
- [x] CI green
- [x] Reviewer reads the decision record before approving (it's the actual artifact; this PR description is just an index)

## Out of scope (filed as follow-up issues)

- CLI surface: `pyrxd setup --coin-type {0,512}` flag with Avian-style help text labels (Phase 2)
- `pyrxd wallet scan-paths` recovery command for users who don't know which path their funds are at
- Quarterly Photonic re-verification cadence
- NEW→OLD→NEW downgrade-corruption documentation in release notes
- Wire gitleaks into CI for defense-in-depth secret scanning

🤖 Generated with [Claude Code](https://claude.com/claude-code)