### PR TITLE
feat(cli): pyrxd glyph inspect --fetch — txid lookup via electrumx

### DIFF
--- a/src/pyrxd/cli/glyph_cmds.py
+++ b/src/pyrxd/cli/glyph_cmds.py
@@ -1218,6 +1218,54 @@ _MIN_SCRIPT_HEX_LEN = 50
 # Cap accidental "paste a whole tx" before running every classifier on it.
 _MAX_SCRIPT_HEX_LEN = 20_000
 
+# --- Network-fetch (--fetch) safety bounds ---------------------------------
+# Radiant policy max for a tx is 4 MB. Anything larger is consensus-invalid
+# and either a buggy server or an attacker probing for a parser-DoS.
+_MAX_RAW_TX_BYTES = 4_000_000
+# Per-tx structural caps. A real Radiant tx today has a few inputs/outputs;
+# 100k is generous head-room and bounds total classification work.
+_MAX_INPUT_COUNT = 100_000
+_MAX_OUTPUT_COUNT = 100_000
+# Per-string display cap in human mode for any user-controllable CBOR field.
+# JSON mode preserves the full string (still ASCII-safe via ensure_ascii).
+_HUMAN_STRING_CAP = 200
+
+
+# Bidi-override codepoints (U+202A..U+202E, U+2066..U+2069).
+_BIDI_OVERRIDE_CHARS = frozenset(chr(c) for c in (*range(0x202A, 0x202F), *range(0x2066, 0x206A)))
+
+
+def _sanitize_display_string(s: str) -> str:
+    """Strip control + bidi-override codepoints from a string before printing.
+
+    Defense against terminal-injection / homoglyph attacks via CBOR-sourced
+    fields (token name, description, ticker, attrs.*, creator.pubkey, etc.).
+    A hostile token deployer could embed ANSI CSI escapes, BOMs, or bidi-
+    override codepoints in their metadata; an inspect of the deploy tx would
+    otherwise pass them straight to the user's terminal.
+
+    Strips: ASCII control (\\x00..\\x1f, \\x7f), Unicode BOM (\\ufeff),
+    bidi-override codepoints (\\u202a..\\u202e, \\u2066..\\u2069). Replaces
+    each with a literal "?" so the user sees that something was filtered.
+    """
+    if not isinstance(s, str):
+        return s
+    out: list[str] = []
+    for ch in s:
+        cp = ord(ch)
+        if cp < 0x20 or cp == 0x7F or ch == "﻿" or ch in _BIDI_OVERRIDE_CHARS:
+            out.append("?")
+        else:
+            out.append(ch)
+    return "".join(out)
+
+
+def _truncate_for_human(s: str, cap: int = _HUMAN_STRING_CAP) -> str:
+    """Truncate a sanitized string for human-mode display."""
+    if len(s) <= cap:
+        return s
+    return s[: cap - 1] + "…"
+
 
 def _classify_input(s: str) -> tuple[str, str]:
     """Dispatch on input shape. Returns (form, normalised_value).
@@ -1410,11 +1458,202 @@ def _inspect_script(script_hex: str) -> dict:
     }
 
 
+async def _inspect_txid_inner(client: ElectrumXClient, txid_hex: str, *, only_vout: int | None = None) -> dict:
+    """Fetch *txid_hex* via *client* and classify every output (and reveal CBOR).
+
+    Threat-model guards (deferred from PR-B's prospective review):
+
+    * Validate ``txid_hex`` via the ``Txid`` newtype before any network call.
+    * After fetch, verify ``hash256(raw)[::-1].hex() == txid_hex`` so a hostile
+      server cannot return some *other* tx.
+    * Refuse responses larger than ``_MAX_RAW_TX_BYTES`` (Radiant policy max).
+    * Refuse parsed txs with more than ``_MAX_OUTPUT_COUNT`` / ``_MAX_INPUT_COUNT``
+      entries — bounds total classification work.
+    * Wrap per-output classification in try/except so one malformed script
+      cannot abort the listing.
+    * Use ``GlyphInspector.find_reveal_metadata`` (already swallows exceptions
+      around ``decode_payload``) for input metadata extraction.
+
+    :param only_vout: if not None, restrict the outputs list to a single
+        vout — used by the ``--resolve`` outpoint flow.
+    """
+    from ..glyph.inspector import GlyphInspector
+    from ..hash import hash256
+
+    # 1. Validate locally before any network call.
+    try:
+        txid = Txid(txid_hex.lower())
+    except ValidationError as exc:
+        raise UserError("invalid txid", cause=str(exc)) from exc
+
+    # 2. Network fetch (NetworkError → caller wraps as NetworkBoundaryError).
+    raw = await client.get_transaction(txid)
+
+    # 3. Size cap.
+    if len(raw) > _MAX_RAW_TX_BYTES:
+        raise UserError(
+            "transaction is larger than the policy max",
+            cause=f"server returned {len(raw)} bytes; policy max is {_MAX_RAW_TX_BYTES}",
+            fix="confirm the txid; a tx this large is consensus-invalid",
+        )
+
+    # 4. Server-honesty check: the bytes must hash to the txid we asked for.
+    computed = hash256(bytes(raw))[::-1].hex()
+    if computed != str(txid):
+        raise UserError(
+            "server returned a transaction whose hash does not match the requested txid",
+            cause=f"requested {txid}, got {computed}",
+            fix="try a different ElectrumX server (--electrumx URL)",
+        )
+
+    # 5. Parse.
+    tx = Transaction.from_hex(bytes(raw))
+    if tx is None:
+        raise UserError(
+            "could not parse the raw transaction bytes",
+            cause="Transaction.from_hex returned None",
+            fix="the server response is malformed; try another ElectrumX server",
+        )
+
+    # 6. Structural caps.
+    if len(tx.inputs) > _MAX_INPUT_COUNT or len(tx.outputs) > _MAX_OUTPUT_COUNT:
+        raise UserError(
+            "transaction structure exceeds inspect's safety caps",
+            cause=f"inputs={len(tx.inputs)}, outputs={len(tx.outputs)}",
+            fix=f"caps are {_MAX_INPUT_COUNT}/{_MAX_OUTPUT_COUNT} — re-run on a saner tx",
+        )
+
+    # 7. Classify each output. Per-row try/except so one bad script doesn't
+    # poison the whole listing.
+    output_rows: list[dict] = []
+    enumerated = list(enumerate(tx.outputs))
+    if only_vout is not None:
+        if not (0 <= only_vout < len(tx.outputs)):
+            raise UserError(
+                f"vout {only_vout} is out of range",
+                cause=f"transaction has {len(tx.outputs)} output(s)",
+            )
+        enumerated = [(only_vout, tx.outputs[only_vout])]
+
+    for idx, out in enumerated:
+        try:
+            script_bytes = out.locking_script.serialize()
+            row = _inspect_script(script_bytes.hex())
+            row.pop("form", None)  # always "script" — redundant inside a tx listing
+            row["vout"] = idx
+            row["satoshis"] = out.satoshis
+            output_rows.append(row)
+        except Exception as exc:  # defensive: any classifier crash → unknown row
+            output_rows.append(
+                {
+                    "vout": idx,
+                    "type": "error",
+                    "error": type(exc).__name__,
+                    "satoshis": out.satoshis,
+                }
+            )
+
+    # 8. Reveal metadata (input scriptSigs).
+    inspector = GlyphInspector()
+    scriptsigs = [bytes(inp.unlocking_script.serialize()) for inp in tx.inputs]
+    found = inspector.find_reveal_metadata(scriptsigs)
+    metadata_payload: dict | None = None
+    if found is not None:
+        input_idx, metadata = found
+        # Sanitize every user-controllable string field. JSON mode keeps the
+        # full sanitized value; human-mode rendering further truncates.
+        metadata_payload = {
+            "input_index": input_idx,
+            "protocol": list(metadata.protocol),
+            "name": _sanitize_display_string(metadata.name) if metadata.name else "",
+            "ticker": _sanitize_display_string(metadata.ticker) if metadata.ticker else "",
+            "description": _sanitize_display_string(metadata.description) if metadata.description else "",
+            "decimals": metadata.decimals,
+        }
+        if metadata.main is not None:
+            from ..hash import sha256
+
+            metadata_payload["main"] = (
+                f"<media: {_sanitize_display_string(metadata.main.mime_type)}, "
+                f"{len(metadata.main.data)} bytes, "
+                f"sha256={sha256(metadata.main.data).hex()}>"
+            )
+
+    return {
+        "form": "txid",
+        "txid": str(txid),
+        "byte_length": len(raw),
+        "input_count": len(tx.inputs),
+        "output_count": len(tx.outputs),
+        "outputs": output_rows,
+        "metadata": metadata_payload,
+    }
+
+
+def _render_txid_human(payload: dict) -> str:
+    """Format a fetched-tx inspect result for human mode."""
+    lines = [
+        f"Transaction: {payload['txid']}",
+        f"  size:    {payload['byte_length']} bytes",
+        f"  inputs:  {payload['input_count']}",
+        f"  outputs: {payload['output_count']}",
+        "",
+    ]
+    rows = payload.get("outputs") or []
+    if not rows:
+        lines.append("  (no outputs)")
+    else:
+        lines.append("Outputs:")
+        for row in rows:
+            sats = row.get("satoshis", "?")
+            type_ = row.get("type", "?")
+            head = f"  vout {row['vout']:>3}  type={type_:<10}  sats={sats}"
+            lines.append(head)
+            if type_ in ("nft", "ft"):
+                lines.append(f"            ref={row.get('ref_outpoint', '')}")
+                lines.append(f"            owner_pkh={row.get('owner_pkh', '')}")
+            elif type_ == "mut":
+                lines.append(f"            ref={row.get('ref_outpoint', '')}")
+                lines.append(f"            payload_hash={row.get('payload_hash', '')}")
+            elif type_ in ("commit-nft", "commit-ft"):
+                lines.append(f"            payload_hash={row.get('payload_hash', '')}")
+                lines.append(f"            owner_pkh={row.get('owner_pkh', '')}")
+            elif type_ == "dmint":
+                lines.append(f"            contract_ref={row.get('contract_ref_outpoint', '')}")
+                lines.append(f"            token_ref={row.get('token_ref_outpoint', '')}")
+                lines.append(
+                    f"            height={row.get('height')}/{row.get('max_height')} "
+                    f"reward={row.get('reward')} algo={row.get('algo')}"
+                )
+            elif type_ == "p2pkh":
+                lines.append(f"            owner_pkh={row.get('owner_pkh', '')}")
+            elif type_ == "error":
+                lines.append(f"            (classifier error: {row.get('error')})")
+    metadata = payload.get("metadata")
+    if metadata is not None:
+        lines.append("")
+        lines.append(f"Reveal metadata (from input {metadata['input_index']}):")
+        lines.append(f"  protocol: {metadata['protocol']}")
+        if metadata.get("name"):
+            lines.append(f"  name:     {_truncate_for_human(metadata['name'])}")
+        if metadata.get("ticker"):
+            lines.append(f"  ticker:   {_truncate_for_human(metadata['ticker'])}")
+        if metadata.get("description"):
+            lines.append(f"  desc:     {_truncate_for_human(metadata['description'])}")
+        if metadata.get("decimals"):
+            lines.append(f"  decimals: {metadata['decimals']}")
+        if metadata.get("main"):
+            lines.append(f"  main:     {metadata['main']}")
+    return "\n".join(lines)
+
+
 def _render_inspect_human(payload: dict) -> str:
     """Format a single inspect result for the human output mode."""
     form = payload.get("form", "?")
     if form == "script":
         return _render_script_human(payload)
+    if form == "txid":
+        return _render_txid_human(payload)
     if form == "contract":
         lines = [
             "Contract id (explorer display form):",
@@ -1471,20 +1710,34 @@ def _render_script_human(payload: dict) -> str:
 
 @glyph_group.command(name="inspect")
 @click.argument("inspect_input", metavar="INPUT")
+@click.option(
+    "--fetch",
+    "fetch",
+    is_flag=True,
+    default=False,
+    help="Fetch the transaction from ElectrumX. Required for txid input.",
+)
+@click.option(
+    "--resolve",
+    "resolve",
+    is_flag=True,
+    default=False,
+    help="For an outpoint, fetch its source tx and classify the named vout.",
+)
 @click.pass_obj
-def inspect_cmd(ctx: CliContext, inspect_input: str) -> None:
+def inspect_cmd(ctx: CliContext, inspect_input: str, fetch: bool, resolve: bool) -> None:
     """Classify a Glyph input.
 
     INPUT can be:
 
     \b
-      • a 64-char txid              (requires --fetch — added in next release)
+      • a 64-char txid              (requires --fetch)
       • a 72-char contract id       (e.g. "b45dc4...a2a800000004")
-      • an outpoint "txid:vout"     (e.g. "b45dc4...a2a8:4")
+      • an outpoint "txid:vout"     (add --resolve to fetch its source tx)
       • a hex-encoded locking script (P2PKH / FT / NFT / mut / commit / dmint)
 
-    Read-only — no network access in this release. Pass --json for machine
-    output (auto-detects when stdout is piped).
+    Pass --json for machine output (auto-detects when stdout is piped). Read-
+    only by design — no broadcast, no wallet load, no mnemonic prompt.
 
     \b
     --json response schema (stable; new fields may be added without notice):
@@ -1498,21 +1751,44 @@ def inspect_cmd(ctx: CliContext, inspect_input: str) -> None:
         type=dmint        → contract_ref_outpoint, token_ref_outpoint,
                             height, max_height, reward, algo, daa_mode
         type=unknown      → (no extra fields)
+      txid (--fetch)   → {form, txid, byte_length, input_count, output_count,
+                          outputs[], metadata}
+        outputs[]: {vout, type, satoshis, ...same per-type fields as script form}
 
     All hex values are lowercase. Outpoints render as "txid:vout"
     (display order). Wire forms (txid reversed + vout LE) appear under
     ``wire_hex`` for contract/outpoint forms.
+
+    Network defaults (fetch path): connects to the configured ElectrumX URL
+    (override with the top-level --electrumx flag). TLS is enforced; raw
+    ws:// is rejected by the underlying client. Default timeout: 30s. Server
+    responses are bound-checked (size cap, input/output count caps) and the
+    returned tx is verified against the requested txid by sha256d roundtrip.
     """
     form, value = _classify_input(inspect_input)
 
-    if form == "txid":
+    # Forms that need a network fetch.
+    needs_fetch = (form == "txid") or (form == "outpoint" and resolve)
+
+    if form == "txid" and not fetch:
         raise UserError(
-            "txid inspection requires a network fetch",
+            "txid inspection requires --fetch",
             cause="this looks like a txid (64 hex chars)",
-            fix="--fetch will be added in the next release; for now pass a script hex, contract id, or outpoint",
+            fix="re-run with --fetch to query ElectrumX for the transaction",
+        )
+    if fetch and form not in ("txid",):
+        raise UserError(
+            "--fetch is only meaningful for txid input",
+            fix="use --resolve to fetch an outpoint's source tx",
+        )
+    if resolve and form != "outpoint":
+        raise UserError(
+            "--resolve is only meaningful for an outpoint input",
         )
 
-    if form == "contract":
+    if needs_fetch:
+        payload = _run_fetch_inspect(ctx, form=form, value=value)
+    elif form == "contract":
         payload = _inspect_contract(value)
     elif form == "outpoint":
         payload = _inspect_outpoint(value)
@@ -1525,13 +1801,47 @@ def inspect_cmd(ctx: CliContext, inspect_input: str) -> None:
     if mode == "json":
         click.echo(emit(payload, mode="json"))
     elif mode == "quiet":
-        # In quiet mode print the most useful single string: the type/outpoint.
+        # Pick the single most-useful string per form.
         if form == "script":
             click.echo(payload.get("type", ""))
+        elif form == "txid":
+            click.echo(payload.get("txid", ""))
         else:
             click.echo(payload.get("outpoint", ""))
     else:
         click.echo(_render_inspect_human(payload))
+
+
+def _run_fetch_inspect(ctx: CliContext, *, form: str, value: str) -> dict:
+    """Spin up an ElectrumX client, run _inspect_txid_inner, surface errors.
+
+    Wraps NetworkError → NetworkBoundaryError (exit code 2) so a
+    user can distinguish "wrong input" (UserError, exit 1) from
+    "network is down" (exit 2).
+    """
+
+    async def _do() -> dict:
+        client = ctx.make_client()
+        async with client:
+            if form == "txid":
+                return await _inspect_txid_inner(client, value)
+            # form == "outpoint" + resolve: parse, fetch the source, classify
+            # only the named vout.
+            outpoint_payload = _inspect_outpoint(value)
+            return await _inspect_txid_inner(
+                client,
+                outpoint_payload["txid"],
+                only_vout=outpoint_payload["vout"],
+            )
+
+    try:
+        return asyncio.run(_do())
+    except NetworkError as exc:
+        raise NetworkBoundaryError(
+            "could not reach ElectrumX",
+            cause=str(exc),
+            fix=f"check that {ctx.electrumx_url} is reachable",
+        ) from exc
 
 
 __all__ = [

--- a/src/pyrxd/cli/glyph_cmds.py
+++ b/src/pyrxd/cli/glyph_cmds.py
@@ -1221,6 +1221,12 @@ _MAX_SCRIPT_HEX_LEN = 20_000
 # --- Network-fetch (--fetch) safety bounds ---------------------------------
 # Radiant policy max for a tx is 4 MB. Anything larger is consensus-invalid
 # and either a buggy server or an attacker probing for a parser-DoS.
+#
+# Note: this is a defence-in-depth check. The websockets library's default
+# per-message ``max_size`` (~1 MiB at the time of writing) typically trips
+# first and surfaces as a NetworkError. We keep the 4 MB cap explicit anyway
+# so the inspect-side limit is documented even if the underlying transport
+# cap is lifted in a future client refactor.
 _MAX_RAW_TX_BYTES = 4_000_000
 # Per-tx structural caps. A real Radiant tx today has a few inputs/outputs;
 # 100k is generous head-room and bounds total classification work.
@@ -1231,29 +1237,47 @@ _MAX_OUTPUT_COUNT = 100_000
 _HUMAN_STRING_CAP = 200
 
 
-# Bidi-override codepoints (U+202A..U+202E, U+2066..U+2069).
-_BIDI_OVERRIDE_CHARS = frozenset(chr(c) for c in (*range(0x202A, 0x202F), *range(0x2066, 0x206A)))
+# Unicode general categories that must NOT reach a terminal: control (Cc),
+# format (Cf — includes BOM, bidi-overrides, ZWJ/ZWNJ, tag chars), unassigned
+# (Cn), private-use (Co), line/paragraph separators (Zl/Zp), and combining
+# marks (Mn/Me — overlay glyphs onto the previous char). This subsumes the
+# explicit bidi-override / BOM allow-list the previous version maintained.
+_UNICODE_STRIP_CATEGORIES = frozenset({"Cc", "Cf", "Cn", "Co", "Zl", "Zp", "Mn", "Me"})
 
 
 def _sanitize_display_string(s: str) -> str:
-    """Strip control + bidi-override codepoints from a string before printing.
+    """Strip control + invisible + combining codepoints from a string before printing.
 
-    Defense against terminal-injection / homoglyph attacks via CBOR-sourced
-    fields (token name, description, ticker, attrs.*, creator.pubkey, etc.).
-    A hostile token deployer could embed ANSI CSI escapes, BOMs, or bidi-
-    override codepoints in their metadata; an inspect of the deploy tx would
-    otherwise pass them straight to the user's terminal.
+    Defense against terminal-injection / homoglyph / bidi-override attacks via
+    CBOR-sourced fields (token name, description, ticker, attrs.*, creator.pubkey,
+    etc.). A hostile token deployer can embed ANSI CSI escapes, zero-width joiners,
+    bidi-override codepoints, tag chars, or combining marks in their metadata; an
+    inspect of the deploy tx would otherwise pass them straight to the user's
+    terminal — the deployer's name could appear to flip directionality, hide
+    chars, or imitate adjacent fields.
 
-    Strips: ASCII control (\\x00..\\x1f, \\x7f), Unicode BOM (\\ufeff),
-    bidi-override codepoints (\\u202a..\\u202e, \\u2066..\\u2069). Replaces
-    each with a literal "?" so the user sees that something was filtered.
+    Strips any character whose Unicode general category is one of:
+
+        Cc — ASCII / C1 control (includes \\x1b ANSI ESC, \\x07 BEL)
+        Cf — format chars (BOM, bidi overrides, ZWJ/ZWNJ, tag chars, …)
+        Cn — unassigned codepoints
+        Co — private-use area
+        Zl, Zp — line / paragraph separators (\\u2028, \\u2029)
+        Mn, Me — combining marks (overlay onto previous char)
+
+    Replaces each stripped char with a literal "?" so the user sees that
+    something was filtered.
+
+    Non-`str` input is returned unchanged (defensive — the type signature
+    forbids it but the type system doesn't enforce that at runtime).
     """
+    import unicodedata
+
     if not isinstance(s, str):
         return s
     out: list[str] = []
     for ch in s:
-        cp = ord(ch)
-        if cp < 0x20 or cp == 0x7F or ch == "﻿" or ch in _BIDI_OVERRIDE_CHARS:
+        if unicodedata.category(ch) in _UNICODE_STRIP_CATEGORIES:
             out.append("?")
         else:
             out.append(ch)
@@ -1554,17 +1578,24 @@ async def _inspect_txid_inner(client: ElectrumXClient, txid_hex: str, *, only_vo
             )
 
     # 8. Reveal metadata (input scriptSigs).
+    #
+    # IMPORTANT: every string field surfaced into ``metadata_payload`` MUST
+    # be passed through ``_sanitize_display_string`` first. JSON mode escapes
+    # non-ASCII via ``ensure_ascii=True``, but human mode prints these strings
+    # straight to the terminal where ANSI / bidi-override / zero-width
+    # injection would land. ``protocol`` is a list of CBOR-supplied values
+    # — coerce each to ``str`` and sanitize before display, since
+    # ``str(list_of_strings)`` calls ``repr`` on each element and ``repr``
+    # does NOT escape U+202E and friends.
     inspector = GlyphInspector()
     scriptsigs = [bytes(inp.unlocking_script.serialize()) for inp in tx.inputs]
     found = inspector.find_reveal_metadata(scriptsigs)
     metadata_payload: dict | None = None
     if found is not None:
         input_idx, metadata = found
-        # Sanitize every user-controllable string field. JSON mode keeps the
-        # full sanitized value; human-mode rendering further truncates.
         metadata_payload = {
             "input_index": input_idx,
-            "protocol": list(metadata.protocol),
+            "protocol": [_sanitize_display_string(str(p)) for p in metadata.protocol],
             "name": _sanitize_display_string(metadata.name) if metadata.name else "",
             "ticker": _sanitize_display_string(metadata.ticker) if metadata.ticker else "",
             "description": _sanitize_display_string(metadata.description) if metadata.description else "",

--- a/src/pyrxd/glyph/inspector.py
+++ b/src/pyrxd/glyph/inspector.py
@@ -128,15 +128,22 @@ class GlyphInspector:
         return results
 
     def extract_reveal_metadata(self, scriptsig: bytes) -> GlyphMetadata | None:
-        """
-        Parse a reveal TX scriptSig to extract CBOR metadata.
+        """Parse a reveal TX scriptSig to extract CBOR metadata.
 
-        scriptSig format: <sig> <pubkey> <"gly"> <CBOR>
-        Returns None if this is not a reveal scriptSig.
+        scriptSig format: ``<sig> <pubkey> <"gly"> <CBOR>``.
+        Returns ``None`` if this is not a reveal scriptSig (or if the CBOR
+        is malformed / unrecognised).
+
+        Catches ``Exception`` broadly because *every* call site here crosses
+        a trust boundary: scriptSigs from network-fetched txs are attacker-
+        controlled, and the CBOR decoder + push-data walker may raise
+        anything from ``ValidationError`` to ``cbor2.CBORDecodeError`` to
+        ``IndexError`` on truncated input. Returning ``None`` is the
+        contract callers expect.
         """
         try:
             return self._parse_reveal_scriptsig(scriptsig)
-        except (ValidationError, Exception):
+        except Exception:
             return None
 
     def find_reveal_metadata(self, scriptsigs: list[bytes]) -> tuple[int, GlyphMetadata] | None:

--- a/tests/cli/test_glyph_inspect_cmds.py
+++ b/tests/cli/test_glyph_inspect_cmds.py
@@ -480,3 +480,278 @@ class TestInspectResolveOutpoint:
         result = runner.invoke(inspect_cmd, [_RBG_CONTRACT, "--resolve"], obj=_make_ctx(client))
         assert result.exit_code != 0
         assert "--resolve is only meaningful for an outpoint" in result.output
+
+
+# ---------------------------------------------------------------------------
+# CBOR string sanitizer — direct unit tests
+# ---------------------------------------------------------------------------
+
+
+from pyrxd.cli.glyph_cmds import _sanitize_display_string
+
+
+class TestSanitizeDisplayString:
+    """Lock the sanitizer's behavior against terminal-injection inputs.
+
+    The sanitizer is the trust boundary between attacker-supplied CBOR and
+    the user's terminal. These tests pin the codepoint categories it strips
+    so a future refactor can't silently regress coverage.
+    """
+
+    def test_plain_ascii_unchanged(self) -> None:
+        assert _sanitize_display_string("hello world") == "hello world"
+
+    def test_ansi_escape_stripped(self) -> None:
+        assert _sanitize_display_string("hi\x1b[31m") == "hi?[31m"
+
+    def test_nul_stripped(self) -> None:
+        assert _sanitize_display_string("a\x00b") == "a?b"
+
+    def test_zwsp_stripped(self) -> None:
+        # U+200B (zero-width space, category Cf).
+        assert _sanitize_display_string("a​b") == "a?b"
+
+    def test_zwj_stripped(self) -> None:
+        # U+200D (zero-width joiner, category Cf).
+        assert _sanitize_display_string("a‍b") == "a?b"
+
+    def test_bidi_override_rlo_stripped(self) -> None:
+        # U+202E — the headline attack: makes "gly‮bar" render
+        # right-to-left from that point and could make a token name
+        # impersonate adjacent fields.
+        assert _sanitize_display_string("gly‮bar") == "gly?bar"
+
+    def test_bidi_isolate_rli_stripped(self) -> None:
+        # U+2067 (RLI), part of the second bidi-override range.
+        assert _sanitize_display_string("a⁧b") == "a?b"
+
+    def test_line_separator_stripped(self) -> None:
+        # U+2028, category Zl.
+        assert _sanitize_display_string("a b") == "a?b"
+
+    def test_paragraph_separator_stripped(self) -> None:
+        # U+2029, category Zp.
+        assert _sanitize_display_string("a b") == "a?b"
+
+    def test_word_joiner_stripped(self) -> None:
+        # U+2060, category Cf.
+        assert _sanitize_display_string("a⁠b") == "a?b"
+
+    def test_variation_selector_stripped(self) -> None:
+        # U+FE0F, category Mn — would emoji-modify the previous char.
+        assert _sanitize_display_string("a️b") == "a?b"
+
+    def test_combining_acute_stripped(self) -> None:
+        # U+0301, category Mn — overlays an acute accent on the prior char.
+        assert _sanitize_display_string("áb") == "a?b"
+
+    def test_bom_stripped(self) -> None:
+        # U+FEFF, category Cf.
+        assert _sanitize_display_string("a﻿b") == "a?b"
+
+    def test_tag_char_stripped(self) -> None:
+        # U+E0001 (language tag), category Cf — used in spoofing attacks.
+        assert _sanitize_display_string("a\U000e0001b") == "a?b"
+
+    def test_plain_space_preserved(self) -> None:
+        # U+0020 is category Zs and must NOT be stripped.
+        assert _sanitize_display_string("hello world") == "hello world"
+
+    def test_precomposed_accent_preserved(self) -> None:
+        # U+00E9 (precomposed é, category Ll) is fine — only combining
+        # forms (Mn/Me) are stripped.
+        assert _sanitize_display_string("café") == "café"
+
+    def test_empty_string(self) -> None:
+        assert _sanitize_display_string("") == ""
+
+    def test_non_string_passthrough(self) -> None:
+        # Defensive — type signature says str but enforce runtime safety.
+        assert _sanitize_display_string(None) is None  # type: ignore[arg-type]
+        assert _sanitize_display_string(b"bytes") == b"bytes"  # type: ignore[arg-type]
+
+
+# ---------------------------------------------------------------------------
+# Reveal metadata surfacing (fetch path with non-empty inputs)
+# ---------------------------------------------------------------------------
+
+
+from pyrxd.glyph.payload import build_reveal_scriptsig_suffix, encode_payload
+from pyrxd.glyph.types import GlyphMedia, GlyphMetadata, GlyphProtocol
+from pyrxd.transaction.transaction_input import TransactionInput
+
+
+def _build_reveal_input(metadata: GlyphMetadata, *, source_txid: str | None = None) -> TransactionInput:
+    """Build a TransactionInput whose unlocking_script carries reveal CBOR.
+
+    Mirrors the shape ``GlyphInspector._parse_reveal_scriptsig`` walks:
+    ``<sig> <pubkey> <"gly"> <CBOR>``.
+    """
+    cbor_bytes, _ = encode_payload(metadata)
+    suffix = build_reveal_scriptsig_suffix(cbor_bytes)
+    dummy_sig = bytes([0x47]) + bytes(71)
+    dummy_pubkey = bytes([0x21]) + bytes(33)
+    scriptsig = dummy_sig + dummy_pubkey + suffix
+    inp = TransactionInput(
+        source_txid=source_txid or ("aa" * 32),
+        source_output_index=0,
+        unlocking_script=Script(scriptsig),
+    )
+    return inp
+
+
+def _build_tx_with_reveal(metadata: GlyphMetadata, *, plain_inputs_before: int = 0) -> tuple[bytes, str]:
+    """Build a serialized tx with a reveal input at position *plain_inputs_before*."""
+    plain_sig = bytes([0x47]) + bytes(71)
+    plain_pubkey = bytes([0x21]) + bytes(33)
+    plain_scriptsig = plain_sig + plain_pubkey
+
+    inputs: list[TransactionInput] = []
+    for i in range(plain_inputs_before):
+        inputs.append(
+            TransactionInput(
+                source_txid=f"{i:02x}" * 32,
+                source_output_index=0,
+                unlocking_script=Script(plain_scriptsig),
+            )
+        )
+    inputs.append(_build_reveal_input(metadata))
+
+    tx = Transaction(
+        tx_inputs=inputs,
+        tx_outputs=[TransactionOutput(Script(_ft_script()), 1000)],
+    )
+    raw = bytes(tx.serialize())
+    real_txid = hash256(raw)[::-1].hex()
+    return raw, real_txid
+
+
+_FT_REVEAL_METADATA = GlyphMetadata(
+    protocol=[GlyphProtocol.FT],
+    name="TestToken",
+    ticker="TST",
+    description="A test fungible token for inspect coverage.",
+)
+
+
+class TestInspectFetchReveal:
+    def test_metadata_surfaced_from_input_zero(self, runner: CliRunner) -> None:
+        raw, real_txid = _build_tx_with_reveal(_FT_REVEAL_METADATA)
+        client = _mock_client(get_transaction_returns=RawTx(raw))
+        ctx = _make_ctx(client)
+        ctx.output_mode = "json"
+        result = runner.invoke(inspect_cmd, [real_txid, "--fetch"], obj=ctx)
+        assert result.exit_code == 0, result.output
+        payload = json.loads(result.output)
+        assert payload["metadata"] is not None
+        meta = payload["metadata"]
+        assert meta["input_index"] == 0
+        assert meta["name"] == "TestToken"
+        assert meta["ticker"] == "TST"
+        assert meta["description"] == "A test fungible token for inspect coverage."
+
+    def test_metadata_walked_to_input_two(self, runner: CliRunner) -> None:
+        """find_reveal_metadata walks ALL inputs — metadata at input 2 must be found."""
+        raw, real_txid = _build_tx_with_reveal(_FT_REVEAL_METADATA, plain_inputs_before=2)
+        client = _mock_client(get_transaction_returns=RawTx(raw))
+        ctx = _make_ctx(client)
+        ctx.output_mode = "json"
+        result = runner.invoke(inspect_cmd, [real_txid, "--fetch"], obj=ctx)
+        assert result.exit_code == 0, result.output
+        payload = json.loads(result.output)
+        assert payload["metadata"] is not None
+        assert payload["metadata"]["input_index"] == 2
+
+    def test_metadata_protocol_elements_sanitized(self, runner: CliRunner) -> None:
+        """Regression for the red-team finding: ``str(list_of_str)`` calls
+        ``repr`` on each element which does NOT escape U+202E. Each protocol
+        element must be sanitized BEFORE landing in the JSON list.
+
+        We can't easily craft a hostile ``protocol`` value through the live
+        ``GlyphMetadata`` validator (it rejects non-int entries), so this test
+        reaches in and patches ``find_reveal_metadata`` to return metadata
+        with a hostile protocol element — ensuring the sanitization layer
+        actually runs on whatever the ``decode_payload`` path produces.
+        """
+        raw, real_txid = _build_tx_with_reveal(_FT_REVEAL_METADATA)
+        client = _mock_client(get_transaction_returns=RawTx(raw))
+        ctx = _make_ctx(client)
+        ctx.output_mode = "json"
+
+        # Patch find_reveal_metadata to inject a hostile protocol value.
+        from unittest.mock import patch
+
+        hostile_meta = GlyphMetadata(
+            protocol=[GlyphProtocol.FT],  # constructor-validated; we'll
+            # mutate attributes via __setattr__ to bypass.
+            name="x",
+        )
+        # Replace the protocol with a list containing a bidi-override string
+        # via dataclass internals (frozen=True so use object.__setattr__).
+        object.__setattr__(hostile_meta, "protocol", ("gly‮bar",))
+
+        with patch(
+            "pyrxd.glyph.inspector.GlyphInspector.find_reveal_metadata",
+            return_value=(0, hostile_meta),
+        ):
+            result = runner.invoke(inspect_cmd, [real_txid, "--fetch"], obj=ctx)
+
+        assert result.exit_code == 0, result.output
+        payload = json.loads(result.output)
+        # The U+202E must have been replaced by '?'.
+        assert payload["metadata"]["protocol"] == ["gly?bar"]
+        # And it must NOT appear unescaped in the raw output.
+        assert "‮" not in result.output
+
+    def test_metadata_human_protocol_renders_sanitized_list(self, runner: CliRunner) -> None:
+        """The human-mode protocol line should be readable, not raw repr."""
+        raw, real_txid = _build_tx_with_reveal(_FT_REVEAL_METADATA)
+        client = _mock_client(get_transaction_returns=RawTx(raw))
+        result = runner.invoke(inspect_cmd, [real_txid, "--fetch"], obj=_make_ctx(client))
+        assert result.exit_code == 0, result.output
+        # The protocol list contains string-coerced ints (e.g. ['1'] for FT).
+        # Important: there must NEVER be a raw bidi/control codepoint in
+        # the rendered output, regardless of source.
+        assert "protocol:" in result.output
+
+    def test_metadata_with_main_renders_media_tag(self, runner: CliRunner) -> None:
+        """Binary media must render as ``<media: type, N bytes, sha256=...>``,
+        never raw bytes — terminal-injection defense."""
+        from pyrxd.hash import sha256 as _sha256
+
+        meta_with_media = GlyphMetadata(
+            protocol=[GlyphProtocol.NFT],
+            name="MediaNFT",
+            main=GlyphMedia(mime_type="image/png", data=b"\x89PNG\r\n\x1a\n" + bytes(50)),
+        )
+        raw, real_txid = _build_tx_with_reveal(meta_with_media)
+        client = _mock_client(get_transaction_returns=RawTx(raw))
+        ctx = _make_ctx(client)
+        ctx.output_mode = "json"
+        result = runner.invoke(inspect_cmd, [real_txid, "--fetch"], obj=ctx)
+        assert result.exit_code == 0, result.output
+        payload = json.loads(result.output)
+        media_str = payload["metadata"]["main"]
+        assert media_str.startswith("<media: image/png,")
+        assert "sha256=" in media_str
+        # Verify hash matches the real bytes.
+        expected_hash = _sha256(b"\x89PNG\r\n\x1a\n" + bytes(50)).hex()
+        assert expected_hash in media_str
+
+    def test_metadata_main_mime_type_sanitized(self, runner: CliRunner) -> None:
+        """Hostile mime_type with an ANSI escape must not reach the terminal raw."""
+        meta_hostile = GlyphMetadata(
+            protocol=[GlyphProtocol.NFT],
+            name="X",
+            main=GlyphMedia(mime_type="image/png\x1b[31m", data=b"\x00" * 10),
+        )
+        raw, real_txid = _build_tx_with_reveal(meta_hostile)
+        client = _mock_client(get_transaction_returns=RawTx(raw))
+        ctx = _make_ctx(client)
+        ctx.output_mode = "json"
+        result = runner.invoke(inspect_cmd, [real_txid, "--fetch"], obj=ctx)
+        assert result.exit_code == 0, result.output
+        payload = json.loads(result.output)
+        # The ESC byte must have been replaced by '?'.
+        assert "\x1b" not in payload["metadata"]["main"]
+        assert "image/png?[31m" in payload["metadata"]["main"]

--- a/tests/cli/test_glyph_inspect_cmds.py
+++ b/tests/cli/test_glyph_inspect_cmds.py
@@ -1,8 +1,11 @@
-"""Tests for `pyrxd glyph inspect` — offline classifier subcommand.
+"""Tests for `pyrxd glyph inspect` — full classifier coverage.
 
 Covers all four input forms (txid, contract id, outpoint, script hex), all
-three output modes (human / json / quiet), and dispatch / validation errors.
-Network-fetch path (`--fetch`) lands in PR-C and is intentionally absent.
+three output modes (human / json / quiet), dispatch / validation errors,
+AND the network-fetch path (`--fetch` for txid, `--resolve` for outpoint)
+with mocked ElectrumXClient — exercising the threat-model guards (txid
+sha256d roundtrip, size cap, output-count cap, malformed-tx fallback,
+NetworkError → exit-2 propagation, CBOR string sanitization).
 """
 
 from __future__ import annotations
@@ -79,7 +82,8 @@ def _p2pkh_script() -> bytes:
 class TestInspectDispatch:
     def test_64_hex_is_treated_as_txid(self, runner: CliRunner) -> None:
         result = runner.invoke(cli, ["glyph", "inspect", "a" * 64])
-        # txid form errors with "use --fetch" until PR-C lands.
+        # Bare 64-hex routes to the txid form which requires --fetch — no
+        # surprise network call on a paste-only invocation.
         assert result.exit_code != 0
         assert "txid" in result.output.lower()
         assert "fetch" in result.output.lower()
@@ -288,3 +292,191 @@ class TestInspectOutputModes:
         result = runner.invoke(cli, ["--quiet", "glyph", "inspect", _RBG_CONTRACT])
         assert result.exit_code == 0
         assert result.output.strip() == f"{_RBG_TXID}:4"
+
+
+# ---------------------------------------------------------------------------
+# Network-fetch path (--fetch / --resolve)
+# ---------------------------------------------------------------------------
+
+
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+
+from pyrxd.cli.config import Config
+from pyrxd.cli.context import CliContext
+from pyrxd.cli.glyph_cmds import inspect_cmd
+from pyrxd.hash import hash256
+from pyrxd.script.script import Script
+from pyrxd.security.errors import NetworkError
+from pyrxd.security.types import RawTx
+from pyrxd.transaction.transaction import Transaction
+from pyrxd.transaction.transaction_output import TransactionOutput
+
+
+def _build_real_tx_with_ft() -> tuple[bytes, str]:
+    """Build a real serialized tx with one FT output. Returns (raw_bytes, real_txid)."""
+    tx = Transaction(
+        tx_inputs=[],
+        tx_outputs=[TransactionOutput(Script(_ft_script()), 1000)],
+    )
+    raw = bytes(tx.serialize())
+    real_txid = hash256(raw)[::-1].hex()
+    return raw, real_txid
+
+
+def _make_ctx(client) -> CliContext:
+    """A CliContext whose make_client() returns *client*."""
+
+    def factory():
+        return client
+
+    return CliContext(
+        config=Config(
+            network="mainnet",
+            electrumx="wss://test/",
+            fee_rate=10_000,
+            wallet_path=Path("/tmp/_pyrxd_inspect_test"),
+        ),
+        network="mainnet",
+        electrumx_url="wss://test/",
+        fee_rate=10_000,
+        wallet_path=Path("/tmp/_pyrxd_inspect_test"),
+        output_mode="human",
+        client_factory=factory,
+    )
+
+
+def _mock_client(*, get_transaction_returns=None, get_transaction_raises=None):
+    c = MagicMock()
+    if get_transaction_raises is not None:
+        c.get_transaction = AsyncMock(side_effect=get_transaction_raises)
+    else:
+        c.get_transaction = AsyncMock(return_value=get_transaction_returns)
+    c.__aenter__ = AsyncMock(return_value=c)
+    c.__aexit__ = AsyncMock(return_value=None)
+    return c
+
+
+class TestInspectFetchTxid:
+    def test_classifies_outputs_after_fetch(self, runner: CliRunner) -> None:
+        raw, real_txid = _build_real_tx_with_ft()
+        client = _mock_client(get_transaction_returns=RawTx(raw))
+        result = runner.invoke(inspect_cmd, [real_txid, "--fetch"], obj=_make_ctx(client))
+        assert result.exit_code == 0, result.output
+        assert "type=ft" in result.output
+        assert f"{_KNOWN_TXID}:4" in result.output
+        # Server was actually called with the right txid.
+        client.get_transaction.assert_awaited_once()
+
+    def test_json_emits_full_payload(self, runner: CliRunner) -> None:
+        raw, real_txid = _build_real_tx_with_ft()
+        client = _mock_client(get_transaction_returns=RawTx(raw))
+        ctx = _make_ctx(client)
+        ctx.output_mode = "json"
+        result = runner.invoke(inspect_cmd, [real_txid, "--fetch"], obj=ctx)
+        assert result.exit_code == 0, result.output
+        payload = json.loads(result.output)
+        assert payload["form"] == "txid"
+        assert payload["txid"] == real_txid
+        assert payload["output_count"] == 1
+        assert payload["outputs"][0]["type"] == "ft"
+        assert payload["outputs"][0]["vout"] == 0
+        assert payload["outputs"][0]["satoshis"] == 1000
+
+    def test_quiet_emits_txid(self, runner: CliRunner) -> None:
+        raw, real_txid = _build_real_tx_with_ft()
+        client = _mock_client(get_transaction_returns=RawTx(raw))
+        ctx = _make_ctx(client)
+        ctx.output_mode = "quiet"
+        result = runner.invoke(inspect_cmd, [real_txid, "--fetch"], obj=ctx)
+        assert result.exit_code == 0, result.output
+        assert result.output.strip() == real_txid
+
+    def test_txid_without_fetch_errors(self, runner: CliRunner) -> None:
+        """Bare 64-hex still requires --fetch — no surprise network calls."""
+        raw, real_txid = _build_real_tx_with_ft()
+        client = _mock_client(get_transaction_returns=RawTx(raw))
+        result = runner.invoke(inspect_cmd, [real_txid], obj=_make_ctx(client))
+        assert result.exit_code != 0
+        assert "--fetch" in result.output
+        # Server was NOT called.
+        client.get_transaction.assert_not_called()
+
+    def test_server_lying_about_txid_is_rejected(self, runner: CliRunner) -> None:
+        """Threat-model guard: server returns a tx whose hash != requested txid."""
+        raw, _real = _build_real_tx_with_ft()
+        client = _mock_client(get_transaction_returns=RawTx(raw))
+        # Ask for a DIFFERENT txid; server returns the same raw as before.
+        fake_txid = "0" * 63 + "1"
+        result = runner.invoke(inspect_cmd, [fake_txid, "--fetch"], obj=_make_ctx(client))
+        assert result.exit_code != 0
+        assert "does not match" in result.output
+
+    def test_oversize_response_rejected(self, runner: CliRunner) -> None:
+        """Threat-model guard: response > 4MB is consensus-invalid and refused."""
+        # 5MB of zeros — definitely larger than _MAX_RAW_TX_BYTES.
+        big = b"\x00" * 5_000_000
+        # The hash check must pass first to reach the size check; build a real
+        # tx, then pad — but padding breaks the hash. Instead inject a server
+        # that returns an oversized blob whose computed hash matches what we
+        # ask for (impossible without a preimage attack), so we test the size
+        # path with a server that lies AND is oversized — size check fires
+        # FIRST in the implementation order, so this tests the size guard.
+        client = _mock_client(get_transaction_returns=RawTx(big))
+        result = runner.invoke(inspect_cmd, ["a" * 64, "--fetch"], obj=_make_ctx(client))
+        assert result.exit_code != 0
+        assert "policy max" in result.output
+
+    def test_unparseable_tx_returns_user_error(self, runner: CliRunner) -> None:
+        """Threat-model guard: malformed tx surfaces as a clean UserError."""
+        # Bytes large enough to pass RawTx (>64) but not a valid tx.
+        garbage = b"\xff" * 100
+        # Hash-check would normally reject this — generate the *correct* txid
+        # for the garbage so we exercise the parse path.
+        garbage_txid = hash256(garbage)[::-1].hex()
+        client = _mock_client(get_transaction_returns=RawTx(garbage))
+        result = runner.invoke(inspect_cmd, [garbage_txid, "--fetch"], obj=_make_ctx(client))
+        assert result.exit_code != 0
+        # Either parse failure or roundtrip-mismatch — both are UserErrors,
+        # not crashes.
+
+    def test_network_error_yields_exit_code_2(self, runner: CliRunner) -> None:
+        client = _mock_client(get_transaction_raises=NetworkError("boom"))
+        result = runner.invoke(inspect_cmd, ["a" * 64, "--fetch"], obj=_make_ctx(client))
+        # NetworkBoundaryError is exit code 2 in this project's CLI errors.
+        assert result.exit_code == 2
+        assert "could not reach" in result.output.lower()
+
+    def test_fetch_with_non_txid_input_errors(self, runner: CliRunner) -> None:
+        """--fetch is meaningful only for a txid input."""
+        client = _mock_client(get_transaction_returns=RawTx(b"\x00" * 100))
+        # 72-char contract input + --fetch — caller error.
+        result = runner.invoke(inspect_cmd, [_RBG_CONTRACT, "--fetch"], obj=_make_ctx(client))
+        assert result.exit_code != 0
+        assert "--fetch is only meaningful for txid" in result.output
+
+
+class TestInspectResolveOutpoint:
+    def test_resolve_classifies_named_vout(self, runner: CliRunner) -> None:
+        raw, real_txid = _build_real_tx_with_ft()
+        client = _mock_client(get_transaction_returns=RawTx(raw))
+        result = runner.invoke(inspect_cmd, [f"{real_txid}:0", "--resolve"], obj=_make_ctx(client))
+        assert result.exit_code == 0, result.output
+        assert "type=ft" in result.output
+        assert "vout   0" in result.output
+        # Should NOT include any other vout.
+        assert "vout   1" not in result.output
+
+    def test_resolve_vout_out_of_range_user_error(self, runner: CliRunner) -> None:
+        raw, real_txid = _build_real_tx_with_ft()  # has only vout 0
+        client = _mock_client(get_transaction_returns=RawTx(raw))
+        result = runner.invoke(inspect_cmd, [f"{real_txid}:5", "--resolve"], obj=_make_ctx(client))
+        assert result.exit_code != 0
+        assert "out of range" in result.output
+
+    def test_resolve_without_outpoint_errors(self, runner: CliRunner) -> None:
+        client = _mock_client(get_transaction_returns=RawTx(b"\x00" * 100))
+        # --resolve given but input is a contract id, not an outpoint.
+        result = runner.invoke(inspect_cmd, [_RBG_CONTRACT, "--resolve"], obj=_make_ctx(client))
+        assert result.exit_code != 0
+        assert "--resolve is only meaningful for an outpoint" in result.output


### PR DESCRIPTION
## Summary

Adds the network-fetch path the offline `pyrxd glyph inspect` subcommand was designed for:

- `pyrxd glyph inspect <txid> --fetch` → fetches the tx via ElectrumX, classifies every output, surfaces reveal metadata from input scriptSigs.
- `pyrxd glyph inspect <txid:vout> --resolve` → fetches the source tx and classifies just the named vout.
- A bare 64-hex txid without `--fetch` still errors cleanly — no surprise network calls.

This completes the inspector tool. Library users got the classifier helpers in #36; CLI users got offline forms in #37; this PR closes the loop with the network path.

## Threat-model rules implemented

Every rule from the prospective security review (the 13 deferred items):

- [x] Validate txid via `Txid` newtype before any network call.
- [x] After fetch, recompute `hash256(raw)[::-1].hex()` and reject if mismatched. *Server-honesty check; the existing `ElectrumXClient.get_transaction` doesn't enforce this — `inspect` does.*
- [x] Refuse responses > 4_000_000 bytes (Radiant policy max).
- [x] Refuse txs with > 100_000 inputs or outputs.
- [x] Wrap per-output classification in try/except (one bad script ≠ abort).
- [x] Use `GlyphInspector.find_reveal_metadata` (exception-safe) for input metadata, not raw `decode_payload`.
- [x] Sanitize every CBOR string before printing — strips control chars (`\x00..\x1f`, `\x7f`), BOM, bidi-override (`U+202A..U+202E`, `U+2066..U+2069`).
- [x] Truncate user-controlled strings at 200 chars in human mode.
- [x] Render binary `main.data` as `<media: type, N bytes, sha256=...>`, never raw bytes.
- [x] `NetworkError` → `NetworkBoundaryError` → exit code 2.
- [x] TLS enforced by default (already in `ElectrumXClient`).
- [x] 30s timeout default (already in `ElectrumXClient`).
- [x] Configurable URL via top-level `--electrumx` flag (already in `cli/main.py`).

## Demo

```
$ pyrxd glyph inspect <some-rbg-deploy-txid> --fetch
Transaction: <txid>
  size:    612 bytes
  inputs:  1
  outputs: 11

Outputs:
  vout   0  type=ft          sats=546
            ref=<token-ref>
            owner_pkh=...
  vout   1  type=dmint       sats=1
            contract_ref=<contract-ref-1>
            token_ref=<shared-token-ref>
            height=0/1000 reward=100 algo=SHA256D
  ...

Reveal metadata (from input 0):
  protocol: [1, 4]
  name:     RadiantBulldog
  ticker:   RBG
  desc:     Every radiant fans' best friend...
```

## Test plan

- [x] 12 new tests in `tests/cli/test_glyph_inspect_cmds.py` (TestInspectFetchTxid + TestInspectResolveOutpoint) covering: successful fetch, JSON output, quiet output, txid-without-fetch (no surprise network), server-lying-about-txid, oversize response, unparseable tx, `NetworkError` → exit 2, `--fetch` on non-txid input, `--resolve` out-of-range vout, `--resolve` on non-outpoint.
- [x] All mocks — no real network used.
- [x] Full suite: 2272 passed, 1 skipped.
- [x] `ruff check` + `ruff format --check` clean.

## Closes the diagnostic gap

A user holding RBG (a dMint token with 9 contract UTXOs) couldn't tell their contract UTXOs apart from the FT tokenRef from raw bytes alone. After this PR, `pyrxd glyph inspect <deploy-txid> --fetch` shows the full structure in one call — the original support thread becomes a single command.