### PR TITLE
chore(security): harden GitHub Actions, fix cyclic import, add user-risk disclaimer

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [main, dev]
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest
@@ -19,8 +22,8 @@ jobs:
         # versions back to this matrix.
         python-version: ["3.12"]
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-python@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install Poetry

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -23,10 +23,10 @@ jobs:
     timeout-minutes: 360
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v3
+        uses: github/codeql-action/init@0daab03d71ff584ef619d027a3fd9146679c5d84  # v3
         with:
           languages: python
           # security-and-quality includes the security-extended ruleset plus
@@ -34,6 +34,6 @@ jobs:
           queries: security-and-quality
 
       - name: Perform CodeQL analysis
-        uses: github/codeql-action/analyze@v3
+        uses: github/codeql-action/analyze@0daab03d71ff584ef619d027a3fd9146679c5d84  # v3
         with:
           category: "/language:python"

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -20,9 +20,9 @@ jobs:
     name: Build Sphinx HTML
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
 
-      - uses: actions/setup-python@v6
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6
         with:
           python-version: "3.12"
           cache: pip
@@ -37,7 +37,7 @@ jobs:
         run: sphinx-build -b html docs docs/_build/html
 
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v4
+        uses: actions/upload-pages-artifact@7b1f4a764d45c48632c6b24a0339c27f5614fb0b  # v4
         with:
           path: docs/_build/html
 
@@ -56,4 +56,4 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
     steps:
       - id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e  # v4

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -6,12 +6,15 @@ on:
   pull_request:
     branches: [main, dev]
 
+permissions:
+  contents: read
+
 jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-python@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6
         with:
           python-version: "3.12"
       - name: Install ruff

--- a/.github/workflows/osv-scanner.yml
+++ b/.github/workflows/osv-scanner.yml
@@ -26,7 +26,7 @@ jobs:
       contents: read
       security-events: write
       actions: read
-    uses: google/osv-scanner-action/.github/workflows/osv-scanner-reusable.yml@v2.3.5
+    uses: google/osv-scanner-action/.github/workflows/osv-scanner-reusable.yml@c51854704019a247608d928f370c98740469d4b5  # v2.3.5
 
   # PR scan — reports only new vulnerabilities introduced by the pull request.
   scan-pr:
@@ -35,4 +35,4 @@ jobs:
       contents: read
       security-events: write
       actions: read
-    uses: google/osv-scanner-action/.github/workflows/osv-scanner-reusable-pr.yml@v2.3.5
+    uses: google/osv-scanner-action/.github/workflows/osv-scanner-reusable-pr.yml@c51854704019a247608d928f370c98740469d4b5  # v2.3.5

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -28,12 +28,12 @@ jobs:
       contents: read
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
         with:
           persist-credentials: false
 
       - name: Run Scorecard
-        uses: ossf/scorecard-action@v2.4.3
+        uses: ossf/scorecard-action@4eaacf0543bb3f2c246792bd56e8cdeffafb205a  # v2.4.3
         with:
           results_file: scorecard-results.sarif
           results_format: sarif
@@ -41,7 +41,7 @@ jobs:
           publish_results: true
 
       - name: Upload SARIF to GitHub code scanning
-        uses: github/codeql-action/upload-sarif@v3
+        uses: github/codeql-action/upload-sarif@0daab03d71ff584ef619d027a3fd9146679c5d84  # v3
         with:
           sarif_file: scorecard-results.sarif
           wait-for-processing: true

--- a/README.md
+++ b/README.md
@@ -17,6 +17,13 @@ ElectrumX network client.
 Cryptographic primitives have not been independently audited. See
 [SECURITY.md](SECURITY.md) for security policy and disclosure.
 
+> ⚠️ **Use at your own risk.** pyrxd is alpha-quality software written
+> primarily by one person; cryptographic code has not been independently
+> audited. **Do not use it to handle funds you cannot afford to lose.**
+> Verify your derivation paths and transaction outputs against an
+> independent wallet before broadcasting on mainnet. If you find a bug
+> that affects funds, report it via the [security policy](SECURITY.md).
+
 **Working on mainnet today:**
 
 - RXD send / send-max, balance and UTXO queries

--- a/src/pyrxd/cli/glyph_cmds.py
+++ b/src/pyrxd/cli/glyph_cmds.py
@@ -52,7 +52,6 @@ from ..transaction.transaction_output import TransactionOutput
 from .context import CliContext
 from .errors import NetworkBoundaryError, UserError, WalletDecryptError
 from .format import emit, emit_table
-from .main import cli
 from .prompts import confirm_action, prompt_mnemonic_input, prompt_passphrase_input
 
 if TYPE_CHECKING:
@@ -65,7 +64,7 @@ if TYPE_CHECKING:
 # ---------------------------------------------------------------------------
 
 
-@cli.group(name="glyph")
+@click.group(name="glyph")
 def glyph_group() -> None:
     """Mint, transfer, and inspect Glyph tokens."""
 

--- a/src/pyrxd/cli/main.py
+++ b/src/pyrxd/cli/main.py
@@ -157,19 +157,21 @@ def run() -> None:
 
 # Subcommand registration. The wallet/address/balance commands attach
 # themselves to the `cli` group via @cli.command / @cli.group decorators.
-# Importing them here is what registers them; they have no side effects
-# beyond decorator attachment.
+# Subcommand modules are imported here and explicitly registered via
+# cli.add_command() below. They do NOT import `cli` from this module —
+# that would create an import cycle that CodeQL flags (py/cyclic-import)
+# and that breaks static analysis even though Python's import system
+# tolerates it at runtime.
 
-# Imports placed at the bottom to avoid circular imports during CLI
-# bootstrap; the subcommand modules import names from main.py via the
-# `cli` group object.
+from . import glyph_cmds, query_cmds, setup_cmd, wallet_cmds  # noqa: E402
 
-from . import (  # noqa: E402  -- bottom-of-file imports are intentional
-    glyph_cmds,  # noqa: F401  -- registers `glyph` group (Cut 2)
-    query_cmds,  # noqa: F401  -- registers `address`, `balance`, `utxos` (Cut 3)
-    setup_cmd,  # noqa: F401  -- registers `setup` (Cut 3)
-    wallet_cmds,  # noqa: F401  -- registers `wallet` group + export-xpub (Cut 3)
-)
+cli.add_command(glyph_cmds.glyph_group)
+cli.add_command(query_cmds.address_cmd)
+cli.add_command(query_cmds.balance_cmd)
+cli.add_command(query_cmds.utxos_cmd)
+cli.add_command(setup_cmd.setup_cmd)
+cli.add_command(wallet_cmds.wallet_group)
+
 
 if __name__ == "__main__":
     run()

--- a/src/pyrxd/cli/query_cmds.py
+++ b/src/pyrxd/cli/query_cmds.py
@@ -17,7 +17,6 @@ from ..security.errors import NetworkError, ValidationError
 from .context import CliContext
 from .errors import NetworkBoundaryError, UserError, WalletDecryptError
 from .format import emit, format_photons
-from .main import cli
 from .prompts import prompt_mnemonic_input, prompt_passphrase_input
 
 
@@ -50,7 +49,7 @@ def _load_wallet(ctx: CliContext, *, prompt_passphrase: bool = False) -> HdWalle
         raise WalletDecryptError() from exc
 
 
-@cli.command(name="address")
+@click.command(name="address")
 @click.option("--next", "next_unused", is_flag=True, default=True, help="Next unused external address (default).")
 @click.option("--index", type=int, default=None, help="Specific index lookup.")
 @click.option("--change", is_flag=True, help="Internal chain instead of external.")
@@ -124,7 +123,7 @@ def _path_for_address(wallet: HdWallet, address: str) -> str:
     return "?"
 
 
-@cli.command(name="balance")
+@click.command(name="balance")
 @click.option("--refresh", is_flag=True, help="Run a gap-limit scan first to discover used addresses.")
 @click.option("--passphrase/--no-passphrase", default=False, help="Prompt for the BIP39 passphrase.")
 @click.pass_obj
@@ -175,7 +174,7 @@ def balance_cmd(ctx: CliContext, refresh: bool, passphrase: bool) -> None:
         click.echo(emit(payload, mode="human", human_lines=lines))
 
 
-@cli.command(name="utxos")
+@click.command(name="utxos")
 @click.option("--min-photons", type=int, default=0, help="Minimum value filter.")
 @click.option("--addr", default=None, help="Restrict to a single wallet address.")
 @click.option("--passphrase/--no-passphrase", default=False)

--- a/src/pyrxd/cli/setup_cmd.py
+++ b/src/pyrxd/cli/setup_cmd.py
@@ -20,7 +20,6 @@ import click
 from . import config as _config
 from .context import CliContext
 from .format import emit
-from .main import cli
 
 # Default Radiant Core mainnet RPC port — matches `radiantd` on
 # 127.0.0.1:7332. Used as a heuristic only; we never authenticate.
@@ -57,7 +56,7 @@ async def _probe_electrumx(url: str) -> bool:
         return False
 
 
-@cli.command(name="setup")
+@click.command(name="setup")
 @click.option(
     "--no-interactive",
     is_flag=True,

--- a/src/pyrxd/cli/wallet_cmds.py
+++ b/src/pyrxd/cli/wallet_cmds.py
@@ -20,7 +20,6 @@ from ..security.rng import secure_random_bytes
 from .context import CliContext
 from .errors import UserError, WalletDecryptError
 from .format import emit
-from .main import cli
 from .prompts import (
     prompt_mnemonic_input,
     prompt_passphrase_input,
@@ -28,7 +27,7 @@ from .prompts import (
 )
 
 
-@cli.group(name="wallet")
+@click.group(name="wallet")
 def wallet_group() -> None:
     """Create, load, and inspect HD wallets."""
 


### PR DESCRIPTION
## Summary

Closes 26 of 30 open code-scanning alerts. CI-config hardening + one CLI structural fix + a README disclaimer.

## Workstream 1 — TokenPermissions (4 × HIGH)

Add \`permissions: contents: read\` to \`ci.yml\` and \`lint.yml\`. The other four workflow files already declared explicit permissions. Restricts the implicit \`GITHUB_TOKEN\` from \`write-all\` (the GitHub default) to read-only for these workflows, which is all they actually need.

## Workstream 2 — PinnedDependencies (21 × MEDIUM)

Pin all 16 GitHub Actions references to commit SHAs across 6 workflow files. Tag comments retained for human readability (e.g. \`# v6\`). Mitigates supply-chain risk where a maintainer compromise could push malicious code to a mutable version tag.

\`.github/dependabot.yml\` already exists with \`github-actions\` ecosystem configured, so SHA pins will get auto-updated by Dependabot PRs going forward — no manual maintenance burden.

## Workstream 3 — CodeQL py/cyclic-import

Break the \`setup_cmd.py ↔ main.py\` import cycle. The same cyclic pattern existed in three other CLI modules (\`glyph_cmds.py\`, \`query_cmds.py\`, \`wallet_cmds.py\`) — all four are fixed for consistency, even though CodeQL only flagged \`setup_cmd.py\`.

**Pattern**: subcommand modules no longer \`from .main import cli\`. Instead, they decorate their commands with \`@click.command\` / \`@click.group\` directly, and \`main.py\` registers them via \`cli.add_command()\` after the bottom-of-file imports. CLI surface is functionally identical (verified via \`pyrxd --help\` showing all 6 commands registered).

## Workstream 4 — README user-risk disclaimer

Add an explicit "use at your own risk" warning above the Status section. Covers: alpha-quality software, single-author cryptographic code that hasn't been independently audited, recommendation to verify against an independent wallet before broadcasting on mainnet.

## Deferred alerts (to be dismissed in GitHub UI after merge)

| Alert | Severity | Reason |
|---|---|---|
| MaintainedID | HIGH | False positive; Scorecard heuristic lag, repo has active commits this week |
| CodeReviewID | HIGH | Real signal but the fix is organizational (second reviewer), not a code change. Dismiss with documented risk acceptance. |
| FuzzingID | MEDIUM | Genuinely valuable for a crypto library, but 4-8 hours of work; wrong PR. Track as issue. |
| CIIBestPracticesID | LOW | Process work, defer until v1.0 |

## Test plan

- [x] All 16 SHA pins verified via \`gh api\` against canonical action repos
- [x] CLI refactor verified: \`pyrxd --help\` shows all 6 commands registered (\`address\`, \`balance\`, \`utxos\`, \`glyph\`, \`setup\`, \`wallet\`)
- [x] Local \`task ci\` passes (2178 tests, 86.26% overall coverage, 100% security module coverage, mypy clean, lint clean, format clean, private-link checker clean)
- [x] Pre-push hook ran \`task ci\` during this push

## Methodology note

This PR was authored with AI assistance. The proposal that drove it was generated by an automated security review of the open code-scanning alerts, then reviewed and revised before implementation. SHA values were verified via \`gh api\` against the canonical action repos. CLI refactor verified by smoke-testing \`pyrxd --help\` after each module change.