### PR TITLE
hash: widen _select_ripemd160 exception breadth

### DIFF
--- a/src/pyrxd/hash.py
+++ b/src/pyrxd/hash.py
@@ -88,9 +88,23 @@ def _select_ripemd160() -> Callable[[bytes], bytes]:
     try:
         if _ripemd160_via_hashlib(b"") == _empty_digest:
             return _ripemd160_via_hashlib
-    except (ValueError, OSError):
-        # ValueError on OpenSSL-3 disabled-legacy-provider; OSError on
-        # exotic FIPS-mode builds. Either way: fall through.
+    except Exception:  # nosec B110 -- intentional broad catch; see comment below
+        # If ``hashlib`` is unusable for any reason, fall through to the
+        # pure-Python path. Better to be slow than to fail import:
+        # ``pyrxd.hash`` is imported during package init, so an
+        # exception here would abort every downstream caller.
+        # Concrete cases this catches:
+        #   - ValueError: OpenSSL-3 with the legacy provider unloaded
+        #     (the common case on Ubuntu 24.04 / Debian 12 / macOS
+        #     python.org installer).
+        #   - OSError: exotic FIPS-mode OpenSSL builds.
+        #   - RuntimeError / AttributeError / ImportError: degenerate
+        #     hashlib environments (vendored Python stubs, partial
+        #     namespace packages, pyodide-style platform variants).
+        # Bandit flags the bare ``except: pass`` shape (B110); annotated
+        # nosec because the failure-mode is an exhaustively-enumerated
+        # universe of "hashlib can't help us right now" — we want to
+        # gracefully degrade, not fail closed.
         pass
     return _ripemd160_pure_python
 

--- a/tests/test_ripemd160_fallback.py
+++ b/tests/test_ripemd160_fallback.py
@@ -106,17 +106,30 @@ class TestSelectRipemd160:
         impl = _select_ripemd160()
         assert impl(b"") == bytes.fromhex("9c1185a5c5e9fc54612808977ee8f548b2258d31")
 
-    def test_falls_back_when_hashlib_raises(self, monkeypatch):
+    @pytest.mark.parametrize(
+        "exception_factory",
+        [
+            lambda: ValueError("simulated OpenSSL-3 disabled-legacy-provider"),
+            lambda: OSError("simulated FIPS-mode hashlib"),
+            lambda: RuntimeError("simulated degenerate hashlib"),
+            lambda: AttributeError("simulated partial namespace package"),
+            lambda: ImportError("simulated vendored hashlib stub"),
+        ],
+    )
+    def test_falls_back_when_hashlib_raises(self, monkeypatch, exception_factory):
         """Force the hashlib path to fail and verify the selector picks
-        the pure-Python implementation."""
+        the pure-Python implementation. The selector catches the broad
+        ``Exception`` so any flavour of degenerate hashlib falls through
+        rather than aborting module import. Cover every exception type
+        the comment in ``_select_ripemd160`` enumerates as a real
+        scenario."""
         from pyrxd import hash as hash_mod
 
         def _boom(_payload):
-            raise ValueError("simulated OpenSSL-3 disabled-legacy-provider")
+            raise exception_factory()
 
         monkeypatch.setattr(hash_mod, "_ripemd160_via_hashlib", _boom)
         impl = hash_mod._select_ripemd160()
-        # The selector should have noticed _boom raises and chosen the pure path.
         assert impl is hash_mod._ripemd160_pure_python
         assert impl(b"") == bytes.fromhex("9c1185a5c5e9fc54612808977ee8f548b2258d31")
 


### PR DESCRIPTION
Closes #54.

## Summary

Widens the exception filter inside [\`_select_ripemd160()\`](src/pyrxd/hash.py) from \`(ValueError, OSError)\` to \`except Exception:\`. The intent of the selector is "be robust to weird Python builds" — the narrow filter only covered what CPython hashlib raises today, leaving every other exception flavour to abort module import.

\`pyrxd.hash\` is imported during package init, so an exception there would cascade through every downstream caller, not just the hash module.

## What's now covered

The comment block in [src/pyrxd/hash.py:91-104](src/pyrxd/hash.py#L91-L104) enumerates concrete scenarios:

- \`ValueError\` — OpenSSL-3 with the legacy provider unloaded (the common case on Ubuntu 24.04 / Debian 12 / macOS python.org installer)
- \`OSError\` — exotic FIPS-mode OpenSSL builds
- \`RuntimeError\` / \`AttributeError\` / \`ImportError\` — degenerate hashlib environments (vendored Python stubs, partial namespace packages, Pyodide platform variants)

## Bandit annotation

The \`except/pass\` shape trips bandit's B110 rule. Annotated with \`# nosec B110\` and an inline justification — the failure-mode here is exhaustive ("hashlib can't help us; fall through"), and failing closed would defeat the whole point of having a fallback.

## Test plan

- [x] Parametrised \`test_falls_back_when_hashlib_raises\` now covers \`ValueError\`, \`OSError\`, \`RuntimeError\`, \`AttributeError\`, \`ImportError\` — the selector picks the pure-Python path in every case
- [x] All 42 \`tests/test_ripemd160_fallback.py\` tests pass (was 38; +4 new parametrised cases)
- [x] Full \`task ci\` — 2424 passed / 4 skipped / 0 failed
- [x] Lint clean (\`ruff check\`); bandit clean

## Stacks on

[#48](https://github.com/MudwoodLabs/pyrxd/pull/48) — this branch sits on top of \`refactor/ripemd160-pure-python-fallback\`. Will rebase onto main once #48 lands.