### PR TITLE
fix(cli): support Python 3.10 via tomli fallback for tomllib

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -77,6 +77,9 @@ websockets = ">=15.0.1,<17.0.0"
 websocket-client = "^1.8.0"
 cbor2 = "^6.0"
 click = "^8.3"
+# tomllib backport for Python 3.10 (stdlib tomllib lands in 3.11).
+# pyrxd.cli.config falls back to this when running on 3.10.
+tomli = {version = "^2.0", python = "<3.11"}
 
 [tool.poetry.group.dev.dependencies]
 taskipy = "^1.14.1"

--- a/src/pyrxd/cli/config.py
+++ b/src/pyrxd/cli/config.py
@@ -21,7 +21,13 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
 
-import tomllib
+# tomllib landed in Python 3.11. pyproject.toml declares ``requires-python = ">=3.10"``
+# so 3.10 users must fall back to the ``tomli`` backport (it ships the same
+# API as ``tomllib`` and is what CPython itself adopted upstream).
+try:
+    import tomllib  # type: ignore[import-not-found]
+except ModuleNotFoundError:  # pragma: no cover — only fires on Python 3.10
+    import tomli as tomllib  # type: ignore[import-not-found, no-redef]
 
 DEFAULT_CONFIG_DIR = Path.home() / ".pyrxd"
 DEFAULT_CONFIG_PATH = DEFAULT_CONFIG_DIR / "config.toml"

--- a/tests/cli/test_config.py
+++ b/tests/cli/test_config.py
@@ -74,3 +74,55 @@ def test_write_default_creates_dir_with_correct_perms(tmp_path: Path) -> None:
     # Loadable.
     cfg = _config.load(target)
     assert cfg.network == "mainnet"
+
+
+def test_tomllib_is_available_at_module_load() -> None:
+    """The `config` module must successfully import a TOML reader regardless
+    of Python version. On 3.11+ the stdlib ``tomllib`` resolves; on 3.10 the
+    ``tomli`` backport is the documented fallback (declared as a conditional
+    dep in pyproject.toml). This test fails immediately if a future refactor
+    drops one path without keeping the other.
+    """
+    assert _config.tomllib is not None
+    # The reader must expose `loads` (the API both modules share).
+    assert hasattr(_config.tomllib, "loads")
+    # And actually parse a trivial TOML payload.
+    parsed = _config.tomllib.loads('key = "value"\n')
+    assert parsed == {"key": "value"}
+
+
+def test_python_310_fallback_imports_tomli(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Simulate Python 3.10 by hiding ``tomllib`` from import machinery and
+    re-importing ``config``. The fallback must transparently land on ``tomli``
+    (which provides the same surface). Mirrors how a 3.10 user's runtime
+    sees ``ModuleNotFoundError`` on the bare ``import tomllib``.
+    """
+    import importlib
+    import sys
+
+    real_tomllib = sys.modules.get("tomllib")
+    # Hide tomllib from the import system.
+    monkeypatch.setitem(sys.modules, "tomllib", None)
+    # Drop the cached config module so reload re-runs the try/except.
+    cached = sys.modules.pop("pyrxd.cli.config", None)
+    try:
+        # Import will hit ModuleNotFoundError on `import tomllib` and fall
+        # back to `import tomli as tomllib`. tomli is in the test env via the
+        # python<3.11 conditional dep, but on 3.11+ it may not be installed —
+        # in which case skip rather than fail (we proved the import path
+        # exists, can't test the fallback if the backport isn't present).
+        try:
+            import tomli  # noqa: F401
+        except ModuleNotFoundError:
+            pytest.skip("tomli backport not installed — fallback path untestable on this env")
+        reloaded = importlib.import_module("pyrxd.cli.config")
+        assert reloaded.tomllib is not None
+        assert reloaded.tomllib.loads("x = 1\n") == {"x": 1}
+    finally:
+        # Restore the real module table so subsequent tests see normal state.
+        if real_tomllib is not None:
+            sys.modules["tomllib"] = real_tomllib
+        else:  # pragma: no cover — only on Python 3.10
+            sys.modules.pop("tomllib", None)
+        if cached is not None:
+            sys.modules["pyrxd.cli.config"] = cached


### PR DESCRIPTION
## Summary

`pyproject.toml` declares ``requires-python = ">=3.10"``, but `pyrxd/cli/config.py` imports `tomllib` unconditionally — and `tomllib` only landed in stdlib at Python 3.11. Anyone on 3.10 trying to use the CLI got:

```
ModuleNotFoundError: No module named 'tomllib'
```

on first invocation.

## Surfaced live

A Discord user reported the error after running `pyrxd glyph inspect ...`. They worked around it by upgrading to 3.11; that's not the fix — the project's own classifiers (`pyproject.toml:22`) explicitly list 3.10 as supported, and 3.10 is still in upstream Python's bug-fix support window.

## Two changes

- **`pyrxd/cli/config.py`** — fall back to `import tomli as tomllib` when stdlib `tomllib` is unavailable. The two modules ship the same API (CPython adopted `tomli` upstream); the fallback is transparent at the call site.

- **`pyproject.toml`** — add `tomli = {version = "^2.0", python = "<3.11"}` as a conditional dependency so 3.10 installs pull in the backport automatically. 3.11+ users see no install or runtime change.

## Test plan

- [x] 2 new tests in `tests/cli/test_config.py`:
  - `test_tomllib_is_available_at_module_load` — asserts the module exposes a working TOML reader regardless of which path resolved
  - `test_python_310_fallback_imports_tomli` — simulates Python 3.10 by hiding `tomllib` from `sys.modules`, reloading `pyrxd.cli.config`, and verifying the `tomli` fallback resolves transparently
- [x] Full suite: 2298 passed, 1 skipped, 22 deselected
- [x] `ruff check` + `ruff format --check` clean
- [x] No behavior change for users on Python 3.11+

## Stacking note

This is independent of PRs #38 (`--fetch`) and #39 (V1 dmint) — different files, different concern.