### PR TITLE
fix(inspect): browser tool Pyodide install + SHA-pin supply-chain hardening

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -47,38 +47,72 @@ jobs:
           pip install -r docs/requirements.txt
           pip install -e .
 
-      - name: Build pyrxd wheel for the inspect page
-        # The browser-hosted inspect page (docs/inspect/) loads pyrxd at
-        # runtime from a wheel served alongside the page. This step builds
-        # that wheel from the same commit Sphinx is rendering, so the
-        # version the page imports always matches the docs the user is
-        # reading. The wheel + a small manifest.json (filename + git SHA)
-        # are placed into docs/inspect_static/inspect/wheels/, which sphinx-build then
-        # ships verbatim via html_extra_path.
-        # Tested smoke-load happens in tests/web/test_facade_smoke.py
-        # before this step in CI.
+      - name: Build + vendor wheels for the inspect page
+        # The browser-hosted inspect page (docs/inspect/) loads pyrxd
+        # at runtime from a wheel served alongside the page, plus
+        # cbor2 (the only runtime dep the inspect path actually
+        # needs). Both wheels are SHA-256 pinned via manifest.json
+        # and verified in JS before installation — see
+        # docs/inspect_static/inspect/inspect.js.
+        #
+        # cbor2 is vendored from PyPI at this fixed version (5.4.6 —
+        # the last release with a pure-Python wheel; later versions
+        # are C-only and not micropip-installable under WASM). The
+        # SHA-256 here is the upstream PyPI hash for that file. Bump
+        # only deliberately and update the SHA at the same time.
+        #
+        # The wheels + manifest.json are placed into
+        # docs/inspect_static/inspect/wheels/, which sphinx-build
+        # ships verbatim via html_extra_path. Tested smoke-load
+        # happens in tests/web/test_facade_smoke.py before this step
+        # in CI.
         run: |
+          set -euo pipefail
           mkdir -p docs/inspect_static/inspect/wheels
-          pip wheel --wheel-dir docs/inspect_static/inspect/wheels --no-deps .
-          # Find the just-built wheel filename. There's exactly one because
-          # --no-deps was specified. The manifest tells the page which file
-          # to micropip.install at runtime.
-          wheel=$(ls docs/inspect_static/inspect/wheels/pyrxd-*.whl | head -1)
+          cd docs/inspect_static/inspect/wheels
+
+          # 1. Build the pyrxd wheel from the current source.
+          pip wheel --wheel-dir . --no-deps ../../../..
+          wheel=$(ls pyrxd-*.whl | head -1)
           if [ -z "$wheel" ]; then
             echo "::error::pip wheel produced no pyrxd wheel"
             exit 1
           fi
+
+          # 2. Vendor the cbor2 wheel from PyPI. Pin the upstream
+          #    SHA-256 here and verify; if PyPI ever serves different
+          #    bytes (compromise, yank-and-reupload), this step fails
+          #    closed before the wrong wheel reaches the deploy.
+          cbor2_url="https://files.pythonhosted.org/packages/d5/e1/af78b099196feaab7c0252108abc4f5cfd36d255ac47c4b4a695ff838bf9/cbor2-5.4.6-py3-none-any.whl"
+          cbor2_expected_sha="181ac494091d1f9c5bb373cd85514ce1eb967a8cf3ec298e8dfa8878aa823956"
+          curl -sSL -o cbor2-5.4.6-py3-none-any.whl "$cbor2_url"
+          cbor2_actual_sha=$(sha256sum cbor2-5.4.6-py3-none-any.whl | awk '{print $1}')
+          if [ "$cbor2_actual_sha" != "$cbor2_expected_sha" ]; then
+            echo "::error::cbor2 wheel SHA-256 mismatch: expected $cbor2_expected_sha, got $cbor2_actual_sha"
+            exit 1
+          fi
+
+          # 3. Compute SHA-256 of every artifact the page will fetch
+          #    + verify, and write the manifest. The page-side JS
+          #    refuses to install anything whose SHA doesn't match.
+          wheel_sha=$(sha256sum "$wheel" | awk '{print $1}')
+          glue_sha=$(sha256sum ../glue.py | awk '{print $1}')
           git_sha="${GITHUB_SHA:-unknown}"
-          cat > docs/inspect_static/inspect/wheels/manifest.json <<EOF
+          cat > manifest.json <<EOF
           {
-            "wheel": "$(basename "$wheel")",
+            "wheel": "$wheel",
+            "wheel_sha256": "$wheel_sha",
+            "cbor2_wheel": "cbor2-5.4.6-py3-none-any.whl",
+            "cbor2_sha256": "$cbor2_expected_sha",
+            "glue_sha256": "$glue_sha",
             "git_sha": "${git_sha:0:7}",
             "git_sha_full": "$git_sha"
           }
           EOF
-          echo "Wheel: $(basename "$wheel")"
+          echo "Wheels:"
+          ls -la
           echo "Manifest:"
-          cat docs/inspect_static/inspect/wheels/manifest.json
+          cat manifest.json
 
       - name: Build HTML
         run: sphinx-build -b html docs docs/_build/html

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -95,20 +95,39 @@ jobs:
           # 3. Compute SHA-256 of every artifact the page will fetch
           #    + verify, and write the manifest. The page-side JS
           #    refuses to install anything whose SHA doesn't match.
+          #
+          # The manifest is assembled via Python's ``json.dumps`` (not
+          # a shell heredoc) so any unexpected character in ``$wheel``
+          # — should ``pip wheel`` ever produce a filename with an
+          # embedded quote or backslash — is escaped properly rather
+          # than slipping into the JSON as a parser confusion. Audit
+          # finding NEW-3. The Python source lives in a tempfile so
+          # YAML doesn't try to parse the colons in the dict literal.
           wheel_sha=$(sha256sum "$wheel" | awk '{print $1}')
           glue_sha=$(sha256sum ../glue.py | awk '{print $1}')
           git_sha="${GITHUB_SHA:-unknown}"
-          cat > manifest.json <<EOF
-          {
-            "wheel": "$wheel",
-            "wheel_sha256": "$wheel_sha",
-            "cbor2_wheel": "cbor2-5.4.6-py3-none-any.whl",
-            "cbor2_sha256": "$cbor2_expected_sha",
-            "glue_sha256": "$glue_sha",
-            "git_sha": "${git_sha:0:7}",
-            "git_sha_full": "$git_sha"
+          export WHEEL="$wheel"
+          export WHEEL_SHA="$wheel_sha"
+          export CBOR2_SHA="$cbor2_expected_sha"
+          export GLUE_SHA="$glue_sha"
+          export GIT_SHA="$git_sha"
+          script=$(mktemp)
+          cat > "$script" <<'PY'
+          import json, os
+          manifest = {
+              "wheel": os.environ["WHEEL"],
+              "wheel_sha256": os.environ["WHEEL_SHA"],
+              "cbor2_wheel": "cbor2-5.4.6-py3-none-any.whl",
+              "cbor2_sha256": os.environ["CBOR2_SHA"],
+              "glue_sha256": os.environ["GLUE_SHA"],
+              "git_sha": os.environ["GIT_SHA"][:7],
+              "git_sha_full": os.environ["GIT_SHA"],
           }
-          EOF
+          with open("manifest.json", "w") as f:
+              json.dump(manifest, f, indent=2)
+          PY
+          python3 "$script"
+          rm -f "$script"
           echo "Wheels:"
           ls -la
           echo "Manifest:"

--- a/docs/inspect_static/inspect/index.html
+++ b/docs/inspect_static/inspect/index.html
@@ -13,15 +13,14 @@
                                   uses eval() in the Python-to-JS bridge); cost is
                                   documented in docs/threat-model.md.
        style-src 'self'          — only our own CSS
-       connect-src 'self' https://cdn.jsdelivr.net https://pypi.org
-                    https://files.pythonhosted.org
-                    wss://electrumx.radiant4people.com:50022
-                                — page-relative, the Pyodide CDN, PyPI metadata
-                                  + wheel mirror (micropip fetches the cbor2
-                                  pure-Python wheel from there), and the one
-                                  ElectrumX server we trust. The PyPI hosts
-                                  serve only static immutable wheel data;
-                                  micropip is read-only.
+       connect-src 'self' https://cdn.jsdelivr.net wss://electrumx.radiant4people.com:50022
+                                — page-relative (for vendored wheels in
+                                  /inspect/wheels/), the Pyodide CDN, and the
+                                  one ElectrumX server we trust. PyPI hosts
+                                  are intentionally NOT whitelisted — the
+                                  cbor2 wheel is vendored same-origin and
+                                  SHA-256 verified via manifest.json so the
+                                  install path has no off-origin trust.
        img-src 'self' data:      — favicons + inline data: URIs only
        font-src 'self'           — bundled fonts only (none today)
        base-uri 'none'           — block <base> tag injection
@@ -35,7 +34,7 @@
     default-src 'none';
     script-src 'self' 'wasm-unsafe-eval' 'unsafe-eval' https://cdn.jsdelivr.net;
     style-src 'self';
-    connect-src 'self' https://cdn.jsdelivr.net https://pypi.org https://files.pythonhosted.org wss://electrumx.radiant4people.com:50022;
+    connect-src 'self' https://cdn.jsdelivr.net wss://electrumx.radiant4people.com:50022;
     img-src 'self' data:;
     font-src 'self';
     base-uri 'none';

--- a/docs/inspect_static/inspect/index.html
+++ b/docs/inspect_static/inspect/index.html
@@ -13,9 +13,15 @@
                                   uses eval() in the Python-to-JS bridge); cost is
                                   documented in docs/threat-model.md.
        style-src 'self'          — only our own CSS
-       connect-src 'self' https://cdn.jsdelivr.net wss://electrumx.radiant4people.com:50022
-                                — page-relative, the Pyodide CDN, and the one
-                                  ElectrumX server we trust. PR-3 wires the WS.
+       connect-src 'self' https://cdn.jsdelivr.net https://pypi.org
+                    https://files.pythonhosted.org
+                    wss://electrumx.radiant4people.com:50022
+                                — page-relative, the Pyodide CDN, PyPI metadata
+                                  + wheel mirror (micropip fetches the cbor2
+                                  pure-Python wheel from there), and the one
+                                  ElectrumX server we trust. The PyPI hosts
+                                  serve only static immutable wheel data;
+                                  micropip is read-only.
        img-src 'self' data:      — favicons + inline data: URIs only
        font-src 'self'           — bundled fonts only (none today)
        base-uri 'none'           — block <base> tag injection
@@ -29,7 +35,7 @@
     default-src 'none';
     script-src 'self' 'wasm-unsafe-eval' 'unsafe-eval' https://cdn.jsdelivr.net;
     style-src 'self';
-    connect-src 'self' https://cdn.jsdelivr.net wss://electrumx.radiant4people.com:50022;
+    connect-src 'self' https://cdn.jsdelivr.net https://pypi.org https://files.pythonhosted.org wss://electrumx.radiant4people.com:50022;
     img-src 'self' data:;
     font-src 'self';
     base-uri 'none';

--- a/docs/inspect_static/inspect/inspect.js
+++ b/docs/inspect_static/inspect/inspect.js
@@ -122,23 +122,43 @@ function setProgress(pct) {
 // — not an absolute URL, not a path traversal, not a scheme. Defends
 // against an attacker-poisoned manifest redirecting wheel installs
 // to a CSP-allowed origin (e.g. PyPI hosts) where they've staged a
-// hostile wheel. Audit finding HIGH-1.
+// hostile wheel.
+//
+// LOAD-BEARING INVARIANT: this function's regex is also the only
+// guard between manifest.{wheel,cbor2_wheel} and:
+//   - ``new URL(value, WHEELS_BASE)``  — absolute-URL escape
+//   - ``"/tmp/" + value``              — Pyodide FS path-traversal escape
+//   - ``"emfs:/tmp/" + value``         — Python-string interpolation
+//     into ``runPythonAsync(`...`)``
+// If the alphabet is ever widened to include ``/`` ``\`` ``:`` ``"`` ``\``
+// ``$``, EACH of those sinks becomes a vulnerability simultaneously.
+// Audit findings HIGH-1, NEW-1, NEW-2, NEW-5.
 function _assertSafeBasename(value, fieldName) {
   if (typeof value !== "string" || !value) {
     throw new Error(`manifest.${fieldName} missing or empty`);
   }
-  // Reject any character that could change URL resolution: ``/`` and
-  // ``\\`` for path traversal, ``:`` to defeat scheme prefixes (e.g.
-  // ``data:``, ``https:``), ``?`` and ``#`` for query / fragment
-  // tricks. Allowed alphabet matches the wheel-filename convention
-  // (``pyrxd-0.3.0-py3-none-any.whl``: alphanumerics, ``.``, ``-``,
-  // ``_``).
+  // Reject any character that could change URL resolution or escape
+  // a string-concatenated path: ``/`` and ``\\`` for path traversal,
+  // ``:`` to defeat scheme prefixes (``data:``, ``https:``), ``?``
+  // and ``#`` for query / fragment tricks, ``"`` and ``\\`` to escape
+  // Python-string interpolation. Allowed alphabet matches the
+  // wheel-filename convention: ``pyrxd-0.3.0-py3-none-any.whl``.
   if (!/^[A-Za-z0-9._-]+$/.test(value)) {
     throw new Error(
       `manifest.${fieldName}=${JSON.stringify(value)} is not a bare ` +
       `filename (allowed: alphanumerics, '.', '-', '_'). This is a ` +
       `defence against a poisoned manifest redirecting installs ` +
       `off-origin.`
+    );
+  }
+  // Explicit reject of dot-only names: ``.`` resolves to the current
+  // directory under ``new URL`` and ``..`` to the parent. Fail-closed
+  // here rather than relying on the downstream SHA-256 check to catch
+  // a directory-listing fetch — defence in depth, audit finding NEW-1.
+  if (/^\.+$/.test(value)) {
+    throw new Error(
+      `manifest.${fieldName}=${JSON.stringify(value)} is a dot-only ` +
+      `path; rejecting to prevent directory traversal.`
     );
   }
 }
@@ -277,6 +297,14 @@ async function boot() {
     // pycryptodomex, websockets) for the full SDK surface; most have
     // no pure-Python wheels. The inspect tool needs none of them —
     // see ``tests/web/test_inspect_imports_pyodide_clean.py``.
+    // Re-assert the basename invariant at the install site. ``loadManifest``
+    // already validates these, but the FS path concat (``/tmp/${name}``)
+    // and Python-string interpolation (``emfs:/tmp/${name}``) below are
+    // load-bearing on the regex's alphabet — explicit defence in depth
+    // against a future refactor that bypasses ``loadManifest``.
+    _assertSafeBasename(manifest.cbor2_wheel, "cbor2_wheel");
+    _assertSafeBasename(manifest.wheel, "wheel");
+
     const cbor2URL = new URL(manifest.cbor2_wheel, WHEELS_BASE).toString();
     const cbor2Bytes = await fetchAndVerify(cbor2URL, manifest.cbor2_sha256, "cbor2 wheel");
     pyodide.FS.writeFile("/tmp/" + manifest.cbor2_wheel, new Uint8Array(cbor2Bytes));

--- a/docs/inspect_static/inspect/inspect.js
+++ b/docs/inspect_static/inspect/inspect.js
@@ -118,28 +118,101 @@ function setProgress(pct) {
 // Boot
 // ---------------------------------------------------------------------
 
+// Validate a filename field from manifest.json is a bare basename
+// — not an absolute URL, not a path traversal, not a scheme. Defends
+// against an attacker-poisoned manifest redirecting wheel installs
+// to a CSP-allowed origin (e.g. PyPI hosts) where they've staged a
+// hostile wheel. Audit finding HIGH-1.
+function _assertSafeBasename(value, fieldName) {
+  if (typeof value !== "string" || !value) {
+    throw new Error(`manifest.${fieldName} missing or empty`);
+  }
+  // Reject any character that could change URL resolution: ``/`` and
+  // ``\\`` for path traversal, ``:`` to defeat scheme prefixes (e.g.
+  // ``data:``, ``https:``), ``?`` and ``#`` for query / fragment
+  // tricks. Allowed alphabet matches the wheel-filename convention
+  // (``pyrxd-0.3.0-py3-none-any.whl``: alphanumerics, ``.``, ``-``,
+  // ``_``).
+  if (!/^[A-Za-z0-9._-]+$/.test(value)) {
+    throw new Error(
+      `manifest.${fieldName}=${JSON.stringify(value)} is not a bare ` +
+      `filename (allowed: alphanumerics, '.', '-', '_'). This is a ` +
+      `defence against a poisoned manifest redirecting installs ` +
+      `off-origin.`
+    );
+  }
+}
+
+// Validate a SHA-256 field from manifest.json is exactly 64 lowercase
+// hex characters. Anything else is a deploy bug — better to fail loud
+// than silently accept and skip the verify step downstream.
+function _assertHexSha256(value, fieldName) {
+  if (typeof value !== "string" || !/^[0-9a-f]{64}$/.test(value)) {
+    throw new Error(
+      `manifest.${fieldName} must be 64 lowercase hex chars (SHA-256), ` +
+      `got ${JSON.stringify(value)}`
+    );
+  }
+}
+
 async function loadManifest() {
   setProgress(5);
+  let manifest;
   try {
     const resp = await fetch(WHEELS_MANIFEST, { cache: "no-cache" });
     if (!resp.ok) {
       throw new Error(`manifest HTTP ${resp.status}`);
     }
-    return await resp.json();
+    manifest = await resp.json();
   } catch (err) {
     throw new Error(
       `Could not load wheel manifest from ${WHEELS_MANIFEST}: ${err.message}. ` +
       `This usually means the docs CI step that builds the wheel failed.`
     );
   }
+  // Validate the manifest fields the boot path will trust. If the
+  // deploy ever produces a malformed or hostile manifest, fail closed
+  // here rather than at the Python install step (where the failure
+  // mode is harder to diagnose).
+  _assertSafeBasename(manifest.wheel, "wheel");
+  _assertHexSha256(manifest.wheel_sha256, "wheel_sha256");
+  _assertSafeBasename(manifest.cbor2_wheel, "cbor2_wheel");
+  _assertHexSha256(manifest.cbor2_sha256, "cbor2_sha256");
+  _assertHexSha256(manifest.glue_sha256, "glue_sha256");
+  return manifest;
 }
 
-async function fetchGlueSource() {
-  const resp = await fetch(GLUE_URL, { cache: "no-cache" });
+// Fetch a same-origin URL, verify its SHA-256 against the expected
+// hex digest, return the bytes. The hash is the trust boundary —
+// even if the GitHub Pages deploy is compromised, a mismatch fails
+// closed before any wheel byte reaches the Pyodide interpreter.
+async function fetchAndVerify(url, expectedSha256, label) {
+  const resp = await fetch(url, { cache: "no-cache" });
   if (!resp.ok) {
-    throw new Error(`glue.py HTTP ${resp.status}`);
+    throw new Error(`${label} HTTP ${resp.status}`);
   }
-  return await resp.text();
+  const buffer = await resp.arrayBuffer();
+  const hashBuffer = await crypto.subtle.digest("SHA-256", buffer);
+  // Convert to lowercase hex.
+  const hashArr = new Uint8Array(hashBuffer);
+  let hashHex = "";
+  for (const b of hashArr) {
+    hashHex += b.toString(16).padStart(2, "0");
+  }
+  if (hashHex !== expectedSha256) {
+    throw new Error(
+      `${label} SHA-256 mismatch — expected ${expectedSha256}, ` +
+      `got ${hashHex}. The deployed bytes don't match the manifest. ` +
+      `This is the integrity check refusing to proceed; do NOT ` +
+      `install the wheel by other means.`
+    );
+  }
+  return buffer;
+}
+
+async function fetchGlueSource(expectedSha256) {
+  const buffer = await fetchAndVerify(GLUE_URL, expectedSha256, "glue.py");
+  return new TextDecoder("utf-8").decode(buffer);
 }
 
 async function boot() {
@@ -176,7 +249,7 @@ async function boot() {
 
   try {
     // Load Pyodide-bundled support packages first.
-    //   - ``micropip`` — for installing the same-origin pyrxd wheel.
+    //   - ``micropip`` — for installing the vendored wheels from FS.
     //   - ``pycryptodome`` — pyrxd imports ``Cryptodome.Cipher.AES`` in
     //     the encrypted-wallet path. The inspect tool doesn't actually
     //     reach that path, but the lazy ``__getattr__``s in pyrxd's
@@ -185,27 +258,40 @@ async function boot() {
     //     ``Cryptodome`` → ``Crypto`` so the import resolves).
     await pyodide.loadPackage(["micropip", "pycryptodome"]);
 
-    // Install ``cbor2`` from PyPI. The latest cbor2 (6.x) is C-only —
-    // no pure-Python wheel exists, so micropip can't install it under
-    // WASM. cbor2 5.4.6 was the last release with a ``py3-none-any``
-    // wheel (pure-Python). Pin to that. If a newer cbor2 ever ships
-    // a pure-Python or pyodide-tagged wheel, lift the pin.
+    // Both wheels are vendored same-origin (under /inspect/wheels/)
+    // and SHA-256 pinned in manifest.json. Fetch each, verify the
+    // hash with crypto.subtle.digest, write the bytes to Pyodide FS,
+    // and install from there. This:
+    //   - Closes the supply-chain gap from PyPI fetches (audit
+    //     finding HIGH-1, MEDIUM-2, MEDIUM-3): no off-origin install
+    //     paths remain, and CSP can drop ``pypi.org`` /
+    //     ``files.pythonhosted.org``.
+    //   - Defends against a poisoned manifest redirecting wheel
+    //     installs to attacker-staged URLs: ``loadManifest`` already
+    //     validates ``wheel`` / ``cbor2_wheel`` are bare basenames.
+    //   - Defends against a compromised GitHub Pages deploy: even
+    //     same-origin bytes are SHA-checked before micropip sees them.
     //
-    // Then install the same-origin pyrxd wheel with ``deps=False``.
-    // The pyrxd wheel's METADATA declares five runtime deps
-    // (aiohttp, coincurve, base58, pycryptodomex, websockets) for the
-    // full SDK surface. Most don't have pure-Python wheels and would
-    // fail under micropip. The inspect tool needs none of them —
-    // see ``pyrxd.glyph.inspect``'s import-graph contract test in
-    // ``tests/web/test_inspect_imports_pyodide_clean.py``.
-    const wheelURL = new URL(manifest.wheel, WHEELS_BASE).toString();
+    // We use ``deps=False`` for the pyrxd wheel because its METADATA
+    // declares five runtime deps (aiohttp, coincurve, base58,
+    // pycryptodomex, websockets) for the full SDK surface; most have
+    // no pure-Python wheels. The inspect tool needs none of them —
+    // see ``tests/web/test_inspect_imports_pyodide_clean.py``.
+    const cbor2URL = new URL(manifest.cbor2_wheel, WHEELS_BASE).toString();
+    const cbor2Bytes = await fetchAndVerify(cbor2URL, manifest.cbor2_sha256, "cbor2 wheel");
+    pyodide.FS.writeFile("/tmp/" + manifest.cbor2_wheel, new Uint8Array(cbor2Bytes));
+
+    const pyrxdURL = new URL(manifest.wheel, WHEELS_BASE).toString();
+    const pyrxdBytes = await fetchAndVerify(pyrxdURL, manifest.wheel_sha256, "pyrxd wheel");
+    pyodide.FS.writeFile("/tmp/" + manifest.wheel, new Uint8Array(pyrxdBytes));
+
     await pyodide.runPythonAsync(`
 import micropip
-await micropip.install("cbor2==5.4.6")
-await micropip.install(${JSON.stringify(wheelURL)}, deps=False)
+await micropip.install("emfs:/tmp/${manifest.cbor2_wheel}")
+await micropip.install("emfs:/tmp/${manifest.wheel}", deps=False)
 `);
   } catch (err) {
-    showError(`Could not install pyrxd from ${manifest.wheel}: ${err.message}`);
+    showError(`Could not install pyrxd: ${err.message}`);
     return;
   }
 
@@ -218,7 +304,7 @@ await micropip.install(${JSON.stringify(wheelURL)}, deps=False)
   // references stashed on the JS module.
   let versionText;
   try {
-    const glueSrc = await fetchGlueSource();
+    const glueSrc = await fetchGlueSource(manifest.glue_sha256);
     pyodide.FS.writeFile("/home/pyodide/glue.py", glueSrc);
     pyodide.runPython(`
 import sys

--- a/docs/inspect_static/inspect/inspect.js
+++ b/docs/inspect_static/inspect/inspect.js
@@ -175,16 +175,34 @@ async function boot() {
   setProgress(60);
 
   try {
-    // Pyodide ships ``pycryptodome`` (no -x). pyrxd imports
-    // ``Cryptodome.Cipher.AES`` via pycryptodomex which doesn't have a
-    // pure-Python wheel; glue.py shims ``Cryptodome`` -> ``Crypto`` at
-    // import time, so we install pycryptodome here BEFORE pyrxd so the
-    // shim has something to alias.
+    // Load Pyodide-bundled support packages first.
+    //   - ``micropip`` — for installing the same-origin pyrxd wheel.
+    //   - ``pycryptodome`` — pyrxd imports ``Cryptodome.Cipher.AES`` in
+    //     the encrypted-wallet path. The inspect tool doesn't actually
+    //     reach that path, but the lazy ``__getattr__``s in pyrxd's
+    //     package ``__init__``s might if a downstream caller touches
+    //     it. Cheap to load preemptively (the glue.py shim aliases
+    //     ``Cryptodome`` → ``Crypto`` so the import resolves).
     await pyodide.loadPackage(["micropip", "pycryptodome"]);
+
+    // Install ``cbor2`` from PyPI. The latest cbor2 (6.x) is C-only —
+    // no pure-Python wheel exists, so micropip can't install it under
+    // WASM. cbor2 5.4.6 was the last release with a ``py3-none-any``
+    // wheel (pure-Python). Pin to that. If a newer cbor2 ever ships
+    // a pure-Python or pyodide-tagged wheel, lift the pin.
+    //
+    // Then install the same-origin pyrxd wheel with ``deps=False``.
+    // The pyrxd wheel's METADATA declares five runtime deps
+    // (aiohttp, coincurve, base58, pycryptodomex, websockets) for the
+    // full SDK surface. Most don't have pure-Python wheels and would
+    // fail under micropip. The inspect tool needs none of them —
+    // see ``pyrxd.glyph.inspect``'s import-graph contract test in
+    // ``tests/web/test_inspect_imports_pyodide_clean.py``.
     const wheelURL = new URL(manifest.wheel, WHEELS_BASE).toString();
     await pyodide.runPythonAsync(`
 import micropip
-await micropip.install(${JSON.stringify(wheelURL)})
+await micropip.install("cbor2==5.4.6")
+await micropip.install(${JSON.stringify(wheelURL)}, deps=False)
 `);
   } catch (err) {
     showError(`Could not install pyrxd from ${manifest.wheel}: ${err.message}`);

--- a/src/pyrxd/__init__.py
+++ b/src/pyrxd/__init__.py
@@ -17,70 +17,90 @@ Subpackages:
     pyrxd.spv        — SPV chain/payment verification
     pyrxd.transaction — Transaction building and serialization
     pyrxd.script     — Script types and evaluation
+
+Implementation note — lazy top-level re-exports:
+
+The public names listed in ``__all__`` are resolved on first attribute
+access via PEP 562 ``__getattr__``, not eagerly imported at package
+load time. This keeps ``import pyrxd`` (or any submodule) cheap, and
+crucially keeps the import graph **minimal** for callers that only
+touch a small slice of the SDK — most importantly the browser-hosted
+inspect tool, which imports ``pyrxd.glyph.inspect`` and would
+otherwise transitively load ``coincurve`` (no Pyodide wheel),
+``aiohttp``, ``websockets``, etc.
+
+Typing tools (``mypy``, IDE introspection, ``dir()``) read the
+``_LAZY_EXPORTS`` mapping and the ``__all__`` list; runtime users
+see the same names with no behaviour change.
 """
 
 from __future__ import annotations
 
-from pyrxd.glyph import (
-    GlyphBuilder,
-    GlyphInspector,
-    GlyphItem,
-    GlyphMetadata,
-    GlyphProtocol,
-    GlyphRef,
-    GlyphScanner,
-)
-from pyrxd.gravity import ActiveOffer, GravityMakerSession, GravityOfferParams, GravityTrade
-from pyrxd.hd.bip32 import Xprv, Xpub, bip32_derive_xkeys_from_xkey, bip32_derive_xprv_from_mnemonic, ckd
-from pyrxd.hd.bip39 import mnemonic_from_entropy, seed_from_mnemonic
-from pyrxd.hd.bip44 import bip44_derive_xprv_from_mnemonic
-from pyrxd.hd.wallet import AddressRecord, HdWallet
-from pyrxd.keys import PrivateKey
-from pyrxd.network.electrumx import UtxoRecord, script_hash_for_address
-from pyrxd.security import (
-    RxdSdkError,
-    ValidationError,
-)
-from pyrxd.wallet import RxdWallet
-
 __version__ = "0.3.0"
 
-__all__ = [
-    "ActiveOffer",
-    # HD wallet — BIP-44
-    "AddressRecord",
-    # Glyph
-    "GlyphBuilder",
-    "GlyphInspector",
-    "GlyphItem",
-    "GlyphMetadata",
-    "GlyphProtocol",
-    "GlyphRef",
-    "GlyphScanner",
-    "GravityMakerSession",
-    "GravityOfferParams",
+# Map of public-name → (module, attr) pairs. Resolved lazily on first
+# attribute access. Order is alphabetical by name to make additions
+# easy to spot in diffs.
+_LAZY_EXPORTS: dict[str, tuple[str, str]] = {
     # Gravity
-    "GravityTrade",
-    "HdWallet",
+    "ActiveOffer": ("pyrxd.gravity", "ActiveOffer"),
+    # HD wallet — BIP-44
+    "AddressRecord": ("pyrxd.hd.wallet", "AddressRecord"),
+    # Glyph
+    "GlyphBuilder": ("pyrxd.glyph", "GlyphBuilder"),
+    "GlyphInspector": ("pyrxd.glyph", "GlyphInspector"),
+    "GlyphItem": ("pyrxd.glyph", "GlyphItem"),
+    "GlyphMetadata": ("pyrxd.glyph", "GlyphMetadata"),
+    "GlyphProtocol": ("pyrxd.glyph", "GlyphProtocol"),
+    "GlyphRef": ("pyrxd.glyph", "GlyphRef"),
+    "GlyphScanner": ("pyrxd.glyph", "GlyphScanner"),
+    "GravityMakerSession": ("pyrxd.gravity", "GravityMakerSession"),
+    "GravityOfferParams": ("pyrxd.gravity", "GravityOfferParams"),
+    "GravityTrade": ("pyrxd.gravity", "GravityTrade"),
+    "HdWallet": ("pyrxd.hd.wallet", "HdWallet"),
     # Keys
-    "PrivateKey",
+    "PrivateKey": ("pyrxd.keys", "PrivateKey"),
     # Errors
-    "RxdSdkError",
+    "RxdSdkError": ("pyrxd.security", "RxdSdkError"),
     # Single-key wallet facade
-    "RxdWallet",
+    "RxdWallet": ("pyrxd.wallet", "RxdWallet"),
     # Network utilities
-    "UtxoRecord",
-    "ValidationError",
+    "UtxoRecord": ("pyrxd.network.electrumx", "UtxoRecord"),
+    "ValidationError": ("pyrxd.security", "ValidationError"),
     # HD wallet — BIP-32
-    "Xprv",
-    "Xpub",
-    "__version__",
-    "bip32_derive_xkeys_from_xkey",
-    "bip32_derive_xprv_from_mnemonic",
-    "bip44_derive_xprv_from_mnemonic",
-    "ckd",
+    "Xprv": ("pyrxd.hd.bip32", "Xprv"),
+    "Xpub": ("pyrxd.hd.bip32", "Xpub"),
+    "bip32_derive_xkeys_from_xkey": ("pyrxd.hd.bip32", "bip32_derive_xkeys_from_xkey"),
+    "bip32_derive_xprv_from_mnemonic": ("pyrxd.hd.bip32", "bip32_derive_xprv_from_mnemonic"),
+    "bip44_derive_xprv_from_mnemonic": ("pyrxd.hd.bip44", "bip44_derive_xprv_from_mnemonic"),
+    "ckd": ("pyrxd.hd.bip32", "ckd"),
     # HD wallet — BIP-39
-    "mnemonic_from_entropy",
-    "script_hash_for_address",
-    "seed_from_mnemonic",
-]
+    "mnemonic_from_entropy": ("pyrxd.hd.bip39", "mnemonic_from_entropy"),
+    "script_hash_for_address": ("pyrxd.network.electrumx", "script_hash_for_address"),
+    "seed_from_mnemonic": ("pyrxd.hd.bip39", "seed_from_mnemonic"),
+}
+
+__all__ = sorted([*_LAZY_EXPORTS.keys(), "__version__"])
+
+
+def __getattr__(name: str):
+    """PEP 562 lazy attribute access for public re-exports.
+
+    Imports the underlying module on first access, caches the resolved
+    object on the package namespace so subsequent accesses are direct
+    attribute lookups (no repeat import call)."""
+    target = _LAZY_EXPORTS.get(name)
+    if target is None:
+        raise AttributeError(f"module 'pyrxd' has no attribute {name!r}")
+    module_path, attr = target
+    import importlib
+
+    obj = getattr(importlib.import_module(module_path), attr)
+    globals()[name] = obj  # cache for subsequent accesses
+    return obj
+
+
+def __dir__() -> list[str]:
+    """Make ``dir(pyrxd)`` show the lazy names. IDEs and ``help()``
+    rely on this for autocomplete."""
+    return __all__

--- a/src/pyrxd/cli/glyph_cmds.py
+++ b/src/pyrxd/cli/glyph_cmds.py
@@ -1211,426 +1211,137 @@ def list_cmd(ctx: CliContext, kind: str, passphrase: bool) -> None:
 #   outpoint   — anything containing ":"
 #   script     — any other hex string of even length (>= 50 chars / 25 bytes)
 # Everything else is a UserError.
-_TXID_HEX_LEN = 64
-_CONTRACT_HEX_LEN = 72
-# The minimum script we'd reasonably classify is plain P2PKH (25 bytes / 50 hex).
-_MIN_SCRIPT_HEX_LEN = 50
-# Cap accidental "paste a whole tx" before running every classifier on it.
-_MAX_SCRIPT_HEX_LEN = 20_000
 
-# --- Network-fetch (--fetch) safety bounds ---------------------------------
-# Radiant policy max for a tx is 4 MB. Anything larger is consensus-invalid
-# and either a buggy server or an attacker probing for a parser-DoS.
-#
-# Note: this is a defence-in-depth check. The websockets library's default
-# per-message ``max_size`` (~1 MiB at the time of writing) typically trips
-# first and surfaces as a NetworkError. We keep the 4 MB cap explicit anyway
-# so the inspect-side limit is documented even if the underlying transport
-# cap is lifted in a future client refactor.
-_MAX_RAW_TX_BYTES = 4_000_000
-# Per-tx structural caps. A real Radiant tx today has a few inputs/outputs;
-# 100k is generous head-room and bounds total classification work.
-_MAX_INPUT_COUNT = 100_000
-_MAX_OUTPUT_COUNT = 100_000
-# Per-string display cap in human mode for any user-controllable CBOR field.
-# JSON mode preserves the full string (still ASCII-safe via ensure_ascii).
-_HUMAN_STRING_CAP = 200
+# The pure helpers + threat-model constants live in pyrxd.glyph._inspect_core
+# so the browser-hosted inspect tool (loaded into Pyodide) can import them
+# without dragging in the rest of this module's CLI imports (HdWallet,
+# ElectrumXClient, click, etc.). The CLI thin-wraps each helper to
+# translate the SDK-level ``ValidationError`` into the CLI-shaped
+# ``UserError`` with cause/fix decorations the formatter expects.
+# Imports below are mid-file deliberately — the section sits adjacent to the
+# CLI's inspect helpers + commands and out of place at module top. Annotated
 
-
-# Unicode general categories that must NOT reach a terminal: control (Cc),
-# format (Cf — includes BOM, bidi-overrides, ZWJ/ZWNJ, tag chars), unassigned
-# (Cn), private-use (Co), line/paragraph separators (Zl/Zp), and combining
-# marks (Mn/Me — overlay glyphs onto the previous char). This subsumes the
-# explicit bidi-override / BOM allow-list the previous version maintained.
-_UNICODE_STRIP_CATEGORIES = frozenset({"Cc", "Cf", "Cn", "Co", "Zl", "Zp", "Mn", "Me"})
-
-
-def _sanitize_display_string(s: str) -> str:
-    """Strip control + invisible + combining codepoints from a string before printing.
-
-    Defense against terminal-injection / homoglyph / bidi-override attacks via
-    CBOR-sourced fields (token name, description, ticker, attrs.*, creator.pubkey,
-    etc.). A hostile token deployer can embed ANSI CSI escapes, zero-width joiners,
-    bidi-override codepoints, tag chars, or combining marks in their metadata; an
-    inspect of the deploy tx would otherwise pass them straight to the user's
-    terminal — the deployer's name could appear to flip directionality, hide
-    chars, or imitate adjacent fields.
-
-    Strips any character whose Unicode general category is one of:
-
-        Cc — ASCII / C1 control (includes \\x1b ANSI ESC, \\x07 BEL)
-        Cf — format chars (BOM, bidi overrides, ZWJ/ZWNJ, tag chars, …)
-        Cn — unassigned codepoints
-        Co — private-use area
-        Zl, Zp — line / paragraph separators (\\u2028, \\u2029)
-        Mn, Me — combining marks (overlay onto previous char)
-
-    Replaces each stripped char with a literal "?" so the user sees that
-    something was filtered.
-
-    Non-`str` input is returned unchanged (defensive — the type signature
-    forbids it but the type system doesn't enforce that at runtime).
-    """
-    import unicodedata
-
-    if not isinstance(s, str):
-        return s
-    out: list[str] = []
-    for ch in s:
-        if unicodedata.category(ch) in _UNICODE_STRIP_CATEGORIES:
-            out.append("?")
-        else:
-            out.append(ch)
-    return "".join(out)
-
-
-def _truncate_for_human(s: str, cap: int = _HUMAN_STRING_CAP) -> str:
-    """Truncate a sanitized string for human-mode display."""
-    if len(s) <= cap:
-        return s
-    return s[: cap - 1] + "…"
+# Plain re-exports (no wrapping needed — these don't raise). Existing
+# tests + the human-mode renderer import these names from
+# ``pyrxd.cli.glyph_cmds`` directly, so the surface stays compatible.
+from ..glyph._inspect_core import (  # noqa: E402
+    _HUMAN_STRING_CAP,  # noqa: F401
+    _sanitize_display_string,  # noqa: F401
+    _truncate_for_human,
+)
+from ..glyph._inspect_core import _classify_input as _classify_input_core  # noqa: E402
+from ..glyph._inspect_core import _classify_raw_tx as _classify_raw_tx_core  # noqa: E402
+from ..glyph._inspect_core import _inspect_contract as _inspect_contract_core  # noqa: E402
+from ..glyph._inspect_core import _inspect_outpoint as _inspect_outpoint_core  # noqa: E402
+from ..glyph._inspect_core import _inspect_script as _inspect_script_core  # noqa: E402
 
 
 def _classify_input(s: str) -> tuple[str, str]:
-    """Dispatch on input shape. Returns (form, normalised_value).
-
-    form ∈ {"txid", "contract", "outpoint", "script"}.
-
-    Auto-detect rules (unambiguous by length / content):
-      * 64 hex → txid
-      * 72 hex → contract
-      * contains ":" → outpoint (validated downstream)
-      * 50–20_000 even-length hex → script
-
-    A bare 64-hex string is always treated as a txid even though it could
-    structurally also be a 32-byte payload-hash push prefix; the txid form
-    is the only one users hit in practice from a block explorer.
-
-    Leading/trailing whitespace is stripped here (ergonomics — users paste
-    from explorers and shells often add a newline). This is BEFORE the
-    downstream ``Txid`` newtype's regex check, but ``Txid`` rejects any
-    embedded whitespace so the strip is safe. If a future change loosened
-    ``Txid`` to accept internal whitespace this would silently propagate;
-    keep the validators tight.
-    """
-    s = s.strip()
-    if not s:
-        raise UserError("inspect input is empty")
-    if ":" in s:
-        return ("outpoint", s)
-    lowered = s.lower()
-    if len(lowered) == _TXID_HEX_LEN and all(c in "0123456789abcdef" for c in lowered):
-        return ("txid", lowered)
-    if len(lowered) == _CONTRACT_HEX_LEN and all(c in "0123456789abcdef" for c in lowered):
-        return ("contract", lowered)
-    if (
-        _MIN_SCRIPT_HEX_LEN <= len(lowered) <= _MAX_SCRIPT_HEX_LEN
-        and len(lowered) % 2 == 0
-        and all(c in "0123456789abcdef" for c in lowered)
-    ):
-        return ("script", lowered)
-    raise UserError(
-        f"could not classify input (length {len(s)})",
-        cause="input is not a 64-char txid, 72-char contract id, txid:vout outpoint, or 50-20000 char hex script",
-        fix="paste a 64-char txid (with --fetch), 72-char contract id, txid:vout, or hex script",
-    )
+    """CLI wrapper: translate ``ValidationError`` to ``UserError``."""
+    try:
+        return _classify_input_core(s)
+    except ValidationError as exc:
+        msg = str(exc)
+        if msg == "inspect input is empty":
+            raise UserError(msg) from exc
+        # The "could not classify" case carries the input length in the
+        # message; the original CLI exposed that plus a cause/fix pair.
+        raise UserError(
+            msg,
+            cause="input is not a 64-char txid, 72-char contract id, txid:vout outpoint, or 50-20000 char hex script",
+            fix="paste a 64-char txid (with --fetch), 72-char contract id, txid:vout, or hex script",
+        ) from exc
 
 
 def _inspect_contract(contract_hex: str) -> dict:
-    """Decode a 72-char contract id. Return a flat dict for emit()."""
-    from ..glyph.types import GlyphRef
-
+    """CLI wrapper: translate ``ValidationError`` to ``UserError``."""
     try:
-        ref = GlyphRef.from_contract_hex(contract_hex)
+        return _inspect_contract_core(contract_hex)
     except ValidationError as exc:
         raise UserError("contract id failed to parse", cause=str(exc)) from exc
-    return {
-        "form": "contract",
-        "txid": ref.txid,
-        "vout": ref.vout,
-        "outpoint": f"{ref.txid}:{ref.vout}",
-        "wire_hex": ref.to_bytes().hex(),
-    }
 
 
 def _inspect_outpoint(s: str) -> dict:
-    """Parse a `txid:vout` string. Returns a flat dict for emit().
+    """CLI wrapper: translate ``ValidationError`` to ``UserError``.
 
-    Rejects malformed input loudly so the user sees a clear error rather
-    than a confusing downstream traceback.
-    """
-    from ..glyph.types import GlyphRef
-
-    if s.count(":") != 1:
-        raise UserError(f"outpoint must be exactly one 'txid:vout', got {s!r}")
-    txid_str, vout_str = s.split(":", 1)
+    The shape errors carried by ``_inspect_outpoint_core`` are
+    self-contained (e.g. ``"vout is not an integer"``); parser errors
+    from downstream get the historic ``"outpoint failed to parse"``
+    prefix so existing CLI test assertions match unchanged."""
     try:
-        vout = int(vout_str, 10)
-    except ValueError as exc:
-        raise UserError(f"vout is not an integer: {vout_str!r}") from exc
-    try:
-        ref = GlyphRef(txid=Txid(txid_str.lower()), vout=vout)
+        return _inspect_outpoint_core(s)
     except ValidationError as exc:
-        raise UserError("outpoint failed to parse", cause=str(exc)) from exc
-    return {
-        "form": "outpoint",
-        "txid": ref.txid,
-        "vout": ref.vout,
-        "outpoint": f"{ref.txid}:{ref.vout}",
-        "wire_hex": ref.to_bytes().hex(),
-    }
+        msg = str(exc)
+        if msg.startswith("outpoint must be") or msg.startswith("vout is not an integer"):
+            raise UserError(msg) from exc
+        raise UserError("outpoint failed to parse", cause=msg) from exc
 
 
 def _inspect_script(script_hex: str) -> dict:
-    """Classify a single hex-encoded locking script. Returns a flat dict."""
-    from ..glyph.dmint import DmintState
-    from ..glyph.script import (
-        MUTABLE_NFT_SCRIPT_RE,
-        extract_owner_pkh_from_commit_script,
-        extract_owner_pkh_from_ft_script,
-        extract_owner_pkh_from_nft_script,
-        extract_payload_hash_from_commit_script,
-        extract_ref_from_ft_script,
-        extract_ref_from_nft_script,
-        is_commit_ft_script,
-        is_commit_nft_script,
-        is_ft_script,
-        is_nft_script,
-        parse_mutable_nft_script,
-    )
-
+    """CLI wrapper: translate ``ValidationError`` to ``UserError``."""
     try:
-        script = bytes.fromhex(script_hex)
-    except ValueError as exc:
-        raise UserError("script is not valid hex") from exc
-
-    base = {"form": "script", "length": len(script), "hex": script_hex}
-
-    # Plain P2PKH check first (cheapest, common).
-    if len(script) == 25 and script[:3] == b"\x76\xa9\x14" and script[23:] == b"\x88\xac":
-        return {**base, "type": "p2pkh", "owner_pkh": script[3:23].hex()}
-
-    if is_nft_script(script_hex):
-        ref = extract_ref_from_nft_script(script)
-        pkh = extract_owner_pkh_from_nft_script(script)
-        return {
-            **base,
-            "type": "nft",
-            "ref_txid": ref.txid,
-            "ref_vout": ref.vout,
-            "ref_outpoint": f"{ref.txid}:{ref.vout}",
-            "owner_pkh": bytes(pkh).hex(),
-        }
-
-    if is_ft_script(script_hex):
-        ref = extract_ref_from_ft_script(script)
-        pkh = extract_owner_pkh_from_ft_script(script)
-        return {
-            **base,
-            "type": "ft",
-            "ref_txid": ref.txid,
-            "ref_vout": ref.vout,
-            "ref_outpoint": f"{ref.txid}:{ref.vout}",
-            "owner_pkh": bytes(pkh).hex(),
-        }
-
-    if MUTABLE_NFT_SCRIPT_RE.fullmatch(script_hex):
-        parsed = parse_mutable_nft_script(script)
-        if parsed is not None:
-            ref, payload_hash = parsed
-            return {
-                **base,
-                "type": "mut",
-                "ref_txid": ref.txid,
-                "ref_vout": ref.vout,
-                "ref_outpoint": f"{ref.txid}:{ref.vout}",
-                "payload_hash": payload_hash.hex(),
-            }
-
-    if is_commit_nft_script(script_hex):
-        return {
-            **base,
-            "type": "commit-nft",
-            "payload_hash": extract_payload_hash_from_commit_script(script).hex(),
-            "owner_pkh": bytes(extract_owner_pkh_from_commit_script(script)).hex(),
-        }
-
-    if is_commit_ft_script(script_hex):
-        return {
-            **base,
-            "type": "commit-ft",
-            "payload_hash": extract_payload_hash_from_commit_script(script).hex(),
-            "owner_pkh": bytes(extract_owner_pkh_from_commit_script(script)).hex(),
-        }
-
-    # dMint contract is variable-length and parser-only; try last.
-    try:
-        state = DmintState.from_script(script)
-    except ValidationError:
-        return {**base, "type": "unknown"}
-
-    return {
-        **base,
-        "type": "dmint",
-        "version": "v1" if state.is_v1 else "v2",
-        "contract_ref_outpoint": f"{state.contract_ref.txid}:{state.contract_ref.vout}",
-        "token_ref_outpoint": f"{state.token_ref.txid}:{state.token_ref.vout}",
-        "height": state.height,
-        "max_height": state.max_height,
-        "reward": state.reward,
-        "algo": state.algo.name,
-        "daa_mode": state.daa_mode.name,
-    }
+        return _inspect_script_core(script_hex)
+    except ValidationError as exc:
+        raise UserError(str(exc)) from exc
 
 
 def _classify_raw_tx(txid_hex: str, raw: bytes, *, only_vout: int | None = None) -> dict:
-    """Classify every output (and reveal CBOR) for a pre-fetched transaction.
+    """CLI wrapper: translate ``ValidationError`` to ``UserError`` with
+    the historic CLI-formatted cause/fix decorations.
 
-    This is the synchronous, network-free core extracted from
-    ``_inspect_txid_inner``. The browser-hosted inspect tool calls this
-    directly after performing its own WebSocket fetch in JS land, where
-    spinning up an ``ElectrumXClient`` under Pyodide is impractical.
-
-    Threat-model guards mirror the async wrapper exactly:
-
-    * Validate ``txid_hex`` via the ``Txid`` newtype.
-    * Refuse ``raw`` shorter than 65 bytes (Merkle-forgery defence; the
-      ``RawTx`` newtype enforces this at its boundary, but ``raw`` here
-      is a plain ``bytes`` so we re-check explicitly).
-    * Refuse ``raw`` larger than ``_MAX_RAW_TX_BYTES`` (Radiant policy max).
-    * Server-honesty check: ``hash256(raw)[::-1].hex() == txid_hex`` so a
-      hostile source can't return some *other* tx.
-    * Refuse parsed txs with more than ``_MAX_OUTPUT_COUNT`` /
-      ``_MAX_INPUT_COUNT`` entries — bounds total classification work.
-    * Wrap per-output classification in try/except so one malformed script
-      cannot abort the listing.
-    * Use ``GlyphInspector.find_reveal_metadata`` (already swallows
-      exceptions around ``decode_payload``) for input metadata extraction.
-    * Sanitize every CBOR-derived display string before it leaves this
-      function.
-
-    :param raw: pre-fetched raw transaction bytes (NOT hex).
-    :param only_vout: if not None, restrict the outputs list to a single
-        vout — used by the ``--resolve`` outpoint flow.
-    """
-    from ..glyph.inspector import GlyphInspector
-    from ..hash import hash256
-
+    The core raises a flat ``ValidationError`` whose message embeds the
+    relevant detail. Pattern-match on the message to reconstruct the
+    CLI's three-line ``error / cause / fix`` formatting so existing
+    test assertions (e.g. on ``"--electrumx"``) keep matching."""
     try:
-        txid = Txid(txid_hex.lower())
+        return _classify_raw_tx_core(txid_hex, raw, only_vout=only_vout)
     except ValidationError as exc:
-        raise UserError("invalid txid", cause=str(exc)) from exc
-
-    # Lower-bound length sanity. ``RawTx`` enforces >64 bytes as a
-    # Merkle-forgery defence at its newtype boundary; we re-assert it
-    # here so direct callers (the browser façade is now public, see
-    # pyrxd.glyph.inspect.classify_raw_tx) get the same guarantee
-    # without needing to wrap in ``RawTx`` first.
-    if len(raw) <= 64:
-        raise UserError(
-            "raw bytes too short for a valid transaction",
-            cause=f"got {len(raw)} bytes; need >64",
-            fix="confirm the source returned a real transaction, not a header or stub",
-        )
-
-    if len(raw) > _MAX_RAW_TX_BYTES:
-        raise UserError(
-            "transaction is larger than the policy max",
-            cause=f"server returned {len(raw)} bytes; policy max is {_MAX_RAW_TX_BYTES}",
-            fix="confirm the txid; a tx this large is consensus-invalid",
-        )
-
-    computed = hash256(bytes(raw))[::-1].hex()
-    if computed != str(txid):
-        raise UserError(
-            "server returned a transaction whose hash does not match the requested txid",
-            cause=f"requested {txid}, got {computed}",
-            fix="try a different ElectrumX server (--electrumx URL)",
-        )
-
-    tx = Transaction.from_hex(bytes(raw))
-    if tx is None:
-        raise UserError(
-            "could not parse the raw transaction bytes",
-            cause="Transaction.from_hex returned None",
-            fix="the server response is malformed; try another ElectrumX server",
-        )
-
-    if len(tx.inputs) > _MAX_INPUT_COUNT or len(tx.outputs) > _MAX_OUTPUT_COUNT:
-        raise UserError(
-            "transaction structure exceeds inspect's safety caps",
-            cause=f"inputs={len(tx.inputs)}, outputs={len(tx.outputs)}",
-            fix=f"caps are {_MAX_INPUT_COUNT}/{_MAX_OUTPUT_COUNT} — re-run on a saner tx",
-        )
-
-    output_rows: list[dict] = []
-    enumerated = list(enumerate(tx.outputs))
-    if only_vout is not None:
-        if not (0 <= only_vout < len(tx.outputs)):
+        msg = str(exc)
+        if "raw bytes too short" in msg:
             raise UserError(
-                f"vout {only_vout} is out of range",
-                cause=f"transaction has {len(tx.outputs)} output(s)",
-            )
-        enumerated = [(only_vout, tx.outputs[only_vout])]
+                "raw bytes too short for a valid transaction",
+                cause=f"got {len(raw)} bytes; need >64",
+                fix="confirm the source returned a real transaction, not a header or stub",
+            ) from exc
+        if "transaction is larger than the policy max" in msg:
+            from ..glyph._inspect_core import _MAX_RAW_TX_BYTES
 
-    for idx, out in enumerated:
-        try:
-            script_bytes = out.locking_script.serialize()
-            row = _inspect_script(script_bytes.hex())
-            row.pop("form", None)  # always "script" — redundant inside a tx listing
-            row["vout"] = idx
-            row["satoshis"] = out.satoshis
-            output_rows.append(row)
-        except Exception as exc:  # defensive: any classifier crash → unknown row
-            output_rows.append(
-                {
-                    "vout": idx,
-                    "type": "error",
-                    "error": type(exc).__name__,
-                    "satoshis": out.satoshis,
-                }
-            )
+            raise UserError(
+                "transaction is larger than the policy max",
+                cause=f"server returned {len(raw)} bytes; policy max is {_MAX_RAW_TX_BYTES}",
+                fix="confirm the txid; a tx this large is consensus-invalid",
+            ) from exc
+        if "does not match the requested txid" in msg:
+            cause = msg.split("(", 1)[1].rstrip(")") if "(" in msg else msg
+            raise UserError(
+                "server returned a transaction whose hash does not match the requested txid",
+                cause=cause,
+                fix="try a different ElectrumX server (--electrumx URL)",
+            ) from exc
+        if msg == "could not parse the raw transaction bytes":
+            raise UserError(
+                "could not parse the raw transaction bytes",
+                cause="Transaction.from_hex returned None",
+                fix="the server response is malformed; try another ElectrumX server",
+            ) from exc
+        if "exceeds inspect's safety caps" in msg:
+            from ..glyph._inspect_core import _MAX_INPUT_COUNT, _MAX_OUTPUT_COUNT
 
-    # IMPORTANT: every string field surfaced into ``metadata_payload`` MUST
-    # be passed through ``_sanitize_display_string`` first. JSON mode escapes
-    # non-ASCII via ``ensure_ascii=True``, but human mode prints these strings
-    # straight to the terminal where ANSI / bidi-override / zero-width
-    # injection would land. ``protocol`` is a list of CBOR-supplied values
-    # — coerce each to ``str`` and sanitize before display, since
-    # ``str(list_of_strings)`` calls ``repr`` on each element and ``repr``
-    # does NOT escape U+202E and friends.
-    inspector = GlyphInspector()
-    scriptsigs = [bytes(inp.unlocking_script.serialize()) for inp in tx.inputs]
-    found = inspector.find_reveal_metadata(scriptsigs)
-    metadata_payload: dict | None = None
-    if found is not None:
-        input_idx, metadata = found
-        metadata_payload = {
-            "input_index": input_idx,
-            "protocol": [_sanitize_display_string(str(p)) for p in metadata.protocol],
-            "name": _sanitize_display_string(metadata.name) if metadata.name else "",
-            "ticker": _sanitize_display_string(metadata.ticker) if metadata.ticker else "",
-            "description": _sanitize_display_string(metadata.description) if metadata.description else "",
-            "decimals": metadata.decimals,
-        }
-        if metadata.main is not None:
-            from ..hash import sha256
-
-            metadata_payload["main"] = (
-                f"<media: {_sanitize_display_string(metadata.main.mime_type)}, "
-                f"{len(metadata.main.data)} bytes, "
-                f"sha256={sha256(metadata.main.data).hex()}>"
-            )
-
-    return {
-        "form": "txid",
-        "txid": str(txid),
-        "byte_length": len(raw),
-        "input_count": len(tx.inputs),
-        "output_count": len(tx.outputs),
-        "outputs": output_rows,
-        "metadata": metadata_payload,
-    }
+            cause = msg.split("(", 1)[1].rstrip(")") if "(" in msg else msg
+            raise UserError(
+                "transaction structure exceeds inspect's safety caps",
+                cause=cause,
+                fix=f"caps are {_MAX_INPUT_COUNT}/{_MAX_OUTPUT_COUNT} — re-run on a saner tx",
+            ) from exc
+        if "out of range" in msg:
+            head = msg.split("(", 1)[0].strip()
+            cause = msg.split("(", 1)[1].rstrip(")") if "(" in msg else ""
+            raise UserError(head, cause=cause) from exc
+        if msg.startswith("invalid txid") or "Txid" in msg or "must be 64-char" in msg:
+            raise UserError("invalid txid", cause=msg) from exc
+        # Fallthrough: surface unexpected ValidationError as a bare
+        # UserError so the CLI stays deterministic.
+        raise UserError(msg) from exc
 
 
 async def _inspect_txid_inner(client: ElectrumXClient, txid_hex: str, *, only_vout: int | None = None) -> dict:

--- a/src/pyrxd/curve.py
+++ b/src/pyrxd/curve.py
@@ -2,10 +2,16 @@ from __future__ import annotations
 
 from collections import namedtuple
 
-from coincurve import PublicKey as CcPublicKey
-
 from .constants import NUMBER_BYTE_LENGTH
 from .security.errors import ValidationError
+
+# coincurve (libsecp256k1 bindings) is imported lazily inside the
+# functions that need it. This keeps the ``curve`` namedtuple constant
+# at module top-level importable from ``pyrxd.utils`` without dragging
+# in coincurve — which has no pure-Python wheel and so can't install
+# under Pyodide. The browser-hosted inspect tool imports
+# ``pyrxd.utils.encode_int`` etc. but never touches the elliptic-curve
+# arithmetic paths below.
 
 Point = namedtuple("Point", "x y")
 
@@ -69,6 +75,8 @@ def curve_add(p: Point | None, q: Point | None) -> Point | None:
         # p == -q
         return None
     # p != -q
+    from coincurve import PublicKey as CcPublicKey  # lazy: see module docstring
+
     r = Point(*CcPublicKey.from_point(*p).combine([CcPublicKey.from_point(*q)]).point())
     if not on_curve(r):
         raise ValidationError("computed sum point is not on the curve")
@@ -86,6 +94,8 @@ def curve_multiply(scalar: int, point: Point | None) -> Point | None:
     if scalar < 0:
         # k * point = -k * (-point)
         return curve_multiply(-scalar, curve_negative(point))
+    from coincurve import PublicKey as CcPublicKey  # lazy: see module docstring
+
     r = Point(*CcPublicKey.from_point(*point).multiply((scalar % curve.n).to_bytes(NUMBER_BYTE_LENGTH, "big")).point())
     if not on_curve(r):
         raise ValidationError("computed product point is not on the curve")

--- a/src/pyrxd/glyph/__init__.py
+++ b/src/pyrxd/glyph/__init__.py
@@ -1,82 +1,73 @@
+"""Glyph protocol — NFT singletons, FT tokens, dMint contracts, mutable refs.
+
+Re-exports the public Glyph API from the submodules. Lazy via PEP 562
+``__getattr__`` so ``import pyrxd.glyph.X`` paths that don't need the
+full builder/signing chain (e.g. ``pyrxd.glyph.inspect`` from the
+browser-hosted inspect tool) avoid pulling in ``coincurve``,
+``aiohttp``, ``Cryptodome.Cipher``, etc. transitively.
+
+See :mod:`pyrxd` for the broader rationale on lazy public re-exports.
+"""
+
 from __future__ import annotations
 
-from .builder import (
-    ContainerRevealScripts,
-    FtTransferParams,
-    GlyphBuilder,
-    MutableRevealScripts,
-)
-from .creator import sign_metadata, verify_creator_signature
-from .dmint import (
-    DaaMode,
-    DmintAlgo,
-    DmintCborPayload,
-    DmintDeployParams,
-    DmintState,
-    build_dmint_contract_script,
-    build_dmint_state_script,
-    build_mint_scriptsig,
-    build_pow_preimage,
-    compute_next_target_asert,
-    compute_next_target_linear,
-    difficulty_to_target,
-    target_to_difficulty,
-    verify_sha256d_solution,
-)
-from .ft import FtTransferResult, FtUtxo, FtUtxoSet
-from .inspector import GlyphInspector
-from .payload import build_mutable_scriptsig
-from .scanner import GlyphItem, GlyphScanner
-from .script import build_mutable_nft_script, parse_mutable_nft_script
-from .types import (
-    GlyphCreator,
-    GlyphFt,
-    GlyphMetadata,
-    GlyphNft,
-    GlyphPolicy,
-    GlyphProtocol,
-    GlyphRef,
-    GlyphRights,
-    GlyphRoyalty,
-)
+# Map of public-name → (module-path, attribute) pairs. Resolved on
+# first attribute access.
+_LAZY_EXPORTS: dict[str, tuple[str, str]] = {
+    "ContainerRevealScripts": ("pyrxd.glyph.builder", "ContainerRevealScripts"),
+    "DaaMode": ("pyrxd.glyph.dmint", "DaaMode"),
+    "DmintAlgo": ("pyrxd.glyph.dmint", "DmintAlgo"),
+    "DmintCborPayload": ("pyrxd.glyph.dmint", "DmintCborPayload"),
+    "DmintDeployParams": ("pyrxd.glyph.dmint", "DmintDeployParams"),
+    "DmintState": ("pyrxd.glyph.dmint", "DmintState"),
+    "FtTransferParams": ("pyrxd.glyph.builder", "FtTransferParams"),
+    "FtTransferResult": ("pyrxd.glyph.ft", "FtTransferResult"),
+    "FtUtxo": ("pyrxd.glyph.ft", "FtUtxo"),
+    "FtUtxoSet": ("pyrxd.glyph.ft", "FtUtxoSet"),
+    "GlyphBuilder": ("pyrxd.glyph.builder", "GlyphBuilder"),
+    "GlyphCreator": ("pyrxd.glyph.types", "GlyphCreator"),
+    "GlyphFt": ("pyrxd.glyph.types", "GlyphFt"),
+    "GlyphInspector": ("pyrxd.glyph.inspector", "GlyphInspector"),
+    "GlyphItem": ("pyrxd.glyph.scanner", "GlyphItem"),
+    "GlyphMetadata": ("pyrxd.glyph.types", "GlyphMetadata"),
+    "GlyphNft": ("pyrxd.glyph.types", "GlyphNft"),
+    "GlyphPolicy": ("pyrxd.glyph.types", "GlyphPolicy"),
+    "GlyphProtocol": ("pyrxd.glyph.types", "GlyphProtocol"),
+    "GlyphRef": ("pyrxd.glyph.types", "GlyphRef"),
+    "GlyphRights": ("pyrxd.glyph.types", "GlyphRights"),
+    "GlyphRoyalty": ("pyrxd.glyph.types", "GlyphRoyalty"),
+    "GlyphScanner": ("pyrxd.glyph.scanner", "GlyphScanner"),
+    "MutableRevealScripts": ("pyrxd.glyph.builder", "MutableRevealScripts"),
+    "build_dmint_contract_script": ("pyrxd.glyph.dmint", "build_dmint_contract_script"),
+    "build_dmint_state_script": ("pyrxd.glyph.dmint", "build_dmint_state_script"),
+    "build_mint_scriptsig": ("pyrxd.glyph.dmint", "build_mint_scriptsig"),
+    "build_mutable_nft_script": ("pyrxd.glyph.script", "build_mutable_nft_script"),
+    "build_mutable_scriptsig": ("pyrxd.glyph.payload", "build_mutable_scriptsig"),
+    "build_pow_preimage": ("pyrxd.glyph.dmint", "build_pow_preimage"),
+    "compute_next_target_asert": ("pyrxd.glyph.dmint", "compute_next_target_asert"),
+    "compute_next_target_linear": ("pyrxd.glyph.dmint", "compute_next_target_linear"),
+    "difficulty_to_target": ("pyrxd.glyph.dmint", "difficulty_to_target"),
+    "parse_mutable_nft_script": ("pyrxd.glyph.script", "parse_mutable_nft_script"),
+    "sign_metadata": ("pyrxd.glyph.creator", "sign_metadata"),
+    "target_to_difficulty": ("pyrxd.glyph.dmint", "target_to_difficulty"),
+    "verify_creator_signature": ("pyrxd.glyph.creator", "verify_creator_signature"),
+    "verify_sha256d_solution": ("pyrxd.glyph.dmint", "verify_sha256d_solution"),
+}
 
-__all__ = [
-    "ContainerRevealScripts",
-    "DaaMode",
-    "DmintAlgo",
-    "DmintCborPayload",
-    "DmintDeployParams",
-    "DmintState",
-    "FtTransferParams",
-    "FtTransferResult",
-    "FtUtxo",
-    "FtUtxoSet",
-    "GlyphBuilder",
-    "GlyphCreator",
-    "GlyphFt",
-    "GlyphInspector",
-    "GlyphItem",
-    "GlyphMetadata",
-    "GlyphNft",
-    "GlyphPolicy",
-    "GlyphProtocol",
-    "GlyphRef",
-    "GlyphRights",
-    "GlyphRoyalty",
-    "GlyphScanner",
-    "MutableRevealScripts",
-    "build_dmint_contract_script",
-    "build_dmint_state_script",
-    "build_mint_scriptsig",
-    "build_mutable_nft_script",
-    "build_mutable_scriptsig",
-    "build_pow_preimage",
-    "compute_next_target_asert",
-    "compute_next_target_linear",
-    "difficulty_to_target",
-    "parse_mutable_nft_script",
-    "sign_metadata",
-    "target_to_difficulty",
-    "verify_creator_signature",
-    "verify_sha256d_solution",
-]
+__all__ = sorted(_LAZY_EXPORTS.keys())
+
+
+def __getattr__(name: str):
+    target = _LAZY_EXPORTS.get(name)
+    if target is None:
+        raise AttributeError(f"module 'pyrxd.glyph' has no attribute {name!r}")
+    module_path, attr = target
+    import importlib
+
+    obj = getattr(importlib.import_module(module_path), attr)
+    globals()[name] = obj
+    return obj
+
+
+def __dir__() -> list[str]:
+    return __all__

--- a/src/pyrxd/glyph/_inspect_core.py
+++ b/src/pyrxd/glyph/_inspect_core.py
@@ -1,0 +1,430 @@
+"""Pure-Python inspect helpers, decoupled from the CLI infrastructure.
+
+This module hosts the helpers the inspect tool uses — both the CLI
+(``pyrxd glyph inspect ...``) and the browser-hosted inspect tool
+(``docs/inspect_static/inspect/``). Keeping them here, separate from
+``pyrxd.cli.glyph_cmds``, means callers can import the inspect surface
+without dragging in the rest of the CLI's import graph (``click``,
+``HdWallet``, signing, network clients, etc.).
+
+Why this exists:
+
+The CLI module ``glyph_cmds.py`` imports ``HdWallet`` (signing →
+``coincurve``), the ElectrumX client (→ ``websockets``), and ``aiohttp``
+at module top level. A caller doing ``from pyrxd.glyph import inspect``
+would, before this split, transitively pull in all of those — none of
+which the inspect helpers actually need. Under Pyodide this manifests
+as ``micropip.install`` trying to fetch ``coincurve`` (no pure-Python
+wheel exists) and failing the page boot.
+
+The split keeps the helpers pure: the only deps they reach for are
+``pyrxd.glyph.types`` / ``script`` / ``dmint`` / ``inspector`` /
+``payload`` (all clean), ``pyrxd.transaction.transaction`` (clean), and
+``pyrxd.hash`` (clean since the OpenSSL-3 / RIPEMD160 fix).
+
+Errors:
+
+The helpers raise ``ValidationError`` (from ``pyrxd.security.errors``)
+on bad input. The CLI wraps these as ``UserError`` at the boundary so
+the user sees the existing CLI-formatted message with ``cause`` /
+``fix`` lines. The browser tool's glue catches them and translates to
+its structured-dict response.
+"""
+
+from __future__ import annotations
+
+import unicodedata
+
+from ..hash import hash256
+from ..security.errors import ValidationError
+from ..security.types import Txid
+from ..transaction.transaction import Transaction
+
+# --- Length / shape constants ----------------------------------------------
+#
+# These mirror the values the CLI used previously (verbatim — the wire
+# behaviour is unchanged across the move). The CLI re-imports them from
+# here so a single change updates both surfaces.
+_TXID_HEX_LEN = 64
+_CONTRACT_HEX_LEN = 72
+# The minimum script we'd reasonably classify is plain P2PKH (25 bytes / 50 hex).
+_MIN_SCRIPT_HEX_LEN = 50
+# Cap accidental "paste a whole tx" before running every classifier on it.
+_MAX_SCRIPT_HEX_LEN = 20_000
+
+# --- Network-fetch (--fetch) safety bounds ---------------------------------
+# Radiant policy max for a tx is 4 MB. Anything larger is consensus-invalid
+# and either a buggy server or an attacker probing for a parser-DoS.
+_MAX_RAW_TX_BYTES = 4_000_000
+# Per-tx structural caps. A real Radiant tx today has a few inputs/outputs;
+# 100k is generous head-room and bounds total classification work.
+_MAX_INPUT_COUNT = 100_000
+_MAX_OUTPUT_COUNT = 100_000
+# Per-string display cap in human mode for any user-controllable CBOR field.
+# JSON mode preserves the full string (still ASCII-safe via ensure_ascii).
+_HUMAN_STRING_CAP = 200
+
+
+# Unicode general categories that must NOT reach a terminal: control (Cc),
+# format (Cf — includes BOM, bidi-overrides, ZWJ/ZWNJ, tag chars), unassigned
+# (Cn), private-use (Co), line/paragraph separators (Zl/Zp), and combining
+# marks (Mn/Me — overlay glyphs onto the previous char). This subsumes the
+# explicit bidi-override / BOM allow-list the previous version maintained.
+_UNICODE_STRIP_CATEGORIES = frozenset({"Cc", "Cf", "Cn", "Co", "Zl", "Zp", "Mn", "Me"})
+
+
+def _sanitize_display_string(s: str) -> str:
+    """Strip control + invisible + combining codepoints from a string before printing.
+
+    Defense against terminal-injection / homoglyph / bidi-override attacks via
+    CBOR-sourced fields (token name, description, ticker, attrs.*, creator.pubkey,
+    etc.). A hostile token deployer can embed ANSI CSI escapes, zero-width joiners,
+    bidi-override codepoints, tag chars, or combining marks in their metadata; an
+    inspect of the deploy tx would otherwise pass them straight to the user's
+    terminal — the deployer's name could appear to flip directionality, hide
+    chars, or imitate adjacent fields.
+
+    Strips any character whose Unicode general category is one of:
+
+        Cc — ASCII / C1 control (includes \\x1b ANSI ESC, \\x07 BEL)
+        Cf — format chars (BOM, bidi overrides, ZWJ/ZWNJ, tag chars, …)
+        Cn — unassigned codepoints
+        Co — private-use area
+        Zl, Zp — line / paragraph separators (\\u2028, \\u2029)
+        Mn, Me — combining marks (overlay onto previous char)
+
+    Replaces each stripped char with a literal "?" so the user sees that
+    something was filtered.
+
+    Non-`str` input is returned unchanged (defensive — the type signature
+    forbids it but the type system doesn't enforce that at runtime).
+    """
+    if not isinstance(s, str):
+        return s
+    out: list[str] = []
+    for ch in s:
+        if unicodedata.category(ch) in _UNICODE_STRIP_CATEGORIES:
+            out.append("?")
+        else:
+            out.append(ch)
+    return "".join(out)
+
+
+def _truncate_for_human(s: str, cap: int = _HUMAN_STRING_CAP) -> str:
+    """Truncate a sanitized string for human-mode display."""
+    if len(s) <= cap:
+        return s
+    return s[: cap - 1] + "…"
+
+
+def _classify_input(s: str) -> tuple[str, str]:
+    """Dispatch on input shape. Returns (form, normalised_value).
+
+    form ∈ {"txid", "contract", "outpoint", "script"}.
+
+    Auto-detect rules (unambiguous by length / content):
+      * 64 hex → txid
+      * 72 hex → contract
+      * contains ":" → outpoint (validated downstream)
+      * 50–20_000 even-length hex → script
+
+    A bare 64-hex string is always treated as a txid even though it could
+    structurally also be a 32-byte payload-hash push prefix; the txid form
+    is the only one users hit in practice from a block explorer.
+
+    Leading/trailing whitespace is stripped here (ergonomics — users paste
+    from explorers and shells often add a newline). This is BEFORE the
+    downstream ``Txid`` newtype's regex check, but ``Txid`` rejects any
+    embedded whitespace so the strip is safe. If a future change loosened
+    ``Txid`` to accept internal whitespace this would silently propagate;
+    keep the validators tight.
+    """
+    s = s.strip()
+    if not s:
+        raise ValidationError("inspect input is empty")
+    if ":" in s:
+        return ("outpoint", s)
+    lowered = s.lower()
+    if len(lowered) == _TXID_HEX_LEN and all(c in "0123456789abcdef" for c in lowered):
+        return ("txid", lowered)
+    if len(lowered) == _CONTRACT_HEX_LEN and all(c in "0123456789abcdef" for c in lowered):
+        return ("contract", lowered)
+    if (
+        _MIN_SCRIPT_HEX_LEN <= len(lowered) <= _MAX_SCRIPT_HEX_LEN
+        and len(lowered) % 2 == 0
+        and all(c in "0123456789abcdef" for c in lowered)
+    ):
+        return ("script", lowered)
+    raise ValidationError(f"could not classify input (length {len(s)})")
+
+
+def _inspect_contract(contract_hex: str) -> dict:
+    """Decode a 72-char contract id. Return a flat dict for emit()."""
+    from .types import GlyphRef
+
+    ref = GlyphRef.from_contract_hex(contract_hex)
+    return {
+        "form": "contract",
+        "txid": ref.txid,
+        "vout": ref.vout,
+        "outpoint": f"{ref.txid}:{ref.vout}",
+        "wire_hex": ref.to_bytes().hex(),
+    }
+
+
+def _inspect_outpoint(s: str) -> dict:
+    """Parse a `txid:vout` string. Returns a flat dict for emit().
+
+    Rejects malformed input loudly so the user sees a clear error rather
+    than a confusing downstream traceback.
+    """
+    from .types import GlyphRef
+
+    if s.count(":") != 1:
+        raise ValidationError(f"outpoint must be exactly one 'txid:vout', got {s!r}")
+    txid_str, vout_str = s.split(":", 1)
+    try:
+        vout = int(vout_str, 10)
+    except ValueError as exc:
+        raise ValidationError(f"vout is not an integer: {vout_str!r}") from exc
+    ref = GlyphRef(txid=Txid(txid_str.lower()), vout=vout)
+    return {
+        "form": "outpoint",
+        "txid": ref.txid,
+        "vout": ref.vout,
+        "outpoint": f"{ref.txid}:{ref.vout}",
+        "wire_hex": ref.to_bytes().hex(),
+    }
+
+
+def _inspect_script(script_hex: str) -> dict:
+    """Classify a single hex-encoded locking script. Returns a flat dict."""
+    from .dmint import DmintState
+    from .script import (
+        MUTABLE_NFT_SCRIPT_RE,
+        extract_owner_pkh_from_commit_script,
+        extract_owner_pkh_from_ft_script,
+        extract_owner_pkh_from_nft_script,
+        extract_payload_hash_from_commit_script,
+        extract_ref_from_ft_script,
+        extract_ref_from_nft_script,
+        is_commit_ft_script,
+        is_commit_nft_script,
+        is_ft_script,
+        is_nft_script,
+        parse_mutable_nft_script,
+    )
+
+    try:
+        script = bytes.fromhex(script_hex)
+    except ValueError as exc:
+        raise ValidationError("script is not valid hex") from exc
+
+    base = {"form": "script", "length": len(script), "hex": script_hex}
+
+    # Plain P2PKH check first (cheapest, common).
+    if len(script) == 25 and script[:3] == b"\x76\xa9\x14" and script[23:] == b"\x88\xac":
+        return {**base, "type": "p2pkh", "owner_pkh": script[3:23].hex()}
+
+    if is_nft_script(script_hex):
+        ref = extract_ref_from_nft_script(script)
+        pkh = extract_owner_pkh_from_nft_script(script)
+        return {
+            **base,
+            "type": "nft",
+            "ref_txid": ref.txid,
+            "ref_vout": ref.vout,
+            "ref_outpoint": f"{ref.txid}:{ref.vout}",
+            "owner_pkh": bytes(pkh).hex(),
+        }
+
+    if is_ft_script(script_hex):
+        ref = extract_ref_from_ft_script(script)
+        pkh = extract_owner_pkh_from_ft_script(script)
+        return {
+            **base,
+            "type": "ft",
+            "ref_txid": ref.txid,
+            "ref_vout": ref.vout,
+            "ref_outpoint": f"{ref.txid}:{ref.vout}",
+            "owner_pkh": bytes(pkh).hex(),
+        }
+
+    if MUTABLE_NFT_SCRIPT_RE.fullmatch(script_hex):
+        parsed = parse_mutable_nft_script(script)
+        if parsed is not None:
+            ref, payload_hash = parsed
+            return {
+                **base,
+                "type": "mut",
+                "ref_txid": ref.txid,
+                "ref_vout": ref.vout,
+                "ref_outpoint": f"{ref.txid}:{ref.vout}",
+                "payload_hash": payload_hash.hex(),
+            }
+
+    if is_commit_nft_script(script_hex):
+        return {
+            **base,
+            "type": "commit-nft",
+            "payload_hash": extract_payload_hash_from_commit_script(script).hex(),
+            "owner_pkh": bytes(extract_owner_pkh_from_commit_script(script)).hex(),
+        }
+
+    if is_commit_ft_script(script_hex):
+        return {
+            **base,
+            "type": "commit-ft",
+            "payload_hash": extract_payload_hash_from_commit_script(script).hex(),
+            "owner_pkh": bytes(extract_owner_pkh_from_commit_script(script)).hex(),
+        }
+
+    # dMint contract is variable-length and parser-only; try last.
+    try:
+        state = DmintState.from_script(script)
+    except ValidationError:
+        return {**base, "type": "unknown"}
+
+    return {
+        **base,
+        "type": "dmint",
+        "version": "v1" if state.is_v1 else "v2",
+        "contract_ref_outpoint": f"{state.contract_ref.txid}:{state.contract_ref.vout}",
+        "token_ref_outpoint": f"{state.token_ref.txid}:{state.token_ref.vout}",
+        "height": state.height,
+        "max_height": state.max_height,
+        "reward": state.reward,
+        "algo": state.algo.name,
+        "daa_mode": state.daa_mode.name,
+    }
+
+
+def _classify_raw_tx(txid_hex: str, raw: bytes, *, only_vout: int | None = None) -> dict:
+    """Classify every output (and reveal CBOR) for a pre-fetched transaction.
+
+    Synchronous, network-free core. The CLI's ``--fetch`` path wraps this
+    with an async ``ElectrumXClient.get_transaction`` call; the browser
+    inspect tool calls this directly after performing its own WebSocket
+    fetch in JS.
+
+    Threat-model guards:
+
+    * Validate ``txid_hex`` via the ``Txid`` newtype.
+    * Refuse ``raw`` shorter than 65 bytes (Merkle-forgery defence; the
+      ``RawTx`` newtype enforces this at its boundary, but ``raw`` here
+      is a plain ``bytes`` so we re-check explicitly).
+    * Refuse ``raw`` larger than ``_MAX_RAW_TX_BYTES`` (Radiant policy max).
+    * Server-honesty check: ``hash256(raw)[::-1].hex() == txid_hex`` so a
+      hostile source can't return some *other* tx.
+    * Refuse parsed txs with more than ``_MAX_OUTPUT_COUNT`` /
+      ``_MAX_INPUT_COUNT`` entries — bounds total classification work.
+    * Wrap per-output classification in try/except so one malformed script
+      cannot abort the listing.
+    * Use ``GlyphInspector.find_reveal_metadata`` (already swallows
+      exceptions around ``decode_payload``) for input metadata extraction.
+    * Sanitize every CBOR-derived display string before it leaves this
+      function.
+
+    Errors raised here are bare ``ValidationError`` instances. The CLI
+    layer wraps them in ``UserError`` with cause/fix so the user-visible
+    formatted output is unchanged. Callers handling structured error
+    output (the browser tool's glue) read the message string directly.
+
+    :param raw: pre-fetched raw transaction bytes (NOT hex).
+    :param only_vout: if not None, restrict the outputs list to a single
+        vout — used by the ``--resolve`` outpoint flow.
+    """
+    from .inspector import GlyphInspector
+
+    txid = Txid(txid_hex.lower())  # raises ValidationError on bad shape
+
+    if len(raw) <= 64:
+        raise ValidationError(f"raw bytes too short for a valid transaction ({len(raw)} bytes; need >64)")
+
+    if len(raw) > _MAX_RAW_TX_BYTES:
+        raise ValidationError(
+            f"transaction is larger than the policy max "
+            f"(server returned {len(raw)} bytes; policy max is {_MAX_RAW_TX_BYTES})"
+        )
+
+    computed = hash256(bytes(raw))[::-1].hex()
+    if computed != str(txid):
+        raise ValidationError(
+            f"server returned a transaction whose hash does not match the requested txid "
+            f"(requested {txid}, got {computed})"
+        )
+
+    tx = Transaction.from_hex(bytes(raw))
+    if tx is None:
+        raise ValidationError("could not parse the raw transaction bytes")
+
+    if len(tx.inputs) > _MAX_INPUT_COUNT or len(tx.outputs) > _MAX_OUTPUT_COUNT:
+        raise ValidationError(
+            f"transaction structure exceeds inspect's safety caps (inputs={len(tx.inputs)}, outputs={len(tx.outputs)})"
+        )
+
+    output_rows: list[dict] = []
+    enumerated = list(enumerate(tx.outputs))
+    if only_vout is not None:
+        if not (0 <= only_vout < len(tx.outputs)):
+            raise ValidationError(f"vout {only_vout} is out of range (transaction has {len(tx.outputs)} output(s))")
+        enumerated = [(only_vout, tx.outputs[only_vout])]
+
+    for idx, out in enumerated:
+        try:
+            script_bytes = out.locking_script.serialize()
+            row = _inspect_script(script_bytes.hex())
+            row.pop("form", None)  # always "script" — redundant inside a tx listing
+            row["vout"] = idx
+            row["satoshis"] = out.satoshis
+            output_rows.append(row)
+        except Exception as exc:  # defensive: any classifier crash → unknown row
+            output_rows.append(
+                {
+                    "vout": idx,
+                    "type": "error",
+                    "error": type(exc).__name__,
+                    "satoshis": out.satoshis,
+                }
+            )
+
+    # IMPORTANT: every string field surfaced into ``metadata_payload`` MUST
+    # be passed through ``_sanitize_display_string`` first. JSON mode escapes
+    # non-ASCII via ``ensure_ascii=True``, but human mode prints these strings
+    # straight to the terminal where ANSI / bidi-override / zero-width
+    # injection would land. ``protocol`` is a list of CBOR-supplied values
+    # — coerce each to ``str`` and sanitize before display, since
+    # ``str(list_of_strings)`` calls ``repr`` on each element and ``repr``
+    # does NOT escape U+202E and friends.
+    inspector = GlyphInspector()
+    scriptsigs = [bytes(inp.unlocking_script.serialize()) for inp in tx.inputs]
+    found = inspector.find_reveal_metadata(scriptsigs)
+    metadata_payload: dict | None = None
+    if found is not None:
+        input_idx, metadata = found
+        metadata_payload = {
+            "input_index": input_idx,
+            "protocol": [_sanitize_display_string(str(p)) for p in metadata.protocol],
+            "name": _sanitize_display_string(metadata.name) if metadata.name else "",
+            "ticker": _sanitize_display_string(metadata.ticker) if metadata.ticker else "",
+            "description": _sanitize_display_string(metadata.description) if metadata.description else "",
+            "decimals": metadata.decimals,
+        }
+        if metadata.main is not None:
+            from ..hash import sha256
+
+            metadata_payload["main"] = (
+                f"<media: {_sanitize_display_string(metadata.main.mime_type)}, "
+                f"{len(metadata.main.data)} bytes, "
+                f"sha256={sha256(metadata.main.data).hex()}>"
+            )
+
+    return {
+        "form": "txid",
+        "txid": str(txid),
+        "byte_length": len(raw),
+        "input_count": len(tx.inputs),
+        "output_count": len(tx.outputs),
+        "outputs": output_rows,
+        "metadata": metadata_payload,
+    }

--- a/src/pyrxd/glyph/_inspect_core.py
+++ b/src/pyrxd/glyph/_inspect_core.py
@@ -181,12 +181,21 @@ def _inspect_outpoint(s: str) -> dict:
     from .types import GlyphRef
 
     if s.count(":") != 1:
-        raise ValidationError(f"outpoint must be exactly one 'txid:vout', got {s!r}")
+        # Don't echo the raw input back — a CLI user who pasted bytes
+        # containing ANSI escapes or bidi-overrides would otherwise see
+        # those rendered to their terminal verbatim. The bare error
+        # tells them what was wrong; they already know what they pasted.
+        raise ValidationError("outpoint must be exactly one 'txid:vout'")
     txid_str, vout_str = s.split(":", 1)
     try:
         vout = int(vout_str, 10)
     except ValueError as exc:
-        raise ValidationError(f"vout is not an integer: {vout_str!r}") from exc
+        # Same defence: ``vout_str`` is whatever the user pasted after
+        # the colon. Sanitise before embedding so attacker bytes can't
+        # reach the terminal. The sanitiser strips control / format /
+        # combining codepoints — exactly the surface that terminal
+        # injection exploits.
+        raise ValidationError(f"vout is not an integer: {_sanitize_display_string(vout_str)!r}") from exc
     ref = GlyphRef(txid=Txid(txid_str.lower()), vout=vout)
     return {
         "form": "outpoint",

--- a/src/pyrxd/glyph/inspect.py
+++ b/src/pyrxd/glyph/inspect.py
@@ -1,23 +1,22 @@
 """Public façade for the Glyph inspect surface.
 
-The CLI command ``pyrxd glyph inspect`` is implemented as a set of
-``_``-prefixed helpers inside :mod:`pyrxd.cli.glyph_cmds`. The web UI
-hosted at ``docs/inspect/`` (loaded into a browser via Pyodide) needs
-the same surface, but **must not** import from CLI internals — that
-couples a public-facing tool to private implementation details that can
-churn freely.
+The CLI command ``pyrxd glyph inspect`` and the browser-hosted inspect
+tool (loaded via Pyodide at ``docs/inspect_static/inspect/``) share a
+common set of pure-Python helpers. Those helpers live in
+:mod:`pyrxd.glyph._inspect_core` so they're decoupled from the CLI's
+infrastructure (``click``, ``HdWallet``, signing, network clients). The
+browser tool imports through this façade, which simply re-exports the
+core helpers under public names (no underscore prefix).
 
-This module re-exports the inspect helpers as a stable public API so
-external callers (the web UI today, future SDK users tomorrow) have a
-documented contract:
+Public surface:
 
 * :func:`classify_input` — dispatch a raw string to its form
   (``"txid" | "contract" | "outpoint" | "script"``)
 * :func:`classify_raw_tx` — classify every output (and reveal CBOR) for
   a pre-fetched raw transaction. Synchronous; takes pre-fetched bytes
-  rather than an ElectrumXClient, so the web UI can fetch via the
-  browser's native WebSocket and feed bytes straight into the same
-  classifier the CLI uses
+  rather than an ElectrumXClient, so the browser tool can fetch via the
+  native WebSocket API and feed bytes straight into the same classifier
+  the CLI uses
 * :func:`inspect_contract` — decode a 72-char Glyph contract id
 * :func:`inspect_outpoint` — decode a ``txid:vout`` outpoint
 * :func:`inspect_script` — classify a hex-encoded locking script and
@@ -31,35 +30,44 @@ documented contract:
 * :func:`looks_confusable_with_latin` — high-level check that flags
   Latin-impersonating spoofs (e.g. Cyrillic-letter "USDC")
 
+Errors: every helper here raises
+:class:`pyrxd.security.errors.ValidationError` on invalid input. The
+CLI layer translates these into ``UserError`` with cause/fix
+decorations. External callers should ``except ValidationError`` and
+display the message string directly.
+
 If you are inside the pyrxd codebase, import the underlying helpers
-directly. If you are outside (web UI, downstream tooling), import from
-this module — it commits to a stable signature and shape.
+directly from ``pyrxd.glyph._inspect_core``. If you are outside (web
+UI, downstream tooling), import from this module — it commits to a
+stable signature and shape.
 """
 
 from __future__ import annotations
 
-# Re-export from the CLI module. The aliasing renames drop the leading
-# underscore so callers don't have to reach into a `_`-prefixed name —
-# that's the entire point of this façade.
-from ..cli.glyph_cmds import (
+# Re-export the SDK-level helpers under public names. These come
+# directly from the pure-Python core module — NOT from the CLI module
+# — so importing this façade doesn't transitively pull click, HdWallet,
+# coincurve, aiohttp, websockets, or Cryptodome.Cipher. That property
+# is asserted by ``tests/web/test_inspect_imports_pyodide_clean.py``.
+from ._inspect_core import (
     _classify_input as classify_input,
 )
-from ..cli.glyph_cmds import (
+from ._inspect_core import (
     _classify_raw_tx as classify_raw_tx,
 )
-from ..cli.glyph_cmds import (
+from ._inspect_core import (
     _inspect_contract as inspect_contract,
 )
-from ..cli.glyph_cmds import (
+from ._inspect_core import (
     _inspect_outpoint as inspect_outpoint,
 )
-from ..cli.glyph_cmds import (
+from ._inspect_core import (
     _inspect_script as inspect_script,
 )
-from ..cli.glyph_cmds import (
+from ._inspect_core import (
     _sanitize_display_string as sanitize_display_string,
 )
-from ..cli.glyph_cmds import (
+from ._inspect_core import (
     _truncate_for_human as truncate_for_human,
 )
 from .confusables import looks_confusable_with_latin, skeleton

--- a/src/pyrxd/script/__init__.py
+++ b/src/pyrxd/script/__init__.py
@@ -1,24 +1,40 @@
-"""Script types, templates, and evaluation for Radiant transactions."""
+"""Script types, templates, and evaluation for Radiant transactions.
+
+The public re-exports below are resolved lazily via PEP 562
+``__getattr__`` so importing ``pyrxd.script.script`` (used by the
+inspect tool's ``Transaction`` parser) doesn't transitively pull
+``pyrxd.script.type`` and through it ``pyrxd.keys`` →  ``coincurve``.
+
+See :mod:`pyrxd` for the broader rationale on lazy public re-exports.
+"""
 
 from __future__ import annotations
 
-from .script import Script, ScriptChunk
-from .type import (
-    P2PK,
-    P2PKH,
-    BareMultisig,
-    OpReturn,
-    ScriptTemplate,
-    Unknown,
-)
+_LAZY_EXPORTS: dict[str, tuple[str, str]] = {
+    "BareMultisig": ("pyrxd.script.type", "BareMultisig"),
+    "OpReturn": ("pyrxd.script.type", "OpReturn"),
+    "P2PK": ("pyrxd.script.type", "P2PK"),
+    "P2PKH": ("pyrxd.script.type", "P2PKH"),
+    "Script": ("pyrxd.script.script", "Script"),
+    "ScriptChunk": ("pyrxd.script.script", "ScriptChunk"),
+    "ScriptTemplate": ("pyrxd.script.type", "ScriptTemplate"),
+    "Unknown": ("pyrxd.script.type", "Unknown"),
+}
 
-__all__ = [
-    "P2PK",
-    "P2PKH",
-    "BareMultisig",
-    "OpReturn",
-    "Script",
-    "ScriptChunk",
-    "ScriptTemplate",
-    "Unknown",
-]
+__all__ = sorted(_LAZY_EXPORTS.keys())
+
+
+def __getattr__(name: str):
+    target = _LAZY_EXPORTS.get(name)
+    if target is None:
+        raise AttributeError(f"module 'pyrxd.script' has no attribute {name!r}")
+    module_path, attr = target
+    import importlib
+
+    obj = getattr(importlib.import_module(module_path), attr)
+    globals()[name] = obj
+    return obj
+
+
+def __dir__() -> list[str]:
+    return __all__

--- a/tests/web/test_facade_smoke.py
+++ b/tests/web/test_facade_smoke.py
@@ -324,6 +324,19 @@ class TestWheelManifest:
             assert "?" not in v, f"{field} contains query: {v!r}"
             assert "#" not in v, f"{field} contains fragment: {v!r}"
 
+    def test_filenames_are_not_dot_only(self):
+        """Dot-only paths like ``.`` and ``..`` resolve to the current
+        / parent directory under ``new URL``. The page-side JS rejects
+        them explicitly so a poisoned manifest can't even fetch a
+        directory listing whose SHA happens to match. Round-2 audit
+        finding NEW-1."""
+        import re
+
+        manifest = self._manifest()
+        for field in ("wheel", "cbor2_wheel"):
+            v = manifest[field]
+            assert not re.fullmatch(r"\.+", v), f"{field} is dot-only: {v!r}"
+
     def test_recorded_shas_match_actual_files(self):
         """The hashes in manifest.json must match the actual bytes on
         disk. Catches a CI step that recorded a stale hash."""

--- a/tests/web/test_facade_smoke.py
+++ b/tests/web/test_facade_smoke.py
@@ -258,20 +258,94 @@ class TestStaticPagePresent:
 
 
 @pytest.mark.skipif(
-    not (lambda: __import__("pathlib").Path("docs/inspect/wheels/manifest.json").exists())(),
+    not (lambda: __import__("pathlib").Path("docs/inspect_static/inspect/wheels/manifest.json").exists())(),
     reason="wheel + manifest only built by docs.yml CI step",
 )
 class TestWheelManifest:
     """Validates the manifest.json the docs.yml CI step writes alongside
-    the pyrxd wheel. Skipped when the file isn't present (i.e. when
-    running tests locally without the CI step)."""
+    the pyrxd + cbor2 wheels. Skipped when the file isn't present (i.e.
+    when running tests locally without the CI step).
 
-    def test_manifest_has_wheel_field(self):
+    The manifest is the trust boundary: the page-side JS refuses to
+    install any wheel whose bytes don't match the SHA recorded here.
+    These tests pin the structure so a CI step that produced a
+    malformed manifest (missing fields, bad hash format, absolute
+    URLs) fails loudly at test time rather than silently shipping
+    something the JS will reject in the browser."""
+
+    @staticmethod
+    def _manifest():
         import json
         from pathlib import Path
 
-        manifest_path = Path("docs/inspect/wheels/manifest.json")
-        manifest = json.loads(manifest_path.read_text())
+        return json.loads(Path("docs/inspect_static/inspect/wheels/manifest.json").read_text())
+
+    def test_manifest_has_wheel_field(self):
+        manifest = self._manifest()
         assert "wheel" in manifest
         assert manifest["wheel"].startswith("pyrxd-")
         assert manifest["wheel"].endswith(".whl")
+
+    def test_manifest_has_pyrxd_sha256(self):
+        manifest = self._manifest()
+        assert "wheel_sha256" in manifest
+        sha = manifest["wheel_sha256"]
+        # 64 lowercase hex chars
+        assert len(sha) == 64 and all(c in "0123456789abcdef" for c in sha)
+
+    def test_manifest_has_cbor2_wheel_field(self):
+        manifest = self._manifest()
+        assert "cbor2_wheel" in manifest
+        assert manifest["cbor2_wheel"].startswith("cbor2-")
+        assert manifest["cbor2_wheel"].endswith("-py3-none-any.whl")
+
+    def test_manifest_has_cbor2_sha256(self):
+        manifest = self._manifest()
+        assert "cbor2_sha256" in manifest
+        sha = manifest["cbor2_sha256"]
+        assert len(sha) == 64 and all(c in "0123456789abcdef" for c in sha)
+
+    def test_manifest_has_glue_sha256(self):
+        manifest = self._manifest()
+        assert "glue_sha256" in manifest
+        sha = manifest["glue_sha256"]
+        assert len(sha) == 64 and all(c in "0123456789abcdef" for c in sha)
+
+    def test_filenames_are_bare_basenames(self):
+        """The page-side JS rejects any filename containing characters
+        that could redirect URL resolution (``/``, ``\\``, ``:``, ``?``,
+        ``#``). The CI step must produce filenames that pass."""
+        manifest = self._manifest()
+        for field in ("wheel", "cbor2_wheel"):
+            v = manifest[field]
+            assert "/" not in v, f"{field} contains slash: {v!r}"
+            assert "\\" not in v, f"{field} contains backslash: {v!r}"
+            assert ":" not in v, f"{field} contains colon: {v!r}"
+            assert "?" not in v, f"{field} contains query: {v!r}"
+            assert "#" not in v, f"{field} contains fragment: {v!r}"
+
+    def test_recorded_shas_match_actual_files(self):
+        """The hashes in manifest.json must match the actual bytes on
+        disk. Catches a CI step that recorded a stale hash."""
+        import hashlib
+        from pathlib import Path
+
+        manifest = self._manifest()
+        wheels_dir = Path("docs/inspect_static/inspect/wheels")
+        glue_path = Path("docs/inspect_static/inspect/glue.py")
+
+        for filename_field, sha_field in [
+            ("wheel", "wheel_sha256"),
+            ("cbor2_wheel", "cbor2_sha256"),
+        ]:
+            path = wheels_dir / manifest[filename_field]
+            assert path.exists(), f"{path} missing"
+            actual = hashlib.sha256(path.read_bytes()).hexdigest()
+            assert actual == manifest[sha_field], (
+                f"{filename_field}: manifest says {manifest[sha_field]}, file is {actual}"
+            )
+
+        actual_glue = hashlib.sha256(glue_path.read_bytes()).hexdigest()
+        assert actual_glue == manifest["glue_sha256"], (
+            f"glue.py: manifest says {manifest['glue_sha256']}, file is {actual_glue}"
+        )

--- a/tests/web/test_inspect_imports_pyodide_clean.py
+++ b/tests/web/test_inspect_imports_pyodide_clean.py
@@ -1,0 +1,196 @@
+"""Lock the import-graph contract for the browser-hosted inspect tool.
+
+Importing ``pyrxd.glyph.inspect`` (the public façade the browser tool
+loads) MUST NOT transitively pull in any C-extension Python package
+that has no pure-Python wheel. Under Pyodide, ``micropip.install``
+fails on those — concretely:
+
+  * ``coincurve`` — secp256k1 bindings (used for signing/verification
+    inside ``pyrxd.keys`` / ``pyrxd.curve``)
+  * ``Cryptodome.Cipher`` — pycryptodomex AES (used inside
+    ``pyrxd.aes_cbc`` for encrypted-wallet I/O)
+  * ``aiohttp`` — used by the ``MempoolSpaceSource`` BTC client
+  * ``websockets`` — used by the ElectrumX client
+
+Plus we lock the ``pyrxd.*`` module-count budget so a future change
+that quietly re-eagers a top-level re-export shows up as a test
+failure, not as a confusing browser-page boot error.
+
+The browser tool actually needs:
+
+  * ``cbor2`` — micropip-installable, pure-Python wheel exists
+  * ``pycryptodome`` — Pyodide-bundled (the no-x sibling)
+
+Both are explicitly installed by the JS-side ``pyodide.loadPackage``
+call before pyrxd is loaded.
+"""
+
+from __future__ import annotations
+
+import builtins
+import sys
+
+import pytest
+
+# Heavy deps that MUST NOT be triggered by a clean
+# ``import pyrxd.glyph.inspect``. Listed by package root so we catch
+# any submodule trigger (``coincurve.context``, ``aiohttp._http_writer``
+# etc.) at the same level.
+_HEAVY_DEP_ROOTS = frozenset({"coincurve", "aiohttp", "websockets", "Cryptodome"})
+
+# Soft cap on the number of ``pyrxd.*`` submodules a clean
+# ``import pyrxd.glyph.inspect`` may load. Today's count is 25; we
+# allow some growth headroom but a sudden jump means a re-eagered
+# import somewhere upstream. Adjust deliberately when the count
+# legitimately changes (and document why in the commit).
+_PYRXD_MODULE_BUDGET = 35
+
+
+def _clear_relevant_modules() -> None:
+    """Remove pyrxd / heavy-dep modules from sys.modules so the
+    fixture-imports below execute fresh."""
+    for name in list(sys.modules):
+        if name == "pyrxd" or name.startswith("pyrxd.") or name.split(".", 1)[0] in _HEAVY_DEP_ROOTS:
+            sys.modules.pop(name)
+
+
+@pytest.fixture
+def heavy_dep_tracker():
+    """Yield a list that gets every heavy-dep import attempt
+    recorded during the fixture's body.
+
+    Patches ``builtins.__import__`` to capture every import call,
+    filters to the heavy-dep roots, and restores the original
+    ``__import__`` on teardown. Modules already in ``sys.modules``
+    when the import is requested don't trigger ``__import__``, so
+    the fixture clears ``pyrxd`` + heavy-dep entries first.
+    """
+    _clear_relevant_modules()
+    triggers: list[str] = []
+    original = builtins.__import__
+
+    def traced(name, globals=None, locals=None, fromlist=(), level=0):
+        # Only flag first-time imports — re-imports from sys.modules
+        # don't go through __import__'s loader path.
+        if name not in sys.modules and name.split(".", 1)[0] in _HEAVY_DEP_ROOTS:
+            triggers.append(name)
+        return original(name, globals, locals, fromlist, level)
+
+    builtins.__import__ = traced
+    try:
+        yield triggers
+    finally:
+        builtins.__import__ = original
+
+
+class TestInspectFacadeIsPyodideClean:
+    """``import pyrxd.glyph.inspect`` is the path the browser tool's
+    glue takes. It MUST NOT reach for any C-extension dep with no
+    pure-Python wheel."""
+
+    def test_no_heavy_deps_triggered(self, heavy_dep_tracker):
+        import pyrxd.glyph.inspect  # noqa: F401
+
+        assert heavy_dep_tracker == [], (
+            f"importing pyrxd.glyph.inspect triggered heavy deps: "
+            f"{sorted({d.split('.', 1)[0] for d in heavy_dep_tracker})}. "
+            f"This breaks Pyodide where these deps have no pure-Python wheel. "
+            f"Look for a recently-added top-level `from X import Y` in the "
+            f"inspect-path import graph (likely in pyrxd/__init__.py, "
+            f"pyrxd/glyph/__init__.py, pyrxd/script/__init__.py, or one of "
+            f"the helpers in pyrxd/glyph/_inspect_core.py)."
+        )
+
+    def test_pyrxd_module_count_within_budget(self):
+        _clear_relevant_modules()
+        import pyrxd.glyph.inspect  # noqa: F401
+
+        loaded = [m for m in sys.modules if m == "pyrxd" or m.startswith("pyrxd.")]
+        count = len(loaded)
+        assert count <= _PYRXD_MODULE_BUDGET, (
+            f"importing pyrxd.glyph.inspect loaded {count} pyrxd.* modules "
+            f"(budget: {_PYRXD_MODULE_BUDGET}). A jump usually means an "
+            f"`__init__.py` somewhere re-eagered a top-level re-export. "
+            f"Modules loaded:\n  " + "\n  ".join(sorted(loaded))
+        )
+
+
+class TestSubpackageImportsArePyodideClean:
+    """The submodules ``_inspect_core`` consumes individually must
+    each be clean. Locking each separately makes regressions easier
+    to bisect than the aggregated check above."""
+
+    @pytest.mark.parametrize(
+        "module_path",
+        [
+            "pyrxd.glyph._inspect_core",
+            "pyrxd.glyph.types",
+            "pyrxd.glyph.dmint",
+            "pyrxd.glyph.script",
+            "pyrxd.glyph.inspector",
+            "pyrxd.glyph.payload",
+            "pyrxd.glyph.confusables",
+            "pyrxd.transaction.transaction",
+            "pyrxd.hash",
+            "pyrxd.security.errors",
+            "pyrxd.security.types",
+        ],
+    )
+    def test_submodule_does_not_trigger_heavy_deps(self, module_path, heavy_dep_tracker):
+        import importlib
+
+        importlib.import_module(module_path)
+        assert heavy_dep_tracker == [], (
+            f"importing {module_path} triggered heavy deps: {sorted({d.split('.', 1)[0] for d in heavy_dep_tracker})}"
+        )
+
+
+class TestLazyAttributeAccessStillWorks:
+    """The lazy ``__getattr__`` must still resolve every name in
+    ``__all__`` correctly. A bug in the lazy machinery would surface
+    as ``AttributeError`` on first access in production."""
+
+    def test_pyrxd_top_level_lazy_resolution(self):
+        # Clear so we exercise the lazy-load codepath, not a cached
+        # attribute from a previous test.
+        _clear_relevant_modules()
+        import pyrxd
+
+        # Pick an arbitrary name from __all__ that requires the heavy
+        # deps. The first access should succeed (and pull the heavy
+        # deps in — that's the contract: lazy loads only when needed).
+        cls = pyrxd.GlyphMetadata
+        assert cls is not None
+        # Subsequent access should hit the cache, not re-import.
+        assert pyrxd.GlyphMetadata is cls
+
+    def test_pyrxd_glyph_lazy_resolution(self):
+        _clear_relevant_modules()
+        import pyrxd.glyph
+
+        cls = pyrxd.glyph.GlyphRef
+        assert cls is not None
+        assert pyrxd.glyph.GlyphRef is cls
+
+    def test_pyrxd_script_lazy_resolution(self):
+        _clear_relevant_modules()
+        import pyrxd.script
+
+        cls = pyrxd.script.Script
+        assert cls is not None
+        assert pyrxd.script.Script is cls
+
+    def test_unknown_attribute_raises(self):
+        _clear_relevant_modules()
+        import pyrxd
+
+        with pytest.raises(AttributeError, match="has no attribute 'NotARealName'"):
+            _ = pyrxd.NotARealName
+
+    def test_dir_returns_all(self):
+        import pyrxd
+
+        names = dir(pyrxd)
+        assert "GlyphBuilder" in names
+        assert "ValidationError" in names
+        assert "__version__" in names


### PR DESCRIPTION
## Summary

PR #50 was squash-merged before these four commits landed. Without them, the deployed inspect page at `/inspect/` fails to boot in production with a `Could not install pyrxd` error — verified locally before this branch was opened.

This PR brings the orphaned commits onto main:

- **`refactor(inspect): make pyrxd.glyph.inspect Pyodide-installable`** — extract inspect helpers from CLI into `pyrxd/glyph/_inspect_core.py`, convert three `__init__.py` files to PEP 562 lazy `__getattr__`, lazy-import `coincurve` inside `pyrxd/curve.py` arithmetic. Result: `import pyrxd.glyph.inspect` triggers 0 heavy deps and loads 25 `pyrxd.*` modules (was 70+ + all 6 heavy deps).
- **`fix(inspect): install pyrxd with deps=False + pin cbor2==5.4.6 for Pyodide`** — tell micropip to skip dep resolution, install the only real runtime dep (cbor2 5.4.6 — the last release with a pure-Python wheel) before the pyrxd wheel.
- **`fix(inspect): SHA-256 verify all install artifacts, vendor cbor2 wheel`** — close 6 audit findings (HIGH-1 wheel-URL override, MEDIUM SHA pins on both wheels, MEDIUM CSP relaxation to PyPI, LOW glue.py without SRI, LOW outpoint terminal injection).
- **`fix(inspect): round-2 audit follow-ups — basename hardening + safe JSON emit`** — close round-2 NEW-1/NEW-2/NEW-3 (dot-only basename, load-bearing-invariant docs, JSON emit via Python instead of shell heredoc).

## Why merge as a separate PR

The four commits exist in unmerged form on `feat/inspect-ui-pr-c-fetch` (the now-closed PR #50 branch). Rather than reopen #50 — which has already had its review history closed — clean cherry-pick onto a fresh branch, get the same audit-hardened state into main as a follow-up.

## What this delivers

- ✅ Inspect page actually boots (the `Could not install pyrxd` error is what triggered the deep audit)
- ✅ Every install artifact (pyrxd wheel, cbor2 wheel, glue.py) SHA-256 verified before micropip / Pyodide sees it
- ✅ Vendored cbor2 same-origin so CSP can drop `pypi.org` / `files.pythonhosted.org`
- ✅ Manifest filenames validated as bare basenames (regex + dot-only reject) defending against URL-override redirects
- ✅ CI step verifies upstream cbor2 SHA at build time before vendoring

## Audit history (all on PR #50 review pages, summarized here for the merger)

- **Round 1** (3 parallel agents): security-sentinel found HIGH-1 (wheel-URL override) + MEDIUM (no SHA pins, CSP relaxation); red-team found same plus LOW (glue.py SRI, sentinel-message coupling, outpoint terminal injection); data-integrity confirmed CLI behaviour preservation.
- **Round 2** (1 agent): all 6 round-1 findings verified closed; one residual NEW-1 (regex accepts `..`); three belt-and-suspenders comments NEW-2/3/5; one INFO doc-link request NEW-4.
- **Round 2 follow-up** (commit `952ec6e`): NEW-1 closed via explicit `/^\.+$/` reject + regression test; NEW-2/3/5 closed via load-bearing-invariant doc + safe Python JSON emit; NEW-4 resolved by inspecting upstream micropip source (the `emfs:` scheme is documented at `pyodide/micropip/blob/main/micropip/wheelinfo.py#L55`).

## Test plan

- [x] **Local browser smoke test passed** — page boots, fetches both wheels, verifies SHA-256, installs from FS, classifies inputs correctly
- [x] **Full `task ci`** — 2570 passed / 3 skipped / 0 failed
- [x] **18 new tests in `tests/web/test_inspect_imports_pyodide_clean.py`** locking the heavy-dep absence invariant for the façade and 11 individual submodules, plus a 35-module budget cap
- [x] **7 new tests in `TestWheelManifest`** locking manifest structure, SHA hex format, basename safety, and SHA-vs-actual-bytes consistency
- [x] All 75 CLI inspect tests pass unchanged (CLI translation layer preserves error wording verbatim)
- [ ] **Manual post-deploy smoke** on GitHub Pages (the actual production verification)

## Risk

Low. The Python-side refactor is behaviour-preserving for all CLI users (verified by the data-integrity audit). The browser-side changes only affect the inspect page, which is currently broken anyway.