### PR TITLE
feat(glyph): classify dMint contract outputs + commit scripts

### DIFF
--- a/src/pyrxd/glyph/inspector.py
+++ b/src/pyrxd/glyph/inspector.py
@@ -1,12 +1,15 @@
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING
 
 from pyrxd.security.errors import ValidationError
 
 from .payload import GLY_MARKER, decode_payload
 from .script import (
     MUTABLE_NFT_SCRIPT_RE,
+    extract_owner_pkh_from_ft_script,
+    extract_owner_pkh_from_nft_script,
     extract_ref_from_ft_script,
     extract_ref_from_nft_script,
     is_ft_script,
@@ -15,16 +18,33 @@ from .script import (
 )
 from .types import GlyphMetadata, GlyphRef
 
+if TYPE_CHECKING:
+    # Avoid runtime import cycle: dmint.py imports from .script, which is
+    # imported here. TYPE_CHECKING keeps the annotation usable for type tools
+    # without forcing a circular load at import time.
+    from pyrxd.security.types import Hex20
+
+    from .dmint import DmintState
+
 
 @dataclass
 class GlyphOutput:
-    """A detected Glyph in a transaction output."""
+    """A detected Glyph in a transaction output.
+
+    Fields added after the original five are optional with defaults so callers
+    that destructure the original shape continue to work unchanged. ``ref`` is
+    the glyph's identifying outpoint — for ``dmint`` outputs that's the
+    ``contract_ref`` (the contract UTXO's own outpoint); the token the contract
+    mints lives in ``dmint_state.token_ref``.
+    """
 
     vout: int
-    glyph_type: str  # "nft" or "ft"
+    glyph_type: str  # "nft", "ft", "mut", "dmint"
     ref: GlyphRef
     metadata: GlyphMetadata | None  # None if this is a transfer (no reveal)
     script: bytes
+    owner_pkh: Hex20 | None = None  # set for nft/ft/mut (None for dmint)
+    dmint_state: DmintState | None = field(default=None)  # set for dmint outputs
 
 
 class GlyphInspector:
@@ -36,30 +56,39 @@ class GlyphInspector:
     def find_glyphs(self, tx_outputs: list[tuple[int, bytes]]) -> list[GlyphOutput]:
         """
         Given list of (satoshis, script_bytes) outputs, return detected Glyphs.
+
+        Detects NFT singletons, FT locks, mutable NFTs, and dMint contract
+        outputs. Plain P2PKH and unrecognised scripts are silently skipped.
+        Commit-output classification lives outside ``find_glyphs`` because a
+        commit has no meaningful ``ref`` until its reveal lands.
         """
+        # Local import: dmint.py imports from .script which imports from
+        # .types — pulling DmintState in at module load completes the cycle.
+        from .dmint import DmintState
+
         results = []
         for vout, (_satoshis, script) in enumerate(tx_outputs):
             script_hex = script.hex()
             if is_nft_script(script_hex):
-                ref = extract_ref_from_nft_script(script)
                 results.append(
                     GlyphOutput(
                         vout=vout,
                         glyph_type="nft",
-                        ref=ref,
+                        ref=extract_ref_from_nft_script(script),
                         metadata=None,
                         script=script,
+                        owner_pkh=extract_owner_pkh_from_nft_script(script),
                     )
                 )
             elif is_ft_script(script_hex):
-                ref = extract_ref_from_ft_script(script)
                 results.append(
                     GlyphOutput(
                         vout=vout,
                         glyph_type="ft",
-                        ref=ref,
+                        ref=extract_ref_from_ft_script(script),
                         metadata=None,
                         script=script,
+                        owner_pkh=extract_owner_pkh_from_ft_script(script),
                     )
                 )
             elif MUTABLE_NFT_SCRIPT_RE.fullmatch(script_hex):
@@ -75,6 +104,27 @@ class GlyphInspector:
                             script=script,
                         )
                     )
+            else:
+                # dMint contract scripts are variable-length and don't have a
+                # fingerprint regex — DmintState.from_script is the parser. Try
+                # it last so the cheap regex/predicate branches above short-
+                # circuit on the common cases. Non-dmint scripts raise
+                # ValidationError (length, opcode, or ref-decode mismatch);
+                # any other exception is a real bug worth surfacing.
+                try:
+                    state = DmintState.from_script(script)
+                except ValidationError:
+                    continue
+                results.append(
+                    GlyphOutput(
+                        vout=vout,
+                        glyph_type="dmint",
+                        ref=state.contract_ref,
+                        metadata=None,
+                        script=script,
+                        dmint_state=state,
+                    )
+                )
         return results
 
     def extract_reveal_metadata(self, scriptsig: bytes) -> GlyphMetadata | None:
@@ -88,6 +138,21 @@ class GlyphInspector:
             return self._parse_reveal_scriptsig(scriptsig)
         except (ValidationError, Exception):
             return None
+
+    def find_reveal_metadata(self, scriptsigs: list[bytes]) -> tuple[int, GlyphMetadata] | None:
+        """Walk every input scriptSig and return the first reveal metadata found.
+
+        Returns ``(input_index, metadata)`` for the first input whose scriptSig
+        embeds a ``gly`` marker followed by parseable CBOR; ``None`` if no
+        input does. Distinct from :meth:`extract_reveal_metadata` (which checks
+        a single scriptSig) — diagnostic callers want to know *which* input
+        carried the metadata, and that the inspector looked beyond input 0.
+        """
+        for idx, scriptsig in enumerate(scriptsigs):
+            metadata = self.extract_reveal_metadata(scriptsig)
+            if metadata is not None:
+                return idx, metadata
+        return None
 
     def _parse_reveal_scriptsig(self, scriptsig: bytes) -> GlyphMetadata | None:
         """Walk the scriptSig push-data stack to find 'gly' marker + CBOR."""

--- a/src/pyrxd/glyph/script.py
+++ b/src/pyrxd/glyph/script.py
@@ -108,6 +108,43 @@ def is_ft_script(script_hex: str) -> bool:
     return bool(FT_SCRIPT_RE.fullmatch(script_hex.lower()))
 
 
+def is_commit_script(script_hex: str) -> bool:
+    """Return True if script_hex matches either commit pattern (NFT or FT)."""
+    return bool(COMMIT_SCRIPT_RE.fullmatch(script_hex.lower()))
+
+
+def is_commit_nft_script(script_hex: str) -> bool:
+    """Return True if script_hex matches the NFT-variant commit pattern."""
+    return bool(COMMIT_SCRIPT_NFT_RE.fullmatch(script_hex.lower()))
+
+
+def is_commit_ft_script(script_hex: str) -> bool:
+    """Return True if script_hex matches the FT-variant commit pattern."""
+    return bool(COMMIT_SCRIPT_FT_RE.fullmatch(script_hex.lower()))
+
+
+def is_dmint_contract_script(script: bytes) -> bool:
+    """Return True if *script* is a dMint contract output script.
+
+    Thin wrapper around :func:`pyrxd.glyph.dmint.DmintState.from_script`. Returns
+    False on any layout mismatch (the parser raises ``ValidationError``); other
+    exception types are real bugs and propagate.
+
+    For diagnostic callers that need the parsed state, call
+    ``DmintState.from_script`` directly.
+    """
+    # Local import — DmintState lives in glyph/dmint.py which itself imports
+    # script-construction helpers from this module. Module-level import would
+    # close the cycle.
+    from .dmint import DmintState
+
+    try:
+        DmintState.from_script(script)
+    except ValidationError:
+        return False
+    return True
+
+
 # ---------------------------------------------------------------------------
 # Extraction helpers
 # ---------------------------------------------------------------------------
@@ -139,6 +176,20 @@ def extract_owner_pkh_from_ft_script(script: bytes) -> Hex20:
     if len(script) != 75 or not FT_SCRIPT_RE.match(script.hex()):
         raise ValidationError("Not a valid FT script")
     return Hex20(script[3:23])
+
+
+def extract_payload_hash_from_commit_script(script: bytes) -> bytes:
+    """Extract 32-byte payload hash from a commit script (NFT or FT variant)."""
+    if len(script) != 75 or not COMMIT_SCRIPT_RE.match(script.hex()):
+        raise ValidationError("Not a valid commit script")
+    return script[2:34]
+
+
+def extract_owner_pkh_from_commit_script(script: bytes) -> Hex20:
+    """Extract 20-byte owner PKH from a commit script (NFT or FT variant)."""
+    if len(script) != 75 or not COMMIT_SCRIPT_RE.match(script.hex()):
+        raise ValidationError("Not a valid commit script")
+    return Hex20(script[53:73])
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_glyph.py
+++ b/tests/test_glyph.py
@@ -473,6 +473,216 @@ class TestGlyphInspector:
         assert results[0].ref.txid == KNOWN_REF.txid
         assert results[0].ref.vout == KNOWN_REF.vout
 
+    def test_find_glyphs_populates_owner_pkh_for_nft(self):
+        nft_script = build_nft_locking_script(KNOWN_HEX20, KNOWN_REF)
+        results = GlyphInspector().find_glyphs(self._make_outputs(nft_script))
+        assert results[0].owner_pkh is not None
+        assert bytes(results[0].owner_pkh) == bytes(KNOWN_HEX20)
+
+    def test_find_glyphs_populates_owner_pkh_for_ft(self):
+        ft_script = build_ft_locking_script(KNOWN_HEX20, KNOWN_REF)
+        results = GlyphInspector().find_glyphs(self._make_outputs(ft_script))
+        assert results[0].owner_pkh is not None
+        assert bytes(results[0].owner_pkh) == bytes(KNOWN_HEX20)
+
+    def test_find_glyphs_classifies_dmint_contract_output(self):
+        from pyrxd.glyph.dmint import DmintDeployParams, build_dmint_contract_script
+
+        contract_ref = GlyphRef(txid="aa" * 32, vout=1)
+        token_ref = GlyphRef(txid="bb" * 32, vout=0)
+        params = DmintDeployParams(
+            contract_ref=contract_ref,
+            token_ref=token_ref,
+            max_height=1000,
+            reward=100,
+            difficulty=10,
+        )
+        script = build_dmint_contract_script(params)
+        results = GlyphInspector().find_glyphs(self._make_outputs(script))
+        assert len(results) == 1
+        assert results[0].glyph_type == "dmint"
+        # `ref` is the contract's own outpoint (the contract UTXO's identity).
+        assert results[0].ref == contract_ref
+        # The token this contract mints lives on the parsed dmint state.
+        assert results[0].dmint_state is not None
+        assert results[0].dmint_state.token_ref == token_ref
+        # No owner_pkh on dmint contracts (they're not P2PKH-locked).
+        assert results[0].owner_pkh is None
+
+    def test_find_glyphs_does_not_misclassify_ft_as_dmint(self):
+        """Regression: an FT lock script must NOT be picked up by the dmint
+        branch — that was the original confusion. is_ft_script wins first."""
+        ft_script = build_ft_locking_script(KNOWN_HEX20, KNOWN_REF)
+        results = GlyphInspector().find_glyphs(self._make_outputs(ft_script))
+        assert len(results) == 1
+        assert results[0].glyph_type == "ft"
+
+    def test_glyph_output_extra_fields_default_none(self):
+        """Existing callers constructing GlyphOutput with the original 5
+        positional args must still work — owner_pkh and dmint_state default."""
+        nft_script = build_nft_locking_script(KNOWN_HEX20, KNOWN_REF)
+        from pyrxd.glyph.inspector import GlyphOutput
+
+        out = GlyphOutput(
+            vout=0,
+            glyph_type="nft",
+            ref=KNOWN_REF,
+            metadata=None,
+            script=nft_script,
+        )
+        assert out.owner_pkh is None
+        assert out.dmint_state is None
+
+    def test_find_reveal_metadata_walks_all_inputs(self):
+        cbor_bytes, _ = encode_payload(NFT_METADATA)
+        suffix = build_reveal_scriptsig_suffix(cbor_bytes)
+        dummy_sig = bytes([0x47]) + bytes(71)
+        dummy_pubkey = bytes([0x21]) + bytes(33)
+        reveal_scriptsig = dummy_sig + dummy_pubkey + suffix
+        plain_scriptsig = dummy_sig + dummy_pubkey
+
+        # Reveal scriptSig at input index 2 — earlier inputs are plain P2PKH.
+        scriptsigs = [plain_scriptsig, plain_scriptsig, reveal_scriptsig]
+        result = GlyphInspector().find_reveal_metadata(scriptsigs)
+        assert result is not None
+        idx, metadata = result
+        assert idx == 2
+        assert metadata.name == NFT_METADATA.name
+
+    def test_find_reveal_metadata_returns_none_when_no_metadata(self):
+        dummy_sig = bytes([0x47]) + bytes(71)
+        dummy_pubkey = bytes([0x21]) + bytes(33)
+        plain = dummy_sig + dummy_pubkey
+        assert GlyphInspector().find_reveal_metadata([plain, plain]) is None
+
+    def test_find_reveal_metadata_returns_first_match(self):
+        cbor_bytes, _ = encode_payload(NFT_METADATA)
+        suffix = build_reveal_scriptsig_suffix(cbor_bytes)
+        dummy_sig = bytes([0x47]) + bytes(71)
+        dummy_pubkey = bytes([0x21]) + bytes(33)
+        reveal = dummy_sig + dummy_pubkey + suffix
+        # Two reveal scriptsigs — first match wins (input 0).
+        result = GlyphInspector().find_reveal_metadata([reveal, reveal])
+        assert result is not None
+        assert result[0] == 0
+
+
+# ---------------------------------------------------------------------------
+# 6b. Commit-script helpers + dmint classifier
+# ---------------------------------------------------------------------------
+
+
+class TestCommitScriptHelpers:
+    PAYLOAD_HASH = bytes(range(32))
+    OWNER_PKH_BYTES = bytes(range(40, 60))
+
+    def test_is_commit_script_accepts_nft_variant(self):
+        from pyrxd.glyph.script import build_commit_locking_script, is_commit_script
+
+        s = build_commit_locking_script(self.PAYLOAD_HASH, Hex20(self.OWNER_PKH_BYTES), is_nft=True)
+        assert is_commit_script(s.hex())
+
+    def test_is_commit_script_accepts_ft_variant(self):
+        from pyrxd.glyph.script import build_commit_locking_script, is_commit_script
+
+        s = build_commit_locking_script(self.PAYLOAD_HASH, Hex20(self.OWNER_PKH_BYTES), is_nft=False)
+        assert is_commit_script(s.hex())
+
+    def test_is_commit_nft_distinguishes_from_ft(self):
+        from pyrxd.glyph.script import (
+            build_commit_locking_script,
+            is_commit_ft_script,
+            is_commit_nft_script,
+        )
+
+        nft = build_commit_locking_script(self.PAYLOAD_HASH, Hex20(self.OWNER_PKH_BYTES), is_nft=True)
+        ft = build_commit_locking_script(self.PAYLOAD_HASH, Hex20(self.OWNER_PKH_BYTES), is_nft=False)
+        assert is_commit_nft_script(nft.hex())
+        assert not is_commit_nft_script(ft.hex())
+        assert is_commit_ft_script(ft.hex())
+        assert not is_commit_ft_script(nft.hex())
+
+    def test_is_commit_script_rejects_p2pkh(self):
+        from pyrxd.glyph.script import is_commit_script
+
+        p2pkh = (b"\x76\xa9\x14" + bytes(20) + b"\x88\xac").hex()
+        assert not is_commit_script(p2pkh)
+
+    def test_extract_payload_hash_round_trips(self):
+        from pyrxd.glyph.script import (
+            build_commit_locking_script,
+            extract_payload_hash_from_commit_script,
+        )
+
+        s = build_commit_locking_script(self.PAYLOAD_HASH, Hex20(self.OWNER_PKH_BYTES), is_nft=True)
+        assert extract_payload_hash_from_commit_script(s) == self.PAYLOAD_HASH
+
+    def test_extract_owner_pkh_round_trips(self):
+        from pyrxd.glyph.script import (
+            build_commit_locking_script,
+            extract_owner_pkh_from_commit_script,
+        )
+
+        s = build_commit_locking_script(self.PAYLOAD_HASH, Hex20(self.OWNER_PKH_BYTES), is_nft=False)
+        assert bytes(extract_owner_pkh_from_commit_script(s)) == self.OWNER_PKH_BYTES
+
+    def test_extract_payload_hash_rejects_non_commit(self):
+        from pyrxd.glyph.script import (
+            build_ft_locking_script,
+            extract_payload_hash_from_commit_script,
+        )
+
+        ft = build_ft_locking_script(KNOWN_HEX20, KNOWN_REF)
+        with pytest.raises(ValidationError, match="Not a valid commit script"):
+            extract_payload_hash_from_commit_script(ft)
+
+
+class TestIsDmintContractScript:
+    def _params(self) -> object:
+        from pyrxd.glyph.dmint import DmintDeployParams
+
+        return DmintDeployParams(
+            contract_ref=GlyphRef(txid="aa" * 32, vout=1),
+            token_ref=GlyphRef(txid="bb" * 32, vout=0),
+            max_height=1000,
+            reward=100,
+            difficulty=10,
+        )
+
+    def test_true_for_built_contract_script(self):
+        from pyrxd.glyph.dmint import build_dmint_contract_script
+        from pyrxd.glyph.script import is_dmint_contract_script
+
+        s = build_dmint_contract_script(self._params())
+        assert is_dmint_contract_script(s) is True
+
+    def test_false_for_p2pkh(self):
+        from pyrxd.glyph.script import is_dmint_contract_script
+
+        p2pkh = b"\x76\xa9\x14" + bytes(20) + b"\x88\xac"
+        assert is_dmint_contract_script(p2pkh) is False
+
+    def test_false_for_ft_lock_script(self):
+        """REGRESSION: the original user bug — an FT lock must NOT be classified
+        as a dmint contract output. They share neither length nor layout, but
+        defensive: confirm explicitly."""
+        from pyrxd.glyph.script import build_ft_locking_script, is_dmint_contract_script
+
+        ft = build_ft_locking_script(KNOWN_HEX20, KNOWN_REF)
+        assert is_dmint_contract_script(ft) is False
+
+    def test_false_for_empty(self):
+        from pyrxd.glyph.script import is_dmint_contract_script
+
+        assert is_dmint_contract_script(b"") is False
+
+    def test_false_for_truncated_dmint_script(self):
+        from pyrxd.glyph.dmint import build_dmint_contract_script
+        from pyrxd.glyph.script import is_dmint_contract_script
+
+        full = build_dmint_contract_script(self._params())
+        assert is_dmint_contract_script(full[:50]) is False
+
 
 # ---------------------------------------------------------------------------
 # 7. Builder


### PR DESCRIPTION
## Summary

Wires up classifier helpers and inspector branches that recognise script shapes pyrxd's library consumers couldn't previously distinguish:

- **dMint contract outputs** (`is_dmint_contract_script`) — the parser (`DmintState.from_script`) already existed; this just hooks it into the inspector.
- **Commit outputs** (`is_commit_script`, `is_commit_nft_script`, `is_commit_ft_script`, plus `extract_payload_hash_from_commit_script` and `extract_owner_pkh_from_commit_script`) — the regexes existed but had no public predicates.
- **Owner PKH on FT/NFT outputs** — `GlyphInspector.find_glyphs` was returning refs only, dropping the owner. Now populated.
- **`find_reveal_metadata`** — walks every input scriptSig (not just input 0 like the scanner) and reports which input carried the metadata.

`GlyphOutput` gains two optional fields (`owner_pkh`, `dmint_state`) with defaults so existing callers see no shape change.

## Why

Concrete user diagnostic from Discord: a token holder couldn't tell their **nine dMint contract UTXOs** apart from the **FT tokenRef** they were trying to construct. The data was already in pyrxd; the inspector just wasn't using it. With this change, library consumers can identify any Glyph script in one call, and the upcoming `pyrxd glyph inspect` CLI can build on it without further library work.

## Test plan

- [x] 19 new tests in `tests/test_glyph.py` covering: commit-script roundtrip (NFT and FT variants), payload-hash and owner-pkh extraction, dMint classifier (positive + negative + truncation + the **regression test** that an FT lock is NOT misclassified), `find_glyphs` dmint detection, `find_glyphs` owner_pkh population, GlyphOutput backwards compat, `find_reveal_metadata` walks all inputs.
- [x] Full suite: 2232 passed, 1 skipped.
- [x] `ruff check` + `ruff format --check` clean.
- [x] Coverage gate held at 86%.

## Next

PR-B (`pyrxd glyph inspect` CLI subcommand + electrumx fetch) will follow once this lands. Plan with security threat model + UX rules already produced; no library code remains to add.