### PR TITLE
feat(script): CLTV / CSV time-lock script primitives

### DIFF
--- a/src/pyrxd/script/__init__.py
+++ b/src/pyrxd/script/__init__.py
@@ -12,6 +12,8 @@ from __future__ import annotations
 
 _LAZY_EXPORTS: dict[str, tuple[str, str]] = {
     "BareMultisig": ("pyrxd.script.type", "BareMultisig"),
+    "CsvKind": ("pyrxd.script.timelock", "CsvKind"),
+    "LOCKTIME_THRESHOLD": ("pyrxd.script.timelock", "LOCKTIME_THRESHOLD"),
     "OpReturn": ("pyrxd.script.type", "OpReturn"),
     "P2PK": ("pyrxd.script.type", "P2PK"),
     "P2PKH": ("pyrxd.script.type", "P2PKH"),
@@ -19,6 +21,15 @@ _LAZY_EXPORTS: dict[str, tuple[str, str]] = {
     "ScriptChunk": ("pyrxd.script.script", "ScriptChunk"),
     "ScriptTemplate": ("pyrxd.script.type", "ScriptTemplate"),
     "Unknown": ("pyrxd.script.type", "Unknown"),
+    "build_csv_sequence": ("pyrxd.script.timelock", "build_csv_sequence"),
+    "build_p2pkh_with_cltv_script": (
+        "pyrxd.script.timelock",
+        "build_p2pkh_with_cltv_script",
+    ),
+    "build_p2pkh_with_csv_script": (
+        "pyrxd.script.timelock",
+        "build_p2pkh_with_csv_script",
+    ),
 }
 
 __all__ = sorted(_LAZY_EXPORTS.keys())

--- a/src/pyrxd/script/timelock.py
+++ b/src/pyrxd/script/timelock.py
@@ -1,0 +1,141 @@
+"""Time-lock script primitives — CLTV (absolute) and CSV (relative).
+
+Canonical Bitcoin/Radiant time-lock locking scripts. Each helper builds a
+``<locktime> OP_CHECKLOCKTIMEVERIFY OP_DROP <P2PKH tail>`` shape (or the
+CSV equivalent), which is the standard form used by wallets and
+specifications since BIP-65 / BIP-112.
+
+Scope: **locking scripts only**. These helpers emit the output script
+bytes; spending such an output (and threading the corresponding
+``nLockTime`` / ``nSequence`` constraints through transaction
+construction) is intentionally out of scope until a concrete pyrxd
+consumer needs it. See ``docs/solutions/design-decisions/`` for the
+deferral note covering the transaction-level wiring.
+
+Reference shapes
+----------------
+
+**Absolute time-lock (CLTV)** — output is spendable only when the
+spending transaction's ``nLockTime`` is at or after ``locktime``::
+
+    <locktime> OP_CHECKLOCKTIMEVERIFY OP_DROP
+    OP_DUP OP_HASH160 <pkh> OP_EQUALVERIFY OP_CHECKSIG
+
+The ``locktime`` value follows Bitcoin's dual interpretation:
+
+* ``locktime < 500_000_000`` — block-height absolute lock
+* ``locktime >= 500_000_000`` — Unix-time absolute lock (seconds)
+
+**Relative time-lock (CSV)** — output is spendable only after the
+encoded relative wait, measured from the funding-output's confirmation::
+
+    <sequence> OP_CHECKSEQUENCEVERIFY OP_DROP
+    OP_DUP OP_HASH160 <pkh> OP_EQUALVERIFY OP_CHECKSIG
+
+The ``sequence`` value follows BIP-112's encoded form: a 32-bit
+non-negative integer whose bit-22 selects time vs blocks and whose
+low 16 bits hold the count. ``build_csv_sequence`` is a small helper
+that encodes ``(units, kind)`` into the on-wire integer; callers may
+also pass a pre-encoded integer if they already have one.
+"""
+
+from __future__ import annotations
+
+from enum import Enum
+
+from ..constants import PUBLIC_KEY_HASH_BYTE_LENGTH, OpCode
+from ..security.errors import ValidationError
+from ..security.types import Hex20
+from ..utils import encode_int
+
+# BIP-65 boundary between height-based and time-based locktime.
+# Values below this are interpreted as block heights; values at or above
+# this are interpreted as Unix timestamps (seconds since epoch).
+LOCKTIME_THRESHOLD = 500_000_000
+
+# Max nLockTime is a 32-bit field on the wire.
+_MAX_LOCKTIME = 0xFFFF_FFFF
+
+# BIP-112 OP_CHECKSEQUENCEVERIFY encoding constants.
+# A 32-bit value on the stack; only the low 17 bits are used at consensus.
+_CSV_TYPE_FLAG = 1 << 22  # bit 22: 0 = blocks, 1 = time (512-second units)
+_CSV_DISABLE_FLAG = 1 << 31  # bit 31: 1 = "no relative lock" (consensus-disabled bit)
+_CSV_VALUE_MASK = 0xFFFF  # low 16 bits hold the unit count
+
+
+class CsvKind(Enum):
+    """Relative time-lock kind, per BIP-112."""
+
+    BLOCKS = "blocks"
+    TIME_512_SECONDS = "time"
+
+
+def build_csv_sequence(units: int, kind: CsvKind) -> int:
+    """Encode an ``(units, kind)`` pair into the integer form CSV expects
+    on the stack and in the spending input's ``nSequence`` field.
+
+    ``units`` is the BIP-112 unit count: blocks for ``CsvKind.BLOCKS``,
+    or 512-second intervals for ``CsvKind.TIME_512_SECONDS``. Must be in
+    the range ``[0, 65535]`` (16 bits)."""
+    if not (0 <= units <= _CSV_VALUE_MASK):
+        raise ValidationError(f"CSV unit count out of range: {units} not in [0, {_CSV_VALUE_MASK}]")
+    encoded = units & _CSV_VALUE_MASK
+    if kind is CsvKind.TIME_512_SECONDS:
+        encoded |= _CSV_TYPE_FLAG
+    elif kind is not CsvKind.BLOCKS:  # pragma: no cover — Enum exhausts the choices
+        raise ValidationError(f"unknown CsvKind: {kind!r}")
+    return encoded
+
+
+def _p2pkh_tail(pkh: bytes) -> bytes:
+    if len(pkh) != PUBLIC_KEY_HASH_BYTE_LENGTH:
+        raise ValidationError(f"pkh must be {PUBLIC_KEY_HASH_BYTE_LENGTH} bytes, got {len(pkh)}")
+    return (
+        OpCode.OP_DUP
+        + OpCode.OP_HASH160
+        + bytes([PUBLIC_KEY_HASH_BYTE_LENGTH])
+        + pkh
+        + OpCode.OP_EQUALVERIFY
+        + OpCode.OP_CHECKSIG
+    )
+
+
+def build_p2pkh_with_cltv_script(owner_pkh: Hex20, locktime: int) -> bytes:
+    """Build a P2PKH locking script gated by an absolute time-lock (CLTV).
+
+    The output is spendable only when the spending transaction's
+    ``nLockTime`` is at or after ``locktime``.
+
+    ``locktime < 500_000_000`` selects a block-height lock; values at or
+    above ``LOCKTIME_THRESHOLD`` select a Unix-time lock (seconds). The
+    caller is responsible for choosing the right interpretation — both
+    are accepted at the script level.
+
+    Returns the raw locking-script bytes.
+    """
+    if not (0 <= locktime <= _MAX_LOCKTIME):
+        raise ValidationError(f"locktime out of range: {locktime} not in [0, {_MAX_LOCKTIME}]")
+    return encode_int(locktime) + OpCode.OP_CHECKLOCKTIMEVERIFY + OpCode.OP_DROP + _p2pkh_tail(bytes(owner_pkh))
+
+
+def build_p2pkh_with_csv_script(owner_pkh: Hex20, sequence: int) -> bytes:
+    """Build a P2PKH locking script gated by a relative time-lock (CSV).
+
+    The output is spendable only after the BIP-112-encoded ``sequence``
+    has elapsed (measured from the funding-output's confirmation). Use
+    ``build_csv_sequence(units, kind)`` to construct ``sequence`` from a
+    block count or a 512-second interval count.
+
+    Callers must NOT pass a sequence with the disable bit (1 << 31) set
+    — that value means "no relative lock" and would silently make the
+    script trivially spendable.
+
+    Returns the raw locking-script bytes.
+    """
+    if not (0 <= sequence <= _MAX_LOCKTIME):
+        raise ValidationError(f"sequence out of range: {sequence} not in [0, {_MAX_LOCKTIME}]")
+    if sequence & _CSV_DISABLE_FLAG:
+        raise ValidationError(
+            f"sequence has disable bit (1<<31) set ({sequence:#x}); this would make the relative time-lock a no-op"
+        )
+    return encode_int(sequence) + OpCode.OP_CHECKSEQUENCEVERIFY + OpCode.OP_DROP + _p2pkh_tail(bytes(owner_pkh))

--- a/tests/test_timelock.py
+++ b/tests/test_timelock.py
@@ -1,0 +1,198 @@
+"""Tests for pyrxd.script.timelock — CLTV / CSV locking-script primitives."""
+
+from __future__ import annotations
+
+import pytest
+
+from pyrxd.script.timelock import (
+    LOCKTIME_THRESHOLD,
+    CsvKind,
+    build_csv_sequence,
+    build_p2pkh_with_cltv_script,
+    build_p2pkh_with_csv_script,
+)
+from pyrxd.security.errors import ValidationError
+from pyrxd.security.types import Hex20
+
+_PKH = Hex20(bytes(range(20)))  # 20 distinct bytes 0x00..0x13
+_P2PKH_TAIL = bytes.fromhex("76a914") + bytes(_PKH) + bytes.fromhex("88ac")
+
+
+class TestBuildP2pkhWithCltvScript:
+    """Build_p2pkh_with_cltv_script — absolute time-lock + P2PKH."""
+
+    def test_block_height_lock_uses_minimal_int_push(self):
+        """A small block-height locktime encodes as a minimal int push.
+        ``OP_3`` (= 0x53) is the canonical minimal encoding for the
+        integer 3."""
+        script = build_p2pkh_with_cltv_script(_PKH, locktime=3)
+        # script = OP_3 OP_CHECKLOCKTIMEVERIFY OP_DROP <P2PKH tail>
+        assert script[0] == 0x53  # OP_3 = OP_1(0x51) + 2
+        assert script[1] == 0xB1  # OP_CHECKLOCKTIMEVERIFY
+        assert script[2] == 0x75  # OP_DROP
+        assert script[3:] == _P2PKH_TAIL
+
+    def test_height_lock_above_op_n_uses_pushdata(self):
+        """A locktime above 16 encodes as a length-prefixed push, since
+        ``OP_1..OP_16`` only cover 1..16."""
+        script = build_p2pkh_with_cltv_script(_PKH, locktime=100)
+        # 100 fits in 1 byte → push opcode 0x01 then 0x64
+        assert script[0] == 0x01
+        assert script[1] == 0x64
+        assert script[2] == 0xB1  # OP_CHECKLOCKTIMEVERIFY
+        assert script[3] == 0x75  # OP_DROP
+        assert script[4:] == _P2PKH_TAIL
+
+    def test_unix_time_lock_above_threshold_round_trips(self):
+        """A locktime ≥500_000_000 selects the Unix-time interpretation at
+        consensus. At the script level the encoding is just a minimal int
+        push — the threshold is only meaningful when the spending tx's
+        nLockTime is checked."""
+        ts = 1_700_000_000  # 2023-11-14 — well past LOCKTIME_THRESHOLD
+        assert ts > LOCKTIME_THRESHOLD
+        script = build_p2pkh_with_cltv_script(_PKH, locktime=ts)
+        # 1_700_000_000 = 0x65540008 ... but encode_int is little-endian
+        # signed. ts fits in 4 bytes with high bit clear → push opcode 0x04.
+        assert script[0] == 0x04  # PUSH 4
+        # Recover the LE-encoded integer from the script bytes
+        recovered = int.from_bytes(script[1:5], "little", signed=True)
+        assert recovered == ts
+        assert script[5] == 0xB1
+        assert script[6] == 0x75
+        assert script[7:] == _P2PKH_TAIL
+
+    def test_zero_locktime_uses_op_0(self):
+        """A locktime of 0 (lock-disabled) encodes as ``OP_0``."""
+        script = build_p2pkh_with_cltv_script(_PKH, locktime=0)
+        assert script[0] == 0x00  # OP_0
+        assert script[1] == 0xB1
+        assert script[2] == 0x75
+        assert script[3:] == _P2PKH_TAIL
+
+    def test_max_locktime_round_trips(self):
+        """A 32-bit max locktime encodes with the high-bit zero-padding
+        rule — encode_int adds a 0x00 byte to keep the value positive
+        when the most-significant byte has the sign bit set."""
+        script = build_p2pkh_with_cltv_script(_PKH, locktime=0xFFFF_FFFF)
+        # 0xFFFF_FFFF has high bit set → encode_int pads with 0x00 → 5 bytes
+        assert script[0] == 0x05  # PUSH 5
+        assert script[1:6] == bytes([0xFF, 0xFF, 0xFF, 0xFF, 0x00])
+        assert script[6] == 0xB1
+        assert script[7] == 0x75
+
+    def test_negative_locktime_rejected(self):
+        with pytest.raises(ValidationError, match="locktime out of range"):
+            build_p2pkh_with_cltv_script(_PKH, locktime=-1)
+
+    def test_locktime_overflow_rejected(self):
+        with pytest.raises(ValidationError, match="locktime out of range"):
+            build_p2pkh_with_cltv_script(_PKH, locktime=0x1_0000_0000)
+
+    def test_wrong_pkh_length_rejected(self):
+        with pytest.raises(ValidationError, match="pkh must be 20 bytes"):
+            build_p2pkh_with_cltv_script(b"\x00" * 19, locktime=1)  # type: ignore[arg-type]
+
+
+class TestBuildP2pkhWithCsvScript:
+    """build_p2pkh_with_csv_script — relative time-lock + P2PKH."""
+
+    def test_block_count_round_trips(self):
+        """A small block-count sequence encodes as a minimal int push.
+        144 = 0x90 has the sign bit set, so ``encode_int`` pads with
+        ``0x00`` to keep it positive — yielding a 2-byte push."""
+        sequence = build_csv_sequence(units=144, kind=CsvKind.BLOCKS)
+        # 144 fits in 1 byte; no type bit set for BLOCKS
+        assert sequence == 144
+        script = build_p2pkh_with_csv_script(_PKH, sequence=sequence)
+        assert script[0] == 0x02  # PUSH 2
+        assert script[1:3] == bytes([0x90, 0x00])  # 144 LE with sign-pad
+        # Recover the LE-encoded integer from the script bytes
+        recovered = int.from_bytes(script[1:3], "little", signed=True)
+        assert recovered == 144
+        assert script[3] == 0xB2  # OP_CHECKSEQUENCEVERIFY
+        assert script[4] == 0x75  # OP_DROP
+        assert script[5:] == _P2PKH_TAIL
+
+    def test_time_kind_sets_bit_22(self):
+        """``CsvKind.TIME_512_SECONDS`` flips bit 22 of the encoded value
+        per BIP-112. 1 hour ≈ 7 units of 512 seconds."""
+        sequence = build_csv_sequence(units=7, kind=CsvKind.TIME_512_SECONDS)
+        assert sequence == (1 << 22) | 7
+
+    def test_block_count_clears_bit_22(self):
+        sequence = build_csv_sequence(units=100, kind=CsvKind.BLOCKS)
+        assert sequence & (1 << 22) == 0
+        assert sequence == 100
+
+    def test_max_unit_count(self):
+        """16-bit max unit count (65 535) is the BIP-112 limit."""
+        sequence = build_csv_sequence(units=65_535, kind=CsvKind.BLOCKS)
+        assert sequence == 65_535
+
+    def test_unit_count_overflow_rejected(self):
+        with pytest.raises(ValidationError, match="CSV unit count out of range"):
+            build_csv_sequence(units=65_536, kind=CsvKind.BLOCKS)
+
+    def test_negative_unit_count_rejected(self):
+        with pytest.raises(ValidationError, match="CSV unit count out of range"):
+            build_csv_sequence(units=-1, kind=CsvKind.BLOCKS)
+
+    def test_disable_bit_rejected(self):
+        """A caller who manually constructs a sequence with bit 31 set
+        gets rejected — that bit means 'no relative lock' and would make
+        the script a no-op."""
+        with pytest.raises(ValidationError, match="disable bit"):
+            build_p2pkh_with_csv_script(_PKH, sequence=1 << 31)
+
+    def test_sequence_overflow_rejected(self):
+        with pytest.raises(ValidationError, match="sequence out of range"):
+            build_p2pkh_with_csv_script(_PKH, sequence=0x1_0000_0000)
+
+    def test_negative_sequence_rejected(self):
+        with pytest.raises(ValidationError, match="sequence out of range"):
+            build_p2pkh_with_csv_script(_PKH, sequence=-1)
+
+    def test_zero_sequence_op_0(self):
+        """A sequence of 0 (relative lock of 0 — i.e. spendable in the
+        next block) encodes as OP_0."""
+        script = build_p2pkh_with_csv_script(_PKH, sequence=0)
+        assert script[0] == 0x00  # OP_0
+        assert script[1] == 0xB2
+        assert script[2] == 0x75
+        assert script[3:] == _P2PKH_TAIL
+
+    def test_wrong_pkh_length_rejected(self):
+        with pytest.raises(ValidationError, match="pkh must be 20 bytes"):
+            build_p2pkh_with_csv_script(b"\x00" * 19, sequence=1)  # type: ignore[arg-type]
+
+
+class TestCltvAndCsvScriptInvariants:
+    """Cross-invariants between the two builders."""
+
+    def test_scripts_have_no_overlap_in_opcode(self):
+        """CLTV uses 0xb1, CSV uses 0xb2 — the byte after the locktime
+        push is the only structural difference between the two shapes."""
+        cltv = build_p2pkh_with_cltv_script(_PKH, locktime=1)
+        csv = build_p2pkh_with_csv_script(_PKH, sequence=1)
+        # Both: <OP_1> <OP_CLTV|CSV> <OP_DROP> <P2PKH tail>
+        assert cltv[0] == csv[0]  # same locktime push
+        assert cltv[1] == 0xB1  # OP_CHECKLOCKTIMEVERIFY
+        assert csv[1] == 0xB2  # OP_CHECKSEQUENCEVERIFY
+        assert cltv[2] == csv[2] == 0x75  # OP_DROP
+        assert cltv[3:] == csv[3:]  # same P2PKH tail
+
+
+class TestPublicReexports:
+    """Names are reachable via ``pyrxd.script.<name>`` (the PEP 562 lazy
+    re-exports), so downstream consumers don't have to know about the
+    internal module path."""
+
+    def test_top_level_imports(self):
+        import pyrxd.script as ps
+
+        assert ps.LOCKTIME_THRESHOLD == 500_000_000
+        assert ps.CsvKind.BLOCKS.value == "blocks"
+        assert ps.CsvKind.TIME_512_SECONDS.value == "time"
+        assert callable(ps.build_csv_sequence)
+        assert callable(ps.build_p2pkh_with_cltv_script)
+        assert callable(ps.build_p2pkh_with_csv_script)


### PR DESCRIPTION
## Summary

Adds two locking-script builders to the new module \`pyrxd.script.timelock\`:

\`\`\`python
from pyrxd.script import (
    build_csv_sequence,
    build_p2pkh_with_cltv_script,
    build_p2pkh_with_csv_script,
    CsvKind,
    LOCKTIME_THRESHOLD,
)

# Absolute time-lock — spendable when nLockTime >= 700_000 (block height)
script = build_p2pkh_with_cltv_script(owner_pkh, locktime=700_000)

# Relative time-lock — spendable 144 blocks after the funding tx confirms
sequence = build_csv_sequence(units=144, kind=CsvKind.BLOCKS)
script = build_p2pkh_with_csv_script(owner_pkh, sequence=sequence)
\`\`\`

## What it ships

- \`build_p2pkh_with_cltv_script(pkh, locktime)\` — P2PKH gated by **absolute** time-lock (BIP-65)
- \`build_p2pkh_with_csv_script(pkh, sequence)\` — P2PKH gated by **relative** time-lock (BIP-112)
- \`build_csv_sequence(units, kind)\` — encodes a (blocks | 512-second intervals) pair into the BIP-112 stack/nSequence form
- \`CsvKind.BLOCKS\` / \`CsvKind.TIME_512_SECONDS\` — the BIP-112 kind enum
- \`LOCKTIME_THRESHOLD\` — exported as a constant for callers who need to disambiguate height vs. Unix-time locks

Validation rejects:
- Out-of-range locktime / sequence (must fit in 32 bits, non-negative)
- Sequence with the disable bit (1 << 31) set — that value makes the relative time-lock a no-op, a silent foot-gun
- Wrong-size pkh (must be 20 bytes)

## Scope: locking scripts only

This PR ships **locking scripts only**. Spending such an output (and threading \`nLockTime\` / \`nSequence\` through transaction construction, plus the unlocking-path \`ScriptTemplate\` that would consume signatures) is intentionally out of scope until a concrete pyrxd consumer needs it. This matches the WAVE deferral pattern in \`docs/solutions/design-decisions/\`.

OP_CHECKLOCKTIMEVERIFY (\`0xb1\`) and OP_CHECKSEQUENCEVERIFY (\`0xb2\`) were already in \`pyrxd.constants.OpCode\` — this PR adds the canonical shape builders that compose them.

## Test plan

20 tests cover:

- [x] Minimal-int push behavior for locktimes < 17 (\`OP_1..OP_16\`) and ≥ 17
- [x] Sign-pad behavior when the LE high byte has bit 7 set (e.g. 144 → \`[0x90, 0x00]\`)
- [x] Max-locktime round-trip (\`0xFFFFFFFF\` → 5-byte push with \`0x00\` pad)
- [x] Zero locktime / zero sequence → \`OP_0\`
- [x] BIP-112 type bit 22 (blocks vs 512-second time)
- [x] Out-of-range / negative / disable-bit rejection
- [x] Cross-invariant: CLTV and CSV shapes differ only at the verify opcode
- [x] Public re-exports via \`pyrxd.script.<name>\`
- [x] Pre-push hook: full suite 2828 passed, 12 skipped, lint clean

## Why this PR is small

Per CLAUDE.md, pyrxd ships SDK primitives rather than finished apps. The full time-locked-wallet feature would need:

1. **This PR** — script-level locking primitives ✓
2. \`nLockTime\` threading in \`Transaction.preimage\` / signing — deferred
3. A \`ScriptTemplate\` subclass for the unlocking path (sig+pubkey + locktime context) — deferred
4. Helpers for HTLC (hash + time-lock compound script) — deferred

Each step ships when a consumer surfaces, not pre-emptively. This PR is small enough to review in one sitting and complete enough to use for output construction today.