### PR TITLE
feat(glyph): GlyphRef.from_contract_hex for explorer-style contract ids

### DIFF
--- a/examples/ft_transfer_demo.py
+++ b/examples/ft_transfer_demo.py
@@ -67,7 +67,7 @@ from pyrxd.glyph.script import extract_ref_from_ft_script, is_ft_script
 from pyrxd.glyph.types import GlyphRef
 from pyrxd.keys import PrivateKey
 from pyrxd.network.electrumx import ElectrumXClient, script_hash_for_address
-from pyrxd.security.errors import NetworkError
+from pyrxd.security.errors import NetworkError, ValidationError
 from pyrxd.security.types import Hex20, Txid
 from pyrxd.transaction.transaction import Transaction
 
@@ -229,8 +229,16 @@ async def main() -> None:
         print("ERROR: SENDER_WIF could not be decoded as a WIF private key", file=sys.stderr)
         sys.exit(1)
     sender_address = sender_key.public_key().address()
-    recipient_pkh = address_to_pkh(RECIPIENT_ADDR)
-    token_ref = _resolve_token_ref()
+    try:
+        recipient_pkh = address_to_pkh(RECIPIENT_ADDR)
+    except ValueError as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        sys.exit(1)
+    try:
+        token_ref = _resolve_token_ref()
+    except (ValueError, ValidationError) as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        sys.exit(1)
 
     print(f"Sender:      {sender_address}")
     print(f"Recipient:   {RECIPIENT_ADDR}")

--- a/examples/ft_transfer_demo.py
+++ b/examples/ft_transfer_demo.py
@@ -42,9 +42,11 @@ Usage
 Environment
 -----------
     SENDER_WIF       WIF private key holding the FT UTXOs (required)
-    TOKEN_REF        Token ref as ``<txid>:<vout>`` — the token's deploy
-                     outpoint (required). Get it from a Radiant explorer
-                     or the CBOR metadata of the token's deploy tx.
+    TOKEN_CONTRACT   72-char contract id as shown in Radiant explorers,
+                     e.g. ``b45dc4...a2a800000004`` for RBG. Either this
+                     OR ``TOKEN_REF`` is required.
+    TOKEN_REF        Alternative form: ``<txid>:<vout>``, e.g.
+                     ``b45dc4...a2a8:4``. Use whichever is more convenient.
     RECIPIENT_ADDR   Radiant address (R…) of the recipient (required)
     AMOUNT           FT units to send (required, integer)
     DRY_RUN          Default ``1``; set to ``0`` to actually broadcast
@@ -76,6 +78,7 @@ from pyrxd.transaction.transaction import Transaction
 DRY_RUN: bool = os.environ.get("DRY_RUN", "1") != "0"
 ELECTRUMX_URL: str = os.environ.get("ELECTRUMX_URL", "wss://electrumx.radiant4people.com:50022/")
 SENDER_WIF: str = os.environ.get("SENDER_WIF", "")
+TOKEN_CONTRACT: str = os.environ.get("TOKEN_CONTRACT", "")
 TOKEN_REF: str = os.environ.get("TOKEN_REF", "")
 RECIPIENT_ADDR: str = os.environ.get("RECIPIENT_ADDR", "")
 AMOUNT: int = int(os.environ.get("AMOUNT", "0"))
@@ -187,12 +190,29 @@ def _parse_token_ref(s: str) -> GlyphRef:
     return GlyphRef(txid=Txid(txid_hex), vout=int(vout_str))
 
 
+def _resolve_token_ref() -> GlyphRef:
+    """Resolve the token ref from either TOKEN_CONTRACT or TOKEN_REF.
+
+    Both forms describe the same deploy outpoint; users supply whichever
+    is more convenient. A 72-char contract id (as shown in explorers) is
+    decoded via :meth:`GlyphRef.from_contract_hex`; a ``txid:vout`` string
+    is parsed directly. Setting both is rejected to avoid silent mismatches.
+    """
+    if TOKEN_CONTRACT and TOKEN_REF:
+        raise ValueError("set either TOKEN_CONTRACT or TOKEN_REF, not both")
+    if TOKEN_CONTRACT:
+        return GlyphRef.from_contract_hex(TOKEN_CONTRACT)
+    if TOKEN_REF:
+        return _parse_token_ref(TOKEN_REF)
+    raise ValueError("set TOKEN_CONTRACT (72-char contract id) or TOKEN_REF (txid:vout)")
+
+
 async def main() -> None:
     if not SENDER_WIF:
         print("ERROR: set SENDER_WIF to the WIF private key holding the FT UTXOs")
         sys.exit(1)
-    if not TOKEN_REF:
-        print("ERROR: set TOKEN_REF=<txid:vout> (the token's deploy outpoint)")
+    if not (TOKEN_CONTRACT or TOKEN_REF):
+        print("ERROR: set TOKEN_CONTRACT (72-char contract id) or TOKEN_REF (txid:vout)")
         sys.exit(1)
     if not RECIPIENT_ADDR:
         print("ERROR: set RECIPIENT_ADDR to the recipient's R… address")
@@ -210,7 +230,7 @@ async def main() -> None:
         sys.exit(1)
     sender_address = sender_key.public_key().address()
     recipient_pkh = address_to_pkh(RECIPIENT_ADDR)
-    token_ref = _parse_token_ref(TOKEN_REF)
+    token_ref = _resolve_token_ref()
 
     print(f"Sender:      {sender_address}")
     print(f"Recipient:   {RECIPIENT_ADDR}")

--- a/src/pyrxd/glyph/types.py
+++ b/src/pyrxd/glyph/types.py
@@ -53,6 +53,47 @@ class GlyphRef:
         vout = struct.unpack("<I", data[32:])[0]
         return cls(txid=Txid(txid), vout=vout)
 
+    @classmethod
+    def from_contract_hex(cls, contract_hex: str) -> GlyphRef:
+        """Parse a 72-char contract id string as displayed in Radiant explorers.
+
+        The Glyph contract id concatenates the display-order txid (64 hex
+        chars) with the big-endian-encoded vout (8 hex chars). Both halves
+        are written in human-readable order so the whole string reads
+        naturally — the trailing ``00000004`` decodes to ``4``::
+
+            b45dc453befb589a...c380eb31deaf96a2a8 00000004
+            └────────── txid (display order) ───┘ └─ vout BE ─┘  (= 4)
+
+        Equivalent forms:
+
+        * ``from_contract_hex("b45dc4...a2a800000004")``
+        * ``GlyphRef(txid=Txid("b45dc4...a2a8"), vout=4)``
+
+        .. warning::
+
+           This is the **explorer / UI display form**, not the on-chain
+           wire form. :meth:`from_bytes` parses the wire form used inside
+           locking scripts, where the txid bytes are reversed *and* the
+           vout is encoded little-endian. If you have raw bytes pulled out
+           of a script, use :meth:`from_bytes`. Use this method only when
+           you have a contract id in the form a Radiant explorer or wallet
+           UI shows it. Mixing them will silently produce a wrong-vout ref.
+        """
+        if not isinstance(contract_hex, str):
+            raise ValidationError(f"contract_hex must be str, got {type(contract_hex).__name__!r}")
+        if len(contract_hex) != 72:
+            raise ValidationError(
+                f"contract_hex must be 72 hex chars (32-byte txid + 4-byte vout), got {len(contract_hex)}"
+            )
+        try:
+            vout_bytes = bytes.fromhex(contract_hex[64:])
+        except ValueError as exc:
+            raise ValidationError("contract_hex contains non-hex characters") from exc
+        txid = contract_hex[:64]
+        vout = int.from_bytes(vout_bytes, "big")
+        return cls(txid=Txid(txid), vout=vout)
+
 
 @dataclass(frozen=True)
 class GlyphMedia:

--- a/tests/test_glyph.py
+++ b/tests/test_glyph.py
@@ -165,6 +165,74 @@ class TestGlyphRefEncoding:
         assert recovered.vout == 0xFFFFFFFF
 
 
+class TestGlyphRefFromContractHex:
+    """Parsing the explorer/UI display form: txid (display order) + vout BE."""
+
+    # RBG mainnet contract id; the trailing "00000004" reads as 4 (big-endian).
+    RBG_CONTRACT = "b45dc453befb589aff8bfd76af0b994615b37eda094f48c380eb31deaf96a2a800000004"
+    RBG_TXID = "b45dc453befb589aff8bfd76af0b994615b37eda094f48c380eb31deaf96a2a8"
+    NON_PALINDROMIC_TXID = "0123456789abcdef" * 4  # 64 chars, reversal-distinct
+
+    def test_decodes_real_world_contract(self):
+        ref = GlyphRef.from_contract_hex(self.RBG_CONTRACT)
+        assert ref.txid == self.RBG_TXID
+        assert ref.vout == 4
+
+    def test_vout_is_big_endian(self):
+        # Contract tail "00000100" reads as 256 in big-endian.
+        contract = "ab" * 32 + "00000100"
+        ref = GlyphRef.from_contract_hex(contract)
+        assert ref.vout == 256
+
+    def test_vout_zero(self):
+        contract = "cd" * 32 + "00000000"
+        ref = GlyphRef.from_contract_hex(contract)
+        assert ref.vout == 0
+
+    def test_vout_max(self):
+        contract = "ef" * 32 + "ffffffff"
+        ref = GlyphRef.from_contract_hex(contract)
+        assert ref.vout == 0xFFFFFFFF
+
+    def test_round_trip(self):
+        # Build a contract string from a known ref, then recover it.
+        ref = GlyphRef(txid=Txid(self.NON_PALINDROMIC_TXID), vout=42)
+        contract = ref.txid + ref.vout.to_bytes(4, "big").hex()
+        recovered = GlyphRef.from_contract_hex(contract)
+        assert recovered == ref
+
+    def test_short_string_raises(self):
+        with pytest.raises(ValidationError, match="72 hex chars"):
+            GlyphRef.from_contract_hex("ab" * 32 + "0000")  # 68 chars
+
+    def test_long_string_raises(self):
+        with pytest.raises(ValidationError, match="72 hex chars"):
+            GlyphRef.from_contract_hex("ab" * 32 + "0000000000")  # 74 chars
+
+    def test_non_hex_in_vout_raises(self):
+        with pytest.raises(ValidationError, match="non-hex"):
+            GlyphRef.from_contract_hex("ab" * 32 + "zzzzzzzz")
+
+    def test_non_str_input_raises(self):
+        with pytest.raises(ValidationError, match="must be str"):
+            GlyphRef.from_contract_hex(b"\x00" * 36)  # type: ignore[arg-type]
+
+    def test_distinct_from_from_bytes(self):
+        """``from_contract_hex`` and ``from_bytes`` parse different formats:
+        contract uses display-order txid + big-endian vout; wire uses
+        reversed txid + little-endian vout."""
+        ref = GlyphRef(txid=Txid(self.NON_PALINDROMIC_TXID), vout=4)
+        wire_hex = ref.to_bytes().hex()  # reversed txid + vout LE
+        contract_hex = ref.txid + ref.vout.to_bytes(4, "big").hex()
+        # Same ref, different serialisations.
+        assert wire_hex != contract_hex
+        assert wire_hex[:64] != contract_hex[:64]  # txid byte order differs
+        assert wire_hex[64:] != contract_hex[64:]  # vout endianness differs (for vout=4)
+        # Both round-trip to the same ref via their respective decoders.
+        assert GlyphRef.from_bytes(bytes.fromhex(wire_hex)) == ref
+        assert GlyphRef.from_contract_hex(contract_hex) == ref
+
+
 # ---------------------------------------------------------------------------
 # 3. Script extraction
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Adds `GlyphRef.from_contract_hex(...)` so users can paste a 72-char contract id straight from a Radiant explorer (e.g. RBG: `b45dc4...a2a800000004` → vout 4) without manually splitting into txid + vout. The trailing 4 bytes of the contract id are **big-endian** (so the whole string reads naturally), even though the on-chain wire form uses little-endian — the new docstring calls out that ambiguity explicitly.

Wires the new helper into `examples/ft_transfer_demo.py` via a `TOKEN_CONTRACT` env var as an alternative to `TOKEN_REF` (txid:vout). Setting both is rejected to avoid silent mismatches.

## Why

Real-world feedback: a user got tripped up trying to construct a token ref from a contract id three different ways — wrong vout (used 0 instead of 4), wrong endianness, and using `_REF_TXID:4` as Python syntax. Three failed transactions later, all the bugs trace back to manual contract-id splitting. One classmethod removes the entire footgun class.

## Diff stat

- `src/pyrxd/glyph/types.py` — +41/-1 (the classmethod + extended docstring)
- `tests/test_glyph.py` — +68/-1 (10 new tests covering RBG round-trip, vout BE, validation, and the wire-vs-display distinction)
- `examples/ft_transfer_demo.py` — +26/-4 (TOKEN_CONTRACT env var support)

## Test plan

- [x] `poetry run pytest tests/test_glyph.py::TestGlyphRefFromContractHex` — 10 passed
- [x] `poetry run pytest tests/test_glyph.py tests/test_ft_transfer.py tests/test_glyph_ft_red_team.py tests/cli/test_glyph_cmds.py` — 187 passed
- [x] Demo end-to-end smoke: `TOKEN_CONTRACT=b45dc4...a2a800000004` resolves to `vout=4`
- [x] `ruff check` + `ruff format --check` clean