### PR TITLE
chore(ci): cancel in-flight runs on push to same branch/PR

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,14 @@ on:
   pull_request:
     branches: [main, dev]
 
+# Cancel any in-flight CI run for the same branch / PR when a new push lands.
+# Dependabot rebases and force-pushes used to fan out wasted runs per chore PR;
+# this collapses that to one in-flight run per ref. Different branches / PRs
+# don't cancel each other (the group key includes ref / PR number).
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -10,6 +10,13 @@ on:
     # CodeQL's queries after our last code change.
     - cron: "0 6 * * 1"
 
+# Cancel old runs when a new push lands on the same branch/PR. See ci.yml.
+# Scheduled runs use refs/heads/main as their ref; they don't normally
+# overlap with push/PR events so concurrency cancellation is safe.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -6,6 +6,11 @@ on:
   pull_request:
     branches: [main, dev]
 
+# Cancel old runs when a new push lands on the same branch/PR. See ci.yml.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 

--- a/.github/workflows/osv-scanner.yml
+++ b/.github/workflows/osv-scanner.yml
@@ -15,6 +15,11 @@ on:
     # CodeQL (06:00) to spread runner load.
     - cron: "0 8 * * 1"
 
+# Cancel old runs when a new push lands on the same branch/PR. See ci.yml.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 


### PR DESCRIPTION
## Summary

Adds concurrency cancellation to four pyrxd workflows that fire on every push and every PR: **CI**, **Lint**, **CodeQL**, **OSV Scanner**. When a new push lands on the same branch/PR, in-flight runs on stale commits get cancelled instead of grinding to completion.

## Why now

This is the smaller of three CI-cost PRs I just opened. Context:

- The MudwoodLabs org has been hitting its 3,000-min Actions quota. Analyzed the May 1–13 billing report and found EquiRead (76%) and Flipperhub (23%) account for ~99% of billed minutes; pyrxd is public so it's free.
- The pattern that wastes minutes is the same in all three repos: pushes and PRs both fire workflows, and stale runs grind to completion when a new commit lands.
- Companion fixes: [EquiRead #108](https://github.com/MudwoodLabs/EquiRead/pull/108) (kills push+PR double-trigger + path-gates jobs), [Flipperhub #36](https://github.com/MudwoodLabs/Flipperhub/pull/36) (kills double-trigger).

pyrxd doesn't have the double-trigger problem (it's already correctly scoped) and is public anyway, so this PR is purely the concurrency-cancellation slice. **The win here is dev UX**: PR feedback is no longer delayed waiting for a stale run to finish.

## Changes

The same edit applied to four workflow files:

```yaml
concurrency:
  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
  cancel-in-progress: true
```

The group expression handles push-vs-PR distinction:
- **Push events** use `github.ref` (e.g. `refs/heads/feat/x`) — pushes to the same branch cancel each other.
- **PR events** use the PR number — pushes within the same PR cancel each other.
- Different PRs / branches don't cancel each other (different group keys).

### Workflows touched
- `ci.yml` — full test suite (~5 min). Biggest UX win.
- `lint.yml` — ruff + bandit (~15s). Fast but still benefits.
- `codeql.yml` — CodeQL security scan (~2 min). Also has a schedule trigger; that's safe because scheduled runs use a different ref than active push/PR refs.
- `osv-scanner.yml` — dependency vulnerability scan (~40s). Same scheduling note.

### Workflows intentionally NOT touched
- `publish.yml` — releases shouldn't be cancellable mid-flight.
- `docs.yml` — already has appropriate concurrency (`cancel-in-progress: false` — Pages deploys can't be cancelled mid-deploy).
- `scorecard.yml` — runs only on push-to-main + cron, no PR trigger. Concurrency adds no value.

## Test plan

- [x] All 4 YAML files parse cleanly
- [x] Tested locally that the concurrency group expression is well-formed
- [ ] After merge: push twice to a feat branch in quick succession; confirm the first run gets cancelled
- [ ] After merge: dependabot rebase on a chore PR; confirm only one CI run is in flight at any time

## What's NOT in this PR

- The bigger cost savings are in the private repos (EquiRead, Flipperhub) — those have separate PRs.
- No path-gating of jobs in pyrxd's CI: the test suite is fast (~5 min) and all jobs are relevant on every commit. Path-gating wouldn't pay back the added workflow complexity.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
