### PR TITLE
glyph: cap CBOR mime_type length at 256 chars

### DIFF
--- a/src/pyrxd/glyph/payload.py
+++ b/src/pyrxd/glyph/payload.py
@@ -51,6 +51,15 @@ def _cbor_str(d: dict, key: str, max_len: int) -> str:
 _MAX_CBOR_PAYLOAD_BYTES = 65_536  # 64 KB hard cap — protects against DoS on decode
 _MAX_ATTRS_COUNT = 64  # unreasonable beyond this; prevents memory bombs
 
+# Per-IANA, real MIME types are short — even very obscure registered
+# values top out around 75 chars (e.g. ``application/vnd.openxmlformats-
+# officedocument.wordprocessingml.document``). 256 is generous and
+# leaves room for parameters (``; charset=…``) without ever being a
+# meaningful expansion vector. A higher cap was attacker-surface for
+# downstream display strings constructed from this field — see
+# https://github.com/MudwoodLabs/pyrxd/issues/52.
+_MAX_MIME_TYPE_CHARS = 256
+
 
 def _decode_attrs(raw: object) -> dict[str, str]:
     """Decode the 'attrs' CBOR field, enforcing count and type constraints."""
@@ -92,7 +101,12 @@ def decode_payload(cbor_bytes: bytes) -> GlyphMetadata:
     if "main" in d:
         m = d["main"]
         if isinstance(m, dict) and "t" in m and "b" in m:
-            main = GlyphMedia(mime_type=str(m["t"]), data=bytes(m["b"]))
+            mime_type = str(m["t"])
+            if len(mime_type) > _MAX_MIME_TYPE_CHARS:
+                raise ValidationError(
+                    f"CBOR field 'main.t' (mime_type) too long: {len(mime_type)} > {_MAX_MIME_TYPE_CHARS}"
+                )
+            main = GlyphMedia(mime_type=mime_type, data=bytes(m["b"]))
 
     version = d.get("v")
     if version is not None:

--- a/src/pyrxd/glyph/types.py
+++ b/src/pyrxd/glyph/types.py
@@ -100,9 +100,19 @@ class GlyphMedia:
     mime_type: str  # e.g. "image/webp"
     data: bytes  # raw binary
 
+    # Real IANA-registered MIME types top out around 75 chars; 256 is
+    # generous and leaves room for parameters (``; charset=…``) while
+    # bounding the expansion vector for display strings constructed
+    # from this field downstream. The CBOR decoder applies the same
+    # cap — this is defence-in-depth so direct constructor callers
+    # (tests, future SDK paths) get the same guarantee.
+    _MAX_MIME_TYPE_CHARS = 256
+
     def __post_init__(self) -> None:
         if not self.mime_type or "/" not in self.mime_type:
             raise ValidationError("Invalid MIME type")
+        if len(self.mime_type) > self._MAX_MIME_TYPE_CHARS:
+            raise ValidationError(f"MIME type too long: {len(self.mime_type)} > {self._MAX_MIME_TYPE_CHARS}")
         if len(self.data) > 100_000:  # 100KB limit for on-chain media
             raise ValidationError("On-chain media too large (max 100KB)")
 

--- a/tests/test_glyph.py
+++ b/tests/test_glyph.py
@@ -1085,6 +1085,37 @@ class TestSecurityRejection:
         with pytest.raises(ValidationError, match="Invalid MIME type"):
             GlyphMedia(mime_type="", data=b"data")
 
+    def test_mime_type_at_256_char_boundary_is_valid(self):
+        """256 chars is the per-IANA generous cap. Real-world MIME
+        types max out around 75; this leaves headroom for parameters
+        without ever being a meaningful expansion vector."""
+        # "image/" prefix (6) + 250 chars to hit exactly 256.
+        boundary = "image/" + "x" * 250
+        assert len(boundary) == 256
+        media = GlyphMedia(mime_type=boundary, data=b"x")
+        assert len(media.mime_type) == 256
+
+    def test_mime_type_over_256_chars_raises(self):
+        """Defends downstream display callers (e.g. the browser inspect
+        tool's ``main`` summary) from a 64KB CBOR mime_type that
+        overflows render frames. See GitHub issue #52."""
+        over = "image/" + "x" * 251  # 257 chars
+        with pytest.raises(ValidationError, match="MIME type too long"):
+            GlyphMedia(mime_type=over, data=b"x")
+
+    def test_decode_payload_caps_hostile_mime_type(self):
+        """End-to-end: a CBOR payload with a giant mime_type is
+        rejected at decode time, not silently propagated to GlyphMedia
+        (where it would also be caught — we want the loud error from
+        the decoder, with the field name the reader can grep for)."""
+        import cbor2
+
+        from pyrxd.glyph.payload import decode_payload
+
+        evil = cbor2.dumps({"p": [GlyphProtocol.NFT.value], "main": {"t": "a" * 65000 + "/b", "b": b"\x00" * 10}})
+        with pytest.raises(ValidationError, match="main.t.*too long"):
+            decode_payload(evil)
+
     def test_commit_script_wrong_hash_len_raises(self):
         with pytest.raises(ValidationError, match="32 bytes"):
             build_commit_locking_script(bytes(31), KNOWN_HEX20)


### PR DESCRIPTION
Closes #52.

## Summary

The CBOR decoder at [\`pyrxd.glyph.payload.decode_payload\`](src/pyrxd/glyph/payload.py) pulled \`mime_type\` from \`m[\"t\"]\` via plain \`str(...)\` with no length cap. Real-world MIME types top out around 75 chars per IANA — even the longest registered one, \`application/vnd.openxmlformats-officedocument.wordprocessingml.document\`, only hits 71. An attacker could put a 64KB-1 \`mime_type\` into a Glyph reveal and the SDK would pass it on to any caller that displays the field.

The browser-hosted inspect tool ([PR #50](https://github.com/MudwoodLabs/pyrxd/pull/50)) constructs a \`<media: {mime_type}, {N} bytes, sha256={hex}>\` summary string from this field. With an unbounded \`mime_type\`, the summary blows past the 200-char display cap and chops off the embedded sha256 — user can't see the full hash anywhere in the UI. Round-1 red-team review flagged this; deferred to a separate PR.

## Fix

Cap at **256 chars** (generous; leaves room for \`; charset=…\` parameters).

Applied at two layers:

- \`decode_payload\` raises \`ValidationError\` with the field name \`main.t\` so the failure message is greppable.
- \`GlyphMedia.__post_init__\` re-asserts via \`_MAX_MIME_TYPE_CHARS = 256\`. Defence in depth — direct constructor callers (tests, future SDK paths, anyone mocking metadata) get the same guarantee without going through the decoder.

## Test plan

- [x] 3 new tests in \`TestSecurityRejection\`:
  - 256-char boundary accepted
  - 257-char rejected (matches \`"MIME type too long"\`)
  - end-to-end: hostile CBOR with 65000-char mime_type rejected by \`decode_payload\` (matches \`"main.t.*too long"\`)
- [x] All existing GlyphMedia tests still pass (legitimate \`image/webp\`, \`application/octet-stream\`, etc.)
- [x] Full \`task ci\` — 2423 passed / 4 skipped / 0 failed
- [x] Lint clean

## Out of scope

This PR only caps \`mime_type\`. Other CBOR string fields go through \`_cbor_str\` which already has per-field caps. The \`creator\` / \`royalty\` / \`policy\` / \`rights\` sub-objects route through their own \`from_cbor_dict\` classmethods which validate independently — out of scope here.