### PR TITLE
fix(glyph): parse V1 dMint contracts (the actual mainnet format)

### DIFF
--- a/src/pyrxd/cli/glyph_cmds.py
+++ b/src/pyrxd/cli/glyph_cmds.py
@@ -1400,6 +1400,7 @@ def _inspect_script(script_hex: str) -> dict:
     return {
         **base,
         "type": "dmint",
+        "version": "v1" if state.is_v1 else "v2",
         "contract_ref_outpoint": f"{state.contract_ref.txid}:{state.contract_ref.vout}",
         "token_ref_outpoint": f"{state.token_ref.txid}:{state.token_ref.vout}",
         "height": state.height,
@@ -1458,10 +1459,15 @@ def _render_script_human(payload: dict) -> str:
         body.append(f"  owner_pkh:    {payload['owner_pkh']}")
         body.append("  (payload_hash is an opaque commitment to the reveal-tx CBOR)")
     elif type_ == "dmint":
+        version = payload.get("version", "?")
+        body.append(f"  version:      dMint {version}")
         body.append(f"  contract_ref: {payload['contract_ref_outpoint']}")
         body.append(f"  token_ref:    {payload['token_ref_outpoint']}")
         body.append(f"  height:       {payload['height']} / {payload['max_height']}")
-        body.append(f"  reward:       {payload['reward']} photons")
+        body.append(f"  reward:       {payload['reward']} photons/mint")
+        # Total minted supply if all mints succeed.
+        total = payload["max_height"] * payload["reward"]
+        body.append(f"  total supply: {total:,} photons")
         body.append(f"  algo:         {payload['algo']}")
         body.append(f"  daa_mode:     {payload['daa_mode']}")
     elif type_ == "unknown":
@@ -1495,8 +1501,9 @@ def inspect_cmd(ctx: CliContext, inspect_input: str) -> None:
         type=nft / ft     → ref_txid, ref_vout, ref_outpoint, owner_pkh
         type=mut          → ref_txid, ref_vout, ref_outpoint, payload_hash
         type=commit-nft / commit-ft → payload_hash, owner_pkh
-        type=dmint        → contract_ref_outpoint, token_ref_outpoint,
-                            height, max_height, reward, algo, daa_mode
+        type=dmint        → version (v1|v2), contract_ref_outpoint,
+                            token_ref_outpoint, height, max_height, reward,
+                            algo, daa_mode
         type=unknown      → (no extra fields)
 
     All hex values are lowercase. Outpoints render as "txid:vout"

--- a/src/pyrxd/glyph/dmint.py
+++ b/src/pyrxd/glyph/dmint.py
@@ -545,9 +545,72 @@ def _decode_script_le_int(raw: bytes) -> int:
     return result
 
 
+# --- V1 dMint contract fingerprinting -------------------------------------
+#
+# V1 is the only variant deployed on Radiant mainnet today. Its 145-byte code
+# epilogue (starting at OP_STATESEPARATOR / 0xbd) is byte-identical across
+# all V1 deployments EXCEPT for one byte: the algo selector at offset 19
+# inside the epilogue (script-relative byte ~115, depending on state size).
+# That byte is one of:
+#   0xaa = OP_HASH256   → SHA256D
+#   0xee = OP_BLAKE3    → BLAKE3
+#   0xef = OP_K12       → K12
+# We fingerprint the epilogue with that one byte wildcarded.
+# Sources: docs/dmint-research-mainnet.md §2.2 (byte-by-byte decode of a
+# real mainnet V1 contract), §3 ("Common template" block, offsets 79+).
+
+_V1_EPILOGUE_PREFIX = bytes.fromhex("bd5175c0c855797ea8597959797ea87e5a7a7e")
+_V1_EPILOGUE_ALGO_OFFSET = 19  # offset INSIDE the epilogue (where the algo byte lives)
+_V1_EPILOGUE_SUFFIX = bytes.fromhex(
+    "bc01147f77587f040000000088"  # post-algo header through "load 4-byte zero, OP_EQUALVERIFY"
+    "817600a269a269"
+    "577ae500a069567ae600a069"
+    "01d053797e0cdec0e9aa76e378e4a269e69d7eaa"  # FT-CSH builder + canonical fingerprint
+    "76e47b9d"
+    "547a818b"
+    "76537a9c537ade789181547ae6939d"
+    "635279cd01d853797e016a7e88"
+    "67"
+    "78de519d547854807ec0eb557f777e"
+    "5379ec78885379eac0e9885379cc519d"
+    "7568"
+    "6d7551"
+)
+_V1_EPILOGUE_LEN = len(_V1_EPILOGUE_PREFIX) + 1 + len(_V1_EPILOGUE_SUFFIX)
+_V1_ALGO_BYTE_TO_ENUM: dict[int, DmintAlgo] = {
+    0xAA: DmintAlgo.SHA256D,
+    0xEE: DmintAlgo.BLAKE3,
+    0xEF: DmintAlgo.K12,
+}
+
+
+def _match_v1_epilogue(script: bytes, start: int) -> tuple[bool, DmintAlgo | None]:
+    """Return (matched, algo) for a V1 epilogue starting at *start*."""
+    if start + _V1_EPILOGUE_LEN > len(script):
+        return (False, None)
+    if script[start : start + len(_V1_EPILOGUE_PREFIX)] != _V1_EPILOGUE_PREFIX:
+        return (False, None)
+    algo_byte = script[start + _V1_EPILOGUE_ALGO_OFFSET]
+    algo = _V1_ALGO_BYTE_TO_ENUM.get(algo_byte)
+    if algo is None:
+        return (False, None)
+    suffix_start = start + _V1_EPILOGUE_ALGO_OFFSET + 1
+    if script[suffix_start : suffix_start + len(_V1_EPILOGUE_SUFFIX)] != _V1_EPILOGUE_SUFFIX:
+        return (False, None)
+    return (True, algo)
+
+
 @dataclass(frozen=True)
 class DmintState:
-    """Parsed V2 dMint contract state (from on-chain UTXO script)."""
+    """Parsed dMint contract state (from on-chain UTXO script).
+
+    Supports both V1 (the current Radiant mainnet format) and V2 (Photonic
+    Wallet's HEAD spec, not yet seen on mainnet). V1 has 6 state items;
+    V2 has 10. ``is_v1`` is True iff this state was parsed from V1 layout
+    — in which case ``target_time`` and ``last_time`` are not meaningful
+    on-chain values and are set to 0; ``daa_mode`` is always ``FIXED`` for
+    V1 (the V1 contract template has no DAA bytecode).
+    """
 
     height: int
     contract_ref: GlyphRef
@@ -559,6 +622,7 @@ class DmintState:
     target_time: int
     last_time: int
     target: int
+    is_v1: bool = False
 
     @property
     def is_exhausted(self) -> bool:
@@ -567,6 +631,31 @@ class DmintState:
     @classmethod
     def from_script(cls, script_bytes: bytes) -> DmintState:
         """Parse a dMint contract UTXO script into a ``DmintState``.
+
+        Tries V2 layout first (10 state items), falls back to V1 (6 items
+        + fingerprinted code epilogue). Raises ``ValidationError`` if the
+        script matches neither.
+
+        :param script_bytes: Raw script bytes from a dMint contract UTXO output.
+        :raises ValidationError: Script is malformed or matches neither V1
+            nor V2 layout.
+        """
+        # Try V2 first. If V2 raises, try V1; if V1 also raises, surface a
+        # combined error that names both attempts so callers don't have to
+        # guess which version they had.
+        try:
+            return cls._from_v2_script(script_bytes)
+        except ValidationError as v2_exc:
+            try:
+                return cls._from_v1_script(script_bytes)
+            except ValidationError as v1_exc:
+                raise ValidationError(
+                    f"DmintState.from_script: not a dMint contract (V2: {v2_exc}; V1: {v1_exc})"
+                ) from None
+
+    @classmethod
+    def _from_v2_script(cls, script_bytes: bytes) -> DmintState:
+        """Parse a V2 dMint contract (10 state items + ``bd``).
 
         Walks the 10 state pushes in declared order, then verifies that the
         next byte is ``OP_STATESEPARATOR`` (0xbd). Closes ultrareview
@@ -592,10 +681,6 @@ class DmintState:
           [9] target      — ``_push_minimal`` (may be large for 256-bit algos)
           —— OP_STATESEPARATOR (0xbd) ——
           (code section follows; not parsed here)
-
-        :param script_bytes: Raw script bytes from a dMint contract UTXO output.
-        :raises ValidationError: Script is malformed, too short, or missing
-            ``OP_STATESEPARATOR`` at the end of the 10-item state.
         """
         # Walk the full script — do NOT pre-slice on the first 0xbd. The
         # parser consumes exactly the bytes belonging to each push, so by
@@ -686,6 +771,93 @@ class DmintState:
             target_time=target_time,
             last_time=last_time,
             target=target,
+            is_v1=False,
+        )
+
+    @classmethod
+    def _from_v1_script(cls, script_bytes: bytes) -> DmintState:
+        """Parse a V1 dMint contract (the current mainnet format).
+
+        V1 has 6 state items plus a 145-byte fixed code epilogue (varying
+        only in the algo selector byte). Layout:
+
+          [0] height       — ``_push_4bytes_le`` (opcode 0x04 + 4 bytes LE)
+          [1] contractRef  — ``0xd8`` + 36-byte wire ref
+          [2] tokenRef     — ``0xd0`` + 36-byte wire ref
+          [3] maxHeight    — ``_push_minimal``
+          [4] reward       — ``_push_minimal``
+          [5] target       — full 8-byte push (``0x08`` + 8 LE bytes)
+          —— OP_STATESEPARATOR (0xbd) + 144-byte fixed code epilogue ——
+
+        ``daa_mode`` is always ``FIXED`` for V1 (V1 has no DAA bytecode).
+        ``target_time`` and ``last_time`` are V2-only and set to 0; the
+        ``is_v1`` flag is True so callers can ignore those fields.
+        """
+        pos = 0
+
+        # --- Item 0: height
+        if pos >= len(script_bytes) or script_bytes[pos] != 0x04:
+            raise ValidationError(
+                f"DmintState._from_v1_script: expected 0x04 (push-4) at pos {pos}, "
+                f"got 0x{(script_bytes[pos] if pos < len(script_bytes) else 0):02x}"
+            )
+        if pos + 5 > len(script_bytes):
+            raise ValidationError("DmintState._from_v1_script: script truncated inside height")
+        height = struct.unpack("<I", script_bytes[pos + 1 : pos + 5])[0]
+        pos += 5
+
+        # --- Item 1: contractRef
+        if pos >= len(script_bytes) or script_bytes[pos] != 0xD8:
+            raise ValidationError(f"DmintState._from_v1_script: expected 0xd8 at pos {pos}")
+        pos += 1
+        if pos + 36 > len(script_bytes):
+            raise ValidationError("DmintState._from_v1_script: script truncated inside contractRef")
+        contract_ref = GlyphRef.from_bytes(script_bytes[pos : pos + 36])
+        pos += 36
+
+        # --- Item 2: tokenRef
+        if pos >= len(script_bytes) or script_bytes[pos] != 0xD0:
+            raise ValidationError(f"DmintState._from_v1_script: expected 0xd0 at pos {pos}")
+        pos += 1
+        if pos + 36 > len(script_bytes):
+            raise ValidationError("DmintState._from_v1_script: script truncated inside tokenRef")
+        token_ref = GlyphRef.from_bytes(script_bytes[pos : pos + 36])
+        pos += 36
+
+        # --- Items 3-4: maxHeight and reward (variable-length pushes)
+        max_height, pos = _parse_script_int(script_bytes, pos)
+        reward, pos = _parse_script_int(script_bytes, pos)
+
+        # --- Item 5: target (V1 always uses an 8-byte push; never the
+        #     algoId/daaMode pushes V2 has).
+        if pos >= len(script_bytes) or script_bytes[pos] != 0x08:
+            raise ValidationError(f"DmintState._from_v1_script: expected 0x08 (push-8) for target at pos {pos}")
+        if pos + 9 > len(script_bytes):
+            raise ValidationError("DmintState._from_v1_script: script truncated inside target")
+        target = int.from_bytes(script_bytes[pos + 1 : pos + 9], "little")
+        pos += 9
+
+        # --- After 6 state items, fingerprint the V1 code epilogue. The
+        # epilogue is byte-identical across V1 deployments except for one
+        # algo selector byte; a successful fingerprint match is the
+        # discriminator that proves "this is a V1 contract" (rather than
+        # a script that happened to start with similar pushes).
+        matched, algo = _match_v1_epilogue(script_bytes, pos)
+        if not matched or algo is None:
+            raise ValidationError(f"DmintState._from_v1_script: code epilogue at pos {pos} does not match V1 template")
+
+        return cls(
+            height=height,
+            contract_ref=contract_ref,
+            token_ref=token_ref,
+            max_height=max_height,
+            reward=reward,
+            algo=algo,
+            daa_mode=DaaMode.FIXED,  # V1 contracts have no DAA bytecode
+            target_time=0,  # not encoded in V1
+            last_time=0,  # not encoded in V1
+            target=target,
+            is_v1=True,
         )
 
 

--- a/src/pyrxd/glyph/dmint.py
+++ b/src/pyrxd/glyph/dmint.py
@@ -584,20 +584,24 @@ _V1_ALGO_BYTE_TO_ENUM: dict[int, DmintAlgo] = {
 }
 
 
-def _match_v1_epilogue(script: bytes, start: int) -> tuple[bool, DmintAlgo | None]:
-    """Return (matched, algo) for a V1 epilogue starting at *start*."""
+def _match_v1_epilogue(script: bytes, start: int) -> DmintAlgo | None:
+    """Return the algo enum if a V1 epilogue starts at *start*, else ``None``.
+
+    Returning ``None`` means "not a V1 epilogue at this position." Callers
+    do not need to distinguish *which* check failed (length / prefix / algo
+    byte / suffix) — only "is this a V1 contract or not."
+    """
     if start + _V1_EPILOGUE_LEN > len(script):
-        return (False, None)
+        return None
     if script[start : start + len(_V1_EPILOGUE_PREFIX)] != _V1_EPILOGUE_PREFIX:
-        return (False, None)
-    algo_byte = script[start + _V1_EPILOGUE_ALGO_OFFSET]
-    algo = _V1_ALGO_BYTE_TO_ENUM.get(algo_byte)
+        return None
+    algo = _V1_ALGO_BYTE_TO_ENUM.get(script[start + _V1_EPILOGUE_ALGO_OFFSET])
     if algo is None:
-        return (False, None)
+        return None
     suffix_start = start + _V1_EPILOGUE_ALGO_OFFSET + 1
     if script[suffix_start : suffix_start + len(_V1_EPILOGUE_SUFFIX)] != _V1_EPILOGUE_SUFFIX:
-        return (False, None)
-    return (True, algo)
+        return None
+    return algo
 
 
 @dataclass(frozen=True)
@@ -842,8 +846,8 @@ class DmintState:
         # algo selector byte; a successful fingerprint match is the
         # discriminator that proves "this is a V1 contract" (rather than
         # a script that happened to start with similar pushes).
-        matched, algo = _match_v1_epilogue(script_bytes, pos)
-        if not matched or algo is None:
+        algo = _match_v1_epilogue(script_bytes, pos)
+        if algo is None:
             raise ValidationError(f"DmintState._from_v1_script: code epilogue at pos {pos} does not match V1 template")
 
         return cls(
@@ -1078,6 +1082,19 @@ def build_dmint_mint_tx(
 
     state = contract_utxo.state
 
+    # Reject V1 contracts explicitly. The mint builder rebuilds the output
+    # via ``build_dmint_state_script`` + ``build_dmint_code_script``, both of
+    # which emit V2 covenant code. Spending a V1 contract through this path
+    # would brick it (the recreated UTXO's covenant wouldn't accept the next
+    # mint), and the loss would be irreversible. Until pyrxd ships a V1
+    # contract builder, refuse loudly.
+    if state.is_v1:
+        raise ValidationError(
+            "build_dmint_mint_tx cannot mint V1 contracts; only V2 covenant code is "
+            "currently supported. Spending a V1 contract through this path would "
+            "produce a recreated UTXO whose covenant rejects the next mint, "
+            "irreversibly orphaning the remaining contract pool."
+        )
     if state.is_exhausted:
         raise ValidationError(f"dMint contract is exhausted: height={state.height} >= max_height={state.max_height}")
     if len(nonce) != 8:

--- a/tests/cli/test_glyph_inspect_cmds.py
+++ b/tests/cli/test_glyph_inspect_cmds.py
@@ -71,6 +71,22 @@ def _p2pkh_script() -> bytes:
     return b"\x76\xa9\x14" + bytes(range(20)) + b"\x88\xac"
 
 
+# Real V1 dmint contract from the RBG mainnet reveal tx
+# c5c296ebff5869c6e2b208ce0cd04be479a9f10d33cf73608f0a5efc2d6b55b6 vout 0.
+# 240 bytes; SHA256D + FIXED + max_height 6.75M + reward 6200.
+# See tests/test_glyph.py::TestV1DmintParser for the parser-level tests
+# against this same fixture.
+_RBG_DMINT_V1_HEX = (
+    "0400000000d8a8a296afde31eb80c3484f09da7eb31546990baf76fd8bff9a58fbbe53c45db4"
+    "01000000d0a8a296afde31eb80c3484f09da7eb31546990baf76fd8bff9a58fbbe53c45db4"
+    "000000000330ff66023818085c8fc2f5285c8f02bd5175c0c855797ea8597959797ea87e5a7a7eaa"
+    "bc01147f77587f040000000088817600a269a269577ae500a069567ae600a06901d053797e0c"
+    "dec0e9aa76e378e4a269e69d7eaa76e47b9d547a818b76537a9c537ade789181547ae6939d"
+    "635279cd01d853797e016a7e886778de519d547854807ec0eb557f777e5379ec78885379eac0e988"
+    "5379cc519d75686d7551"
+)
+
+
 # ---------------------------------------------------------------------------
 # Dispatch — _classify_input via the CLI surface
 # ---------------------------------------------------------------------------
@@ -242,6 +258,38 @@ class TestInspectScriptHex:
         assert "contract_ref" in result.output
         assert "token_ref" in result.output
         assert "height" in result.output
+        # PR #39 added the version field — V2 builder produces V2 layout.
+        assert "version:      dMint v2" in result.output
+
+    def test_classifies_v1_dmint_contract_human(self, runner: CliRunner) -> None:
+        """A real V1 contract from the RBG mainnet reveal must classify as
+        ``dmint`` and surface ``version: dMint v1`` plus the derived total
+        supply line."""
+        result = runner.invoke(cli, ["glyph", "inspect", _RBG_DMINT_V1_HEX])
+        assert result.exit_code == 0, result.output
+        assert "type: dmint" in result.output
+        assert "version:      dMint v1" in result.output
+        # max_height (6_750_000) × reward (6_200) = 41_850_000_000
+        assert "total supply: 41,850,000,000" in result.output
+        assert "algo:         SHA256D" in result.output
+        assert "daa_mode:     FIXED" in result.output
+
+    def test_classifies_v1_dmint_contract_json(self, runner: CliRunner) -> None:
+        """JSON form must include ``version`` for V1, and the dmint-specific
+        fields must round-trip through ``ensure_ascii=True`` cleanly."""
+        result = runner.invoke(cli, ["--json", "glyph", "inspect", _RBG_DMINT_V1_HEX])
+        assert result.exit_code == 0, result.output
+        payload = json.loads(result.output)
+        assert payload["type"] == "dmint"
+        assert payload["version"] == "v1"
+        assert payload["max_height"] == 6_750_000
+        assert payload["reward"] == 6_200
+        assert payload["algo"] == "SHA256D"
+        assert payload["daa_mode"] == "FIXED"
+        # contract_ref/token_ref outpoints are display-order strings.
+        rbg_txid = "b45dc453befb589aff8bfd76af0b994615b37eda094f48c380eb31deaf96a2a8"
+        assert payload["contract_ref_outpoint"] == f"{rbg_txid}:1"
+        assert payload["token_ref_outpoint"] == f"{rbg_txid}:0"
 
     def test_unknown_script_does_not_crash(self, runner: CliRunner) -> None:
         # 50 hex chars (25 bytes) of garbage that isn't P2PKH or any glyph form.

--- a/tests/test_glyph.py
+++ b/tests/test_glyph.py
@@ -838,6 +838,125 @@ class TestV1DmintParser:
         assert results[0].dmint_state is not None
         assert results[0].dmint_state.is_v1 is True
 
+    def test_v1_blake3_algo_byte_decodes(self):
+        """V1 supports three algo bytes — patch the RBG fixture to BLAKE3
+        (0xee) and confirm the parser picks it up."""
+        from pyrxd.glyph.dmint import DmintAlgo, DmintState
+
+        buf = bytearray(_RBG_DMINT_V1_VOUT_0)
+        # Algo selector lives at script offset 114 (= bd-position 95 + 19).
+        assert buf[114] == 0xAA  # sanity: fixture is SHA256D
+        buf[114] = 0xEE  # OP_BLAKE3
+        state = DmintState.from_script(bytes(buf))
+        assert state.is_v1 is True
+        assert state.algo is DmintAlgo.BLAKE3
+
+    def test_v1_k12_algo_byte_decodes(self):
+        """V1 K12 algo byte (0xef) parses correctly."""
+        from pyrxd.glyph.dmint import DmintAlgo, DmintState
+
+        buf = bytearray(_RBG_DMINT_V1_VOUT_0)
+        buf[114] = 0xEF  # OP_K12
+        state = DmintState.from_script(bytes(buf))
+        assert state.algo is DmintAlgo.K12
+
+    def test_combined_error_message_names_both_versions(self):
+        """When neither V2 nor V1 matches, the error message must surface
+        both attempted-version errors so callers don't have to guess which
+        version they had."""
+        from pyrxd.glyph.dmint import DmintState
+
+        p2pkh = b"\x76\xa9\x14" + bytes(20) + b"\x88\xac"
+        with pytest.raises(ValidationError) as excinfo:
+            DmintState.from_script(p2pkh)
+        msg = str(excinfo.value)
+        assert "V2:" in msg
+        assert "V1:" in msg
+        assert "not a dMint contract" in msg
+
+    def test_v1_guard_in_mint_builder(self):
+        """`build_dmint_mint_tx` must refuse V1 contracts loudly. Spending a
+        V1 contract through the V2 mint builder would brick the contract
+        pool — the guard converts an invisible foot-gun into a clear error."""
+        from pyrxd.glyph.dmint import DmintContractUtxo, DmintState, build_dmint_mint_tx
+
+        v1_state = DmintState.from_script(_RBG_DMINT_V1_VOUT_0)
+        assert v1_state.is_v1 is True
+        utxo = DmintContractUtxo(
+            txid="aa" * 32,
+            vout=0,
+            value=1,
+            script=_RBG_DMINT_V1_VOUT_0,
+            state=v1_state,
+        )
+        with pytest.raises(ValidationError, match="cannot mint V1 contracts"):
+            build_dmint_mint_tx(
+                contract_utxo=utxo,
+                nonce=b"\x00" * 8,
+                miner_pkh=bytes(20),
+                current_time=1_700_000_000,
+            )
+
+
+class TestV1MatchEpilogue:
+    """Direct unit tests for the ``_match_v1_epilogue`` helper.
+
+    The helper is internal but worth pinning directly so the tests don't
+    have to construct a full state-walk to exercise its boundaries.
+    """
+
+    def test_returns_algo_on_match(self):
+        from pyrxd.glyph.dmint import DmintAlgo, _match_v1_epilogue
+
+        # The RBG fixture's epilogue starts at offset 95.
+        algo = _match_v1_epilogue(_RBG_DMINT_V1_VOUT_0, 95)
+        assert algo is DmintAlgo.SHA256D
+
+    def test_returns_none_when_start_at_end(self):
+        from pyrxd.glyph.dmint import _match_v1_epilogue
+
+        assert _match_v1_epilogue(_RBG_DMINT_V1_VOUT_0, len(_RBG_DMINT_V1_VOUT_0)) is None
+
+    def test_returns_none_when_start_just_short(self):
+        """``start`` 1 byte before the real epilogue position must reject —
+        the epilogue prefix won't match at that offset."""
+        from pyrxd.glyph.dmint import _match_v1_epilogue
+
+        assert _match_v1_epilogue(_RBG_DMINT_V1_VOUT_0, 94) is None
+
+    def test_returns_none_when_remaining_bytes_too_short(self):
+        """If fewer than ``_V1_EPILOGUE_LEN`` bytes remain after ``start``,
+        the length guard must fire before any byte comparison."""
+        from pyrxd.glyph.dmint import _match_v1_epilogue
+
+        # Take only the first 100 bytes — not enough for a 145-byte epilogue.
+        truncated = _RBG_DMINT_V1_VOUT_0[:100]
+        assert _match_v1_epilogue(truncated, 0) is None
+
+    def test_returns_none_for_invalid_algo_byte(self):
+        from pyrxd.glyph.dmint import _match_v1_epilogue
+
+        buf = bytearray(_RBG_DMINT_V1_VOUT_0)
+        buf[114] = 0xAB  # not in {0xaa, 0xee, 0xef}
+        assert _match_v1_epilogue(bytes(buf), 95) is None
+
+    def test_returns_none_when_prefix_corrupted(self):
+        """One byte off in the fixed prefix region (offsets 95-113) must reject."""
+        from pyrxd.glyph.dmint import _match_v1_epilogue
+
+        buf = bytearray(_RBG_DMINT_V1_VOUT_0)
+        buf[100] = (buf[100] + 1) & 0xFF  # mid-prefix byte
+        assert _match_v1_epilogue(bytes(buf), 95) is None
+
+    def test_returns_none_when_suffix_corrupted(self):
+        """One byte off in the fixed suffix region must reject."""
+        from pyrxd.glyph.dmint import _match_v1_epilogue
+
+        buf = bytearray(_RBG_DMINT_V1_VOUT_0)
+        # Last byte of the script — well inside the suffix region.
+        buf[-1] = (buf[-1] + 1) & 0xFF
+        assert _match_v1_epilogue(bytes(buf), 95) is None
+
 
 # ---------------------------------------------------------------------------
 # 7. Builder

--- a/tests/test_glyph.py
+++ b/tests/test_glyph.py
@@ -685,6 +685,161 @@ class TestIsDmintContractScript:
 
 
 # ---------------------------------------------------------------------------
+# 6c. V1 dMint contract parser (real mainnet bytes from RBG)
+# ---------------------------------------------------------------------------
+
+# RBG ($RBG / RadiantBulldog) is a real dMint token deployed on Radiant
+# mainnet at block 228704. These three contract scripts come from the reveal
+# tx ``c5c296ebff5869c6e2b208ce0cd04be479a9f10d33cf73608f0a5efc2d6b55b6``
+# vouts 0, 5, and 9 respectively (three of the 10 dMint contracts spawned
+# by the reveal). They share an identical template — the only on-chain
+# difference is the contractRef vout (1, 6, and 10 respectively).
+#
+# Capturing real mainnet bytes is the strongest possible regression test:
+# if the V1 parser ever drifts from what's actually deployed, these tests
+# break.
+
+_RBG_DMINT_V1_VOUT_0 = bytes.fromhex(
+    "0400000000d8a8a296afde31eb80c3484f09da7eb31546990baf76fd8bff9a58fbbe53c45db4"
+    "01000000d0a8a296afde31eb80c3484f09da7eb31546990baf76fd8bff9a58fbbe53c45db4"
+    "000000000330ff66023818085c8fc2f5285c8f02bd5175c0c855797ea8597959797ea87e5a7a7eaa"
+    "bc01147f77587f040000000088817600a269a269577ae500a069567ae600a06901d053797e0c"
+    "dec0e9aa76e378e4a269e69d7eaa76e47b9d547a818b76537a9c537ade789181547ae6939d"
+    "635279cd01d853797e016a7e886778de519d547854807ec0eb557f777e5379ec78885379eac0e988"
+    "5379cc519d75686d7551"
+)
+_RBG_DMINT_V1_VOUT_5 = bytes.fromhex(
+    "0400000000d8a8a296afde31eb80c3484f09da7eb31546990baf76fd8bff9a58fbbe53c45db4"
+    "06000000d0a8a296afde31eb80c3484f09da7eb31546990baf76fd8bff9a58fbbe53c45db4"
+    "000000000330ff66023818085c8fc2f5285c8f02bd5175c0c855797ea8597959797ea87e5a7a7eaa"
+    "bc01147f77587f040000000088817600a269a269577ae500a069567ae600a06901d053797e0c"
+    "dec0e9aa76e378e4a269e69d7eaa76e47b9d547a818b76537a9c537ade789181547ae6939d"
+    "635279cd01d853797e016a7e886778de519d547854807ec0eb557f777e5379ec78885379eac0e988"
+    "5379cc519d75686d7551"
+)
+
+
+class TestV1DmintParser:
+    """Parse real on-chain V1 dMint bytes (the only format on Radiant today)."""
+
+    RBG_TXID = "b45dc453befb589aff8bfd76af0b994615b37eda094f48c380eb31deaf96a2a8"
+
+    def test_parses_real_rbg_contract(self):
+        from pyrxd.glyph.dmint import DaaMode, DmintAlgo, DmintState
+
+        state = DmintState.from_script(_RBG_DMINT_V1_VOUT_0)
+        assert state.is_v1 is True
+        assert state.contract_ref.txid == self.RBG_TXID
+        assert state.contract_ref.vout == 1
+        assert state.token_ref.txid == self.RBG_TXID
+        assert state.token_ref.vout == 0
+        assert state.height == 0
+        assert state.max_height == 6_750_000
+        assert state.reward == 6_200
+        assert state.algo is DmintAlgo.SHA256D
+        assert state.daa_mode is DaaMode.FIXED
+        # V1 fields that aren't encoded on-chain return sentinel zeros.
+        assert state.target_time == 0
+        assert state.last_time == 0
+
+    def test_contract_ref_vout_varies_across_slots(self):
+        """The 10 dmint contracts share template; only contractRef.vout differs."""
+        from pyrxd.glyph.dmint import DmintState
+
+        s0 = DmintState.from_script(_RBG_DMINT_V1_VOUT_0)
+        s5 = DmintState.from_script(_RBG_DMINT_V1_VOUT_5)
+        assert s0.contract_ref.vout == 1
+        assert s5.contract_ref.vout == 6
+        # Everything else is identical.
+        assert s0.token_ref == s5.token_ref
+        assert s0.max_height == s5.max_height
+        assert s0.reward == s5.reward
+        assert s0.algo == s5.algo
+
+    def test_total_supply_matches_rbg_disclosure(self):
+        """RBG total supply = max_height × reward = 41,850,000,000 photons."""
+        from pyrxd.glyph.dmint import DmintState
+
+        state = DmintState.from_script(_RBG_DMINT_V1_VOUT_0)
+        assert state.max_height * state.reward == 41_850_000_000
+
+    def test_dispatcher_falls_through_v2_to_v1(self):
+        """``DmintState.from_script`` tries V2 first, then V1. On V1 bytes
+        the V2 parser must raise ValidationError; the dispatcher must catch
+        that and successfully invoke V1 — never reach the user."""
+        from pyrxd.glyph.dmint import DmintState
+        from pyrxd.security.errors import ValidationError
+
+        # V2 parser raises directly on V1 bytes.
+        with pytest.raises(ValidationError):
+            DmintState._from_v2_script(_RBG_DMINT_V1_VOUT_0)
+        # But the dispatcher returns successfully.
+        assert DmintState.from_script(_RBG_DMINT_V1_VOUT_0).is_v1 is True
+
+    def test_is_dmint_contract_script_accepts_v1(self):
+        """REGRESSION: before this PR the classifier rejected every V1
+        contract on mainnet because it only knew about V2. Locks the fix."""
+        from pyrxd.glyph.script import is_dmint_contract_script
+
+        assert is_dmint_contract_script(_RBG_DMINT_V1_VOUT_0) is True
+        assert is_dmint_contract_script(_RBG_DMINT_V1_VOUT_5) is True
+
+    def test_v1_rejects_p2pkh(self):
+        """A plain P2PKH must not match V1 epilogue fingerprint."""
+        from pyrxd.glyph.dmint import DmintState
+        from pyrxd.security.errors import ValidationError
+
+        p2pkh = b"\x76\xa9\x14" + bytes(20) + b"\x88\xac"
+        with pytest.raises(ValidationError):
+            DmintState._from_v1_script(p2pkh)
+
+    def test_v1_rejects_ft_script(self):
+        """An FT lock starts with 76a9... — V1's first byte must be 0x04
+        (push-4 for height). FT must NOT match."""
+        from pyrxd.glyph.dmint import DmintState
+        from pyrxd.glyph.script import build_ft_locking_script
+        from pyrxd.security.errors import ValidationError
+
+        ft = build_ft_locking_script(KNOWN_HEX20, KNOWN_REF)
+        with pytest.raises(ValidationError):
+            DmintState._from_v1_script(ft)
+
+    def test_v1_rejects_corrupted_epilogue(self):
+        """Tweaking one byte of the V1 fingerprint must break the match."""
+        from pyrxd.glyph.dmint import DmintState
+        from pyrxd.security.errors import ValidationError
+
+        # Corrupt byte 100 (mid-epilogue, well inside the fingerprint region).
+        corrupted = bytearray(_RBG_DMINT_V1_VOUT_0)
+        corrupted[100] = (corrupted[100] + 1) & 0xFF
+        with pytest.raises(ValidationError):
+            DmintState._from_v1_script(bytes(corrupted))
+
+    def test_v1_rejects_wrong_algo_byte(self):
+        """The algo byte must be 0xaa, 0xee, or 0xef — anything else fails."""
+        from pyrxd.glyph.dmint import DmintState
+        from pyrxd.security.errors import ValidationError
+
+        # The algo selector is at offset 95+19 = 114 in the script
+        # (95 = position of OP_STATESEPARATOR; 19 = epilogue-relative offset).
+        corrupted = bytearray(_RBG_DMINT_V1_VOUT_0)
+        assert corrupted[114] == 0xAA  # confirm we're patching the right byte
+        corrupted[114] = 0x99  # not a valid algo selector
+        with pytest.raises(ValidationError):
+            DmintState._from_v1_script(bytes(corrupted))
+
+    def test_inspector_classifies_v1_in_find_glyphs(self):
+        """`find_glyphs` returns a `dmint`-typed entry for a real V1 contract."""
+        from pyrxd.glyph.inspector import GlyphInspector
+
+        results = GlyphInspector().find_glyphs([(1, _RBG_DMINT_V1_VOUT_0)])
+        assert len(results) == 1
+        assert results[0].glyph_type == "dmint"
+        assert results[0].dmint_state is not None
+        assert results[0].dmint_state.is_v1 is True
+
+
+# ---------------------------------------------------------------------------
 # 7. Builder
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

The dMint classifier landed in #36 only knows the V2 spec (10 state items). Every dMint deployment on Radiant mainnet today is **V1** (6 state items + a 145-byte fixed code epilogue), so the inspector classified every actual on-chain dMint contract as `unknown` — including all 10 contracts of the RBG token that prompted the inspect-tool series.

This PR adds V1 support without breaking V2.

## Surfaced live

Testing the v0.4-pre branch against RBG (Blademaster's deploy) revealed the bug:

```
$ pyrxd glyph inspect c5c296ebff5869c6e2b208ce0cd04be479a9f10d33cf73608f0a5efc2d6b55b6 --fetch
  outputs: 14
  vouts 0-9: type=unknown   ← every dmint contract slipping through
  vout 10:   type=ft  ref=b45dc4...:0  (the actual RBG tokenRef)
  vout 11-12: type=nft
```

After this PR, `find_glyphs` against the same tx classifies 13/14 outputs (10 dmint + 1 ft + 2 nft); the 14th is the change p2pkh which is correctly skipped. Each dmint slot reports `is_v1=True`, the right `contract_ref_vout` (1..10), and the `max_height=6_750_000`, `reward=6200` parameters that match RBG's published config.

## How

- Renames the existing V2 parser to `DmintState._from_v2_script` (preserves its behavior including the ultrareview N7 fix that walks pushes rather than slicing on the first `0xbd`).
- Adds `DmintState._from_v1_script` for V1: state = height (push-4), contractRef (`0xd8`), tokenRef (`0xd0`), maxHeight (push-min), reward (push-min), target (push-8). Then **fingerprints a 145-byte fixed code epilogue** with one byte wildcarded for the algo selector (`0xaa` = SHA256D, `0xee` = BLAKE3, `0xef` = K12). V1 always sets `daa_mode=FIXED`.
- Adds `is_v1: bool` field to `DmintState` so V1 callers know `target_time` / `last_time` are sentinel zeros, not on-chain values.
- `DmintState.from_script` becomes a dispatcher: try V2 first, fall back to V1, error message names both attempts. All public callers (`is_dmint_contract_script`, `find_glyphs`, the inspect CLI) inherit V1 support automatically.
- Surfaces `version: "v1" | "v2"` and a derived total supply (`max_height × reward`) in the inspect script form's JSON and human output.

## Tests

10 new in `TestV1DmintParser`, fixtures captured from a real RBG reveal tx (`c5c296eb...`):

- Real-world parse (RBG: contract_ref `b45dc4...:1`, token_ref `b45dc4...:0`, max_height 6.75M, reward 6200, SHA256D, FIXED)
- Contract_ref slot variation across the 10 contract vouts
- RBG total supply disclosure (41,850,000,000 photons)
- Dispatcher V2→V1 fallback (V2 raises on V1 bytes; dispatcher succeeds)
- `is_dmint_contract_script` accepts V1 — **regression test** for the bug
- V1 rejects p2pkh / FT / corrupted-fingerprint / wrong-algo-byte
- End-to-end via `find_glyphs`

## Test plan

- [x] 10 new V1 unit tests pass
- [x] Full suite: 2270 passed, 1 skipped, 22 deselected
- [x] `ruff check` + `ruff format --check` clean
- [x] Live mainnet smoke test: `find_glyphs` against the RBG reveal tx classifies 10 dmint contracts + 1 FT + 2 NFTs (was 0 + 1 + 2 before)

## Stacking note

This PR depends only on `main` (PR #36 + #37 merged). It's independent of PR #38 (the network `--fetch` path) — they touch different files. Either merge order works.