### PR TITLE
ci: automate PyPI publishing via Trusted Publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,91 @@
+name: Publish to PyPI
+
+# Triggered by GitHub Releases. The release event is a deliberate
+# "publish now" gesture — pushing a tag alone won't publish, which
+# avoids accidental releases.
+#
+# Auth uses PyPI Trusted Publishing (OIDC). No long-lived token is
+# stored in GitHub Secrets — PyPI verifies the workflow's identity
+# via the id-token claim and issues a short-lived upload credential.
+#
+# One-time PyPI setup (already-existing project):
+#   1. https://pypi.org/manage/project/pyrxd/settings/publishing/
+#   2. Add a trusted publisher with:
+#        - Owner:           MudwoodLabs
+#        - Repository:      pyrxd
+#        - Workflow:        publish.yml
+#        - Environment:     pypi
+#   3. Optional but recommended: configure the `pypi` environment in
+#      GitHub repo settings with required reviewers, so a second pair
+#      of eyes approves each publish.
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    name: Build sdist + wheel
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6
+        with:
+          python-version: "3.12"
+      - name: Install Poetry
+        run: pip install poetry
+      - name: Verify version matches release tag
+        # Reject the publish if pyproject.toml's version doesn't match
+        # the tag the release was created from. This catches the
+        # "forgot to bump pyproject.toml" mistake before any artifact
+        # reaches PyPI.
+        run: |
+          tag="${GITHUB_REF_NAME#v}"
+          pkg_version=$(poetry version --short)
+          if [ "$tag" != "$pkg_version" ]; then
+            echo "::error::Release tag v$tag does not match pyproject.toml version $pkg_version"
+            exit 1
+          fi
+          echo "Version OK: $pkg_version"
+      - name: Build distributions
+        run: poetry build
+      - name: Upload distributions as workflow artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
+        with:
+          name: dist
+          path: dist/
+          if-no-files-found: error
+
+  publish:
+    name: Publish to PyPI
+    needs: build
+    runs-on: ubuntu-latest
+    # The `pypi` environment is the second-factor: configure required
+    # reviewers under repo Settings → Environments → pypi to gate
+    # publishes on a manual approval click.
+    environment:
+      name: pypi
+      url: https://pypi.org/p/pyrxd
+    permissions:
+      # id-token: write is required for PyPI Trusted Publishing OIDC.
+      # contents: read inherited from the workflow default would be
+      # dropped without re-declaring at the job level when overriding
+      # any permission, so re-declare both explicitly.
+      id-token: write
+      contents: read
+    steps:
+      - name: Download built distributions
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131  # v7.0.0
+        with:
+          name: dist
+          path: dist/
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b  # v1.14.0
+        # No `with:` block: defaults publish to PyPI from ./dist using
+        # Trusted Publishing OIDC. Print the upload URL so the workflow
+        # log links straight to the new release page.
+        with:
+          print-hash: true


### PR DESCRIPTION
## Summary

Adds `.github/workflows/publish.yml` — automatic PyPI publishing triggered by GitHub Release events. Uses PyPI Trusted Publishing (OIDC), so no long-lived API token is stored in GitHub Secrets.

## How it works

1. You bump version + update CHANGELOG, merge to main
2. `git tag -a vX.Y.Z -m vX.Y.Z && git push origin vX.Y.Z`
3. `gh release create vX.Y.Z --notes-from-tag` (or via UI)
4. **Workflow auto-runs**: validates tag matches `pyproject.toml`, builds sdist + wheel, uploads to PyPI

## Required one-time setup (NOT automated by this PR)

Two manual steps before the first auto-publish will work:

### 1. Add the trusted publisher on PyPI
- Go to https://pypi.org/manage/project/pyrxd/settings/publishing/
- Add a new publisher with:
  - Owner: `MudwoodLabs`
  - Repository: `pyrxd`
  - Workflow filename: `publish.yml`
  - Environment: `pypi`

### 2. Create the `pypi` GitHub environment (recommended)
- Repo → Settings → Environments → New environment → name `pypi`
- Add yourself as a required reviewer (gates each publish on a manual approval click — second factor against accidental releases)

The IDE warning about `pypi` not being a valid environment value disappears once step 2 is done.

## Why Trusted Publishing instead of a token

- No credential to leak. Workflow proves identity via short-lived OIDC token PyPI verifies on each upload.
- Scoped to this repo + this workflow file. A fork or a different workflow can't use it.
- PyPA's recommended modern approach.

## Why the version-match guard

The workflow rejects publishes where the release tag doesn't match `pyproject.toml`. Catches the "forgot to bump pyproject.toml" mistake before any artifact reaches PyPI.

## Test plan

- [x] YAML syntax valid (`python3 -c "import yaml; yaml.safe_load(...)"`)
- [x] All actions SHA-pinned per repo convention (PR #31)
- [x] Local `task ci` clean (pre-push hook ran, 2218 passed)
- [ ] After merge: complete the two manual setup steps above, then test by cutting a v0.3.1 patch release for any reason