### PR TITLE
fix(cli): pass hex str to is_ft_script in transfer-ft path

### DIFF
--- a/examples/ft_transfer_demo.py
+++ b/examples/ft_transfer_demo.py
@@ -1,0 +1,283 @@
+#!/usr/bin/env python3
+"""Transfer an existing Glyph FT token between addresses on Radiant mainnet.
+
+This is the "send tokens you already own" flow. Unlike ``ft_deploy_premine.py``
+(which mints a brand-new token), this script spends FT-bearing UTXOs the
+sender already holds and produces a recipient FT output (plus FT change if
+the transfer is partial).
+
+Why this example exists
+-----------------------
+The unit test ``tests/test_ft_transfer.py`` synthesises FT UTXOs in-process
+via ``build_ft_locking_script(...)``. That works to validate conservation
+arithmetic and signing — but it bypasses the "is this UTXO actually an
+on-chain FT UTXO holding the token I think it holds?" question entirely.
+Adapting the test pattern to live data without that filter produces txs
+the network rejects with::
+
+    bad-txns-inputs-outputs-invalid-transaction-reference-operations
+    (code 19)
+
+…because Radiant's ref-conservation rule forbids materialising
+``OP_PUSHINPUTREF`` outputs without an input that already carries the same
+ref. Plain RXD UTXOs can't fund FT transfers — only the *FT UTXOs of the
+specific token* can.
+
+This example shows the correct filter: fetch the wallet's UTXOs, fetch each
+source tx, classify the locking script, and only build ``FtUtxo`` records
+for outputs that are actually FT scripts for the target token's ref.
+
+Usage
+-----
+    SENDER_WIF=<wif> \\
+    TOKEN_REF=<txid:vout> \\
+    RECIPIENT_ADDR=<R…> \\
+    AMOUNT=<units> \\
+    python examples/ft_transfer_demo.py
+
+    # Dry-run (builds + prints raw hex but does not broadcast):
+    DRY_RUN=1 SENDER_WIF=… TOKEN_REF=… RECIPIENT_ADDR=… AMOUNT=… \\
+      python examples/ft_transfer_demo.py
+
+Environment
+-----------
+    SENDER_WIF       WIF private key holding the FT UTXOs (required)
+    TOKEN_REF        Token ref as ``<txid>:<vout>`` — the token's deploy
+                     outpoint (required). Get it from a Radiant explorer
+                     or the CBOR metadata of the token's deploy tx.
+    RECIPIENT_ADDR   Radiant address (R…) of the recipient (required)
+    AMOUNT           FT units to send (required, integer)
+    DRY_RUN          Default ``1``; set to ``0`` to actually broadcast
+    ELECTRUMX_URL    WebSocket URL (default: radiant4people mainnet)
+    FEE_RATE         photons/byte for the transfer (default: 10000)
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
+
+from pyrxd.glyph.builder import FtTransferParams, FtUtxo, GlyphBuilder
+from pyrxd.glyph.script import extract_ref_from_ft_script, is_ft_script
+from pyrxd.glyph.types import GlyphRef
+from pyrxd.keys import PrivateKey
+from pyrxd.network.electrumx import ElectrumXClient, script_hash_for_address
+from pyrxd.security.errors import NetworkError
+from pyrxd.security.types import Hex20, Txid
+from pyrxd.transaction.transaction import Transaction
+
+# ---------------------------------------------------------------------------
+# Configuration
+# ---------------------------------------------------------------------------
+
+DRY_RUN: bool = os.environ.get("DRY_RUN", "1") != "0"
+ELECTRUMX_URL: str = os.environ.get("ELECTRUMX_URL", "wss://electrumx.radiant4people.com:50022/")
+SENDER_WIF: str = os.environ.get("SENDER_WIF", "")
+TOKEN_REF: str = os.environ.get("TOKEN_REF", "")
+RECIPIENT_ADDR: str = os.environ.get("RECIPIENT_ADDR", "")
+AMOUNT: int = int(os.environ.get("AMOUNT", "0"))
+FEE_RATE: int = int(os.environ.get("FEE_RATE", "10000"))
+
+
+# ---------------------------------------------------------------------------
+# Address → PKH (Radiant base58check P2PKH)
+# ---------------------------------------------------------------------------
+
+
+_RADIANT_MAINNET_VERSION_BYTE = 0x00  # Radiant uses Bitcoin mainnet's P2PKH version
+
+
+def address_to_pkh(address: str) -> Hex20:
+    """Decode a Radiant P2PKH address to its 20-byte hash160.
+
+    Validates base58check, payload length, and version byte. Mismatched
+    version (e.g. a Bitcoin testnet or Litecoin address pasted by mistake)
+    is rejected — silently accepting cross-network addresses would let a
+    transfer go to an unspendable script.
+
+    .. warning::
+
+       Radiant mainnet P2PKH shares Bitcoin mainnet's ``0x00`` version byte.
+       This check **cannot** distinguish a Bitcoin mainnet address from a
+       Radiant one — both decode the same way. Confirm the address is a
+       Radiant address out-of-band before broadcasting, or the transfer will
+       go to an unspendable script.
+    """
+    from pyrxd.base58 import base58check_decode
+
+    try:
+        payload = base58check_decode(address)
+    except Exception as exc:
+        raise ValueError(f"invalid Radiant address: {address!r}") from exc
+    if len(payload) != 21:
+        raise ValueError(f"address must decode to 21 bytes (1 version + 20 hash); got {len(payload)}")
+    if payload[0] != _RADIANT_MAINNET_VERSION_BYTE:
+        raise ValueError(
+            f"unsupported address version byte {payload[0]:#x}: "
+            f"expected {_RADIANT_MAINNET_VERSION_BYTE:#x} (Radiant mainnet P2PKH)"
+        )
+    return Hex20(payload[1:])
+
+
+# ---------------------------------------------------------------------------
+# FT UTXO collection — the key step the unit test fixtures hide
+# ---------------------------------------------------------------------------
+
+
+async def collect_ft_utxos(
+    client: ElectrumXClient,
+    sender_address: str,
+    token_ref: GlyphRef,
+) -> list[FtUtxo]:
+    """Find every FT UTXO at *sender_address* that holds the *token_ref* token.
+
+    For each raw UTXO from electrumx ``listunspent``:
+
+    1. Fetch the source transaction (electrumx doesn't include the locking
+       script in ``listunspent``; we have to fetch it).
+    2. Classify the output's locking script — only 75-byte FT scripts qualify.
+    3. Decode the ref encoded inside the script and require an exact match to
+       *token_ref*. Different tokens have different refs even though their
+       script layout is identical.
+
+    UTXOs that fail any check are silently skipped. The returned list contains
+    only correctly-classified, ref-matching FT UTXOs ready for ``FtUtxoSet``.
+    """
+    raw_utxos = await client.get_utxos(script_hash_for_address(sender_address))
+    ft_utxos: list[FtUtxo] = []
+
+    for u in raw_utxos:
+        try:
+            raw = await client.get_transaction(Txid(u.tx_hash))
+        except NetworkError:
+            continue
+        tx = Transaction.from_hex(bytes(raw))
+        if tx is None or u.tx_pos >= len(tx.outputs):
+            continue
+        script = tx.outputs[u.tx_pos].locking_script.serialize()  # bytes
+        if not is_ft_script(script.hex()):
+            continue  # not an FT lock at all (probably plain P2PKH RXD)
+        if extract_ref_from_ft_script(script) != token_ref:
+            continue  # FT, but a different token
+        ft_utxos.append(
+            FtUtxo(
+                txid=u.tx_hash,
+                vout=u.tx_pos,
+                value=u.value,
+                ft_amount=u.value,  # 1 photon = 1 FT unit (consensus rule)
+                ft_script=script,
+            )
+        )
+
+    return ft_utxos
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+
+def _parse_token_ref(s: str) -> GlyphRef:
+    if ":" not in s:
+        raise ValueError(f"TOKEN_REF must be 'txid:vout', got {s!r}")
+    txid_hex, vout_str = s.split(":", 1)
+    return GlyphRef(txid=Txid(txid_hex), vout=int(vout_str))
+
+
+async def main() -> None:
+    if not SENDER_WIF:
+        print("ERROR: set SENDER_WIF to the WIF private key holding the FT UTXOs")
+        sys.exit(1)
+    if not TOKEN_REF:
+        print("ERROR: set TOKEN_REF=<txid:vout> (the token's deploy outpoint)")
+        sys.exit(1)
+    if not RECIPIENT_ADDR:
+        print("ERROR: set RECIPIENT_ADDR to the recipient's R… address")
+        sys.exit(1)
+    if AMOUNT <= 0:
+        print("ERROR: set AMOUNT to a positive integer (FT units to send)")
+        sys.exit(1)
+
+    # Wrap the WIF decode so a malformed key doesn't surface a base58
+    # ValueError whose traceback echoes the (almost-correct) WIF on stderr.
+    try:
+        sender_key = PrivateKey(SENDER_WIF)
+    except Exception:
+        print("ERROR: SENDER_WIF could not be decoded as a WIF private key", file=sys.stderr)
+        sys.exit(1)
+    sender_address = sender_key.public_key().address()
+    recipient_pkh = address_to_pkh(RECIPIENT_ADDR)
+    token_ref = _parse_token_ref(TOKEN_REF)
+
+    print(f"Sender:      {sender_address}")
+    print(f"Recipient:   {RECIPIENT_ADDR}")
+    print(f"Token ref:   {token_ref.txid}:{token_ref.vout}")
+    print(f"Amount:      {AMOUNT:,} FT units")
+    print(f"Fee rate:    {FEE_RATE} photons/byte")
+    print(f"DRY_RUN:     {DRY_RUN}")
+    print()
+
+    async with ElectrumXClient([ELECTRUMX_URL]) as client:
+        print("Scanning for FT UTXOs...")
+        ft_utxos = await collect_ft_utxos(client, sender_address, token_ref)
+        if not ft_utxos:
+            print(f"No FT UTXOs found at {sender_address} for ref {token_ref.txid}:{token_ref.vout}.")
+            print()
+            print("Things to check:")
+            print(f"  - confirm with a Radiant explorer that {sender_address}")
+            print(f"    actually holds the token at ref {token_ref.txid}:{token_ref.vout}")
+            print("  - confirm TOKEN_REF is the token's *deploy* outpoint, not a transfer outpoint")
+            print("  - confirm the wallet derivation matches the address holding the FTs")
+            sys.exit(2)
+        total_ft = sum(u.ft_amount for u in ft_utxos)
+        print(f"Found {len(ft_utxos)} FT UTXO(s), total: {total_ft:,} FT units")
+        if total_ft < AMOUNT:
+            print(f"ERROR: insufficient FT balance — need {AMOUNT:,}, have {total_ft:,}")
+            sys.exit(2)
+
+        builder = GlyphBuilder()
+        result = builder.build_ft_transfer_tx(
+            FtTransferParams(
+                ref=token_ref,
+                utxos=ft_utxos,
+                amount=AMOUNT,
+                new_owner_pkh=recipient_pkh,
+                private_key=sender_key,
+                fee_rate=FEE_RATE,
+            )
+        )
+
+        print()
+        print(f"Transfer tx: {result.tx.txid()}")
+        print(f"  size:      {result.tx.byte_length()} bytes")
+        print(f"  fee:       {result.fee:,} photons")
+        print(f"  inputs:    {len(result.tx.inputs)}")
+        print(f"  outputs:   {len(result.tx.outputs)}")
+        print(f"  to:        {RECIPIENT_ADDR} ({AMOUNT:,} FT units)")
+        if result.change_ft_script is not None:
+            # Recover selected inputs by matching tx.inputs back to the offered
+            # ft_utxos pool by (txid, vout). Greedy-largest-first selection
+            # means tx.inputs is a *subset* of ft_utxos, so total_ft - AMOUNT
+            # would over-report the change.
+            selected_keys = {(str(inp.source_txid), inp.source_output_index) for inp in result.tx.inputs}
+            selected_ft_in = sum(u.ft_amount for u in ft_utxos if (u.txid, u.vout) in selected_keys)
+            change_amount = selected_ft_in - AMOUNT
+            print(f"  change:    {sender_address} ({change_amount:,} FT units)")
+        print()
+
+        if DRY_RUN:
+            print("[DRY RUN] Transfer tx not broadcast. Set DRY_RUN=0 to broadcast.")
+            print()
+            print(f"Raw tx hex:\n{result.tx.hex()}")
+            return
+
+        print("Broadcasting transfer tx...")
+        txid = await client.broadcast(result.tx.serialize())
+        print(f"Broadcast result: {txid}")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/src/pyrxd/cli/glyph_cmds.py
+++ b/src/pyrxd/cli/glyph_cmds.py
@@ -925,7 +925,7 @@ async def _transfer_ft_inner(
             if tx is None or utxo.tx_pos >= len(tx.outputs):
                 continue
             out_script = tx.outputs[utxo.tx_pos].locking_script.serialize()
-            if not is_ft_script(out_script):
+            if not is_ft_script(out_script.hex()):
                 continue
             ref_in_script = _try_extract_ft_ref(out_script)
             if ref_in_script != ref:

--- a/src/pyrxd/glyph/ft.py
+++ b/src/pyrxd/glyph/ft.py
@@ -31,7 +31,7 @@ from typing import Any
 from pyrxd.security.errors import ValidationError
 from pyrxd.security.types import Hex20
 
-from .script import build_ft_locking_script, extract_ref_from_ft_script
+from .script import build_ft_locking_script, extract_ref_from_ft_script, is_ft_script
 from .types import GlyphRef
 
 # Post-V2 relay minimum — mirrored from builder.py to avoid an import cycle.
@@ -104,6 +104,28 @@ class FtUtxoSet:
                 raise ValidationError(f"value must be int, got {type(u.value).__name__!r}: {u.value!r}")
             if u.value < 0:
                 raise ValidationError("value must be >= 0")
+            # Reject non-FT scripts (e.g. plain P2PKH) up front. The Radiant
+            # node would later reject the broadcast with "bad-txns-inputs-
+            # outputs-invalid-transaction-reference-operations" because no
+            # input carries the ref the output materialises — fail fast with
+            # a useful error instead of a cryptic mempool rejection.
+            if not isinstance(u.ft_script, (bytes, bytearray)):
+                raise ValidationError(
+                    f"ft_script must be bytes (the 75-byte on-chain locking script of the UTXO "
+                    f"you're spending), got {type(u.ft_script).__name__!r}"
+                )
+            if not is_ft_script(bytes(u.ft_script).hex()):
+                raise ValidationError(
+                    f"UTXO {u.txid}:{u.vout} ft_script is not a valid 75-byte FT locking script. "
+                    f"FT transfers can only spend FT UTXOs (script: 76a914<pkh>88ac bdd0 <ref:36> "
+                    f"dec0e9aa76e378e4a269e69d). Spending a plain P2PKH UTXO and producing an FT "
+                    f"output violates ref conservation and will be rejected by the network."
+                )
+            input_ref = extract_ref_from_ft_script(bytes(u.ft_script))
+            if input_ref != ref:
+                raise ValidationError(
+                    f"UTXO {u.txid}:{u.vout} carries ref {input_ref} which differs from the set's ref {ref}"
+                )
         self.ref = ref
         self.utxos = list(utxos)
 
@@ -202,18 +224,7 @@ class FtUtxoSet:
                 f"out={amount}, change={ft_change} (negative change means inputs insufficient)"
             )
 
-        # 3. Validate every selected input's script matches the set's ref.
-        #    An input with a different ref would silently fund a transfer of
-        #    the wrong token — refuse loudly.
-        for u in selected:
-            input_ref = extract_ref_from_ft_script(u.ft_script)
-            if input_ref != self.ref:
-                raise ValidationError(
-                    f"Selected UTXO {u.txid}:{u.vout} carries ref "
-                    f"{input_ref} which differs from the set's ref {self.ref}"
-                )
-
-        # 4. Resolve change_pkh.
+        # 3. Resolve change_pkh.
         if change_pkh is None:
             # Derive sender's PKH from the signing key. PrivateKey.public_key()
             # .hash160() returns 20 bytes.

--- a/tests/test_ft_transfer.py
+++ b/tests/test_ft_transfer.py
@@ -316,7 +316,7 @@ class TestRefPreservation:
         assert extract_ref_from_ft_script(result.change_ft_script) == _token_ref()
 
     def test_mismatched_input_ref_raises(self):
-        """A UTXO carrying a different ref in its script is refused."""
+        """A UTXO carrying a different ref in its script is refused at construction."""
         other_ref = GlyphRef(txid=Txid("ff" * 32), vout=7)
         utxo_wrong_ref = FtUtxo(
             txid="aa" * 32,
@@ -325,14 +325,36 @@ class TestRefPreservation:
             ft_amount=100,
             ft_script=_ft_script_for(_alice_pkh(), ref=other_ref),
         )
-        # The UTXO set's ref says _token_ref(), but the UTXO's script carries other_ref.
-        s = FtUtxoSet(ref=_token_ref(), utxos=[utxo_wrong_ref])
         with pytest.raises(ValidationError, match="differs from the set's ref"):
-            s.build_transfer_tx(
-                amount=40,
-                new_owner_pkh=Hex20(_BOB_PKH),
-                private_key=_alice_key(),
-            )
+            FtUtxoSet(ref=_token_ref(), utxos=[utxo_wrong_ref])
+
+    def test_p2pkh_script_rejected_at_construction(self):
+        """A plain P2PKH script (not an FT lock) must be refused — the network would
+        otherwise reject the broadcast with `bad-txns-inputs-outputs-invalid-
+        transaction-reference-operations` because the output materialises a ref that
+        no input carries."""
+        plain_p2pkh = b"\x76\xa9\x14" + _alice_pkh() + b"\x88\xac"  # 25 bytes, not FT
+        utxo = FtUtxo(
+            txid="aa" * 32,
+            vout=0,
+            value=_DEFAULT_RXD_VALUE,
+            ft_amount=100,
+            ft_script=plain_p2pkh,
+        )
+        with pytest.raises(ValidationError, match="not a valid 75-byte FT locking script"):
+            FtUtxoSet(ref=_token_ref(), utxos=[utxo])
+
+    def test_non_bytes_ft_script_rejected(self):
+        """A hex-string ft_script (instead of bytes) is rejected with a clear type error."""
+        utxo = FtUtxo(
+            txid="aa" * 32,
+            vout=0,
+            value=_DEFAULT_RXD_VALUE,
+            ft_amount=100,
+            ft_script=_ft_script_for(_alice_pkh()).hex(),  # type: ignore[arg-type]
+        )
+        with pytest.raises(ValidationError, match="ft_script must be bytes"):
+            FtUtxoSet(ref=_token_ref(), utxos=[utxo])
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_glyph.py
+++ b/tests/test_glyph.py
@@ -96,6 +96,14 @@ class TestScriptConstruction:
         assert not is_nft_script("")
         assert not is_ft_script("")
 
+    def test_is_ft_script_requires_hex_str_not_bytes(self):
+        from pyrxd.script.script import Script
+
+        script_bytes = Script(build_ft_locking_script(KNOWN_HEX20, KNOWN_REF)).serialize()
+        assert is_ft_script(script_bytes.hex())
+        with pytest.raises(TypeError):
+            is_ft_script(script_bytes)  # type: ignore[arg-type]
+
     def test_nft_script_starts_with_d8(self):
         script = build_nft_locking_script(KNOWN_HEX20, KNOWN_REF)
         assert script[0] == 0xD8

--- a/tests/test_glyph_ft_red_team.py
+++ b/tests/test_glyph_ft_red_team.py
@@ -146,16 +146,11 @@ class TestFtMismatchedRef:
             ft_amount=100,
             ft_script=_ft_script_for(_alice_pkh(), ref=other_ref),
         )
-        s = FtUtxoSet(ref=_token_ref(), utxos=[mismatched_utxo])
         with pytest.raises(ValidationError, match="differs from the set's ref"):
-            s.build_transfer_tx(
-                amount=40,
-                new_owner_pkh=Hex20(_BOB_PKH),
-                private_key=_alice_key(),
-            )
+            FtUtxoSet(ref=_token_ref(), utxos=[mismatched_utxo])
 
     def test_mixed_refs_one_matching_one_not_rejected(self):
-        """Even if only one of the selected UTXOs carries a foreign ref, reject."""
+        """Even if only one of the UTXOs carries a foreign ref, reject the whole set."""
         other_ref = GlyphRef(txid=Txid("ff" * 32), vout=7)
         good = _make_utxo(60, txid_byte=0x01)
         bad = FtUtxo(
@@ -165,15 +160,8 @@ class TestFtMismatchedRef:
             ft_amount=50,
             ft_script=_ft_script_for(_alice_pkh(), ref=other_ref),
         )
-        # Selection is greedy-desc by ft_amount → good (60) first, then bad (50).
-        # To force BOTH to be selected, request 100.
-        s = FtUtxoSet(ref=_token_ref(), utxos=[good, bad])
         with pytest.raises(ValidationError, match="differs from the set's ref"):
-            s.build_transfer_tx(
-                amount=100,
-                new_owner_pkh=Hex20(_BOB_PKH),
-                private_key=_alice_key(),
-            )
+            FtUtxoSet(ref=_token_ref(), utxos=[good, bad])
 
 
 class TestFtAmountOverflow:


### PR DESCRIPTION
## Summary

- `pyrxd glyph transfer-ft` was unusable from a real ElectrumX session: `is_ft_script(out_script)` was called with `bytes` (from `Script.serialize()`), but the function's `str` regex `fullmatch` raises `TypeError: cannot use a string pattern on a bytes-like object`. The surrounding `try/except` only catches `NetworkError`, so the command crashed on every UTXO it inspected.
- Fix: pass `out_script.hex()` so the classifier sees the hex string it expects.
- Adds a regression test in `test_glyph.py` that round-trips an FT script through `Script(...).serialize()` (the exact pattern the CLI uses) and pins the str-only contract.

## How to reproduce (before the fix)

A user reported "FT not accepted" while building a glyph transfer tx after wiring in ElectrumX following the unit-test transfer sample. The root cause is the same call-site as the CLI's:

```python
out_script = tx.outputs[utxo.tx_pos].locking_script.serialize()  # bytes
is_ft_script(out_script)  # TypeError
```

After the fix, `is_ft_script(out_script.hex())` returns `True` for canonical 75-byte FT scripts.

## Notes for users hitting "FT not accepted" outside the CLI

The CLI bug above is one path. When constructing `FtUtxo` directly from ElectrumX data (the unit-test sample doesn't show this — it builds the script in-process), three things must hold:

1. `FtUtxo.ft_script` is **bytes** (not hex), exactly **75 bytes**, in canonical layout `76 a9 14 <pkh-20B> 88 ac bd d0 <ref-36B> de c0 e9 aa 76 e3 78 e4 a2 69 e6 9d`. ElectrumX `listunspent` does not include the locking script — fetch the source tx and read `tx.outputs[vout].locking_script.serialize()`.
2. The `GlyphRef` passed to `FtUtxoSet(ref=…)` must match the ref encoded inside the script. `GlyphRef` stores the txid as a normal display-order hex string; do not pre-reverse.
3. The script's owner PKH must match the signing key.

## Test plan

- [x] `poetry run pytest tests/test_glyph.py tests/test_ft_transfer.py tests/cli/test_glyph_cmds.py` — 127 passed
- [x] Full suite (`pre-push` hook): 2219 passed, 3 skipped, coverage 86.32%
- [x] `ruff check` + `ruff format --check` clean