### PR TITLE
feat(inspect): PR-C — txid --fetch via browser WebSocket

### DIFF
--- a/docs/inspect_static/inspect/glue.py
+++ b/docs/inspect_static/inspect/glue.py
@@ -26,6 +26,7 @@ Design rules:
 from __future__ import annotations
 
 import sys
+import unicodedata
 
 # AES shim for Pyodide. ``pyrxd`` imports ``Cryptodome.Cipher.AES``
 # (from ``pycryptodomex``), which only ships C-extension wheels and
@@ -228,6 +229,24 @@ def inspect_txid_with_raw(txid: str, raw_hex: str) -> dict:
             ),
         )
 
+    # Annotate metadata strings with homoglyph / script-mixing warnings.
+    # The control-byte sanitizer runs in the next step, but it doesn't
+    # catch a token deployer who names their token "USDC" using a
+    # Cyrillic 'U' (U+0405) and a Cyrillic 'С' (U+0421) — visually
+    # identical to Latin, but a different token. We compute a per-field
+    # "looks_suspicious" bool and surface it so the JS renderer can
+    # mark the field with a warning glyph.
+    metadata = payload.get("metadata") if isinstance(payload, dict) else None
+    if isinstance(metadata, dict):
+        warnings = {}
+        for field_name in ("name", "ticker", "description"):
+            field_value = metadata.get(field_name)
+            if isinstance(field_value, str) and field_value:
+                if _looks_suspicious(field_value):
+                    warnings[field_name] = "mixed scripts (possible homoglyph)"
+        if warnings:
+            metadata["display_warnings"] = warnings
+
     sanitized = _sanitize_payload_strings(payload)
     return {
         "ok": True,
@@ -235,6 +254,55 @@ def inspect_txid_with_raw(txid: str, raw_hex: str) -> dict:
         "input": txid,
         "payload": sanitized,
     }
+
+
+# Unicode script blocks we treat as "the user probably meant Latin".
+# A string containing characters from any *other* script alongside Latin
+# ASCII letters is flagged as suspicious — that's the classic homoglyph
+# attack shape (Cyrillic 'а' inside an otherwise-Latin token name).
+_LATIN_SCRIPT_RANGES = (
+    (0x0041, 0x005A),  # A-Z
+    (0x0061, 0x007A),  # a-z
+)
+
+
+def _is_latin_letter(cp: int) -> bool:
+    return any(lo <= cp <= hi for lo, hi in _LATIN_SCRIPT_RANGES)
+
+
+def _looks_suspicious(s: str) -> bool:
+    """Return True if *s* mixes Latin ASCII letters with letters from
+    another script — the canonical homoglyph-spoofing shape (e.g.
+    "USDC" with a Cyrillic 'U' / 'С').
+
+    NFKC-normalise first so compatibility forms (full-width letters,
+    fraction-slash, etc.) collapse to their canonical form before we
+    check categories. A pure-Latin or pure-Cyrillic string is fine
+    — only mixed scripts trip the flag, because that's the attack shape.
+
+    Pure-non-letter strings (digits, punctuation, emoji) are not
+    flagged. Combining marks alone are sanitized away upstream.
+    """
+    if not isinstance(s, str) or not s:
+        return False
+    normalised = unicodedata.normalize("NFKC", s)
+    has_latin = False
+    has_other_letter = False
+    for ch in normalised:
+        cp = ord(ch)
+        cat = unicodedata.category(ch)
+        # Only Letter categories matter for confusables. (Lu / Ll / Lt /
+        # Lm / Lo). Symbols, punctuation, digits, and marks don't carry
+        # script identity for this check.
+        if not cat.startswith("L"):
+            continue
+        if _is_latin_letter(cp):
+            has_latin = True
+        else:
+            has_other_letter = True
+        if has_latin and has_other_letter:
+            return True
+    return False
 
 
 def _hint_for(form: str) -> str:
@@ -285,25 +353,56 @@ def _truncate(s: str, cap: int = _HUMAN_STRING_CAP) -> str:
     return _inspect.truncate_for_human(s, cap=cap) if isinstance(s, str) else s
 
 
-def _sanitize_payload_strings(value):
-    """Recursively walk a dict/list payload and sanitize every string.
+# Hex-shaped fields don't get truncated — txids, refs, payload hashes,
+# and addresses are full-fidelity primary keys; chopping them visually
+# misleads the user into thinking a different identifier is in use.
+# Field names enumerated explicitly so a future field doesn't sneak
+# past the cap by being unexpectedly hex-shaped.
+_HEX_FIELDS_NEVER_TRUNCATED = frozenset(
+    {
+        "txid",
+        "ref_txid",
+        "ref_outpoint",
+        "contract_ref_outpoint",
+        "token_ref_outpoint",
+        "outpoint",
+        "owner_pkh",
+        "payload_hash",
+        "wire_hex",
+        "input",
+        "main",  # already an opaque "<media: …>" summary string with embedded sha256
+    }
+)
 
-    Leaves non-strings alone. Used as the final step before the result
-    dict crosses the bridge: any string the JS side will eventually
-    write to the DOM has already had control / format / combining
-    codepoints stripped.
 
-    This is paranoid — today's offline forms don't carry CBOR strings —
-    but threading the sanitizer through a single point now means PR-C
-    can't accidentally regress when it adds ``main``, ``name``,
-    ``description``, ``ticker``, etc. to the payload.
+def _sanitize_payload_strings(value, *, key=None):
+    """Recursively walk a dict/list payload, sanitize and length-cap
+    every string.
+
+    Two transforms are applied:
+
+    1. ``sanitize_display_string`` strips control / format / combining
+       codepoints — defends against bidi overrides, ANSI escapes, ZWJ
+       fakery in CBOR-derived names/tickers/descriptions.
+    2. ``truncate_for_human`` caps the result at ``_HUMAN_STRING_CAP``
+       (200 chars) — defends against attacker descriptions that would
+       overflow the card and dominate the visual frame. Hex-shaped
+       primary keys (txid, refs, owner_pkh, etc.) are NEVER truncated;
+       chopping them visually misleads the user into thinking a
+       different identifier is in use.
+
+    The ``key`` keyword propagates the parent dict key down so the
+    truncation rule can opt out for known hex fields.
     """
     if isinstance(value, str):
-        return _inspect.sanitize_display_string(value)
+        sanitized = _inspect.sanitize_display_string(value)
+        if key in _HEX_FIELDS_NEVER_TRUNCATED:
+            return sanitized
+        return _truncate(sanitized)
     if isinstance(value, dict):
-        return {k: _sanitize_payload_strings(v) for k, v in value.items()}
+        return {k: _sanitize_payload_strings(v, key=k) for k, v in value.items()}
     if isinstance(value, list):
-        return [_sanitize_payload_strings(v) for v in value]
+        return [_sanitize_payload_strings(v, key=key) for v in value]
     if isinstance(value, tuple):
-        return tuple(_sanitize_payload_strings(v) for v in value)
+        return tuple(_sanitize_payload_strings(v, key=key) for v in value)
     return value

--- a/docs/inspect_static/inspect/glue.py
+++ b/docs/inspect_static/inspect/glue.py
@@ -25,6 +25,7 @@ Design rules:
 
 from __future__ import annotations
 
+import functools
 import sys
 import unicodedata
 
@@ -233,17 +234,40 @@ def inspect_txid_with_raw(txid: str, raw_hex: str) -> dict:
     # The control-byte sanitizer runs in the next step, but it doesn't
     # catch a token deployer who names their token "USDC" using a
     # Cyrillic 'U' (U+0405) and a Cyrillic 'С' (U+0421) — visually
-    # identical to Latin, but a different token. We compute a per-field
-    # "looks_suspicious" bool and surface it so the JS renderer can
-    # mark the field with a warning glyph.
+    # identical to Latin, but a different token.
+    #
+    # Two attack shapes get flagged:
+    #
+    #   - "mixed scripts" — Latin ASCII letters mixed with letters from
+    #     another script. Classic per-character substitution attack.
+    #   - "non-Latin script" — every Letter codepoint comes from a
+    #     non-Latin script. Whole-word substitution: pure-Cyrillic
+    #     "ВNВ" mimicking Latin "BNB". Doesn't mix scripts but still
+    #     visually impersonates Latin to a Latin-default reader.
+    #
+    # Both surface as ``metadata.display_warnings[<field>]`` so the JS
+    # renderer paints a warning band on the affected card.
     metadata = payload.get("metadata") if isinstance(payload, dict) else None
     if isinstance(metadata, dict):
         warnings = {}
         for field_name in ("name", "ticker", "description"):
             field_value = metadata.get(field_name)
             if isinstance(field_value, str) and field_value:
-                if _looks_suspicious(field_value):
-                    warnings[field_name] = "mixed scripts (possible homoglyph)"
+                reason = _suspicious_reason(field_value)
+                if reason:
+                    warnings[field_name] = reason
+        # ``protocol`` is a list of CBOR-supplied values rendered to the
+        # user as a comma-joined string. An attacker can put a homoglyph
+        # in any element. Walk the list and flag the field if any entry
+        # is suspicious.
+        protocol = metadata.get("protocol")
+        if isinstance(protocol, list):
+            for entry in protocol:
+                if isinstance(entry, str) and entry:
+                    reason = _suspicious_reason(entry)
+                    if reason:
+                        warnings["protocol"] = reason
+                        break
         if warnings:
             metadata["display_warnings"] = warnings
 
@@ -256,35 +280,46 @@ def inspect_txid_with_raw(txid: str, raw_hex: str) -> dict:
     }
 
 
-# Unicode script blocks we treat as "the user probably meant Latin".
-# A string containing characters from any *other* script alongside Latin
-# ASCII letters is flagged as suspicious — that's the classic homoglyph
-# attack shape (Cyrillic 'а' inside an otherwise-Latin token name).
-_LATIN_SCRIPT_RANGES = (
-    (0x0041, 0x005A),  # A-Z
-    (0x0061, 0x007A),  # a-z
-)
-
-
+# Whether a Letter codepoint is Latin-script (A-Z, a-z, plus Latin
+# Extended ranges that legitimately occur in user-facing names like
+# "Café", "naïve", "Zürich"). Python's stdlib doesn't expose the
+# Unicode "script" property directly, but ``unicodedata.name()``
+# returns a name string that always starts with the script's English
+# label ("LATIN ...", "CYRILLIC ...", "GREEK ...", etc.) — we use that
+# prefix as the script identifier. Cached per codepoint to amortise
+# the name-lookup cost across long strings.
+@functools.lru_cache(maxsize=4096)
 def _is_latin_letter(cp: int) -> bool:
-    return any(lo <= cp <= hi for lo, hi in _LATIN_SCRIPT_RANGES)
+    try:
+        name = unicodedata.name(chr(cp))
+    except ValueError:
+        return False
+    return name.startswith("LATIN ")
 
 
-def _looks_suspicious(s: str) -> bool:
-    """Return True if *s* mixes Latin ASCII letters with letters from
-    another script — the canonical homoglyph-spoofing shape (e.g.
-    "USDC" with a Cyrillic 'U' / 'С').
+def _suspicious_reason(s: str) -> str:
+    """Return a short reason string if *s* might be a homoglyph spoof,
+    or empty string if the input is benign.
 
     NFKC-normalise first so compatibility forms (full-width letters,
     fraction-slash, etc.) collapse to their canonical form before we
-    check categories. A pure-Latin or pure-Cyrillic string is fine
-    — only mixed scripts trip the flag, because that's the attack shape.
+    check categories.
 
-    Pure-non-letter strings (digits, punctuation, emoji) are not
-    flagged. Combining marks alone are sanitized away upstream.
+    Two attack shapes are caught:
+
+    - **mixed scripts** — Latin ASCII letters alongside letters from
+      another script. Per-character substitution: "USDC" with a
+      Cyrillic 'U'.
+    - **non-Latin script** — every Letter codepoint is non-Latin.
+      Whole-word substitution: "ВNВ" mimicking Latin "BNB".
+
+    Pure-Latin strings, pure-non-letter strings (digits / punctuation /
+    emoji), and the empty string return "" (benign). Combining marks
+    alone are sanitised away upstream by ``sanitize_display_string``;
+    we only inspect Letter codepoints here.
     """
     if not isinstance(s, str) or not s:
-        return False
+        return ""
     normalised = unicodedata.normalize("NFKC", s)
     has_latin = False
     has_other_letter = False
@@ -301,8 +336,18 @@ def _looks_suspicious(s: str) -> bool:
         else:
             has_other_letter = True
         if has_latin and has_other_letter:
-            return True
-    return False
+            return "mixed scripts (possible homoglyph)"
+    if has_other_letter and not has_latin:
+        return "non-Latin script (verify by txid, not by visual name)"
+    return ""
+
+
+def _looks_suspicious(s: str) -> bool:
+    """Backwards-compatible boolean wrapper around
+    :func:`_suspicious_reason`. Kept for the existing test suite; new
+    code should prefer ``_suspicious_reason`` so the actual reason
+    surfaces to the user."""
+    return bool(_suspicious_reason(s))
 
 
 def _hint_for(form: str) -> str:
@@ -358,6 +403,14 @@ def _truncate(s: str, cap: int = _HUMAN_STRING_CAP) -> str:
 # misleads the user into thinking a different identifier is in use.
 # Field names enumerated explicitly so a future field doesn't sneak
 # past the cap by being unexpectedly hex-shaped.
+#
+# Note: ``main`` is NOT in this list even though the Python side
+# constructs it as a ``<media: {mime_type}, {N} bytes, sha256={hex}>``
+# summary. The CBOR-supplied ``mime_type`` has no length cap upstream
+# (``decode_payload`` doesn't constrain ``m["t"]``), so an attacker
+# could put 64KB of mime_type into the constructed string. The
+# embedded sha256 is fine to truncate at 200 chars — the user can read
+# the full hash via the JSON drawer if needed.
 _HEX_FIELDS_NEVER_TRUNCATED = frozenset(
     {
         "txid",
@@ -370,7 +423,6 @@ _HEX_FIELDS_NEVER_TRUNCATED = frozenset(
         "payload_hash",
         "wire_hex",
         "input",
-        "main",  # already an opaque "<media: …>" summary string with embedded sha256
     }
 )
 

--- a/docs/inspect_static/inspect/glue.py
+++ b/docs/inspect_static/inspect/glue.py
@@ -1,9 +1,10 @@
 """Pyodide-side glue between the browser UI and the ``pyrxd.glyph.inspect`` façade.
 
 This module is loaded into the Pyodide WASM runtime by ``inspect.js`` and
-exposes one entry point — :func:`run` — that the JS side calls with a
-user-pasted string. It returns a JSON-serialisable dict that the JS side
-renders without any further parsing.
+exposes two entry points — :func:`run` for offline classification of a
+user-pasted string, and :func:`inspect_txid_with_raw` for classifying a
+transaction whose raw bytes JS already fetched. Both return a
+JSON-serialisable dict that the JS side renders without further parsing.
 
 Design rules:
 
@@ -11,8 +12,8 @@ Design rules:
   ``{"ok": False, "error": ..., "form": ...}`` dict that the JS side can
   display directly. Pyodide can surface Python exceptions to JS but the
   resulting `Error` objects are awkward to inspect from the renderer.
-* **No async.** Network fetches happen in JS (see PR-C); this module is
-  pure synchronous classification.
+* **No async.** Network fetches happen in JS using the browser's native
+  WebSocket API; this module is pure synchronous classification.
 * **Sanitize once, here.** Any string that came out of CBOR or any other
   attacker-controllable source passes through ``sanitize_display_string``
   before going into the returned dict. The JS side trusts the dict;
@@ -23,6 +24,38 @@ Design rules:
 """
 
 from __future__ import annotations
+
+import sys
+
+# AES shim for Pyodide. ``pyrxd`` imports ``Cryptodome.Cipher.AES``
+# (from ``pycryptodomex``), which only ships C-extension wheels and
+# therefore can't be installed via micropip under WASM. Pyodide ships
+# the sibling package ``pycryptodome`` (no -x), which exposes the same
+# API under the ``Crypto`` namespace. Installing it via micropip and
+# aliasing ``Cryptodome`` → ``Crypto`` lets pyrxd import unchanged.
+#
+# This block is a no-op when ``Cryptodome`` is already importable
+# (i.e. native Python with pycryptodomex installed) — the import below
+# fails on Pyodide before pyrxd's import chain triggers, then we route
+# every ``Cryptodome.*`` lookup through the ``Crypto.*`` package.
+try:
+    import Cryptodome  # noqa: F401  # native pycryptodomex path
+except ImportError:
+    import Crypto
+    import Crypto.Cipher
+    import Crypto.Hash
+
+    sys.modules["Cryptodome"] = Crypto
+    sys.modules["Cryptodome.Cipher"] = Crypto.Cipher
+    sys.modules["Cryptodome.Hash"] = Crypto.Hash
+    # The two specific submodules pyrxd actually imports from. Aliasing
+    # the parent isn't enough because ``from Cryptodome.Cipher import AES``
+    # walks the dotted path and looks up ``AES`` as an attribute of
+    # ``Cryptodome.Cipher``. We populate the same namespace so the
+    # attribute exists.
+    from Crypto.Cipher import AES as _AES
+
+    sys.modules["Cryptodome.Cipher.AES"] = _AES
 
 from pyrxd.glyph import inspect as _inspect
 
@@ -116,22 +149,91 @@ def run(raw_input: str) -> dict:
 
 
 def _inspect_txid_offline(value: str) -> dict:
-    """txid form without --fetch: render a friendly placeholder.
+    """txid form before fetch: render a "press the button to fetch" stub.
 
-    PR-C wires the network fetch path. Until then a bare 64-hex paste
-    just gets a "looks like a txid; use --fetch" rendering so the user
-    knows the input was recognised but action is required.
+    The page renders this as a card with a "Fetch from network" button.
+    On click, JS uses the browser's native WebSocket to pull the raw
+    transaction from the configured ElectrumX server, then calls
+    :func:`inspect_txid_with_raw` to classify the result.
     """
     return {
         "form": "txid",
         "txid": value,
         "needs_fetch": True,
         "message": (
-            "This looks like a txid. Fetching the transaction from the "
-            "Radiant network is the next step — that path is wired in "
-            "the next release. For now, paste a script hex, contract id, "
-            "or outpoint to see classification offline."
+            "This looks like a txid. Press the button below to fetch the "
+            "raw transaction from the Radiant network and classify each "
+            "output."
         ),
+    }
+
+
+def inspect_txid_with_raw(txid: str, raw_hex: str) -> dict:
+    """Classify a transaction whose raw bytes JS already fetched.
+
+    The JS side opens a WebSocket to the configured ElectrumX server,
+    sends ``blockchain.transaction.get`` for ``txid``, and hands the
+    returned hex to this function. The same threat-model guards that
+    the CLI's ``--fetch`` path applies — size cap, hash256 server-honesty
+    check, structural caps, per-output try/except, sanitised metadata —
+    run here as well, because we re-use the same ``classify_raw_tx``
+    helper the CLI uses.
+
+    Result shape mirrors :func:`run` for consistency: a top-level dict
+    with ``ok``, ``form="txid"``, ``input`` (the txid), and ``payload``
+    (the classification dict from ``classify_raw_tx``). On failure,
+    ``ok=False`` and a structured error+hint pair as elsewhere.
+    """
+    if not isinstance(txid, str) or not isinstance(raw_hex, str):
+        return _err("txid and raw_hex must both be strings", form="error")
+
+    txid = txid.strip().lower()
+    raw_hex = raw_hex.strip()
+
+    if len(txid) != 64:
+        return _err(
+            f"txid is {len(txid)} chars; expected 64",
+            form="error",
+            hint=_hint_for("contract"),
+        )
+
+    if not raw_hex:
+        return _err("raw_hex is empty", form="error")
+
+    # Length cap on the *hex string* — equivalent to twice the byte cap
+    # the CLI applies (4 MB binary = 8 MB hex). Refusing oversize input
+    # before parsing avoids spending classifier work on pathological
+    # responses from a hostile or buggy server.
+    if len(raw_hex) > 8_000_000:
+        return _err(
+            f"raw_hex too long ({len(raw_hex):,} chars); cap is 8,000,000",
+            form="error",
+        )
+
+    try:
+        raw = bytes.fromhex(raw_hex)
+    except ValueError as exc:
+        return _err(f"raw_hex is not valid hex: {_safe_error(exc)}", form="error")
+
+    try:
+        payload = _inspect.classify_raw_tx(txid, raw)
+    except Exception as exc:
+        return _err(
+            _safe_error(exc),
+            form="error",
+            hint=(
+                "If the error mentions hash mismatch, the ElectrumX server "
+                "returned the wrong transaction — try again or change "
+                "servers. Other errors usually mean the bytes are malformed."
+            ),
+        )
+
+    sanitized = _sanitize_payload_strings(payload)
+    return {
+        "ok": True,
+        "form": "txid",
+        "input": txid,
+        "payload": sanitized,
     }
 
 

--- a/docs/inspect_static/inspect/inspect.css
+++ b/docs/inspect_static/inspect/inspect.css
@@ -398,6 +398,33 @@ textarea#paste-input:disabled {
 .badge-outpoint { background: var(--color-commit); }
 .badge-script   { background: var(--color-p2pkh); }
 
+/* --- Homoglyph / display warnings --------------------------------- */
+
+.warning-banner {
+  margin-top: 1rem;
+  margin-bottom: 0;
+  padding: 0.75rem 1rem;
+  background: var(--error-bg);
+  color: var(--error-fg);
+  border: 1px solid var(--error-border);
+  border-radius: 6px;
+  font-size: 0.9rem;
+  line-height: 1.4;
+}
+
+.kv-warning {
+  /* The value text itself is unchanged — colour cue only. */
+  color: var(--error-fg);
+}
+
+.kv-warning-note {
+  margin-top: 0.2rem;
+  font-size: 0.8rem;
+  font-style: italic;
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+  color: var(--error-fg);
+}
+
 /* --- Fetch button (txid card) -------------------------------------- */
 
 .fetch-row {

--- a/docs/inspect_static/inspect/inspect.css
+++ b/docs/inspect_static/inspect/inspect.css
@@ -398,6 +398,83 @@ textarea#paste-input:disabled {
 .badge-outpoint { background: var(--color-commit); }
 .badge-script   { background: var(--color-p2pkh); }
 
+/* --- Fetch button (txid card) -------------------------------------- */
+
+.fetch-row {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  margin-top: 0.75rem;
+}
+
+.fetch-btn {
+  font: inherit;
+  font-size: 0.9rem;
+  padding: 0.45rem 0.9rem;
+  background: var(--link);
+  color: #fff;
+  border: 1px solid var(--link);
+  border-radius: 6px;
+  cursor: pointer;
+}
+
+.fetch-btn:hover:not(:disabled) {
+  filter: brightness(1.1);
+}
+
+.fetch-btn:disabled {
+  opacity: 0.5;
+  cursor: progress;
+}
+
+.fetch-status {
+  font-size: 0.85rem;
+  color: var(--muted);
+  font-style: italic;
+}
+
+/* --- Fetched-tx output rows ---------------------------------------- */
+
+.result-subhead {
+  font-size: 1rem;
+  font-weight: 600;
+  margin: 1rem 0 0.5rem 0;
+}
+
+.output-rows {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.output-row {
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  padding: 0.6rem 0.75rem;
+  background: var(--code-bg);
+}
+
+.output-row-head {
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+  margin-bottom: 0.4rem;
+  font-size: 0.9rem;
+}
+
+.output-vout {
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, "Liberation Mono",
+               "Consolas", monospace;
+  font-weight: 600;
+}
+
+.output-sats {
+  margin-left: auto;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, "Liberation Mono",
+               "Consolas", monospace;
+  color: var(--muted);
+}
+
 /* --- JSON drawer ---------------------------------------------------- */
 
 .json-drawer {

--- a/docs/inspect_static/inspect/inspect.js
+++ b/docs/inspect_static/inspect/inspect.js
@@ -512,7 +512,7 @@ function renderFetchedTxCard(payload) {
     const warnings = (metadata && metadata.display_warnings) || {};
     mdl.appendChild(kv("input index", metadata.input_index));
     if (Array.isArray(metadata.protocol) && metadata.protocol.length > 0) {
-      mdl.appendChild(kv("protocol", metadata.protocol.join(", ")));
+      mdl.appendChild(kvWithWarning("protocol", metadata.protocol.join(", "), warnings.protocol));
     }
     if (metadata.name) mdl.appendChild(kvWithWarning("name", metadata.name, warnings.name));
     if (metadata.ticker) mdl.appendChild(kvWithWarning("ticker", metadata.ticker, warnings.ticker));
@@ -526,15 +526,20 @@ function renderFetchedTxCard(payload) {
     // Top-level warning banner if any field tripped a homoglyph flag.
     // The Python side sets metadata.display_warnings as a {field: reason}
     // dict; we surface it visibly so a user reading "USDC" can tell at a
-    // glance whether the string is what it looks like.
+    // glance whether the string is what it looks like. Two reason
+    // shapes today: "mixed scripts" (per-character substitution like
+    // Latin "USDC" with Cyrillic "С") and "non-Latin script"
+    // (whole-word substitution like Cyrillic "ВТС" mimicking Latin
+    // "BTC"). Both warrant a banner; the body text covers both shapes.
     if (Object.keys(warnings).length > 0) {
       const banner = el("p", { class: "warning-banner" });
       banner.textContent =
-        "⚠ This token's metadata contains characters that visually mimic other " +
-        "scripts. Treat the displayed name/ticker/description with care — " +
-        "characters that look like Latin letters may actually be from another " +
-        "alphabet (e.g. Cyrillic 'а' instead of Latin 'a'). Verify the txid, " +
-        "not the name, before trusting this token.";
+        "⚠ This token's metadata contains characters that visually mimic " +
+        "Latin letters. Treat the displayed name, ticker, description, " +
+        "and protocol fields with care — they may use letters from a " +
+        "different alphabet (e.g. Cyrillic 'а' looks identical to Latin " +
+        "'a'). The only reliable identifier for this token is the txid " +
+        "above; verify by txid, not by visual name.";
       wrapper.appendChild(banner);
     }
   }

--- a/docs/inspect_static/inspect/inspect.js
+++ b/docs/inspect_static/inspect/inspect.js
@@ -63,10 +63,28 @@ const WHEELS_BASE = new URL("./wheels/", document.baseURI).toString();
 const WHEELS_MANIFEST = new URL("./manifest.json", WHEELS_BASE).toString();
 const GLUE_URL = new URL("./glue.py", document.baseURI).toString();
 
-// Module-scope handle to the Python `run` function once boot completes.
-// Keeping this on the module rather than `window` avoids polluting the
+// Module-scope handles to the Python entry points once boot completes.
+// Keeping these on the module rather than `window` avoids polluting the
 // global namespace and keeps the surface explicit.
-let pyGlue = null;
+let pyGlue = null;          // glue.run(text) -> dict
+let pyGlueFetch = null;     // glue.inspect_txid_with_raw(txid, raw_hex) -> dict
+
+// ElectrumX WebSocket endpoint. Hard-coded to the one URL the page's
+// CSP whitelists in ``connect-src``. Changing this also requires
+// updating the CSP meta-tag in index.html.
+const ELECTRUMX_WSS_URL = "wss://electrumx.radiant4people.com:50022";
+
+// Hard cap on a fetched transaction's hex length. Mirrors the cap
+// glue.py applies on the Python side (8 MB hex = 4 MB binary, the
+// Radiant policy maximum). Clipping in JS too means a hostile server
+// can't make us spend memory holding a multi-gigabyte response while
+// the Python guard rejects it.
+const MAX_FETCHED_TX_HEX_LEN = 8_000_000;
+
+// Per-fetch timeout. Real ElectrumX servers respond in <1s; 10 seconds
+// is generous and bounds the worst case where the connection succeeds
+// but the server hangs without responding.
+const FETCH_TIMEOUT_MS = 10_000;
 
 // ---------------------------------------------------------------------
 // Status / error helpers
@@ -157,12 +175,16 @@ async function boot() {
   setProgress(60);
 
   try {
-    await pyodide.loadPackage(["micropip"]);
+    // Pyodide ships ``pycryptodome`` (no -x). pyrxd imports
+    // ``Cryptodome.Cipher.AES`` via pycryptodomex which doesn't have a
+    // pure-Python wheel; glue.py shims ``Cryptodome`` -> ``Crypto`` at
+    // import time, so we install pycryptodome here BEFORE pyrxd so the
+    // shim has something to alias.
+    await pyodide.loadPackage(["micropip", "pycryptodome"]);
     const wheelURL = new URL(manifest.wheel, WHEELS_BASE).toString();
     await pyodide.runPythonAsync(`
 import micropip
 await micropip.install(${JSON.stringify(wheelURL)})
-import pyrxd
 `);
   } catch (err) {
     showError(`Could not install pyrxd from ${manifest.wheel}: ${err.message}`);
@@ -171,24 +193,12 @@ import pyrxd
 
   setProgress(85);
 
-  // Read the installed pyrxd version back through the bridge.
+  // Load the Pyodide-side glue. The glue module installs the
+  // Cryptodome→Crypto shim at import time and then imports pyrxd, so
+  // pyrxd's import chain (which references Cryptodome.Cipher.AES via
+  // aes_cbc) resolves cleanly. Both entry points come back as PyProxy
+  // references stashed on the JS module.
   let versionText;
-  try {
-    const py = pyodide.runPython(`
-import pyrxd
-import sys
-v = getattr(pyrxd, "__version__", "unknown")
-f"pyrxd {v} loaded under Python {sys.version.split()[0]}"
-`);
-    versionText = String(py);
-  } catch (err) {
-    showError(`Could not read pyrxd.__version__: ${err.message}`);
-    return;
-  }
-
-  // Load the Pyodide-side glue and grab a reference to its `run` function.
-  // We fetch the source text and execute it under a synthetic module name
-  // so any future `from pyrxd_inspect_glue import ...` would also resolve.
   try {
     const glueSrc = await fetchGlueSource();
     pyodide.FS.writeFile("/home/pyodide/glue.py", glueSrc);
@@ -196,8 +206,15 @@ f"pyrxd {v} loaded under Python {sys.version.split()[0]}"
 import sys
 sys.path.insert(0, "/home/pyodide")
 import glue as _pyrxd_glue
+import pyrxd
+_pyrxd_version_blob = (
+    f"pyrxd {getattr(pyrxd, '__version__', 'unknown')} "
+    f"loaded under Python {sys.version.split()[0]}"
+)
 `);
     pyGlue = pyodide.globals.get("_pyrxd_glue").run;
+    pyGlueFetch = pyodide.globals.get("_pyrxd_glue").inspect_txid_with_raw;
+    versionText = String(pyodide.globals.get("_pyrxd_version_blob"));
   } catch (err) {
     showError(`Could not load inspect glue: ${err.message}`);
     return;
@@ -358,7 +375,12 @@ function renderResult(result) {
 
   let card;
   if (form === "txid") {
-    card = renderTxidCard(payload);
+    // Fetched-tx payloads carry byte_length / output_count / etc.;
+    // pre-fetch placeholder payloads carry needs_fetch=true. Pick the
+    // richer card when the data's there.
+    card = (payload && payload.byte_length !== undefined)
+      ? renderFetchedTxCard(payload)
+      : renderTxidCard(payload);
   } else if (form === "contract") {
     card = renderContractCard(payload);
   } else if (form === "outpoint") {
@@ -418,12 +440,98 @@ function renderTxidCard(payload) {
   const wrapper = card("Transaction id", "txid");
   const dl = el("dl", { class: "kv-list" });
   dl.appendChild(kv("txid", payload.txid));
-  dl.appendChild(kv("status", payload.needs_fetch ? "needs --fetch" : "ready"));
+  dl.appendChild(kv("status", payload.needs_fetch ? "ready to fetch" : "loaded"));
   wrapper.appendChild(dl);
   if (payload.message) {
     const note = el("p", { class: "card-note", text: payload.message });
     wrapper.appendChild(note);
   }
+
+  if (payload.needs_fetch) {
+    const actionRow = el("div", { class: "fetch-row" });
+    const fetchBtn = el("button", {
+      class: "fetch-btn",
+      text: "Fetch from network",
+    });
+    fetchBtn.type = "button";
+    const status = el("span", { class: "fetch-status" });
+    actionRow.appendChild(fetchBtn);
+    actionRow.appendChild(status);
+    wrapper.appendChild(actionRow);
+
+    fetchBtn.addEventListener("click", () => onFetchTxid(payload.txid, fetchBtn, status));
+  }
+
+  return wrapper;
+}
+
+function renderFetchedTxCard(payload) {
+  const wrapper = card("Fetched transaction", "txid");
+  const dl = el("dl", { class: "kv-list" });
+  dl.appendChild(kv("txid", payload.txid));
+  dl.appendChild(kv("size", `${payload.byte_length} bytes`));
+  dl.appendChild(kv("inputs", payload.input_count));
+  dl.appendChild(kv("outputs", payload.output_count));
+  wrapper.appendChild(dl);
+
+  // Per-output rows.
+  const outputs = payload.outputs || [];
+  if (outputs.length > 0) {
+    wrapper.appendChild(el("h3", { class: "result-subhead", text: "Outputs" }));
+    const outList = el("div", { class: "output-rows" });
+    for (const row of outputs) {
+      outList.appendChild(renderOutputRow(row));
+    }
+    wrapper.appendChild(outList);
+  }
+
+  // Reveal metadata (if present).
+  const metadata = payload.metadata;
+  if (metadata) {
+    wrapper.appendChild(el("h3", { class: "result-subhead", text: "Reveal metadata" }));
+    const mdl = el("dl", { class: "kv-list" });
+    mdl.appendChild(kv("input index", metadata.input_index));
+    if (Array.isArray(metadata.protocol) && metadata.protocol.length > 0) {
+      mdl.appendChild(kv("protocol", metadata.protocol.join(", ")));
+    }
+    if (metadata.name) mdl.appendChild(kv("name", metadata.name));
+    if (metadata.ticker) mdl.appendChild(kv("ticker", metadata.ticker));
+    if (metadata.description) mdl.appendChild(kv("description", metadata.description));
+    if (metadata.decimals !== undefined && metadata.decimals !== null) {
+      mdl.appendChild(kv("decimals", metadata.decimals));
+    }
+    if (metadata.main) mdl.appendChild(kv("main", metadata.main));
+    wrapper.appendChild(mdl);
+  }
+
+  return wrapper;
+}
+
+function renderOutputRow(row) {
+  const type = String(row.type || "unknown").toLowerCase();
+  const wrapper = el("section", { class: "output-row" });
+  const head = el("header", { class: "output-row-head" });
+  head.appendChild(el("span", { class: "output-vout", text: `vout ${row.vout}` }));
+  head.appendChild(badge(type.toUpperCase(), scriptBadgeKind(type)));
+  head.appendChild(el("span", { class: "output-sats", text: `${row.satoshis} sats` }));
+  wrapper.appendChild(head);
+
+  const dl = el("dl", { class: "kv-list" });
+  if (row.owner_pkh) dl.appendChild(kv("owner pkh", row.owner_pkh));
+  if (row.ref_outpoint) dl.appendChild(kv("ref", row.ref_outpoint));
+  if (row.payload_hash) dl.appendChild(kv("payload hash", row.payload_hash));
+  if (row.contract_ref_outpoint) dl.appendChild(kv("contract ref", row.contract_ref_outpoint));
+  if (row.token_ref_outpoint) dl.appendChild(kv("token ref", row.token_ref_outpoint));
+  if (row.height !== undefined) dl.appendChild(kv("height", row.height));
+  if (row.max_height !== undefined) dl.appendChild(kv("max height", row.max_height));
+  if (row.reward !== undefined) dl.appendChild(kv("reward", row.reward));
+  if (row.algo) dl.appendChild(kv("algo", row.algo));
+  if (row.daa_mode) dl.appendChild(kv("daa mode", row.daa_mode));
+  if (row.version) dl.appendChild(kv("version", row.version));
+  if (type === "error") {
+    dl.appendChild(kv("error", row.error || "(unknown)"));
+  }
+  wrapper.appendChild(dl);
   return wrapper;
 }
 
@@ -567,6 +675,148 @@ function renderJsonDrawer(result) {
   });
   details.appendChild(copyBtn);
   return details;
+}
+
+// ---------------------------------------------------------------------
+// WebSocket fetch — pulls raw bytes for a txid from the configured
+// ElectrumX server. Returns a Promise<string> of the hex-encoded raw
+// transaction or rejects with an Error on any failure mode.
+//
+// Wire protocol: ElectrumX uses JSON-RPC 2.0 over WebSocket with
+// newline-delimited frames. We send one request, await the matching
+// response by id, and close. No long-lived connection — this is a
+// "fetch and forget" pattern, simpler than maintaining the kind of
+// reader loop the Python ElectrumXClient uses.
+// ---------------------------------------------------------------------
+
+function fetchRawTxFromElectrumx(txid) {
+  return new Promise((resolve, reject) => {
+    let ws;
+    try {
+      ws = new WebSocket(ELECTRUMX_WSS_URL);
+    } catch (err) {
+      reject(new Error(`could not open WebSocket: ${err.message || err}`));
+      return;
+    }
+
+    let settled = false;
+    const settle = (fn, value) => {
+      if (settled) return;
+      settled = true;
+      try { ws.close(); } catch { /* already closed */ }
+      fn(value);
+    };
+
+    const timer = setTimeout(() => {
+      settle(reject, new Error(`timed out after ${FETCH_TIMEOUT_MS}ms`));
+    }, FETCH_TIMEOUT_MS);
+
+    ws.addEventListener("open", () => {
+      const req = JSON.stringify({
+        id: 1,
+        method: "blockchain.transaction.get",
+        params: [txid, false],
+      });
+      // ElectrumX expects newline-terminated frames.
+      ws.send(req + "\n");
+    });
+
+    ws.addEventListener("message", (ev) => {
+      clearTimeout(timer);
+      let frame;
+      try {
+        frame = JSON.parse(typeof ev.data === "string" ? ev.data : "");
+      } catch (err) {
+        settle(reject, new Error(`server returned non-JSON: ${err.message}`));
+        return;
+      }
+      if (frame.id !== 1) {
+        // Unexpected id — discard and keep waiting (cheap defence
+        // against a server that buffers other clients' responses).
+        return;
+      }
+      if (frame.error) {
+        const msg = (frame.error && frame.error.message) || JSON.stringify(frame.error);
+        settle(reject, new Error(`server error: ${msg}`));
+        return;
+      }
+      const result = frame.result;
+      if (typeof result !== "string") {
+        settle(reject, new Error("server returned non-string result"));
+        return;
+      }
+      if (result.length > MAX_FETCHED_TX_HEX_LEN) {
+        settle(reject, new Error(
+          `response is ${result.length.toLocaleString()} chars; cap is ` +
+          `${MAX_FETCHED_TX_HEX_LEN.toLocaleString()}`
+        ));
+        return;
+      }
+      // Light hex sanity check — Python side does the real validation.
+      if (!/^[0-9a-fA-F]*$/.test(result)) {
+        settle(reject, new Error("server returned a non-hex string"));
+        return;
+      }
+      settle(resolve, result);
+    });
+
+    ws.addEventListener("error", () => {
+      clearTimeout(timer);
+      settle(reject, new Error("WebSocket error connecting to ElectrumX"));
+    });
+
+    ws.addEventListener("close", () => {
+      clearTimeout(timer);
+      settle(reject, new Error("WebSocket closed before any response"));
+    });
+  });
+}
+
+async function onFetchTxid(txid, fetchBtn, statusEl) {
+  if (!pyGlueFetch) {
+    statusEl.textContent = "(glue not ready)";
+    return;
+  }
+  fetchBtn.disabled = true;
+  statusEl.textContent = "fetching…";
+
+  let rawHex;
+  try {
+    rawHex = await fetchRawTxFromElectrumx(txid);
+  } catch (err) {
+    fetchBtn.disabled = false;
+    statusEl.textContent = "";
+    renderResult({
+      ok: false,
+      form: "error",
+      error: `fetch failed: ${err.message || err}`,
+      hint:
+        "Try again, check that wss://electrumx.radiant4people.com:50022 is " +
+        "reachable, or use the CLI: pyrxd glyph inspect <txid> --fetch",
+    });
+    return;
+  }
+
+  statusEl.textContent = "classifying…";
+
+  let result;
+  try {
+    const pyResult = pyGlueFetch(txid, rawHex);
+    result = pyResult.toJs({ dict_converter: Object.fromEntries });
+    pyResult.destroy();
+  } catch (err) {
+    fetchBtn.disabled = false;
+    statusEl.textContent = "";
+    renderResult({
+      ok: false,
+      form: "error",
+      error: `bridge error: ${err.message || err}`,
+      hint: "",
+    });
+    return;
+  }
+
+  renderResult(result);
 }
 
 // ---------------------------------------------------------------------

--- a/docs/inspect_static/inspect/inspect.js
+++ b/docs/inspect_static/inspect/inspect.js
@@ -417,6 +417,25 @@ function kv(label, value, valueClass) {
   return row;
 }
 
+// Render a kv pair where the value carries a per-field warning (e.g.
+// "mixed scripts (possible homoglyph)"). The value text remains
+// unmodified — sanitisation already happened on the Python side and
+// truncation on the recursive walker — but we attach a visible warning
+// label and a CSS class so the user can't miss the suspicion.
+function kvWithWarning(label, value, warningText) {
+  const row = el("div", { class: "kv-row" });
+  row.appendChild(el("dt", { class: "kv-label", text: label }));
+  const dd = el("dd", { class: warningText ? "kv-value kv-warning" : "kv-value" });
+  dd.textContent = value === null || value === undefined ? "—" : String(value);
+  if (warningText) {
+    const warning = el("div", { class: "kv-warning-note" });
+    warning.textContent = `⚠ ${warningText}`;
+    dd.appendChild(warning);
+  }
+  row.appendChild(dd);
+  return row;
+}
+
 function badge(label, kind) {
   // Type badge (FT, NFT, MUT, DMINT, COMMIT, P2PKH, UNKNOWN). The CSS
   // class controls colour from the Okabe-Ito palette.
@@ -490,18 +509,34 @@ function renderFetchedTxCard(payload) {
   if (metadata) {
     wrapper.appendChild(el("h3", { class: "result-subhead", text: "Reveal metadata" }));
     const mdl = el("dl", { class: "kv-list" });
+    const warnings = (metadata && metadata.display_warnings) || {};
     mdl.appendChild(kv("input index", metadata.input_index));
     if (Array.isArray(metadata.protocol) && metadata.protocol.length > 0) {
       mdl.appendChild(kv("protocol", metadata.protocol.join(", ")));
     }
-    if (metadata.name) mdl.appendChild(kv("name", metadata.name));
-    if (metadata.ticker) mdl.appendChild(kv("ticker", metadata.ticker));
-    if (metadata.description) mdl.appendChild(kv("description", metadata.description));
+    if (metadata.name) mdl.appendChild(kvWithWarning("name", metadata.name, warnings.name));
+    if (metadata.ticker) mdl.appendChild(kvWithWarning("ticker", metadata.ticker, warnings.ticker));
+    if (metadata.description) mdl.appendChild(kvWithWarning("description", metadata.description, warnings.description));
     if (metadata.decimals !== undefined && metadata.decimals !== null) {
       mdl.appendChild(kv("decimals", metadata.decimals));
     }
     if (metadata.main) mdl.appendChild(kv("main", metadata.main));
     wrapper.appendChild(mdl);
+
+    // Top-level warning banner if any field tripped a homoglyph flag.
+    // The Python side sets metadata.display_warnings as a {field: reason}
+    // dict; we surface it visibly so a user reading "USDC" can tell at a
+    // glance whether the string is what it looks like.
+    if (Object.keys(warnings).length > 0) {
+      const banner = el("p", { class: "warning-banner" });
+      banner.textContent =
+        "⚠ This token's metadata contains characters that visually mimic other " +
+        "scripts. Treat the displayed name/ticker/description with care — " +
+        "characters that look like Latin letters may actually be from another " +
+        "alphabet (e.g. Cyrillic 'а' instead of Latin 'a'). Verify the txid, " +
+        "not the name, before trusting this token.";
+      wrapper.appendChild(banner);
+    }
   }
 
   return wrapper;
@@ -700,14 +735,16 @@ function fetchRawTxFromElectrumx(txid) {
     }
 
     let settled = false;
+    let timer = null;
     const settle = (fn, value) => {
       if (settled) return;
       settled = true;
+      if (timer !== null) clearTimeout(timer);
       try { ws.close(); } catch { /* already closed */ }
       fn(value);
     };
 
-    const timer = setTimeout(() => {
+    timer = setTimeout(() => {
       settle(reject, new Error(`timed out after ${FETCH_TIMEOUT_MS}ms`));
     }, FETCH_TIMEOUT_MS);
 
@@ -722,10 +759,24 @@ function fetchRawTxFromElectrumx(txid) {
     });
 
     ws.addEventListener("message", (ev) => {
-      clearTimeout(timer);
+      // Cap raw frame size BEFORE JSON.parse so a hostile server
+      // can't make us allocate a multi-GB string in the parser. The
+      // hex cap below is a downstream sanity check on the parsed
+      // result; this one is the actual memory guard.
+      const data = typeof ev.data === "string" ? ev.data : "";
+      if (data.length > MAX_FETCHED_TX_HEX_LEN + 4096) {
+        settle(reject, new Error(
+          `frame is ${data.length.toLocaleString()} chars; over the hex cap`
+        ));
+        return;
+      }
+
+      // NOTE: do not clearTimeout here. Mismatched-id frames are
+      // silently discarded (see below), so we must keep the timer
+      // armed until we actually settle. settle() clears the timer.
       let frame;
       try {
-        frame = JSON.parse(typeof ev.data === "string" ? ev.data : "");
+        frame = JSON.parse(data);
       } catch (err) {
         settle(reject, new Error(`server returned non-JSON: ${err.message}`));
         return;
@@ -733,11 +784,13 @@ function fetchRawTxFromElectrumx(txid) {
       if (frame.id !== 1) {
         // Unexpected id — discard and keep waiting (cheap defence
         // against a server that buffers other clients' responses).
+        // The 10s timer keeps running, so an attacker drip-feeding
+        // mismatched-id frames cannot hold the connection forever.
         return;
       }
       if (frame.error) {
-        const msg = (frame.error && frame.error.message) || JSON.stringify(frame.error);
-        settle(reject, new Error(`server error: ${msg}`));
+        const rawMsg = (frame.error && frame.error.message) || JSON.stringify(frame.error);
+        settle(reject, new Error(`server error: ${stripControlChars(rawMsg)}`));
         return;
       }
       const result = frame.result;
@@ -761,15 +814,28 @@ function fetchRawTxFromElectrumx(txid) {
     });
 
     ws.addEventListener("error", () => {
-      clearTimeout(timer);
       settle(reject, new Error("WebSocket error connecting to ElectrumX"));
     });
 
     ws.addEventListener("close", () => {
-      clearTimeout(timer);
       settle(reject, new Error("WebSocket closed before any response"));
     });
   });
+}
+
+// Strip control / format codepoints from server-supplied strings
+// before they reach the DOM. textContent makes XSS impossible, but
+// a hostile ElectrumX server could still embed bidi overrides or
+// zero-width characters into an error message that would render
+// visually misleading text inside the error card. Mirrors the
+// Python side's _sanitize_display_string for messages that don't
+// cross the bridge.
+function stripControlChars(s) {
+  if (typeof s !== "string") return String(s);
+  // \p{C} = control + format + surrogate + private + unassigned.
+  // \p{M} = combining marks. Both trimmed for parity with the
+  // Python side's category list.
+  return s.replace(/[\p{C}\p{M}]/gu, "?");
 }
 
 async function onFetchTxid(txid, fetchBtn, statusEl) {

--- a/src/pyrxd/glyph/inspect.py
+++ b/src/pyrxd/glyph/inspect.py
@@ -13,6 +13,11 @@ documented contract:
 
 * :func:`classify_input` — dispatch a raw string to its form
   (``"txid" | "contract" | "outpoint" | "script"``)
+* :func:`classify_raw_tx` — classify every output (and reveal CBOR) for
+  a pre-fetched raw transaction. Synchronous; takes pre-fetched bytes
+  rather than an ElectrumXClient, so the web UI can fetch via the
+  browser's native WebSocket and feed bytes straight into the same
+  classifier the CLI uses
 * :func:`inspect_contract` — decode a 72-char Glyph contract id
 * :func:`inspect_outpoint` — decode a ``txid:vout`` outpoint
 * :func:`inspect_script` — classify a hex-encoded locking script and
@@ -40,6 +45,9 @@ from ..cli.glyph_cmds import (
     _classify_input as classify_input,
 )
 from ..cli.glyph_cmds import (
+    _classify_raw_tx as classify_raw_tx,
+)
+from ..cli.glyph_cmds import (
     _inspect_contract as inspect_contract,
 )
 from ..cli.glyph_cmds import (
@@ -60,12 +68,14 @@ from .confusables import looks_confusable_with_latin, skeleton
 # something quacking like one) plus an event loop, neither of which is
 # straightforward to set up under Pyodide's WASM runtime. The web UI
 # fetches the raw bytes via the browser's native ``WebSocket`` API and
-# hands the bytes to this module's ``inspect_script`` per-output instead.
-# We deliberately do not re-export ``_inspect_txid_inner`` here — that
-# coupling stays inside the CLI for now.
+# hands them to ``classify_raw_tx`` instead — that helper does the same
+# threat-model checks the CLI's --fetch path applies, just without the
+# coroutine + client coupling. We deliberately do not re-export
+# ``_inspect_txid_inner`` here.
 
 __all__ = [
     "classify_input",
+    "classify_raw_tx",
     "inspect_contract",
     "inspect_outpoint",
     "inspect_script",

--- a/tests/web/test_facade_smoke.py
+++ b/tests/web/test_facade_smoke.py
@@ -153,6 +153,51 @@ class TestTruncateForHuman:
         assert inspect.truncate_for_human("short") == "short"
 
 
+class TestClassifyRawTx:
+    """The façade re-exports the synchronous classify_raw_tx helper that
+    the browser-hosted inspect tool calls after fetching raw bytes via
+    its own WebSocket. The CLI side already covers the threat-model
+    guards exhaustively; here we just lock the re-export contract."""
+
+    def test_classify_raw_tx_is_exported(self):
+        from pyrxd.glyph import inspect
+
+        assert "classify_raw_tx" in inspect.__all__
+        assert callable(inspect.classify_raw_tx)
+
+    def test_returns_form_txid_dict(self):
+        """Smoke against a tiny synthetic 1-input/1-output tx so no fixture
+        bytes are needed and no network ever runs."""
+        from pyrxd.glyph import inspect
+
+        # Simplest possible raw tx structure: 4-byte version, 1 vin (with
+        # 32-byte zero-prevout-hash + 0xffffffff vout + empty script + max
+        # sequence), 1 vout (zero satoshis + empty script), 4-byte locktime.
+        raw = bytes.fromhex(
+            "01000000"  # version
+            "01"  # vin count
+            + "00" * 32  # prev txid
+            + "ffffffff"  # prev vout
+            + "00"  # scriptSig length
+            + "ffffffff"  # sequence
+            + "01"  # vout count
+            + "0000000000000000"  # satoshis (0)
+            + "00"  # scriptPubKey length
+            + "00000000"  # locktime
+        )
+
+        # Compute the txid the way the parser does.
+        from pyrxd.hash import hash256
+
+        txid = hash256(raw)[::-1].hex()
+
+        result = inspect.classify_raw_tx(txid, raw)
+        assert result["form"] == "txid"
+        assert result["txid"] == txid
+        assert result["input_count"] == 1
+        assert result["output_count"] == 1
+
+
 class TestNoDirectCliImport:
     """The browser tool must NOT reach into CLI internals.
 

--- a/tests/web/test_facade_smoke.py
+++ b/tests/web/test_facade_smoke.py
@@ -167,12 +167,15 @@ class TestClassifyRawTx:
 
     def test_returns_form_txid_dict(self):
         """Smoke against a tiny synthetic 1-input/1-output tx so no fixture
-        bytes are needed and no network ever runs."""
+        bytes are needed and no network ever runs.
+
+        The classifier rejects raw bytes <= 64 (Merkle-forgery defence
+        inherited from the ``RawTx`` newtype invariant), so the synthetic
+        tx must be at least 65 bytes. We give the output a real 25-byte
+        P2PKH locking script, which puts the total at ~85 bytes."""
         from pyrxd.glyph import inspect
 
-        # Simplest possible raw tx structure: 4-byte version, 1 vin (with
-        # 32-byte zero-prevout-hash + 0xffffffff vout + empty script + max
-        # sequence), 1 vout (zero satoshis + empty script), 4-byte locktime.
+        p2pkh_script = "76a914" + "aa" * 20 + "88ac"  # 25 bytes / 50 hex
         raw = bytes.fromhex(
             "01000000"  # version
             "01"  # vin count
@@ -182,7 +185,8 @@ class TestClassifyRawTx:
             + "ffffffff"  # sequence
             + "01"  # vout count
             + "0000000000000000"  # satoshis (0)
-            + "00"  # scriptPubKey length
+            + "19"  # scriptPubKey length (25 bytes)
+            + p2pkh_script
             + "00000000"  # locktime
         )
 
@@ -196,6 +200,7 @@ class TestClassifyRawTx:
         assert result["txid"] == txid
         assert result["input_count"] == 1
         assert result["output_count"] == 1
+        assert result["outputs"][0]["type"] == "p2pkh"
 
 
 class TestNoDirectCliImport:

--- a/tests/web/test_glue_integration.py
+++ b/tests/web/test_glue_integration.py
@@ -192,3 +192,124 @@ class TestErrorHints:
         # If the parser ever does raise, the hint must mention 72 hex.
         # For now: just validate that the hint table has the key.
         assert "72 hex" in glue._hint_for("contract")
+
+
+# ---------------------------------------------------------------------------
+# inspect_txid_with_raw — the fetch path
+# ---------------------------------------------------------------------------
+
+# Live mainnet RBG transfer (same fixture the CLI's --fetch tests use).
+# Real tx with 2 inputs, 3 outputs (ft / ft / p2pkh).
+_RBG_TRANSFER_TXID = "ac7f1f705086a3a4cb2a354bf778fe2da829a90372742db076f542398cc60ae4"
+_RBG_TRANSFER_OWNER_PKH = "d84b8c371ea11f051dfed9daae05c8dee24d9eba"
+_RBG_TRANSFER_RAW_HEX = (
+    "01000000029565e76c9e80570d3f9f38f961bc1719f866de2e81a73797f1da70fc77a8276300"
+    "0000006b483045022100a4635b1d89a79e5e5e2d9613ed1813b1ebdf5333bef0ad5005b743fe"
+    "d834dcff022068bd415a8157b69ca693e0a1dce77f8bb6a6aa929acfc16985c0dae557917280"
+    "4121034f4d886d85dc38da1b2a6f49d299990b57032821edc092109f0d93fd00537720ffffff"
+    "fffd432df44ff9627a0c6adb9c459a9d4e8677e54553d3e9896c2b6d0de03a93ba010000006a"
+    "47304402203faf1061260e218738834f83b05d23390d6ecb57c2c8d150642b6965ce3f719202"
+    "20226f828b994a1c3176fa52ddd6194b72b28d9949017edc782f6868adf704228f4121034f4d"
+    "886d85dc38da1b2a6f49d299990b57032821edc092109f0d93fd00537720ffffffff03010000"
+    "00000000004b76a914d84b8c371ea11f051dfed9daae05c8dee24d9eba88acbdd0a8a296afde"
+    "31eb80c3484f09da7eb31546990baf76fd8bff9a58fbbe53c45db400000000dec0e9aa76e378"
+    "e4a269e69dcfb95700000000004b76a914d84b8c371ea11f051dfed9daae05c8dee24d9eba88"
+    "acbdd0a8a296afde31eb80c3484f09da7eb31546990baf76fd8bff9a58fbbe53c45db4000000"
+    "00dec0e9aa76e378e4a269e69d6895b1439f0300001976a914d84b8c371ea11f051dfed9daae"
+    "05c8dee24d9eba88ac00000000"
+)
+
+
+class TestInspectTxidWithRaw:
+    """The fetch path: JS hands raw hex bytes to Python, Python applies
+    the same threat-model guards as the CLI's --fetch path and returns
+    a structured dict."""
+
+    def test_classifies_real_rbg_transfer(self, glue):
+        result = glue.inspect_txid_with_raw(_RBG_TRANSFER_TXID, _RBG_TRANSFER_RAW_HEX)
+        assert result["ok"] is True
+        assert result["form"] == "txid"
+        assert result["input"] == _RBG_TRANSFER_TXID
+
+        payload = result["payload"]
+        assert payload["txid"] == _RBG_TRANSFER_TXID
+        assert payload["input_count"] == 2
+        assert payload["output_count"] == 3
+
+        # Three outputs: vout 0 ft, vout 1 ft, vout 2 p2pkh — all share owner_pkh.
+        outputs = payload["outputs"]
+        assert outputs[0]["type"] == "ft"
+        assert outputs[1]["type"] == "ft"
+        assert outputs[2]["type"] == "p2pkh"
+        for row in outputs:
+            assert row["owner_pkh"] == _RBG_TRANSFER_OWNER_PKH
+
+    def test_hash_mismatch_rejected(self, glue):
+        """Server-honesty check: raw bytes that don't hash to the
+        requested txid must be refused (the CLI threat-model guard,
+        preserved verbatim)."""
+        fake_txid = "0" * 64
+        result = glue.inspect_txid_with_raw(fake_txid, _RBG_TRANSFER_RAW_HEX)
+        assert result["ok"] is False
+        assert result["form"] == "error"
+        assert "does not match" in result["error"]
+
+    def test_oversize_raw_hex_refused_before_classification(self, glue):
+        """Refused before the classifier runs — the cap defends against a
+        hostile server returning a multi-gigabyte response."""
+        result = glue.inspect_txid_with_raw(_RBG_TRANSFER_TXID, "a" * 9_000_000)
+        assert result["ok"] is False
+        assert "too long" in result["error"]
+
+    def test_non_hex_raw_rejected(self, glue):
+        result = glue.inspect_txid_with_raw(_RBG_TRANSFER_TXID, "not hex zzz")
+        assert result["ok"] is False
+        assert "not valid hex" in result["error"]
+
+    def test_short_txid_rejected(self, glue):
+        result = glue.inspect_txid_with_raw("abc", _RBG_TRANSFER_RAW_HEX)
+        assert result["ok"] is False
+        assert "64" in result["error"]
+
+    def test_empty_raw_rejected(self, glue):
+        result = glue.inspect_txid_with_raw(_RBG_TRANSFER_TXID, "")
+        assert result["ok"] is False
+        assert "empty" in result["error"]
+
+    @pytest.mark.parametrize("bad", [None, 42, [], {}])
+    def test_non_string_arguments_rejected(self, glue, bad):
+        result = glue.inspect_txid_with_raw(bad, _RBG_TRANSFER_RAW_HEX)
+        assert result["ok"] is False
+        assert "string" in result["error"]
+
+    def test_uppercase_txid_normalised(self, glue):
+        """Mirrors the run() normalisation contract: input is canonical
+        lowercased even when the user paste-from-explorer was uppercase."""
+        result = glue.inspect_txid_with_raw(_RBG_TRANSFER_TXID.upper(), _RBG_TRANSFER_RAW_HEX)
+        assert result["ok"] is True
+        assert result["input"] == _RBG_TRANSFER_TXID  # lowercase
+
+    def test_payload_strings_pass_through_sanitiser(self, glue, monkeypatch):
+        """The recursive sanitiser is applied to the classify_raw_tx
+        result before the dict crosses the bridge. We can't easily
+        introduce a CBOR string into the real fixture, so unit-test the
+        invariant directly: any string anywhere in the returned payload
+        comes back sanitised."""
+        # Inject a fake classify_raw_tx that returns a CBOR-like string with
+        # a bidi-override character. Sanitiser must strip it before return.
+        from pyrxd.glyph import inspect as facade
+
+        def _evil(_txid, _raw):
+            return {"form": "txid", "txid": _txid, "metadata": {"name": "gly‮bar"}}
+
+        monkeypatch.setattr(facade, "classify_raw_tx", _evil)
+        # Need a hex that matches the _txid argument's hash. Easiest way:
+        # bypass the hash check by using the real fixture and asserting the
+        # name field (which the fake injects). The hash check fires before
+        # classify_raw_tx is called — but we patched classify_raw_tx
+        # directly, so we need to also bypass the size + hash checks. The
+        # glue's path goes hex-decode → classify_raw_tx, so the patched
+        # classify_raw_tx is the only sink for the fake data here.
+        result = glue.inspect_txid_with_raw(_RBG_TRANSFER_TXID, _RBG_TRANSFER_RAW_HEX)
+        assert result["ok"] is True
+        assert "‮" not in result["payload"]["metadata"]["name"]

--- a/tests/web/test_glue_integration.py
+++ b/tests/web/test_glue_integration.py
@@ -317,45 +317,132 @@ class TestInspectTxidWithRaw:
 
 class TestHomoglyphDetection:
     """A token deployer can put any CBOR string into name/ticker/desc.
-    The Python-side `_looks_suspicious` flags strings that mix Latin ASCII
-    letters with letters from another script — the canonical homoglyph
-    spoofing shape (e.g. "USDC" with a Cyrillic 'U' / 'С'). The flag is
-    surfaced as `metadata.display_warnings` so the JS side can render a
-    visible banner on the card."""
+    Two attack shapes are flagged:
 
-    def test_pure_latin_not_flagged(self, glue):
-        assert glue._looks_suspicious("USDC") is False
-        assert glue._looks_suspicious("MyToken") is False
+    - **mixed scripts** — Latin ASCII letters mixed with letters from
+      another script. Per-character substitution (USDC with Cyrillic С).
+    - **non-Latin script** — every Letter codepoint is non-Latin.
+      Whole-word substitution (Cyrillic ВТС mimicking Latin BTC).
 
-    def test_pure_cyrillic_not_flagged(self, glue):
-        # All-Cyrillic is fine — it's only a problem when MIXED with Latin.
-        assert glue._looks_suspicious("УСДС") is False
+    The flag is surfaced as ``metadata.display_warnings[<field>]`` so the
+    JS side can render a banner + per-field warning. ``_suspicious_reason``
+    returns the reason string; ``_looks_suspicious`` is a backwards-
+    compat boolean wrapper.
+    """
 
-    def test_mixed_latin_cyrillic_flagged(self, glue):
-        # "USDC" with Cyrillic "С" (U+0421) instead of Latin "C".
-        spoofed = "USDС"  # ends in Cyrillic Es
-        assert glue._looks_suspicious(spoofed) is True
+    def test_pure_latin_ascii_not_flagged(self, glue):
+        assert glue._suspicious_reason("USDC") == ""
+        assert glue._suspicious_reason("MyToken") == ""
+        assert glue._suspicious_reason("BNB") == ""
+
+    def test_legit_latin_extended_not_flagged(self, glue):
+        """Real-world token names use accented Latin letters routinely.
+        Café / naïve / Zürich must NOT trip the flag — that would
+        damage trust in the legitimate non-English token namespace."""
+        for name in ["Café", "naïve", "Zürich", "piñata", "résumé"]:
+            assert glue._suspicious_reason(name) == "", f"false positive: {name!r}"
+
+    def test_mixed_latin_cyrillic_flagged_as_mixed(self, glue):
+        spoofed = "USDС"  # final char is Cyrillic С (U+0421)
+        assert glue._suspicious_reason(spoofed) == "mixed scripts (possible homoglyph)"
+
+    def test_pure_cyrillic_flagged_as_non_latin(self, glue):
+        """Pure-non-Latin token names that visually mimic Latin (the
+        classic ВТС-mimicking-BTC attack) must trip the flag too —
+        a Latin-default reader sees "BTC" but the token is something
+        else entirely."""
+        for name in ["ВТС", "ΟΜΓ", "аррӏе"]:
+            reason = glue._suspicious_reason(name)
+            assert reason == "non-Latin script (verify by txid, not by visual name)", (
+                f"unexpected reason for {name!r}: {reason!r}"
+            )
 
     def test_latin_with_digits_not_flagged(self, glue):
         # Digits and punctuation aren't Letters — they don't trip the flag.
-        assert glue._looks_suspicious("TOKEN123") is False
-        assert glue._looks_suspicious("A.B.C-1") is False
+        assert glue._suspicious_reason("TOKEN123") == ""
+        assert glue._suspicious_reason("A.B.C-1") == ""
 
     def test_latin_with_emoji_not_flagged(self, glue):
         # Emoji are not Letter category; legitimate token names can contain them.
-        assert glue._looks_suspicious("TOKEN \U0001f680") is False
+        assert glue._suspicious_reason("TOKEN \U0001f680") == ""
 
     def test_empty_or_none_not_flagged(self, glue):
-        assert glue._looks_suspicious("") is False
-        assert glue._looks_suspicious(None) is False
+        assert glue._suspicious_reason("") == ""
+        assert glue._suspicious_reason(None) == ""
 
     def test_nfkc_normalisation_applied(self, glue):
         # Full-width Latin letters look like Latin to a viewer; NFKC
         # collapses them so the script-mixing check operates on the
-        # canonical form. A pure-fullwidth string should not be flagged
-        # (it's still all "Latin" after normalisation).
+        # canonical form. A pure-fullwidth Latin string is still Latin
+        # after normalisation — must not be flagged.
         full_width_latin = "ＵＳＤＣ"  # "USDC" in full-width
-        assert glue._looks_suspicious(full_width_latin) is False
+        assert glue._suspicious_reason(full_width_latin) == ""
+
+    def test_bool_wrapper_still_works(self, glue):
+        """``_looks_suspicious`` kept as a boolean adapter for callers
+        that don't care about the reason."""
+        assert glue._looks_suspicious("USDC") is False
+        assert glue._looks_suspicious("USDС") is True  # mixed
+        assert glue._looks_suspicious("ВТС") is True  # pure non-Latin
+
+
+class TestProtocolFieldHomoglyphCoverage:
+    """The homoglyph check walks ``metadata.protocol`` array entries, not
+    just name/ticker/description. An attacker who puts a homoglyph in
+    the protocol field gets it surfaced via display_warnings the same
+    way."""
+
+    def test_protocol_with_mixed_script_entry_flagged(self, glue, monkeypatch):
+        from pyrxd.glyph import inspect as facade
+
+        def _evil(_txid, _raw):
+            return {
+                "form": "txid",
+                "txid": _txid,
+                "byte_length": 100,
+                "input_count": 1,
+                "output_count": 1,
+                "outputs": [],
+                "metadata": {
+                    "input_index": 0,
+                    "protocol": ["gly", "rxd", "USDС"],  # final entry mixed
+                    "name": "",
+                    "ticker": "",
+                    "description": "",
+                },
+            }
+
+        monkeypatch.setattr(facade, "classify_raw_tx", _evil)
+        result = glue.inspect_txid_with_raw(_RBG_TRANSFER_TXID, _RBG_TRANSFER_RAW_HEX)
+        warnings = result["payload"]["metadata"]["display_warnings"]
+        assert "protocol" in warnings
+        assert warnings["protocol"] == "mixed scripts (possible homoglyph)"
+
+    def test_benign_protocol_not_flagged(self, glue, monkeypatch):
+        from pyrxd.glyph import inspect as facade
+
+        def _benign(_txid, _raw):
+            return {
+                "form": "txid",
+                "txid": _txid,
+                "byte_length": 100,
+                "input_count": 1,
+                "output_count": 1,
+                "outputs": [],
+                "metadata": {
+                    "input_index": 0,
+                    "protocol": ["gly", "rxd"],
+                    "name": "",
+                    "ticker": "",
+                    "description": "",
+                },
+            }
+
+        monkeypatch.setattr(facade, "classify_raw_tx", _benign)
+        result = glue.inspect_txid_with_raw(_RBG_TRANSFER_TXID, _RBG_TRANSFER_RAW_HEX)
+        # display_warnings should be entirely absent (or have no protocol key).
+        warnings = result["payload"]["metadata"].get("display_warnings", {})
+        assert "protocol" not in warnings
 
 
 class TestPayloadTruncation:
@@ -399,3 +486,13 @@ class TestPayloadTruncation:
         assert result["ok"] is True
         for row in result["payload"]["outputs"]:
             assert len(row["owner_pkh"]) == 40, row
+
+    def test_main_field_is_truncated(self, glue):
+        """``main`` is constructed by Python as ``<media: {mime}, {N}
+        bytes, sha256={hex}>`` but the CBOR-supplied mime_type has no
+        upstream length cap, so an attacker mime_type of 64KB makes the
+        constructed string overflow the card. ``main`` is therefore
+        NOT in the never-truncate allowlist — must be capped at 200."""
+        long_main = "<media: " + "x" * 1000 + ">"
+        walked = glue._sanitize_payload_strings({"metadata": {"main": long_main}})
+        assert len(walked["metadata"]["main"]) <= 200

--- a/tests/web/test_glue_integration.py
+++ b/tests/web/test_glue_integration.py
@@ -313,3 +313,89 @@ class TestInspectTxidWithRaw:
         result = glue.inspect_txid_with_raw(_RBG_TRANSFER_TXID, _RBG_TRANSFER_RAW_HEX)
         assert result["ok"] is True
         assert "‮" not in result["payload"]["metadata"]["name"]
+
+
+class TestHomoglyphDetection:
+    """A token deployer can put any CBOR string into name/ticker/desc.
+    The Python-side `_looks_suspicious` flags strings that mix Latin ASCII
+    letters with letters from another script — the canonical homoglyph
+    spoofing shape (e.g. "USDC" with a Cyrillic 'U' / 'С'). The flag is
+    surfaced as `metadata.display_warnings` so the JS side can render a
+    visible banner on the card."""
+
+    def test_pure_latin_not_flagged(self, glue):
+        assert glue._looks_suspicious("USDC") is False
+        assert glue._looks_suspicious("MyToken") is False
+
+    def test_pure_cyrillic_not_flagged(self, glue):
+        # All-Cyrillic is fine — it's only a problem when MIXED with Latin.
+        assert glue._looks_suspicious("УСДС") is False
+
+    def test_mixed_latin_cyrillic_flagged(self, glue):
+        # "USDC" with Cyrillic "С" (U+0421) instead of Latin "C".
+        spoofed = "USDС"  # ends in Cyrillic Es
+        assert glue._looks_suspicious(spoofed) is True
+
+    def test_latin_with_digits_not_flagged(self, glue):
+        # Digits and punctuation aren't Letters — they don't trip the flag.
+        assert glue._looks_suspicious("TOKEN123") is False
+        assert glue._looks_suspicious("A.B.C-1") is False
+
+    def test_latin_with_emoji_not_flagged(self, glue):
+        # Emoji are not Letter category; legitimate token names can contain them.
+        assert glue._looks_suspicious("TOKEN \U0001f680") is False
+
+    def test_empty_or_none_not_flagged(self, glue):
+        assert glue._looks_suspicious("") is False
+        assert glue._looks_suspicious(None) is False
+
+    def test_nfkc_normalisation_applied(self, glue):
+        # Full-width Latin letters look like Latin to a viewer; NFKC
+        # collapses them so the script-mixing check operates on the
+        # canonical form. A pure-fullwidth string should not be flagged
+        # (it's still all "Latin" after normalisation).
+        full_width_latin = "ＵＳＤＣ"  # "USDC" in full-width
+        assert glue._looks_suspicious(full_width_latin) is False
+
+
+class TestPayloadTruncation:
+    """The recursive sanitiser caps free-form strings at the human-display
+    limit so an attacker description can't overflow the card. Hex-shaped
+    primary keys (txid, refs, owner_pkh) MUST be passed through unchanged
+    — chopping a txid visually misleads the user about which transaction
+    they're inspecting."""
+
+    def test_long_description_truncated(self, glue):
+        long = "x" * 500
+        walked = glue._sanitize_payload_strings({"metadata": {"description": long}})
+        assert len(walked["metadata"]["description"]) <= 200
+
+    def test_long_name_truncated(self, glue):
+        long = "y" * 500
+        walked = glue._sanitize_payload_strings({"metadata": {"name": long}})
+        assert len(walked["metadata"]["name"]) <= 200
+
+    def test_full_length_txid_preserved(self, glue):
+        txid = "a" * 64
+        walked = glue._sanitize_payload_strings({"txid": txid})
+        assert walked["txid"] == txid
+
+    def test_owner_pkh_preserved_in_nested_output_row(self, glue):
+        pkh = "d" * 40
+        walked = glue._sanitize_payload_strings({"outputs": [{"owner_pkh": pkh, "type": "p2pkh"}]})
+        assert walked["outputs"][0]["owner_pkh"] == pkh
+
+    def test_ref_outpoint_preserved(self, glue):
+        ref = "b45dc453befb589aff8bfd76af0b994615b37eda094f48c380eb31deaf96a2a8:0"
+        walked = glue._sanitize_payload_strings({"ref_outpoint": ref})
+        assert walked["ref_outpoint"] == ref
+
+    def test_real_rbg_fixture_owner_pkh_untruncated_end_to_end(self, glue):
+        """End-to-end: even after going through inspect_txid_with_raw +
+        the recursive sanitiser, every output row's owner_pkh is full
+        40-char fidelity. Locks against a future change that
+        accidentally adds 'owner_pkh' to the truncate list."""
+        result = glue.inspect_txid_with_raw(_RBG_TRANSFER_TXID, _RBG_TRANSFER_RAW_HEX)
+        assert result["ok"] is True
+        for row in result["payload"]["outputs"]:
+            assert len(row["owner_pkh"]) == 40, row


### PR DESCRIPTION
## Summary

Wires the **txid form's "Fetch from network" path** for the browser-hosted inspect tool. After PR-A (#46) shipped the static page and PR-B (#47) wired the offline classifier, a bare 64-hex paste rendered an offline placeholder ("looks like a txid; come back next release"). This PR makes it actually work.

The flow:

1. User pastes a txid → offline classifier renders the txid card with a **"Fetch from network"** button.
2. Click → JS opens a WebSocket to \`wss://electrumx.radiant4people.com:50022\` (already CSP-whitelisted from PR-A), sends \`blockchain.transaction.get(txid, false)\`.
3. Receives raw hex, hands it to the new Pyodide entry \`glue.inspect_txid_with_raw(txid, raw_hex)\`.
4. Python applies the **same threat-model guards** as the CLI's \`--fetch\` path and returns a structured result dict.
5. JS renders it as a Fetched-tx card: per-vout output rows with type badges + owner_pkh + ref outpoints, plus reveal metadata (input index, protocol, name, ticker, decimals, main media hash) when present.

## Threat model (preserved verbatim from CLI)

- Validate txid via the \`Txid\` newtype before any work.
- \`hash256(raw)[::-1].hex() == requested txid\` (server-honesty check).
- \`len(raw) <= _MAX_RAW_TX_BYTES\` (4MB Radiant policy max).
- \`len(tx.inputs) <= _MAX_INPUT_COUNT\`, \`len(tx.outputs) <= _MAX_OUTPUT_COUNT\`.
- Per-output try/except so one malformed script never poisons the listing.
- Recursive sanitiser strips control / format / bidi-override codepoints from every CBOR-derived display string (\`name\`, \`ticker\`, \`description\`, \`protocol[*]\`) before the dict crosses the JS bridge.

**Single source of truth.** The Python entry calls \`pyrxd.glyph.inspect.classify_raw_tx\` (re-exported via the public façade). \`classify_raw_tx\` was extracted from \`_inspect_txid_inner\` in #49. The CLI's \`--fetch\` path and the browser's \`--fetch\` path now share **one code path and one set of guard sequences**, not two parallel copies.

## Pyodide ergonomics

- micropip installs \`pycryptodome\` (no -x — the sibling Pyodide ships) in addition to the pyrxd wheel.
- \`glue.py\` installs a \`sys.modules['Cryptodome'] = Crypto\` shim at import time so pyrxd's existing \`Cryptodome.Cipher.AES\` imports resolve unchanged.
- The shim is a **no-op on native CPython** (where \`pycryptodomex\` is importable directly), so it doesn't affect existing test or CLI paths.

## Trust boundary at the WebSocket

- JS validates the WebSocket response is a string, is hex, and is below an 8MB hex cap **before** handing to Python — avoids materialising a multi-gigabyte hostile-server response in memory while waiting for Python to reject it.
- The Python side enforces the same caps as ground truth (the JS check is defence-in-depth, not the trust boundary).
- All DOM writes for fetched output rows use \`textContent\` only — no \`innerHTML\`, no string concatenation into HTML.

## Test plan

- [x] \`tests/web/test_glue_integration.py\` — 12 new tests covering \`inspect_txid_with_raw\` against the real RBG mainnet transfer fixture (2 inputs, 3 outputs ft/ft/p2pkh), all error paths (hash mismatch, oversize, non-hex, short txid, empty raw, non-string args, uppercase txid normalisation), and a monkeypatch test that locks the recursive sanitiser invariant for any future \`classify_raw_tx\` that surfaces CBOR strings.
- [x] \`tests/web/test_facade_smoke.py\` — 2 new tests for the \`classify_raw_tx\` re-export + a synthetic-tx round-trip smoke.
- [x] Full \`task ci\` — 2396 passed / 4 skipped / 0 failed.
- [x] Sphinx build — all four files (\`index.html\`, \`inspect.css\`, \`inspect.js\`, \`glue.py\`) ship into \`_build/html/inspect/\`.
- [ ] **Manual post-deploy smoke**: paste an RBG mainnet txid, click Fetch, verify 2-in/3-out classification renders with FT/FT/P2PKH badges and the correct owner_pkh on each row. (Can't be CI'd — the WebSocket layer is live network.)

## Depends on

- **#49** (the \`_classify_raw_tx\` refactor) — PR-C re-exports that helper and calls it from glue.py. If #49 lands first, PR-C rebases trivially. If they land out of order, PR-C carries the refactor commit until #49 is merged.

## Out of scope (followup ideas)

- Multiple ElectrumX server URLs with race / failover (today: one hardcoded URL).
- A \`tests/web/test_facade_smoke_pyodide.py\` running headless Pyodide-in-browser to catch JS↔Python bridge regressions in CI rather than only at manual smoke.
- A \`?fetch=1\` URL param to auto-fetch on load when hydrating from a shared link.