### PR TITLE
feat(cli): qualify FT/NFT/MUT/dMint as 'structural pattern match'

### DIFF
--- a/src/pyrxd/cli/glyph_cmds.py
+++ b/src/pyrxd/cli/glyph_cmds.py
@@ -1719,15 +1719,19 @@ def _render_script_human(payload: dict) -> str:
     elif type_ in ("nft", "ft"):
         body.append(f"  ref:       {payload['ref_outpoint']}")
         body.append(f"  owner_pkh: {payload['owner_pkh']}")
+        body.append("  (structural pattern match: bytes match the FT/NFT script template;")
+        body.append("   does NOT verify the ref points to a valid Glyph contract)")
     elif type_ == "mut":
         body.append(f"  ref:          {payload['ref_outpoint']}")
         body.append(f"  payload_hash: {payload['payload_hash']}")
-        body.append("  (payload_hash is an opaque commitment to off-chain CBOR;")
-        body.append("   resolve via the reveal tx — `inspect` cannot resolve it locally)")
+        body.append("  (structural pattern match; payload_hash is an opaque commitment")
+        body.append("   to off-chain CBOR — resolve via the reveal tx; `inspect` cannot")
+        body.append("   verify provenance of the ref locally)")
     elif type_ in ("commit-nft", "commit-ft"):
         body.append(f"  payload_hash: {payload['payload_hash']}")
         body.append(f"  owner_pkh:    {payload['owner_pkh']}")
-        body.append("  (payload_hash is an opaque commitment to the reveal-tx CBOR)")
+        body.append("  (structural pattern match; payload_hash is an opaque commitment")
+        body.append("   to the reveal-tx CBOR)")
     elif type_ == "dmint":
         version = payload.get("version", "?")
         body.append(f"  version:      dMint {version}")
@@ -1740,6 +1744,8 @@ def _render_script_human(payload: dict) -> str:
         body.append(f"  total supply: {total:,} photons")
         body.append(f"  algo:         {payload['algo']}")
         body.append(f"  daa_mode:     {payload['daa_mode']}")
+        body.append("  (structural pattern match; does NOT verify the contract_ref points")
+        body.append("   to a valid mint chain or that the parameters match a deployed token)")
     elif type_ == "unknown":
         body.append("  (script does not match any known Glyph or P2PKH layout)")
     return "\n".join([head, *body])

--- a/tests/cli/test_glyph_inspect_cmds.py
+++ b/tests/cli/test_glyph_inspect_cmds.py
@@ -278,6 +278,55 @@ class TestInspectScriptHex:
         assert "algo:         SHA256D" in result.output
         assert "daa_mode:     FIXED" in result.output
 
+
+class TestStructuralMatchQualifier:
+    """The script classifier matches by hex pattern, not by cryptographic
+    verification — it can't tell whether the ref points to a valid
+    Glyph contract or whether the dMint params match a deployed token.
+    The human-mode renderer must qualify FT/NFT/MUT/dMint outputs with
+    a "structural pattern match" note so a user reading the card
+    doesn't conclude the classification is provenance-verified.
+
+    See GitHub issue #53.
+    """
+
+    def test_ft_carries_structural_match_qualifier(self, runner: CliRunner) -> None:
+        result = runner.invoke(cli, ["glyph", "inspect", _ft_script().hex()])
+        assert result.exit_code == 0
+        assert "type: ft" in result.output
+        assert "structural pattern match" in result.output
+        assert "does NOT verify the ref" in result.output
+
+    def test_nft_carries_structural_match_qualifier(self, runner: CliRunner) -> None:
+        result = runner.invoke(cli, ["glyph", "inspect", _nft_script().hex()])
+        assert result.exit_code == 0
+        assert "type: nft" in result.output
+        assert "structural pattern match" in result.output
+
+    def test_mut_carries_structural_match_qualifier(self, runner: CliRunner) -> None:
+        result = runner.invoke(cli, ["glyph", "inspect", _mutable_script().hex()])
+        assert result.exit_code == 0
+        assert "type: mut" in result.output
+        assert "structural pattern match" in result.output
+        # The wording is split across two lines in the human renderer;
+        # check both halves so the test survives if line breaks shift.
+        assert "verify provenance" in result.output
+
+    def test_dmint_carries_structural_match_qualifier(self, runner: CliRunner) -> None:
+        result = runner.invoke(cli, ["glyph", "inspect", _dmint_contract_script().hex()])
+        assert result.exit_code == 0
+        assert "type: dmint" in result.output
+        assert "structural pattern match" in result.output
+        assert "does NOT verify the contract_ref" in result.output
+
+    def test_p2pkh_does_NOT_carry_structural_qualifier(self, runner: CliRunner) -> None:
+        """P2PKH classification is exact (3-byte prefix + 20-byte pkh + 2-byte
+        suffix), not structural. The qualifier would be misleading."""
+        result = runner.invoke(cli, ["glyph", "inspect", _p2pkh_script().hex()])
+        assert result.exit_code == 0
+        assert "type: p2pkh" in result.output
+        assert "structural pattern match" not in result.output
+
     def test_classifies_v1_dmint_contract_json(self, runner: CliRunner) -> None:
         """JSON form must include ``version`` for V1, and the dmint-specific
         fields must round-trip through ``ensure_ascii=True`` cleanly."""


### PR DESCRIPTION
Closes #53.

## Summary

\`is_ft_script\` / \`is_nft_script\` / \`MUTABLE_NFT_SCRIPT_RE\` / \`DmintState.from_script\` etc. (in [\`pyrxd/glyph/script.py\`](src/pyrxd/glyph/script.py) and [\`pyrxd/glyph/dmint.py\`](src/pyrxd/glyph/dmint.py)) are **structural pattern matches** — they match the regex shape of a known script template, but do NOT cryptographically verify provenance (e.g., that the ref points to a valid Glyph contract, or that the dMint parameters match a deployed token).

The classifier itself is honest about that — it doesn't claim verification. But the human-mode renderer didn't communicate the distinction. A user reading the CLI output would reasonably conclude *"this is an FT output of [token X] owned by [pkh Y]"* even when the bytes are a custom non-Glyph script that happens to fit the template. Round-1 red-team review on PR #50 flagged this; deferred to a separate PR.

## Fix

Adds a one-line **"(structural pattern match …)"** qualifier to the \`ft\` / \`nft\` / \`mut\` / \`dmint\` branches of [\`_render_script_human\`](src/pyrxd/cli/glyph_cmds.py). The parenthetical is conservative — most pattern-matched outputs ARE legitimate FTs / NFTs — but the \`mut\` and \`commit\` cases already had similar parentheticals about payload_hash opacity, so this matches the existing tone:

\`\`\`
type: ft    length: 75 bytes
  ref:       a1b2c3...:0
  owner_pkh: d84b8c37...
  (structural pattern match: bytes match the FT/NFT script template;
   does NOT verify the ref points to a valid Glyph contract)
\`\`\`

P2PKH stays unqualified — it's an exact byte match (3-byte prefix + 20-byte pkh + 2-byte suffix), not a structural match. Adding the qualifier there would be misleading.

## Test plan

- [x] **5 new tests** in \`TestStructuralMatchQualifier\` covering ft / nft / mut / dmint qualifier presence
- [x] Test confirming p2pkh does NOT carry the qualifier
- [x] All 75 existing CLI inspect tests still pass
- [x] Full \`task ci\` — 2476 passed / 4 skipped / 0 failed

## Out of scope

The browser-hosted inspect tool's renderer ([PR #50](https://github.com/MudwoodLabs/pyrxd/pull/50)) will get the same qualifier as a small follow-up commit on that PR's branch. Keeps the diffs decoupled.