### PR TITLE
docs(glyph): explain Radiant FTs are on-chain + capture fuzzing strategy

### DIFF
--- a/docs/concepts/index.md
+++ b/docs/concepts/index.md
@@ -7,6 +7,7 @@ and how Radiant differs from related blockchains.
 :maxdepth: 1
 
 gravity
+radiant-fts-are-on-chain
 ```
 
 ## Available now
@@ -15,6 +16,11 @@ gravity
   Gravity protocol is, what a covenant is, and the difference between
   the mainnet-proven sentinel-artifact path and the experimental
   covenant variants. Read this before integrating `pyrxd.gravity`.
+- **[Radiant FTs are on-chain (not metadata-on-P2PKH)](radiant-fts-are-on-chain.md)** —
+  the most common confusion when porting from Atomicals / Runes / SPL
+  is to assume Radiant FTs are plain UTXOs with off-chain meaning. This
+  page explains the difference and shows the 75-byte FT script layout,
+  the conservation rule, and what wallet code has to filter for.
 
 ## Adjacent reading (not yet promoted to concept docs)
 

--- a/docs/concepts/radiant-fts-are-on-chain.md
+++ b/docs/concepts/radiant-fts-are-on-chain.md
@@ -1,0 +1,226 @@
+# Radiant FTs are on-chain (not metadata-on-P2PKH)
+
+**Why this page exists:** people coming from Bitcoin tokens (Atomicals, Runes,
+Ordinals) or Solana SPL often assume Radiant FTs work the same way — *plain
+UTXOs with off-chain meaning assigned by an indexer*. That model is wrong for
+Radiant. The script bytes **are** the token. This page explains the
+difference and what it means in practice.
+
+---
+
+## TL;DR
+
+A Radiant FT UTXO is a **75-byte locking script** with consensus-enforced
+token semantics. There is no off-chain indexer required to know what it is or
+how much it holds. Compare this to Atomicals / Runes / SPL tokens, where the
+on-chain UTXO is a plain P2PKH and an external database tracks "this UTXO
+holds 100 FOO."
+
+---
+
+## The two models, side by side
+
+|                                | ❌ NOT how Radiant FTs work                | ✅ How Radiant FTs ACTUALLY work       |
+|--------------------------------|--------------------------------------------|----------------------------------------|
+| **Examples of this model**     | Atomicals (BTC), Runes, Ordinals, Solana SPL | **Radiant Glyph FTs**, BCH CashTokens, BSV STAS |
+| **On-chain script**            | Plain P2PKH (25 bytes)                     | 75-byte FT lock script                 |
+| **Token semantics enforced by**| Off-chain indexer rules                    | Consensus opcodes (`OP_PUSHINPUTREF` family) |
+| **What "holds the token"**     | An indexer database row pointing at a UTXO | The UTXO's locking script bytes        |
+| **Wallet without protocol support** | Sees plain RXD/BTC; can spend the token away by accident | Sees a 75-byte script it can't unlock without the matching key — token is safe |
+| **Indexer goes down / disagrees** | Token "vanishes" (or worse, double-spend if indexer state diverges) | Doesn't matter — the chain is the source of truth |
+| **Where is the token amount stored?** | In the indexer's database                  | The output's `satoshis` field. **1 photon = 1 token unit.** |
+
+---
+
+## The 75-byte FT layout
+
+Every Radiant FT UTXO has this exact shape:
+
+```
+┌─ standard P2PKH (25 B) ─┐  ┌─ ref ──┐  ┌── FT-CSH epilogue (12 B) ─┐
+│                         │  │        │  │                            │
+76 a9 14 <pkh:20> 88 ac    bd d0 <ref:36>   de c0 e9 aa 76 e3 78 e4 a2 69 e6 9d
+▲                         ▲       ▲             ▲
+OP_DUP                    │       │             │
+OP_HASH160                │       │             │
+PUSH(20) <pkh>            │       │             │
+OP_EQUALVERIFY            │       │             │
+OP_CHECKSIG               │       │             │
+                          │       │             │
+                          │       │             Hashed by the dMint contract to enforce
+                          │       │             conservation: sum(input ft) == sum(output ft).
+                          │       │             This is the canonical "FT-CSH" fingerprint that
+                          │       │             pyrxd's classifier matches.
+                          │       │
+                          │       OP_PUSHINPUTREF <36-byte wire ref>
+                          │       (consensus opcode 0xd0; the ref is
+                          │        txid_LE_reversed + vout_LE = 36 bytes)
+                          │
+                          OP_STATESEPARATOR (0xbd)
+                          (marks the boundary between owner-spend logic
+                           and FT-conservation logic)
+```
+
+The first 25 bytes are a perfectly normal P2PKH — that's why a key holder can
+sign and spend the UTXO with a regular `<sig> <pubkey>` scriptSig. The next
+38 bytes (`bd d0 <ref:36>`) bind the UTXO to a specific token via consensus.
+The trailing 12 bytes are the conservation "fingerprint" — the dMint
+contract hashes them as part of enforcing `sum(input ft) == sum(output ft)`.
+
+**The ref is the token's permanent identity.** Every UTXO of the same FT
+encodes the same 36 bytes there. Different tokens have different refs.
+
+---
+
+## The conservation rule
+
+Every `OP_PUSHINPUTREF` (`0xd0`) ref appearing in any **output** script must
+also appear in some **input** being spent. This is enforced at consensus
+level by the Radiant node:
+
+```
+INPUTS                         OUTPUTS
+──────                         ───────
+[FT lock with ref=R]   ──→     [FT lock with ref=R]   ✓ ref R survives
+                               [FT lock with ref=R]   ✓ R can split
+
+[P2PKH only]           ──→     [FT lock with ref=R]   ✗ REJECTED
+                                                        R never came from input
+```
+
+When the rule is violated, the node rejects the broadcast with:
+
+```
+bad-txns-inputs-outputs-invalid-transaction-reference-operations
+```
+
+**Refs cannot be conjured from thin air — only carried forward.**
+
+This is why a transfer that funds itself from a plain P2PKH UTXO (regular
+RXD) and tries to produce an FT output **always fails**. The output declares
+"I carry ref R" but no input ever carried R. There's nothing wrong with the
+signature or the math; the chain refuses on principle.
+
+---
+
+## Wallets at one address can hold mixed UTXOs
+
+A typical Radiant wallet address holds **both** plain P2PKH UTXOs (regular
+RXD for fees) and FT lock UTXOs (token balances). They are different shapes
+at the same address:
+
+```
+Address ──┬── UTXO 1: P2PKH 25 bytes,     sats=39825 RXD     (RXD for fees)
+          ├── UTXO 2: FT 75 bytes,         sats=5_749_199    (RBG token balance)
+          ├── UTXO 3: P2PKH 25 bytes,      sats=1            (RXD dust)
+          └── UTXO 4: FT 75 bytes (different ref), sats=100  (a different FT)
+```
+
+Same address, four UTXOs, four different shapes/meanings. Your wallet
+scanner returns all of them. When transferring an FT, your code must filter
+to:
+
+1. UTXOs whose locking script is the 75-byte FT shape (`is_ft_script`)
+2. AND whose embedded ref matches the token you want to transfer
+   (`extract_ref_from_ft_script(...) == target_ref`)
+
+**Skipping that filter does not help.** Feeding a P2PKH UTXO into pyrxd's
+`FtUtxoSet` will produce a tx that violates the conservation rule above.
+The script-shape check that rejects "Not a valid FT script" is correct —
+it's protecting you from broadcasting a tx the network would reject.
+
+---
+
+## Implications for transfer code
+
+The canonical pattern, also implemented in
+[`examples/ft_transfer_demo.py`](../../examples/ft_transfer_demo.py):
+
+```python
+from pyrxd.glyph.script import is_ft_script, extract_ref_from_ft_script
+from pyrxd.network.electrumx import script_hash_for_address
+from pyrxd.security.types import Txid
+from pyrxd.transaction.transaction import Transaction
+
+ft_utxos = []
+raw_utxos = await client.get_utxos(script_hash_for_address(my_address))
+for u in raw_utxos:
+    raw = await client.get_transaction(Txid(u.tx_hash))
+    tx = Transaction.from_hex(bytes(raw))
+    script = tx.outputs[u.tx_pos].locking_script.serialize()
+
+    # Filter 1: must be a 75-byte FT lock (skip plain P2PKH RXD).
+    if not is_ft_script(script.hex()):
+        continue
+
+    # Filter 2: must be the token we want (skip other FTs).
+    if extract_ref_from_ft_script(script) != target_token_ref:
+        continue
+
+    # OK, this is a UTXO of the target FT.
+    ft_utxos.append(FtUtxo(
+        txid=u.tx_hash, vout=u.tx_pos, value=u.value,
+        ft_amount=u.value,                # 1 photon = 1 FT unit
+        ft_script=script,                 # bytes, 75 long
+    ))
+
+# Now feed ft_utxos into FtUtxoSet for transfer construction.
+```
+
+---
+
+## How to verify a UTXO is "actually FT-bearing"
+
+Use `pyrxd glyph inspect` against a tx to see exactly what each output is:
+
+```bash
+$ pyrxd glyph inspect <txid> --fetch
+Transaction: ...
+  vout 0  type=ft     ref=b45dc4...:0  sats=5         (FT — 5 RBG to recipient)
+  vout 1  type=ft     ref=b45dc4...:0  sats=9990      (FT — 9990 RBG change)
+  vout 2  type=p2pkh                    sats=39825 RXD (regular RXD change)
+```
+
+If a UTXO classifies as `type=p2pkh`, it is not an FT — the chain itself
+will not let you spend it as one regardless of what an off-chain tool tells
+you to do.
+
+---
+
+## Source-of-truth references
+
+- **Consensus opcodes.** `OP_PUSHINPUTREF` (`0xd0`),
+  `OP_PUSHINPUTREFSINGLETON` (`0xd8`), `OP_REQUIREINPUTREF` (`0xd1`),
+  `OP_REFTYPE_OUTPUT` (`0xda`), `OP_STATESEPARATOR` (`0xbd`). These are
+  Radiant-specific opcodes added by the node fork; they don't exist on
+  Bitcoin or BCH.
+- **Glyph protocol spec.** The 75-byte FT layout and the conservation
+  fingerprint `dec0e9aa76e378e4a269e69d` are defined by the Glyph
+  protocol (REP-3010 for V2 dMint).
+- **Classifier code.** [`src/pyrxd/glyph/script.py`](../../src/pyrxd/glyph/script.py)
+  has the regex (`FT_SCRIPT_RE`), constructor (`build_ft_locking_script`),
+  predicate (`is_ft_script`), and extractors
+  (`extract_ref_from_ft_script`, `extract_owner_pkh_from_ft_script`).
+- **Live evidence.** Three independent on-chain witnesses confirm the
+  75-byte form is the canonical FT shape: any FT premine output, any FT
+  transfer output, any dMint reward output. Run
+  `pyrxd glyph inspect <any-FT-tx-id> --fetch` to see the bytes yourself.
+
+---
+
+## When in doubt, trust the bytes
+
+If a tool, chatbot, or doc tells you Radiant FTs are "P2PKH outputs with
+metadata interpreted by an indexer," that tool is **describing a different
+protocol** (Atomicals / Runes / Ordinals / SPL — all of which use that
+model). Radiant is not that.
+
+Three things you can always check yourself:
+
+1. **The chain.** `pyrxd glyph inspect <txid> --fetch` will show you the
+   exact byte shape of every output. FT outputs are 75 bytes; P2PKH is 25.
+2. **The opcodes.** A 75-byte script with `bd d0` at offset 25-26 is an FT
+   lock. A 25-byte script ending `88 ac` is plain P2PKH.
+3. **The error.** If your transfer is rejected with
+   `bad-txns-inputs-outputs-invalid-transaction-reference-operations`,
+   you violated the conservation rule. There is no off-chain workaround.

--- a/docs/solutions/design-decisions/fuzzing-strategy-graduated-approach.md
+++ b/docs/solutions/design-decisions/fuzzing-strategy-graduated-approach.md
@@ -1,0 +1,174 @@
+---
+title: Fuzzing strategy — graduated approach (hypothesis → atheris → OSS-Fuzz)
+problem_type: design_decision
+component: pyrxd (testing strategy, parser hardening)
+status: planned
+date_captured: 2026-05-06
+tags: [fuzzing, testing, hypothesis, atheris, oss-fuzz, parsers, security]
+---
+
+## Context
+
+The dmint V1 classifier gap (see
+[`docs/solutions/logic-errors/dmint-v1-classifier-gap.md`](../logic-errors/dmint-v1-classifier-gap.md))
+surfaced because pyrxd's parser tests round-tripped a synthetic builder
+through the parser they were testing. That bug was *spec mismatch*, not
+*memory corruption / hang / crash on adversarial input*. The next class
+of parser bug — what fuzzing actually finds — is still latent in pyrxd's
+attacker-facing parser surface:
+
+- `Transaction.from_hex(bytes_from_electrumx_server)` — adversarial varints
+- `DmintState.from_script(bytes_from_some_output)` — adversarial state pushes
+- `decode_payload(cbor_bytes_from_attacker_reveal_tx)` — adversarial CBOR
+- `extract_reveal_metadata(scriptsig_bytes)` — adversarial scriptSig push-data
+- `GlyphRef.from_bytes` / `GlyphRef.from_contract_hex` — short-input edge cases
+
+Every one of these takes attacker-controllable bytes and walks them. They
+are exactly where fuzzing pays off.
+
+## What was decided
+
+A **graduated approach** rather than jumping straight to OSS-Fuzz. Three
+stages, each independently valuable, increasing in setup cost:
+
+### Stage 1 — `hypothesis` property tests (next session)
+
+`hypothesis` is already in the dev dependencies (`hypothesis = "^6.98.0"` in
+`pyproject.toml`). Property-based tests via `@hypothesis.given(binary())`
+provide ~80% of the fuzzing value with ~zero new infrastructure. They run
+inside the existing `pytest` invocation, surface failures as normal test
+output, and seed-shrink any failing input down to the minimum reproducer.
+
+**Targets and properties to assert:**
+
+| Function | Property |
+|---|---|
+| `Transaction.from_hex(arbitrary_bytes)` | Never crashes; either returns `None` or a `Transaction` instance. If it returns a `Transaction`, calling `.serialize()` does not crash. |
+| `DmintState.from_script(arbitrary_bytes)` | Never raises anything but `ValidationError` (defends the dispatcher contract). |
+| `DmintState._from_v1_script(arbitrary_bytes)` | Same — only `ValidationError`. |
+| `DmintState._from_v2_script(arbitrary_bytes)` | Same. |
+| `GlyphRef.from_bytes(arbitrary_bytes)` | Never raises anything but `ValidationError`. |
+| `GlyphRef.from_contract_hex(arbitrary_str)` | Never raises anything but `ValidationError`. |
+| `decode_payload(arbitrary_bytes)` | Never raises anything but `ValidationError` or `cbor2.CBORDecodeError`; for inputs > 64 KB the size cap fires before any CBOR walk. |
+| `extract_reveal_metadata(arbitrary_bytes)` | Never raises (returns `None` for unrecognised inputs — already documented invariant). |
+| `is_ft_script(arbitrary_str_of_hex)` / `is_nft_script` / `is_dmint_contract_script` | Never raises; always returns `bool`. |
+
+**Estimated cost:** ~50 LOC across `tests/property/test_parser_robustness.py`,
+~1-2 hours of work, runs in the existing pytest invocation.
+
+**Estimated value:** if any of these properties fail, that's a real
+crash-on-adversarial-input bug. Hypothesis will minimise the failing input
+to the smallest possible reproducer, making the fix and regression test
+trivial.
+
+### Stage 2 — `atheris` harnesses (when there's a free afternoon)
+
+`atheris` is Google's `libFuzzer`-based fuzzer for Python. It instruments
+imports for coverage feedback and runs at ~10k executions/sec on a single
+core. Compared to hypothesis:
+
+- Coverage-guided (mutates inputs that reached new branches)
+- Higher throughput (orders of magnitude more inputs per second)
+- Persists a corpus of "interesting" inputs across runs
+- Catches subtle bugs hypothesis's random generation misses
+
+**Targets:** the same parsers as Stage 1, but as standalone fuzz harnesses
+under `fuzz/`. Each harness is ~10-30 lines:
+
+```python
+# fuzz/fuzz_transaction_parse.py
+import sys
+import struct
+import atheris
+with atheris.instrument_imports():
+    from pyrxd.transaction.transaction import Transaction
+
+def TestOneInput(data: bytes) -> None:
+    try:
+        tx = Transaction.from_hex(data)
+        if tx is not None:
+            tx.serialize()
+    except (ValueError, IndexError, struct.error):
+        pass  # documented failure modes
+    # ANY OTHER exception is a bug.
+
+atheris.Setup(sys.argv, TestOneInput)
+atheris.Fuzz()
+```
+
+Run locally for hours/days; whenever a crash is found, atheris dumps the
+offending bytes. Add the bytes to `tests/property/corpus/` as a regression
+seed and fix the bug.
+
+**Estimated cost:** ~1 day initial setup (4-5 harnesses, dev-dep on
+`atheris`, optional seed corpus from real-mainnet fixtures).
+
+### Stage 3 — OSS-Fuzz integration (when pyrxd hits a v1.0 / security milestone)
+
+[OSS-Fuzz](https://github.com/google/oss-fuzz) is Google's free continuous
+fuzzing service. After Stage 2 harnesses exist, submitting them to OSS-Fuzz
+takes ~1 day (3 files: `build.sh`, `Dockerfile`, `project.yaml` in the
+OSS-Fuzz monorepo). After that:
+
+- Google runs the harnesses on their cluster, their CPUs, their bill
+- 90-day responsible-disclosure window on findings
+- Sanitizer-instrumented build catches memory errors and undefined behaviour
+- Auto-bisects to the introducing commit
+- Public coverage stats
+
+**Why not skip straight to Stage 3:** common mistake. Going to OSS-Fuzz
+before doing the cheap hypothesis wins floods you with shallow bugs that
+were obvious in retrospect. Stage 1 squashes those in a few hours; OSS-Fuzz
+then finds the deep bugs without noise.
+
+## What was rejected
+
+- **Going straight to OSS-Fuzz.** See above.
+- **One mega-harness covering all parsers.** Hypothesis's
+  `@hypothesis.given()` per-test-function model is the right granularity.
+  One harness per parser keeps failures localized.
+- **Custom mutators.** Both hypothesis and atheris generate inputs well
+  enough for our parsers. Adding format-aware mutators is premature
+  optimisation.
+- **Fuzzing the CBOR codec itself.** `cbor2` is upstream and already
+  fuzzed. Our exposure is the post-decode validation in
+  `decode_payload` — that's what we test.
+
+## Open questions for Stage 1 implementation
+
+- **Where do the property tests live?** Recommend `tests/property/` to
+  match the existing `tests/security/` (special-cased coverage gate)
+  and `tests/cli/` (sub-package layout) conventions.
+- **What's the failure budget?** Each property test should run for at
+  least ~200 generated inputs by default; raise via
+  `@settings(max_examples=...)` for the slow ones. Keep total runtime
+  under 30s so the existing test suite doesn't balloon.
+- **Should we ship the seed corpus?** Inline-as-bytes in the test file is
+  the project norm (see `_RBG_DMINT_V1_HEX` in
+  `tests/test_glyph.py::TestV1DmintParser`). A `tests/property/corpus/`
+  directory would only matter for atheris later.
+
+## Pointers for whoever picks this up
+
+- Already in dev deps: `hypothesis = "^6.98.0"` (`pyproject.toml` line ~88)
+- Existing hypothesis usage in pyrxd: search `tests/` for
+  `@hypothesis.given` to see the project's idiom.
+- Useful strategies for parser fuzzing:
+  - `binary(min_size=0, max_size=10_000)` — general byte fuzzing
+  - `binary(min_size=0, max_size=100)` — short-input edge cases
+  - `text(alphabet="0123456789abcdef")` — hex-string parsers
+  - `tuples(...)` to combine valid prefixes with random suffixes
+- The corrective rule from
+  [`docs/solutions/logic-errors/dmint-v1-classifier-gap.md`](../logic-errors/dmint-v1-classifier-gap.md)
+  applies: synthetic round-trips aren't enough — the property test must
+  also be exercised on real-mainnet bytes (use existing fixtures as
+  hypothesis seeds via the `@example()` decorator).
+
+## Related
+
+- [`docs/solutions/logic-errors/dmint-v1-classifier-gap.md`](../logic-errors/dmint-v1-classifier-gap.md) —
+  the bug that prompted thinking about fuzzing
+- Conversation context (May 6, 2026): the inspect-tool series PR chain
+  (#34-#43) hardened these parsers against many shapes of malformed
+  input via threat-model-driven security review. Fuzzing is the next
+  layer of the same defense.

--- a/src/pyrxd/glyph/script.py
+++ b/src/pyrxd/glyph/script.py
@@ -1,3 +1,101 @@
+"""Glyph script construction, classification, and extraction.
+
+Mental model — Radiant FTs are FIRST-CLASS, ON-CHAIN tokens
+==============================================================
+
+A common confusion (especially when LLMs answer questions about it) is to
+treat Radiant FTs as "metadata-on-P2PKH that an off-chain indexer
+interprets" — like Atomicals on Bitcoin, or Runes, or Solana SPL tokens.
+
+**That model is wrong for Radiant.** Radiant FTs are 75-byte locking
+scripts whose token semantics are enforced by consensus (the
+``OP_PUSHINPUTREF`` family of opcodes). The script bytes ARE the token.
+No external indexer is required to know "this UTXO holds N RBG" — the
+ref is encoded in the script and conservation is enforced by the chain.
+
+::
+
+   ┌──────────────────────────────────┬──────────────────────────────────┐
+   │ ❌ NOT how Radiant FTs work      │ ✅ How Radiant FTs ACTUALLY work │
+   │ (Atomicals / Runes / SPL / ord)  │ (Glyph protocol on Radiant)      │
+   ├──────────────────────────────────┼──────────────────────────────────┤
+   │                                  │                                  │
+   │   On-chain:                      │   On-chain:                      │
+   │     plain P2PKH (25 bytes)       │     75-byte FT locking script    │
+   │     76a914<pkh>88ac              │     76a914<pkh>88ac              │
+   │                                  │     bdd0<ref:36>                 │
+   │     ↓ off-chain indexer          │     dec0e9aa76e378e4a269e69d     │
+   │       assigns FT meaning         │                                  │
+   │   Off-chain database:            │   No external indexer needed:    │
+   │     "this UTXO holds 100 FOO"    │     consensus enforces FT rules  │
+   │                                  │     directly on the script bytes.│
+   │                                  │                                  │
+   │   Indexer disagreement / loss    │   No indexer. The token IS the   │
+   │   = the token "vanishes."        │   script bytes.                  │
+   └──────────────────────────────────┴──────────────────────────────────┘
+
+The 75-byte FT layout in detail
+-------------------------------
+
+::
+
+      ┌─ standard P2PKH (25 B) ─┐  ┌─ ref ──┐  ┌── FT-CSH epilogue (12 B) ─┐
+      │                         │  │        │  │                            │
+      76 a9 14 <pkh:20> 88 ac    bd d0 <ref:36>   de c0 e9 aa 76 e3 78 e4 a2 69 e6 9d
+      ▲                         ▲       ▲             ▲
+      OP_DUP                    │       │             │
+      OP_HASH160                │       │             │
+      PUSH(20) <pkh>            │       │             │
+      OP_EQUALVERIFY            │       │             │
+      OP_CHECKSIG               │       │             │
+                                │       │             │
+                                │       │             Hashed by the dMint contract
+                                │       │             to enforce conservation:
+                                │       │             sum(input ft) == sum(output ft)
+                                │       │
+                                │       OP_PUSHINPUTREF <36-byte wire ref>
+                                │       ─ wire ref = txid_LE_reversed + vout_LE
+                                │
+                                OP_STATESEPARATOR
+
+Conservation rule
+-----------------
+
+Every ``OP_PUSHINPUTREF`` (``0xd0``) ref appearing in any OUTPUT script
+must also appear in some INPUT being spent::
+
+      INPUTS                         OUTPUTS
+      ──────                         ───────
+      [FT lock with ref=R]   ──→     [FT lock with ref=R]   ✓ ref R survives
+                                     [FT lock with ref=R]   ✓ R can split
+
+      [P2PKH only]           ──→     [FT lock with ref=R]   ✗ REJECTED
+                                                              R never came from input
+
+The Radiant node enforces this with the consensus error
+``bad-txns-inputs-outputs-invalid-transaction-reference-operations``.
+Refs cannot be conjured from thin air — only carried forward.
+
+Wallets at a single address can hold mixed UTXO shapes
+------------------------------------------------------
+
+A typical wallet address holds **both** plain P2PKH UTXOs (regular RXD
+for fees) and FT lock UTXOs (token balances). They are different shapes
+at the same address::
+
+   Address ──┬── UTXO 1: P2PKH 25 bytes,   sats=39825 RXD     (RXD for fees)
+             ├── UTXO 2: FT 75 bytes,       sats=5_749_199    (RBG balance)
+             ├── UTXO 3: P2PKH 25 bytes,    sats=1            (RXD dust)
+             └── UTXO 4: FT 75 bytes (different ref), sats=100 (a different token)
+
+When transferring an FT, code must filter to only FT-shaped UTXOs whose
+embedded ref matches the target token. Skipping the ``is_ft_script(...)``
+filter and feeding a P2PKH UTXO into ``FtUtxoSet`` produces a tx that
+violates the conservation rule and is rejected by the network.
+
+See ``examples/ft_transfer_demo.py`` for the canonical filter pattern.
+"""
+
 from __future__ import annotations
 
 import hashlib


### PR DESCRIPTION
## Summary

Two related docs commits — both addressing recurring confusions surfaced during the inspect-tool diagnostic loop with a real user.

### Commit 1: explain Radiant FTs are on-chain (not metadata-on-P2PKH)

**Why:** A user (debugging an FT transfer in Discord) was told by ChatGPT "FT is NOT an extended script. It is a normal P2PKH output with FT metadata interpreted by higher-level rules (ElectrumX / indexer / protocol layer)." That advice would lead to broadcasting malformed transactions that fail consensus. GPT confused Radiant with Atomicals/Runes/Ordinals/SPL — different protocols where tokens *are* P2PKH-with-off-chain-meaning.

Two artifacts that establish the corrective claim:

- `docs/concepts/radiant-fts-are-on-chain.md` — full conceptual explainer with side-by-side comparison table, byte-layout diagram of the 75-byte FT script, conservation rule, mixed-UTXO-shapes example, canonical filter pattern, source-of-truth references. Renders cleanly on raw GitHub (shareable via direct link) AND on the Sphinx site (part of the published doc tree). Wired into `docs/concepts/index.md` for discoverability.
- `src/pyrxd/glyph/script.py` module-level docstring — same content in shorter form, embedded where library users actually look.

The corrective claim, defensible from three independent on-chain witnesses (any FT premine output, any FT transfer, any dMint reward): a Radiant FT UTXO is a 75-byte script of shape `76a914<pkh>88ac bdd0 <ref:36> dec0e9aa76e378e4a269e69d` with consensus-enforced ref conservation. Not 25-byte P2PKH.

### Commit 2: capture fuzzing strategy

**Why:** During the May 2026 security review of the inspect-tool PR chain (#34-#43), we decided on a graduated fuzzing approach but didn't have a place to capture it. Rather than relitigating the approach when picking up the work, this captures the spec.

`docs/solutions/design-decisions/fuzzing-strategy-graduated-approach.md` covers:

1. **Stage 1 — `hypothesis` property tests** (~50 LOC, 1-2 hours, uses hypothesis dev-dep already in `pyproject.toml`). Targets: `Transaction.from_hex`, `DmintState.from_script` (V1 + V2 + dispatcher), `GlyphRef.from_bytes`, `GlyphRef.from_contract_hex`, `decode_payload`, `extract_reveal_metadata`, `is_*_script` predicates. Catches ~80% of crash-on-adversarial-input bugs with zero new infrastructure.
2. **Stage 2 — `atheris` harnesses** (~1 day initial setup; coverage-guided libFuzzer). Higher throughput, persistent corpus.
3. **Stage 3 — OSS-Fuzz integration** (1 day initial, then free continuous fuzzing on Google's infra). Explicitly NOT step 1 — going there before the cheap hypothesis wins floods you with shallow bugs.

Plus what was rejected (custom mutators, mega-harness, fuzzing cbor2 itself) and open questions for stage 1 (test layout, runtime budget, seed corpus shape).

## Test plan

- [x] `ruff check` clean
- [x] `pytest tests/test_glyph.py` — 125 passed
- [x] Sphinx build renders the new page; no warnings on the new files
- [x] Markdown valid on raw GitHub render (tables, code blocks, internal links all GFM-compatible)
- [x] Pre-push CI: full suite green

## Stacking

Independent of any other open PRs.