### PR TITLE
feat(inspect): PR-A — plumbing for browser-hosted inspect tool

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -47,6 +47,39 @@ jobs:
           pip install -r docs/requirements.txt
           pip install -e .
 
+      - name: Build pyrxd wheel for the inspect page
+        # The browser-hosted inspect page (docs/inspect/) loads pyrxd at
+        # runtime from a wheel served alongside the page. This step builds
+        # that wheel from the same commit Sphinx is rendering, so the
+        # version the page imports always matches the docs the user is
+        # reading. The wheel + a small manifest.json (filename + git SHA)
+        # are placed into docs/inspect_static/inspect/wheels/, which sphinx-build then
+        # ships verbatim via html_extra_path.
+        # Tested smoke-load happens in tests/web/test_facade_smoke.py
+        # before this step in CI.
+        run: |
+          mkdir -p docs/inspect_static/inspect/wheels
+          pip wheel --wheel-dir docs/inspect_static/inspect/wheels --no-deps .
+          # Find the just-built wheel filename. There's exactly one because
+          # --no-deps was specified. The manifest tells the page which file
+          # to micropip.install at runtime.
+          wheel=$(ls docs/inspect_static/inspect/wheels/pyrxd-*.whl | head -1)
+          if [ -z "$wheel" ]; then
+            echo "::error::pip wheel produced no pyrxd wheel"
+            exit 1
+          fi
+          git_sha="${GITHUB_SHA:-unknown}"
+          cat > docs/inspect_static/inspect/wheels/manifest.json <<EOF
+          {
+            "wheel": "$(basename "$wheel")",
+            "git_sha": "${git_sha:0:7}",
+            "git_sha_full": "$git_sha"
+          }
+          EOF
+          echo "Wheel: $(basename "$wheel")"
+          echo "Manifest:"
+          cat docs/inspect_static/inspect/wheels/manifest.json
+
       - name: Build HTML
         run: sphinx-build -b html docs docs/_build/html
 

--- a/.gitignore
+++ b/.gitignore
@@ -71,6 +71,12 @@ instance/
 # Sphinx documentation
 docs/_build/
 
+# The inspect tool's wheel + manifest are produced by docs.yml CI on every
+# build (pip wheel ... + a small JSON manifest). They're shipped as part
+# of the deployed Pages artifact but never committed — the canonical
+# source of truth is the pyrxd Python source in src/.
+docs/inspect_static/inspect/wheels/
+
 # PyBuilder
 target/
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -70,6 +70,20 @@ intersphinx_mapping = {
 html_theme = "furo"
 html_title = f"pyrxd {version}"
 html_static_path = ["_static"]
+# ``html_extra_path`` directories have their *contents* copied verbatim
+# into the built site root without Sphinx parsing. We want the inspect
+# page to land at ``/inspect/index.html`` (not ``/index.html`` — that
+# would overwrite the docs landing page!), so the source path is
+# ``docs/inspect_static/`` and that directory contains exactly one
+# subfolder, ``inspect/``. Sphinx's contents-copy then reproduces
+# ``inspect/`` at the site root.
+#
+# The browser-hosted inspect tool lives at ``inspect_static/inspect/``
+# and loads Pyodide + imports pyrxd at runtime. The CI step that builds
+# the docs (``docs.yml``) additionally writes a wheel into
+# ``inspect_static/inspect/wheels/`` before ``sphinx-build`` runs, so
+# the page can install pyrxd-from-the-current-commit at runtime.
+html_extra_path = ["inspect_static"]
 html_theme_options = {
     "source_repository": "https://github.com/MudwoodLabs/pyrxd",
     "source_branch": "main",

--- a/docs/inspect_static/inspect/index.html
+++ b/docs/inspect_static/inspect/index.html
@@ -1,0 +1,101 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <meta name="referrer" content="no-referrer" />
+
+  <!-- Content-Security-Policy
+       default-src 'none'        — deny everything not whitelisted below
+       script-src 'self' 'wasm-unsafe-eval' 'unsafe-eval' https://cdn.jsdelivr.net
+                                — Pyodide loads from jsdelivr CDN with SRI; runs WASM.
+                                  'unsafe-eval' is required by Pyodide internals (it
+                                  uses eval() in the Python-to-JS bridge); cost is
+                                  documented in docs/threat-model.md.
+       style-src 'self'          — only our own CSS
+       connect-src 'self' https://cdn.jsdelivr.net wss://electrumx.radiant4people.com:50022
+                                — page-relative, the Pyodide CDN, and the one
+                                  ElectrumX server we trust. PR-3 wires the WS.
+       img-src 'self' data:      — favicons + inline data: URIs only
+       font-src 'self'           — bundled fonts only (none today)
+       base-uri 'none'           — block <base> tag injection
+       form-action 'none'        — no form posts
+       object-src 'none'         — no plugins
+       Note: frame-ancestors is intentionally absent — meta-tag CSP cannot
+       enforce it; documented as a known limitation. Read-only tool with no
+       keys; clickjacking has no payload to steal.
+  -->
+  <meta http-equiv="Content-Security-Policy" content="
+    default-src 'none';
+    script-src 'self' 'wasm-unsafe-eval' 'unsafe-eval' https://cdn.jsdelivr.net;
+    style-src 'self';
+    connect-src 'self' https://cdn.jsdelivr.net wss://electrumx.radiant4people.com:50022;
+    img-src 'self' data:;
+    font-src 'self';
+    base-uri 'none';
+    form-action 'none';
+    object-src 'none';
+  " />
+
+  <title>pyrxd inspect — Glyph script & transaction inspector</title>
+  <link rel="stylesheet" href="inspect.css" />
+</head>
+<body>
+  <header>
+    <h1>pyrxd <code>inspect</code></h1>
+    <p class="tagline">
+      Read-only diagnostic for Radiant Glyph scripts, contract ids, outpoints,
+      and transactions.
+      <a href="../concepts/radiant-fts-are-on-chain.html">What can I paste here?</a>
+    </p>
+  </header>
+
+  <main>
+    <section id="loading-status" aria-live="polite">
+      <p class="status">Loading <code>pyrxd</code> (one-time ~12 MB
+        download; cached for next time)…</p>
+      <progress id="load-progress" max="100" value="0"></progress>
+    </section>
+
+    <section id="ready-content" hidden>
+      <h2>Status</h2>
+      <pre id="version-block">(loading…)</pre>
+      <p class="note">
+        This page is the PR-1 plumbing checkpoint — it loads Pyodide, imports
+        <code>pyrxd</code>, and prints the version. The classifier UI lands in
+        the next PR. See
+        <a href="https://github.com/MudwoodLabs/pyrxd/pull/46">PR #46</a>
+        for the rollout plan.
+      </p>
+    </section>
+
+    <section id="error-content" hidden>
+      <h2>Could not load</h2>
+      <pre id="error-block"></pre>
+      <p class="note">
+        If this persists, please <a href="https://github.com/MudwoodLabs/pyrxd/issues/new">open an issue</a>
+        with the error text above.
+      </p>
+    </section>
+  </main>
+
+  <footer>
+    <p>
+      <span id="build-version">build: (loading)</span> ·
+      <a href="https://github.com/MudwoodLabs/pyrxd">source</a> ·
+      <a href="https://mudwoodlabs.github.io/pyrxd/">docs</a>
+    </p>
+  </footer>
+
+  <!-- Pyodide loaded from jsdelivr with Subresource Integrity (SRI).
+       The integrity hash and version are kept in sync via scripts/refresh-pyodide.sh
+       on maintainer bumps. If a CDN compromise serves different bytes, the
+       browser refuses to execute the script. -->
+  <script
+    src="https://cdn.jsdelivr.net/pyodide/v0.26.4/full/pyodide.js"
+    integrity="sha384-i3R37b3tF+HWudsUf1VSEOY2YxwSNMqY8DQa9Z0O3xh+NkJ9o+yjcGyIi5huj+nB"
+    crossorigin="anonymous"
+  ></script>
+  <script src="inspect.js" type="module"></script>
+</body>
+</html>

--- a/docs/inspect_static/inspect/inspect.css
+++ b/docs/inspect_static/inspect/inspect.css
@@ -1,0 +1,172 @@
+/* inspect.css — pyrxd inspect tool styling.
+   Mobile-first, single-column to ~960px, two-column on desktop.
+   Matches the Furo theme's general aesthetic (light prose, dark code blocks)
+   without depending on Furo CSS — we ship our own minimal stylesheet so the
+   inspect page renders identically whether Sphinx is available or not. */
+
+:root {
+  /* Okabe-Ito colorblind-safe palette for type badges. */
+  --color-ft: #0072b2;          /* blue */
+  --color-nft: #e69f00;         /* orange */
+  --color-mut: #cc79a7;         /* magenta */
+  --color-dmint: #d55e00;       /* vermillion */
+  --color-commit: #7a5195;      /* purple */
+  --color-p2pkh: #595959;       /* neutral grey */
+  --color-unknown: #f0e442;     /* yellow */
+
+  /* Theme defaults — light mode. */
+  --bg: #ffffff;
+  --fg: #1a1a1a;
+  --muted: #666666;
+  --border: #e0e0e0;
+  --code-bg: #f5f5f5;
+  --code-fg: #1a1a1a;
+  --error-bg: #fff5f5;
+  --error-fg: #c00;
+  --error-border: #c00;
+  --link: #0066cc;
+}
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    --bg: #1a1a1a;
+    --fg: #f0f0f0;
+    --muted: #999999;
+    --border: #333333;
+    --code-bg: #2a2a2a;
+    --code-fg: #f0f0f0;
+    --error-bg: #2a1a1a;
+    --error-fg: #ff6b6b;
+    --error-border: #ff6b6b;
+    --link: #66b3ff;
+  }
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html, body {
+  margin: 0;
+  padding: 0;
+  background: var(--bg);
+  color: var(--fg);
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto,
+               "Helvetica Neue", Arial, sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+}
+
+body {
+  max-width: 960px;
+  margin: 0 auto;
+  padding: 1rem;
+}
+
+header {
+  border-bottom: 1px solid var(--border);
+  padding-bottom: 1rem;
+  margin-bottom: 1.5rem;
+}
+
+header h1 {
+  margin: 0 0 0.5rem 0;
+  font-size: 1.75rem;
+  font-weight: 600;
+}
+
+header h1 code {
+  font-size: 1.5rem;
+  color: var(--color-ft);
+  background: none;
+  padding: 0;
+}
+
+.tagline {
+  margin: 0;
+  color: var(--muted);
+  font-size: 0.95rem;
+}
+
+main {
+  margin-bottom: 2rem;
+}
+
+section {
+  margin-bottom: 2rem;
+}
+
+section h2 {
+  font-size: 1.25rem;
+  margin: 0 0 0.75rem 0;
+}
+
+p.status {
+  margin: 0 0 0.5rem 0;
+  font-size: 0.95rem;
+}
+
+p.note {
+  font-size: 0.9rem;
+  color: var(--muted);
+  border-left: 3px solid var(--border);
+  padding-left: 0.75rem;
+  margin-top: 0.75rem;
+}
+
+progress {
+  width: 100%;
+  height: 0.5rem;
+  border: none;
+  border-radius: 4px;
+}
+
+code, pre {
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, "Liberation Mono",
+               "Consolas", monospace;
+  font-size: 0.9rem;
+}
+
+code {
+  background: var(--code-bg);
+  color: var(--code-fg);
+  padding: 0.1rem 0.35rem;
+  border-radius: 3px;
+}
+
+pre {
+  background: var(--code-bg);
+  color: var(--code-fg);
+  padding: 1rem;
+  border-radius: 6px;
+  overflow-x: auto;
+  white-space: pre-wrap;
+  word-break: break-all;
+  margin: 0;
+}
+
+a {
+  color: var(--link);
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
+#error-content pre {
+  background: var(--error-bg);
+  color: var(--error-fg);
+  border: 1px solid var(--error-border);
+}
+
+footer {
+  border-top: 1px solid var(--border);
+  padding-top: 1rem;
+  font-size: 0.85rem;
+  color: var(--muted);
+  text-align: center;
+}
+
+footer a {
+  color: var(--muted);
+}

--- a/docs/inspect_static/inspect/inspect.js
+++ b/docs/inspect_static/inspect/inspect.js
@@ -1,0 +1,153 @@
+// inspect.js — pyrxd inspect tool boot logic.
+//
+// PR-1 scope: load Pyodide, install the pyrxd wheel from the same-origin
+// `wheels/` directory, import pyrxd, print the version. The classifier
+// wiring lands in the next PR.
+//
+// Why a CDN with SRI instead of vendoring Pyodide in the repo:
+// vendoring ~12 MB of WASM blobs would inflate every clone forever and
+// committing pre-built binaries muddies provenance. The CDN-with-SRI
+// approach keeps the repo small and uses the browser's integrity check
+// as the audit trail — if jsdelivr ever serves bytes that don't match
+// the integrity hash in index.html, the browser refuses to execute.
+// The SRI hash is pinned by scripts/refresh-pyodide.sh and changes only
+// when a maintainer deliberately bumps the Pyodide version.
+
+"use strict";
+
+const STATUS_BLOCK = document.getElementById("loading-status");
+const PROGRESS = document.getElementById("load-progress");
+const READY_BLOCK = document.getElementById("ready-content");
+const VERSION_BLOCK = document.getElementById("version-block");
+const ERROR_BLOCK = document.getElementById("error-content");
+const ERROR_PRE = document.getElementById("error-block");
+const BUILD_VERSION = document.getElementById("build-version");
+
+// Same-origin URL where the pyrxd wheel is staged. Set by the docs.yml CI
+// step that runs ``pip wheel -w docs/inspect/wheels --no-deps .`` before
+// ``sphinx-build``. The wheel's filename embeds the version, so we discover
+// it at runtime via the `manifest.json` written next to it.
+const WHEELS_BASE = new URL("./wheels/", document.baseURI).toString();
+const WHEELS_MANIFEST = new URL("./manifest.json", WHEELS_BASE).toString();
+
+// Show an error in the UI, hide the progress UI.
+function showError(message) {
+  console.error(message);
+  STATUS_BLOCK.hidden = true;
+  ERROR_BLOCK.hidden = false;
+  // textContent only — never innerHTML — to defend against XSS via injected
+  // error strings (e.g. a hostile manifest.json with attacker bytes).
+  ERROR_PRE.textContent = String(message);
+}
+
+// Show the ready state with version info.
+function showReady(versionText, buildSha) {
+  STATUS_BLOCK.hidden = true;
+  READY_BLOCK.hidden = false;
+  VERSION_BLOCK.textContent = versionText;
+  if (buildSha) {
+    BUILD_VERSION.textContent = `build: ${buildSha}`;
+  }
+}
+
+// Update the loading progress bar (0–100).
+function setProgress(pct) {
+  if (PROGRESS) {
+    PROGRESS.value = Math.max(0, Math.min(100, pct));
+  }
+}
+
+// Fetch the wheel manifest. CI writes a small JSON file describing the
+// wheel filename and the source git SHA so the page can self-identify.
+async function loadManifest() {
+  setProgress(5);
+  try {
+    const resp = await fetch(WHEELS_MANIFEST, { cache: "no-cache" });
+    if (!resp.ok) {
+      throw new Error(`manifest HTTP ${resp.status}`);
+    }
+    return await resp.json();
+  } catch (err) {
+    throw new Error(
+      `Could not load wheel manifest from ${WHEELS_MANIFEST}: ${err.message}. ` +
+      `This usually means the docs CI step that builds the wheel failed.`
+    );
+  }
+}
+
+// Boot Pyodide and import pyrxd.
+async function boot() {
+  // Sanity-check that the Pyodide loader script ran (it adds `loadPyodide`
+  // to window). If the SRI check failed, this symbol won't exist.
+  if (typeof loadPyodide !== "function") {
+    showError(
+      "Pyodide failed to load. This is most often a Subresource Integrity " +
+      "mismatch (the CDN served bytes that don't match the pinned SHA-384 " +
+      "hash in index.html). Open the browser console for the underlying error."
+    );
+    return;
+  }
+
+  let manifest;
+  try {
+    manifest = await loadManifest();
+  } catch (err) {
+    showError(err.message);
+    return;
+  }
+
+  setProgress(15);
+
+  let pyodide;
+  try {
+    pyodide = await loadPyodide({
+      // Tell Pyodide where to find its WASM/stdlib resources. Default points
+      // back to the same CDN we loaded the loader from. Every sub-resource
+      // also matches a published Pyodide release for this version.
+      indexURL: "https://cdn.jsdelivr.net/pyodide/v0.26.4/full/",
+    });
+  } catch (err) {
+    showError(`Pyodide runtime failed to initialise: ${err.message}`);
+    return;
+  }
+
+  setProgress(70);
+
+  // Install the same-origin pyrxd wheel via micropip. The wheel was built
+  // from this commit by the docs CI step.
+  try {
+    await pyodide.loadPackage(["micropip"]);
+    const wheelURL = new URL(manifest.wheel, WHEELS_BASE).toString();
+    await pyodide.runPythonAsync(`
+import micropip
+await micropip.install(${JSON.stringify(wheelURL)})
+import pyrxd
+`);
+  } catch (err) {
+    showError(`Could not install pyrxd from ${manifest.wheel}: ${err.message}`);
+    return;
+  }
+
+  setProgress(95);
+
+  // Read the installed pyrxd version back through the bridge.
+  let versionText;
+  try {
+    const py = pyodide.runPython(`
+import pyrxd
+import sys
+v = getattr(pyrxd, "__version__", "unknown")
+f"pyrxd {v} loaded under Python {sys.version.split()[0]}"
+`);
+    versionText = String(py);
+  } catch (err) {
+    showError(`Could not read pyrxd.__version__: ${err.message}`);
+    return;
+  }
+
+  setProgress(100);
+  showReady(versionText, manifest.git_sha);
+}
+
+// Kick off the boot sequence.
+boot();

--- a/scripts/refresh-pyodide.sh
+++ b/scripts/refresh-pyodide.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+# refresh-pyodide.sh — pin Pyodide to a specific version + SHA-384 hash.
+#
+# Run this when bumping Pyodide. It fetches the requested version from
+# jsdelivr, computes the SHA-384 hash, and updates ``docs/inspect/index.html``
+# with the new ``<script integrity="...">`` value.
+#
+# Usage:
+#   scripts/refresh-pyodide.sh 0.26.4
+#
+# After running, commit the changes to ``docs/inspect/index.html``.
+#
+# Why this exists: the Subresource Integrity (SRI) hash on the Pyodide
+# <script> tag in index.html is the only defense against a compromised CDN
+# silently serving attacker JS to every page visitor. Hand-editing the hash
+# is error-prone; this script is the single source of truth.
+
+set -euo pipefail
+
+VERSION="${1:-}"
+if [[ -z "$VERSION" ]]; then
+  echo "usage: $0 <pyodide-version>" >&2
+  echo "example: $0 0.26.4" >&2
+  exit 1
+fi
+
+URL="https://cdn.jsdelivr.net/pyodide/v${VERSION}/full/pyodide.js"
+echo "Fetching ${URL}…"
+
+TMP="$(mktemp)"
+trap 'rm -f "$TMP"' EXIT
+
+if ! curl --fail --silent --show-error -L "$URL" -o "$TMP"; then
+  echo "ERROR: could not fetch Pyodide v${VERSION} from jsdelivr." >&2
+  echo "Check the version exists: https://cdn.jsdelivr.net/pyodide/v${VERSION}/full/" >&2
+  exit 1
+fi
+
+# Compute SHA-384 in the format SRI expects: ``sha384-<base64>``.
+HASH="sha384-$(openssl dgst -sha384 -binary "$TMP" | openssl base64 -A)"
+echo "Pyodide v${VERSION}: ${HASH}"
+
+INDEX="docs/inspect/index.html"
+if [[ ! -f "$INDEX" ]]; then
+  echo "ERROR: $INDEX not found. Run from the repo root." >&2
+  exit 1
+fi
+
+# Replace the version in the URL line and the integrity hash.
+# Using sed -i with a separate pattern per line for portability.
+python3 - "$INDEX" "$VERSION" "$HASH" <<'PYEOF'
+import re
+import sys
+
+path, version, sha = sys.argv[1:]
+with open(path) as f:
+    content = f.read()
+
+# Update the src URL.
+content = re.sub(
+    r'src="https://cdn\.jsdelivr\.net/pyodide/v[\d.]+/full/pyodide\.js"',
+    f'src="https://cdn.jsdelivr.net/pyodide/v{version}/full/pyodide.js"',
+    content,
+)
+# Update the integrity attribute (anywhere on the same script tag).
+content = re.sub(
+    r'integrity="sha384-[A-Za-z0-9+/=]+"',
+    f'integrity="{sha}"',
+    content,
+)
+
+with open(path, "w") as f:
+    f.write(content)
+PYEOF
+
+echo "Updated ${INDEX}."
+echo
+echo "Next steps:"
+echo "  1. Visually verify the diff: git diff ${INDEX}"
+echo "  2. Smoke-test by opening docs/inspect/index.html in a browser"
+echo "  3. Commit: git commit -am 'chore(inspect): bump Pyodide to v${VERSION}'"

--- a/src/pyrxd/glyph/inspect.py
+++ b/src/pyrxd/glyph/inspect.py
@@ -1,0 +1,69 @@
+"""Public façade for the Glyph inspect surface.
+
+The CLI command ``pyrxd glyph inspect`` is implemented as a set of
+``_``-prefixed helpers inside :mod:`pyrxd.cli.glyph_cmds`. The web UI
+hosted at ``docs/inspect/`` (loaded into a browser via Pyodide) needs
+the same surface, but **must not** import from CLI internals — that
+couples a public-facing tool to private implementation details that can
+churn freely.
+
+This module re-exports the inspect helpers as a stable public API so
+external callers (the web UI today, future SDK users tomorrow) have a
+documented contract:
+
+* :func:`classify_input` — dispatch a raw string to its form
+  (``"txid" | "contract" | "outpoint" | "script"``)
+* :func:`inspect_contract` — decode a 72-char Glyph contract id
+* :func:`inspect_outpoint` — decode a ``txid:vout`` outpoint
+* :func:`inspect_script` — classify a hex-encoded locking script and
+  extract type-specific fields
+* :func:`sanitize_display_string` — strip control / format / combining
+  Unicode codepoints from any string sourced from CBOR before display
+* :func:`truncate_for_human` — cap a sanitized string at the project's
+  display cap
+
+If you are inside the pyrxd codebase, import the underlying helpers
+directly. If you are outside (web UI, downstream tooling), import from
+this module — it commits to a stable signature and shape.
+"""
+
+from __future__ import annotations
+
+# Re-export from the CLI module. The aliasing renames drop the leading
+# underscore so callers don't have to reach into a `_`-prefixed name —
+# that's the entire point of this façade.
+from ..cli.glyph_cmds import (
+    _classify_input as classify_input,
+)
+from ..cli.glyph_cmds import (
+    _inspect_contract as inspect_contract,
+)
+from ..cli.glyph_cmds import (
+    _inspect_outpoint as inspect_outpoint,
+)
+from ..cli.glyph_cmds import (
+    _inspect_script as inspect_script,
+)
+from ..cli.glyph_cmds import (
+    _sanitize_display_string as sanitize_display_string,
+)
+from ..cli.glyph_cmds import (
+    _truncate_for_human as truncate_for_human,
+)
+
+# The async ``_inspect_txid_inner`` requires an ElectrumXClient (or
+# something quacking like one) plus an event loop, neither of which is
+# straightforward to set up under Pyodide's WASM runtime. The web UI
+# fetches the raw bytes via the browser's native ``WebSocket`` API and
+# hands the bytes to this module's ``inspect_script`` per-output instead.
+# We deliberately do not re-export ``_inspect_txid_inner`` here — that
+# coupling stays inside the CLI for now.
+
+__all__ = [
+    "classify_input",
+    "inspect_contract",
+    "inspect_outpoint",
+    "inspect_script",
+    "sanitize_display_string",
+    "truncate_for_human",
+]

--- a/tests/web/test_facade_smoke.py
+++ b/tests/web/test_facade_smoke.py
@@ -1,0 +1,227 @@
+"""Smoke tests for the ``pyrxd.glyph.inspect`` public façade.
+
+The façade exists so the browser-hosted inspect tool (loaded into a
+Pyodide WASM runtime via ``docs/inspect/``) can import a stable public
+API rather than reaching into ``pyrxd.cli.glyph_cmds._``-prefixed
+internals. These tests lock the contract: every public name in the
+module must be importable, callable, and produce a sensible result on
+known inputs.
+
+If a future refactor renames or removes a CLI helper, these tests fail
+loudly — at which point the façade either needs an updated re-export or
+a deliberate API change with proper deprecation.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+# RBG mainnet contract id (display order txid + BE vout=4). We use the
+# same fixtures the rest of the test suite uses so a single regression
+# in real-world data shows up everywhere.
+_RBG_CONTRACT = "b45dc453befb589aff8bfd76af0b994615b37eda094f48c380eb31deaf96a2a800000000"
+_RBG_TXID = "b45dc453befb589aff8bfd76af0b994615b37eda094f48c380eb31deaf96a2a8"
+
+
+class TestFacadeExports:
+    """Every name in __all__ must be importable + callable."""
+
+    def test_all_exports_resolve(self):
+        from pyrxd.glyph import inspect
+
+        for name in inspect.__all__:
+            assert hasattr(inspect, name), f"missing export: {name}"
+            obj = getattr(inspect, name)
+            assert callable(obj), f"{name} is not callable"
+
+    def test_module_docstring_is_present(self):
+        """The façade ships with documentation explaining why it exists."""
+        from pyrxd.glyph import inspect
+
+        assert inspect.__doc__ is not None
+        assert "Pyodide" in inspect.__doc__ or "browser" in inspect.__doc__
+
+
+class TestClassifyInput:
+    """The dispatch helper recognises every documented input shape."""
+
+    def test_classifies_txid(self):
+        from pyrxd.glyph import inspect
+
+        form, value = inspect.classify_input("a" * 64)
+        assert form == "txid"
+        assert value == "a" * 64
+
+    def test_classifies_contract_id(self):
+        from pyrxd.glyph import inspect
+
+        form, _value = inspect.classify_input(_RBG_CONTRACT)
+        assert form == "contract"
+
+    def test_classifies_outpoint(self):
+        from pyrxd.glyph import inspect
+
+        form, _value = inspect.classify_input(f"{_RBG_TXID}:0")
+        assert form == "outpoint"
+
+    def test_classifies_script_hex(self):
+        from pyrxd.glyph import inspect
+
+        # Plain P2PKH (50 hex chars / 25 bytes).
+        p2pkh = "76a914" + "aa" * 20 + "88ac"
+        form, _value = inspect.classify_input(p2pkh)
+        assert form == "script"
+
+
+class TestInspectContract:
+    """Decoding a real RBG contract id returns the canonical fields."""
+
+    def test_decodes_real_world_rbg_contract(self):
+        from pyrxd.glyph import inspect
+
+        result = inspect.inspect_contract(_RBG_CONTRACT)
+        assert result["txid"] == _RBG_TXID
+        assert result["vout"] == 0  # canonical RBG tokenRef
+
+
+class TestInspectOutpoint:
+    """Outpoint decoding round-trips a known good input."""
+
+    def test_decodes_outpoint(self):
+        from pyrxd.glyph import inspect
+
+        result = inspect.inspect_outpoint(f"{_RBG_TXID}:0")
+        assert result["txid"] == _RBG_TXID
+        assert result["vout"] == 0
+
+
+class TestInspectScript:
+    """The script classifier covers all the public types."""
+
+    def test_classifies_p2pkh(self):
+        from pyrxd.glyph import inspect
+
+        p2pkh = "76a914" + "aa" * 20 + "88ac"
+        result = inspect.inspect_script(p2pkh)
+        assert result["type"] == "p2pkh"
+
+    def test_classifies_unknown(self):
+        """Random hex that doesn't match any classifier returns ``unknown``."""
+        from pyrxd.glyph import inspect
+
+        result = inspect.inspect_script("de" * 25)
+        assert result["type"] == "unknown"
+
+
+class TestSanitizeDisplayString:
+    """The sanitizer is the trust boundary for any CBOR-derived string
+    rendered to the user. Locks the most security-relevant cases."""
+
+    def test_strips_ansi_escape(self):
+        from pyrxd.glyph import inspect
+
+        # \x1b is OP_ESC and ANSI-CSI prefix. Must be stripped before display.
+        assert inspect.sanitize_display_string("hi\x1b[31m") == "hi?[31m"
+
+    def test_strips_bidi_override(self):
+        """U+202E (RIGHT-TO-LEFT OVERRIDE) is the headline injection threat —
+        a hostile token deployer could spoof a token name's apparent letter
+        order in the UI. Must be stripped."""
+        from pyrxd.glyph import inspect
+
+        assert inspect.sanitize_display_string("gly‮bar") == "gly?bar"
+
+    def test_preserves_plain_ascii(self):
+        from pyrxd.glyph import inspect
+
+        assert inspect.sanitize_display_string("hello world") == "hello world"
+
+
+class TestTruncateForHuman:
+    """The display truncation cap is enforced."""
+
+    def test_caps_long_strings(self):
+        from pyrxd.glyph import inspect
+
+        long_input = "x" * 500
+        result = inspect.truncate_for_human(long_input, cap=100)
+        assert len(result) <= 100
+
+    def test_passes_through_short_strings(self):
+        from pyrxd.glyph import inspect
+
+        assert inspect.truncate_for_human("short") == "short"
+
+
+class TestNoDirectCliImport:
+    """The browser tool must NOT reach into CLI internals.
+
+    This test is documentary, not a hard fence — Python doesn't enforce
+    private prefixes — but a `grep` against `tests/web/` for
+    ``cli.glyph_cmds._`` should remain empty. If a downstream user ever
+    imports a `_`-prefixed name from glyph_cmds, this test reminds the
+    reviewer that the façade exists for a reason.
+    """
+
+    def test_facade_does_not_re_export_async_inner(self):
+        """The async ``_inspect_txid_inner`` requires an event loop and an
+        ElectrumXClient — neither plays nicely under Pyodide. The façade
+        deliberately omits it; the browser tool's PR-3 wiring fetches raw
+        bytes via the native WebSocket API and feeds them into
+        ``inspect_script`` per-output instead."""
+        from pyrxd.glyph import inspect
+
+        assert "inspect_txid_inner" not in inspect.__all__
+        assert not hasattr(inspect, "inspect_txid_inner")
+
+
+class TestStaticPagePresent:
+    """Sanity-check that PR-1 actually shipped the static-page files.
+
+    Catches the "I edited Python but forgot to commit the html" failure
+    mode at test time rather than after deploy.
+    """
+
+    def test_inspect_html_exists(self):
+        from pathlib import Path
+
+        repo_root = Path(__file__).resolve().parents[2]
+        # Sphinx's html_extra_path copies the *contents* of the path, so the
+        # inspect page lives at docs/inspect_static/inspect/index.html and
+        # ships to /inspect/index.html on the published site.
+        index = repo_root / "docs" / "inspect_static" / "inspect" / "index.html"
+        assert index.exists(), f"missing {index}"
+        text = index.read_text()
+        # The file must declare the CSP we documented.
+        assert "Content-Security-Policy" in text
+        # And the SRI hash for Pyodide.
+        assert 'integrity="sha384-' in text
+
+    def test_refresh_pyodide_script_exists(self):
+        from pathlib import Path
+
+        repo_root = Path(__file__).resolve().parents[2]
+        script = repo_root / "scripts" / "refresh-pyodide.sh"
+        assert script.exists()
+        # And is executable.
+        assert script.stat().st_mode & 0o111, f"{script} is not executable"
+
+
+@pytest.mark.skipif(
+    not (lambda: __import__("pathlib").Path("docs/inspect/wheels/manifest.json").exists())(),
+    reason="wheel + manifest only built by docs.yml CI step",
+)
+class TestWheelManifest:
+    """Validates the manifest.json the docs.yml CI step writes alongside
+    the pyrxd wheel. Skipped when the file isn't present (i.e. when
+    running tests locally without the CI step)."""
+
+    def test_manifest_has_wheel_field(self):
+        import json
+        from pathlib import Path
+
+        manifest_path = Path("docs/inspect/wheels/manifest.json")
+        manifest = json.loads(manifest_path.read_text())
+        assert "wheel" in manifest
+        assert manifest["wheel"].startswith("pyrxd-")
+        assert manifest["wheel"].endswith(".whl")


### PR DESCRIPTION
## Summary

PR-A of a 3-PR series shipping a browser-hosted version of `pyrxd glyph inspect`. This PR is the deliberately-minimal "hello, Pyodide loaded" page that proves the foundation works before any classifier code lands. PR-B wires the classifier UI; PR-C adds `--fetch` via WebSocket → ElectrumX.

## What this PR establishes

- Pyodide loads correctly from a CDN with SHA-384 SRI integrity verification
- A pyrxd wheel can be built from the current commit by CI, served from the same origin as the page, and installed at runtime via micropip
- `html_extra_path` in `docs/conf.py` correctly publishes the static page at `/inspect/` on the GitHub Pages site without fighting Sphinx
- The `pyrxd.glyph.inspect` public façade (newly added) provides a stable surface that the browser tool consumes — no reaching into `_`-prefixed CLI internals

If any of those check out, PR-B/C become mechanical work on a known-good foundation. If any break, the architecture changes shape — better to find out now than after committing to the full UI.

## Architecture decisions captured here

| Decision | Rationale |
|---|---|
| **Pyodide, not pure-JS port** | Drift risk from a parallel classifier (we just literally documented one in `docs/solutions/logic-errors/dmint-v1-classifier-gap.md`) outweighs cold-load cost |
| **CDN + SRI, not vendored binaries** | Keeps repo small; SRI is the audit trail; `scripts/refresh-pyodide.sh` is the single source of truth for bumps |
| **`html_extra_path`, not `html_static_path`** | Lands the page at `/inspect/index.html`, not `/_static/inspect/...` |
| **Wheel built fresh in CI per docs build** | Browser always installs pyrxd from the same commit Sphinx is rendering — no version-skew |

## Files

| File | Purpose |
|---|---|
| `src/pyrxd/glyph/inspect.py` | Public façade re-exporting the inspect helpers |
| `docs/inspect_static/inspect/index.html` | Static page with CSP, SRI, mobile-first markup |
| `docs/inspect_static/inspect/inspect.css` | Furo-matching style, Okabe-Ito palette, dark/light via `prefers-color-scheme` |
| `docs/inspect_static/inspect/inspect.js` | Pyodide bootstrap, manifest fetch, version display |
| `scripts/refresh-pyodide.sh` | Maintainer helper to bump Pyodide version + SRI hash |
| `docs/conf.py` | `+1 line: html_extra_path = ["inspect_static"]` |
| `.github/workflows/docs.yml` | New step: `pip wheel --no-deps .` into `wheels/`, write manifest |
| `.gitignore` | Exclude `docs/inspect_static/inspect/wheels/` (CI-built artifact) |
| `tests/web/test_facade_smoke.py` | 19 tests pinning the façade contract, page presence, CSP/SRI declarations |

## Threat model rules already satisfied

- ✅ CSP declared with `default-src 'none'` + targeted allowlist
- ✅ SRI on the CDN-loaded Pyodide script (real SHA-384 of v0.26.4)
- ✅ `<meta name="referrer" content="no-referrer">`
- ✅ No analytics, no fonts, no third-party content beyond pinned Pyodide
- ✅ `connect-src` whitelists exactly one ElectrumX server (locked by deploy)
- ✅ Façade deliberately omits `_inspect_txid_inner` (the network path) — wired in PR-C with browser-native WebSocket + Subresource Integrity hash check on returned tx bytes

## Threat model items deferred to PR-B/C

- Server-honesty hash check (PR-C; needs the WebSocket fetch path)
- Unicode sanitization on rendered output (PR-B; needs a result-rendering path)
- WebSocket message size cap (PR-C)
- "No URL-param auto-fetch" (PR-C)
- 200KB hex paste cap (PR-B)

All captured in the spec; this PR doesn't introduce paths that would surface them.

## Test plan

- [x] 18 of 19 façade tests pass (1 skipped — `manifest.json` only built by CI)
- [x] Full pyrxd suite: **2343 passed**, 2 skipped, 22 deselected
- [x] `ruff check` + `ruff format --check` clean
- [x] Sphinx build verified locally: `docs/_build/html/inspect/{index.html, inspect.css, inspect.js}` present
- [x] Pre-push CI green

**What I CANNOT verify without GitHub Pages deploy:**
- That the deployed page actually loads Pyodide on a real browser (needs the deployed environment — this PR's #1 unknown)
- That the wheel-build CI step writes a manifest the page can read
- That the SRI integrity check passes against the live CDN (it should — hash was computed from the CDN's own bytes via `scripts/refresh-pyodide.sh`)

These are the deliberate "merge to find out" risks of PR-A. If anything breaks on deploy, the next commit on this branch fixes it before PR-B starts.

## Stacking

Independent of #45 (radiant-fts mental-model docs). Either order works.