### PR TITLE
test(fuzz): fuzz harnesses for attacker-controlled parsers

### DIFF
--- a/scripts/fuzz_atheris/harness_classify_input.py
+++ b/scripts/fuzz_atheris/harness_classify_input.py
@@ -1,0 +1,43 @@
+"""Atheris harness for ``pyrxd.glyph._inspect_core._classify_input``.
+
+This is the very first thing the inspect tool runs against a user paste.
+It must classify (txid / contract / outpoint / script) or raise
+``ValidationError`` — never crash with a deeper exception type.
+
+The fuzzer feeds a UTF-8-decoded string, since that's what the CLI
+boundary deals in. Bytes that fail to decode are skipped.
+
+Run:
+    python3 scripts/fuzz_atheris/harness_classify_input.py \\
+        -atheris_runs=0 \\
+        -max_total_time=3600 \\
+        -artifact_prefix=logs/atheris-classify-
+"""
+
+from __future__ import annotations
+
+import sys
+
+import atheris
+
+with atheris.instrument_imports(include=["pyrxd.glyph"]):
+    from pyrxd.glyph._inspect_core import _classify_input
+    from pyrxd.security.errors import ValidationError
+
+
+def TestOneInput(data: bytes) -> None:
+    fdp = atheris.FuzzedDataProvider(data)
+    s = fdp.ConsumeUnicodeNoSurrogates(512)
+    try:
+        _classify_input(s)
+    except ValidationError:
+        pass
+
+
+def main() -> None:
+    atheris.Setup(sys.argv, TestOneInput)
+    atheris.Fuzz()
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/fuzz_atheris/harness_classify_input.py
+++ b/scripts/fuzz_atheris/harness_classify_input.py
@@ -31,7 +31,7 @@ def TestOneInput(data: bytes) -> None:
     try:
         _classify_input(s)
     except ValidationError:
-        pass
+        pass  # expected: classifier rejected malformed input cleanly
 
 
 def main() -> None:

--- a/scripts/fuzz_atheris/harness_decode_payload.py
+++ b/scripts/fuzz_atheris/harness_decode_payload.py
@@ -1,0 +1,44 @@
+"""Atheris coverage-guided fuzz harness for ``pyrxd.glyph.payload.decode_payload``.
+
+Run:
+    python3 scripts/fuzz_atheris/harness_decode_payload.py \\
+        -atheris_runs=0 \\
+        -max_total_time=3600 \\
+        -artifact_prefix=logs/atheris-decode_payload-
+
+Atheris instruments pyrxd.glyph.* on import and uses libFuzzer's coverage
+feedback to guide input mutation toward unexplored code paths. Anything
+the harness raises that isn't ``ValidationError`` will be reported as a
+finding with a reproducer file dropped at ``artifact_prefix``.
+
+This is independent of and complements ``tests/test_fuzz_parsers.py``:
+Hypothesis is random + shrinking, atheris is coverage-guided.
+"""
+
+from __future__ import annotations
+
+import sys
+
+import atheris
+
+# Instrument pyrxd's parser modules. Keep the surface narrow so we don't
+# pay instrumentation cost on stdlib / cbor2 / etc.
+with atheris.instrument_imports(include=["pyrxd.glyph"]):
+    from pyrxd.glyph.payload import decode_payload
+    from pyrxd.security.errors import ValidationError
+
+
+def TestOneInput(data: bytes) -> None:
+    try:
+        decode_payload(data)
+    except ValidationError:
+        pass  # expected: parser converted a malformed input cleanly
+
+
+def main() -> None:
+    atheris.Setup(sys.argv, TestOneInput)
+    atheris.Fuzz()
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/fuzz_atheris/harness_dmint_from_script.py
+++ b/scripts/fuzz_atheris/harness_dmint_from_script.py
@@ -1,0 +1,41 @@
+"""Atheris harness for ``pyrxd.glyph.dmint.DmintState.from_script``.
+
+The dMint state-script parser is a hand-written variable-length opcode
+walker: it dispatches on per-byte opcodes, reads pushed lengths from the
+stream, and decodes 36-byte ``GlyphRef`` blobs from inside the script.
+Coverage-guided mutation is well-suited to finding edge cases (truncated
+PUSHDATA, mismatched STATESEPARATOR, malformed ref-bytes) the random
+Hypothesis fuzzer can take a long time to reach.
+
+Run:
+    python3 scripts/fuzz_atheris/harness_dmint_from_script.py \\
+        -atheris_runs=0 \\
+        -max_total_time=3600 \\
+        -artifact_prefix=logs/atheris-dmint-
+"""
+
+from __future__ import annotations
+
+import sys
+
+import atheris
+
+with atheris.instrument_imports(include=["pyrxd.glyph"]):
+    from pyrxd.glyph.dmint import DmintState
+    from pyrxd.security.errors import ValidationError
+
+
+def TestOneInput(data: bytes) -> None:
+    try:
+        DmintState.from_script(data)
+    except ValidationError:
+        pass
+
+
+def main() -> None:
+    atheris.Setup(sys.argv, TestOneInput)
+    atheris.Fuzz()
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/fuzz_atheris/harness_dmint_from_script.py
+++ b/scripts/fuzz_atheris/harness_dmint_from_script.py
@@ -29,7 +29,7 @@ def TestOneInput(data: bytes) -> None:
     try:
         DmintState.from_script(data)
     except ValidationError:
-        pass
+        pass  # expected: parser converted a malformed input cleanly
 
 
 def main() -> None:

--- a/scripts/fuzz_atheris/harness_extract_reveal_metadata.py
+++ b/scripts/fuzz_atheris/harness_extract_reveal_metadata.py
@@ -1,0 +1,41 @@
+"""Atheris harness for ``GlyphInspector.extract_reveal_metadata``.
+
+The reveal-metadata extractor walks an attacker-controlled scriptSig
+push-data stream looking for the ``gly`` marker followed by CBOR. The
+contract is "never raises" — any exception escaping is a bug because
+the caller (``find_reveal_metadata`` and the inspect tool) does not
+catch them at the call site.
+
+Run:
+    python3 scripts/fuzz_atheris/harness_extract_reveal_metadata.py \\
+        -atheris_runs=0 \\
+        -max_total_time=3600 \\
+        -artifact_prefix=logs/atheris-reveal-
+"""
+
+from __future__ import annotations
+
+import sys
+
+import atheris
+
+with atheris.instrument_imports(include=["pyrxd.glyph"]):
+    from pyrxd.glyph.inspector import GlyphInspector
+
+
+_inspector = GlyphInspector()
+
+
+def TestOneInput(data: bytes) -> None:
+    # No try/except: the contract says this never raises. Atheris will
+    # report any uncaught exception as a finding.
+    _inspector.extract_reveal_metadata(data)
+
+
+def main() -> None:
+    atheris.Setup(sys.argv, TestOneInput)
+    atheris.Fuzz()
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/fuzz_atheris/harness_inspect_script.py
+++ b/scripts/fuzz_atheris/harness_inspect_script.py
@@ -1,0 +1,54 @@
+"""Atheris harness for ``pyrxd.glyph._inspect_core._inspect_script``.
+
+This is the dispatch the inspect tool runs when a user pastes a hex-
+encoded locking script. It tries P2PKH, OP_RETURN, NFT, FT, mutable-NFT,
+commit-NFT, commit-FT, and dMint classifiers in order. The whole chain
+must surface failures as ``ValidationError`` only.
+
+Atheris's ``FuzzedDataProvider`` is used to construct hex strings rather
+than feeding raw bytes — the function expects hex input, so feeding it
+arbitrary bytes mostly exercises the front-door hex check. We build a
+hex string from the fuzzer's bytes so coverage feedback flows into the
+deeper classifiers.
+
+Run:
+    python3 scripts/fuzz_atheris/harness_inspect_script.py \\
+        -atheris_runs=0 \\
+        -max_total_time=3600 \\
+        -artifact_prefix=logs/atheris-inspect_script-
+"""
+
+from __future__ import annotations
+
+import sys
+
+import atheris
+
+with atheris.instrument_imports(include=["pyrxd.glyph"]):
+    from pyrxd.glyph._inspect_core import _inspect_script
+    from pyrxd.security.errors import ValidationError
+
+
+def TestOneInput(data: bytes) -> None:
+    fdp = atheris.FuzzedDataProvider(data)
+    # Use the fuzzer's bytes as the hex source — every byte becomes 2 hex
+    # chars, which keeps the hex even-length by construction so the
+    # classifier reaches the deeper branches rather than failing on the
+    # length-parity check.
+    raw = fdp.ConsumeBytes(1024)
+    hex_in = raw.hex()
+    if not (50 <= len(hex_in) <= 20_000):
+        return  # outside the inspector's accepted length window
+    try:
+        _inspect_script(hex_in)
+    except ValidationError:
+        pass
+
+
+def main() -> None:
+    atheris.Setup(sys.argv, TestOneInput)
+    atheris.Fuzz()
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/fuzz_atheris/harness_inspect_script.py
+++ b/scripts/fuzz_atheris/harness_inspect_script.py
@@ -42,7 +42,7 @@ def TestOneInput(data: bytes) -> None:
     try:
         _inspect_script(hex_in)
     except ValidationError:
-        pass
+        pass  # expected: inspector rejected malformed hex at the boundary
 
 
 def main() -> None:

--- a/scripts/fuzz_deep.sh
+++ b/scripts/fuzz_deep.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+#
+# Deep Hypothesis fuzz run — re-executes tests/test_fuzz_parsers.py and
+# tests/test_property_based.py with a much higher example budget than CI.
+#
+# Usage:
+#   scripts/fuzz_deep.sh                 # 25 000× per-test budget (~30-60 min)
+#   scripts/fuzz_deep.sh overnight       # 250 000× budget (hours)
+#   scripts/fuzz_deep.sh quick           # 5 000× budget (~5 min smoke)
+#
+# Output:
+#   logs/fuzz-deep-<profile>-<timestamp>.log  — full pytest output
+#
+# Same code as the CI fuzz run; FUZZ_BUDGET_MULTIPLIER scales every per-test
+# `max_examples`, and HYPOTHESIS_PROFILE switches Hypothesis to a no-deadline
+# profile so deep searches don't trip the per-example timeout.
+#
+# Why a separate script (not a `task fuzz` target): this is a one-off
+# stress run, not part of the standard `task ci` pipeline. Adding it to
+# taskipy would tempt callers to run it routinely; keeping it as an
+# explicit script makes the cost obvious.
+
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+profile="${1:-deep}"
+
+case "$profile" in
+  quick)
+    multiplier=12     # 400 → 4_800 examples per test
+    hypothesis_profile=deep
+    ;;
+  deep)
+    multiplier=62     # 400 → ~25_000 examples per test
+    hypothesis_profile=deep
+    ;;
+  overnight)
+    multiplier=625    # 400 → ~250_000 examples per test
+    hypothesis_profile=overnight
+    ;;
+  *)
+    echo "Unknown profile: $profile" >&2
+    echo "Use one of: quick, deep, overnight" >&2
+    exit 2
+    ;;
+esac
+
+mkdir -p logs
+timestamp="$(date +%Y%m%d-%H%M%S)"
+log="logs/fuzz-deep-${profile}-${timestamp}.log"
+
+echo "Hypothesis deep fuzz — profile=$profile, multiplier=${multiplier}x"
+echo "Logging to: $log"
+echo
+
+# -p no:cacheprovider keeps the fuzz run from polluting the rootdir's
+# .pytest_cache (Hypothesis's own database lives separately under
+# .hypothesis/ and *is* useful between runs — Hypothesis re-tries
+# previously-failing inputs from there).
+FUZZ_BUDGET_MULTIPLIER="$multiplier" \
+HYPOTHESIS_PROFILE="$hypothesis_profile" \
+PYTHONUNBUFFERED=1 \
+  python3 -m pytest \
+    tests/test_fuzz_parsers.py \
+    tests/test_property_based.py \
+    --no-cov \
+    -p no:cacheprovider \
+    -v \
+    --tb=short \
+    -o addopts= \
+    2>&1 | tee "$log"
+
+echo
+echo "Done. Full log: $log"

--- a/scripts/fuzz_overnight.sh
+++ b/scripts/fuzz_overnight.sh
@@ -1,0 +1,119 @@
+#!/usr/bin/env bash
+#
+# Run the full fuzz suite — Hypothesis deep + every atheris harness — in
+# parallel for an overnight stress run. Each lane logs to its own file under
+# logs/. The script returns a non-zero exit if *any* lane found a crash.
+#
+# Usage:
+#   scripts/fuzz_overnight.sh                   # 8 hours per atheris lane
+#   scripts/fuzz_overnight.sh 3600              # 1 hour per atheris lane
+#   scripts/fuzz_overnight.sh 28800 overnight   # 8h atheris + overnight Hypothesis
+#
+# Args:
+#   $1 — atheris max_total_time per harness (seconds, default 28800 = 8h)
+#   $2 — Hypothesis profile (quick / deep / overnight, default deep)
+#
+# Lanes (all in parallel):
+#   - Hypothesis deep run (CPU-bound, single Python process)
+#   - 5 atheris harnesses (each is its own Python+libFuzzer process)
+#
+# Total CPU footprint: 6 cores at ~100%. If you have fewer cores, atheris
+# lanes share CPU — they're libFuzzer mutators bottlenecked on Python
+# execution speed and degrade gracefully.
+#
+# Findings:
+#   Each atheris harness crashes loudly into its log on first failure and
+#   drops a reproducer at logs/atheris-<target>-crash-<sha>. The
+#   Hypothesis lane fails the pytest run.
+#
+# Atheris is not pinned in pyproject.toml (it's a one-off dev tool, not a
+# CI dep). Install with: pip install atheris
+
+set -uo pipefail  # NOT -e: we want all lanes to run even if one fails.
+
+cd "$(dirname "$0")/.."
+
+atheris_seconds="${1:-28800}"   # default 8 hours
+hypothesis_profile="${2:-deep}"
+
+# Confirm atheris is importable before launching anything.
+if ! .venv/bin/python3 -c "import atheris" 2>/dev/null; then
+    echo "atheris is not installed in .venv/. Install with:" >&2
+    echo "    .venv/bin/pip install atheris" >&2
+    exit 2
+fi
+
+mkdir -p logs
+timestamp="$(date +%Y%m%d-%H%M%S)"
+
+echo "=============================================="
+echo "Overnight fuzz run — $timestamp"
+echo "  atheris max_total_time per lane : ${atheris_seconds}s"
+echo "  hypothesis profile              : $hypothesis_profile"
+echo "  logs                            : logs/fuzz-overnight-${timestamp}/"
+echo "=============================================="
+
+run_dir="logs/fuzz-overnight-${timestamp}"
+mkdir -p "$run_dir"
+
+declare -a pids=()
+declare -a names=()
+
+# --- Lane 1: Hypothesis deep run ---
+(
+    HYPOTHESIS_PROFILE="$hypothesis_profile" \
+        scripts/fuzz_deep.sh "$hypothesis_profile" \
+        > "$run_dir/hypothesis.log" 2>&1
+    echo "$?" > "$run_dir/hypothesis.exit"
+) &
+pids+=($!)
+names+=("hypothesis")
+
+# --- Lanes 2..N: one per atheris harness ---
+for harness in scripts/fuzz_atheris/harness_*.py; do
+    name="$(basename "$harness" .py)"
+    name="${name#harness_}"
+    artifact_prefix="$run_dir/atheris-${name}-crash-"
+    (
+        .venv/bin/python3 "$harness" \
+            -atheris_runs=0 \
+            -max_total_time="$atheris_seconds" \
+            -artifact_prefix="$artifact_prefix" \
+            > "$run_dir/atheris-${name}.log" 2>&1
+        echo "$?" > "$run_dir/atheris-${name}.exit"
+    ) &
+    pids+=($!)
+    names+=("atheris-$name")
+done
+
+echo
+echo "Launched ${#pids[@]} fuzz lanes:"
+for i in "${!pids[@]}"; do
+    echo "  - ${names[$i]} (pid ${pids[$i]})"
+done
+echo
+echo "Monitor with:  tail -f $run_dir/*.log"
+echo
+
+# Wait for everything; track failures.
+failures=0
+for i in "${!pids[@]}"; do
+    wait "${pids[$i]}" || true
+    exit_file="$run_dir/${names[$i]}.exit"
+    code="$(cat "$exit_file" 2>/dev/null || echo "?")"
+    if [[ "$code" != "0" ]]; then
+        failures=$((failures + 1))
+        echo "FAILED: ${names[$i]} (exit $code) — see $run_dir/${names[$i]}.log"
+    else
+        echo "OK:     ${names[$i]}"
+    fi
+done
+
+echo
+if [[ $failures -gt 0 ]]; then
+    echo "Total failures: $failures / ${#pids[@]}"
+    echo "Reproducers (if any) are in $run_dir/atheris-*-crash-*"
+    exit 1
+fi
+
+echo "All ${#pids[@]} lanes finished cleanly."

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,8 +10,40 @@ In VSCode, Code Coverage is recorded in config.xml. Delete this file to reset re
 
 from __future__ import annotations
 
+import os
+
 import pytest
 from _pytest.nodes import Item
+
+# Hypothesis profiles for fuzz tests. The default `max_examples` is set per
+# test (via @settings) and aimed at fast CI feedback. The "deep" profile
+# overrides every test globally for a thorough one-off run — selected with
+# HYPOTHESIS_PROFILE=deep (used by scripts/fuzz_deep.sh).
+#
+# Profile values:
+#   ci       — CI default; no override (per-test settings win).
+#   deep     — overnight run: 25_000 examples, no deadline.
+#   overnight — extreme: 250_000 examples, no deadline. Hours per file.
+try:
+    from hypothesis import HealthCheck, settings
+
+    settings.register_profile("ci")  # no overrides
+    settings.register_profile(
+        "deep",
+        max_examples=25_000,
+        deadline=None,
+        suppress_health_check=[HealthCheck.too_slow, HealthCheck.large_base_example],
+    )
+    settings.register_profile(
+        "overnight",
+        max_examples=250_000,
+        deadline=None,
+        suppress_health_check=[HealthCheck.too_slow, HealthCheck.large_base_example],
+    )
+    settings.load_profile(os.environ.get("HYPOTHESIS_PROFILE", "ci"))
+except ImportError:
+    # Hypothesis not installed — non-fuzz tests should still run.
+    pass
 
 
 def pytest_collection_modifyitems(items: list[Item]):

--- a/tests/test_fuzz_parsers.py
+++ b/tests/test_fuzz_parsers.py
@@ -1,0 +1,399 @@
+"""Fuzz tests for attacker-controlled parsers.
+
+Complements ``test_property_based.py`` by targeting the inspect-tool
+surface — the parsers that consume *fully attacker-supplied* input
+arriving from a block explorer paste, an ElectrumX response, or a
+hostile reveal scriptSig. Each test asserts the same contract:
+
+    Either return a structured value, or raise ``ValidationError``.
+    Any other exception type (``IndexError``, ``struct.error``,
+    ``cbor2.CBORDecodeError``, ``ValueError``, ``TypeError``) is a
+    bug — that is the parser leaking its internal failure mode past
+    its trust boundary.
+
+Hypothesis searches the input space; when it finds a counterexample
+the test prints the offending bytes/hex so the fix is reproducible.
+
+Targets:
+
+    1. ``decode_payload(arbitrary bytes)``
+       — CBOR decode boundary
+    2. ``DmintState.from_script(arbitrary bytes)``
+       — variable-length opcode walker
+    3. ``GlyphInspector.extract_reveal_metadata(arbitrary bytes)``
+       — push-data walker; documented contract is "never raises"
+    4. ``GlyphInspector.find_glyphs(arbitrary scripts)``
+       — script classifier dispatch
+    5. ``_inspect_script(arbitrary hex)``
+       — CLI/browser inspect dispatch
+    6. ``_classify_input(arbitrary string)``
+       — top-level inspect classifier
+    7. ``GlyphRef.from_bytes`` / ``from_contract_hex``
+       — fixed-shape ref decoders
+    8. round-trip: ``build_mutable_scriptsig`` →
+       ``_parse_reveal_scriptsig`` recovers the embedded CBOR
+"""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+from hypothesis import HealthCheck, given, settings
+from hypothesis import strategies as st
+
+from pyrxd.glyph._inspect_core import _classify_input, _inspect_script
+from pyrxd.glyph.dmint import DmintState
+from pyrxd.glyph.inspector import GlyphInspector
+from pyrxd.glyph.payload import build_mutable_scriptsig, decode_payload
+from pyrxd.glyph.types import GlyphRef
+from pyrxd.security.errors import ValidationError
+
+# Fuzz budget multiplier. CI default is 1; scripts/fuzz_deep.sh sets
+# HYPOTHESIS_PROFILE=deep which (combined with FUZZ_BUDGET_MULTIPLIER) scales
+# every per-test max_examples — Hypothesis's decorator @settings overrides
+# the profile's max_examples, so we multiply the decorator value directly.
+_BUDGET_MULT = int(os.environ.get("FUZZ_BUDGET_MULTIPLIER", "1"))
+
+
+def _budget(n: int) -> int:
+    return n * _BUDGET_MULT
+
+
+def _fail_unexpected(target: str, exc: BaseException, raw: bytes | str) -> None:
+    """Produce a test failure with enough context to reproduce the crash."""
+    payload = raw.hex() if isinstance(raw, (bytes, bytearray)) else repr(raw)
+    pytest.fail(f"{target} raised unexpected {type(exc).__name__}: {exc}\n  input ({len(raw)}): {payload}")
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# 1. decode_payload — CBOR boundary
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+@given(data=st.binary(min_size=0, max_size=1024))
+@settings(max_examples=_budget(400), suppress_health_check=[HealthCheck.too_slow])
+def test_decode_payload_only_validation_error(data):
+    """``decode_payload`` must convert every cbor2 / structural failure to
+    ``ValidationError``. A bare ``cbor2.CBORDecodeError`` or ``TypeError``
+    leaking out means a caller's ``except ValidationError`` will miss it,
+    which is exactly the bug class that broke the inspect tool's browser
+    flow before the boundary was hardened.
+    """
+    try:
+        decode_payload(data)
+    except ValidationError:
+        pass
+    except Exception as exc:
+        _fail_unexpected("decode_payload", exc, data)
+
+
+# Targeted: oversize payloads must be rejected with ValidationError before
+# any cbor2 work — the size guard is the cheap-and-correct front line.
+# Plain parametrize rather than @given because Hypothesis treats 64KB+ as
+# unreasonably large to shrink.
+@pytest.mark.parametrize("size", [65_537, 100_000, 1_000_000])
+def test_decode_payload_oversize_rejected(size):
+    with pytest.raises(ValidationError):
+        decode_payload(b"\x00" * size)
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# 2. DmintState.from_script — opcode walker
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+@given(data=st.binary(min_size=0, max_size=2_048))
+@settings(max_examples=_budget(400), suppress_health_check=[HealthCheck.too_slow])
+def test_dmint_from_script_only_validation_error(data):
+    """``DmintState.from_script`` walks a variable-length opcode stream.
+    Every truncation, opcode mismatch, and ref-decode failure must surface
+    as ``ValidationError`` — never an ``IndexError``, ``struct.error``,
+    or ``ValueError`` from the underlying byte slicing / int decoding.
+    """
+    try:
+        DmintState.from_script(data)
+    except ValidationError:
+        pass
+    except Exception as exc:
+        _fail_unexpected("DmintState.from_script", exc, data)
+
+
+# Bias toward the V2 prefix (``0x04 <4 bytes>``) so the fuzzer spends some
+# of its budget inside the parser's deeper branches rather than bailing
+# immediately on the first byte. Without this, most random inputs short-
+# circuit at byte 0 and the deeper opcode walker stays uncovered.
+@given(
+    height_push=st.binary(min_size=4, max_size=4),
+    tail=st.binary(min_size=0, max_size=512),
+)
+@settings(max_examples=_budget(200), suppress_health_check=[HealthCheck.too_slow])
+def test_dmint_from_script_v2_prefix_only_validation_error(height_push, tail):
+    data = b"\x04" + height_push + tail
+    try:
+        DmintState.from_script(data)
+    except ValidationError:
+        pass
+    except Exception as exc:
+        _fail_unexpected("DmintState.from_script (v2-prefix)", exc, data)
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# 3. GlyphInspector.extract_reveal_metadata — push-data walker
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+@given(data=st.binary(min_size=0, max_size=1024))
+@settings(max_examples=_budget(400), suppress_health_check=[HealthCheck.too_slow])
+def test_extract_reveal_metadata_never_raises(data):
+    """The wrapper documents "never raises" — it catches ``Exception``
+    broadly because the inner push-data walker is unguarded against
+    truncated OP_PUSHDATA1/2 length bytes. Verify the contract holds for
+    every byte string."""
+    inspector = GlyphInspector()
+    try:
+        result = inspector.extract_reveal_metadata(data)
+    except Exception as exc:
+        _fail_unexpected("extract_reveal_metadata", exc, data)
+        return
+    # When None, no recognisable gly-marker; otherwise a GlyphMetadata.
+    assert result is None or hasattr(result, "protocol")
+
+
+@given(scriptsigs=st.lists(st.binary(min_size=0, max_size=256), min_size=0, max_size=8))
+@settings(max_examples=_budget(200), suppress_health_check=[HealthCheck.too_slow])
+def test_find_reveal_metadata_never_raises(scriptsigs):
+    """``find_reveal_metadata`` walks a list of scriptSigs; same contract."""
+    inspector = GlyphInspector()
+    try:
+        result = inspector.find_reveal_metadata(scriptsigs)
+    except Exception as exc:
+        _fail_unexpected("find_reveal_metadata", exc, b"".join(scriptsigs))
+        return
+    assert result is None or (isinstance(result, tuple) and len(result) == 2 and isinstance(result[0], int))
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# 4. GlyphInspector.find_glyphs — script classifier dispatch
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+@given(
+    outputs=st.lists(
+        st.tuples(
+            st.integers(min_value=0, max_value=2_100_000_000_000_000),
+            st.binary(min_size=0, max_size=512),
+        ),
+        min_size=0,
+        max_size=8,
+    )
+)
+@settings(max_examples=_budget(200), suppress_health_check=[HealthCheck.too_slow])
+def test_find_glyphs_never_raises_on_arbitrary_scripts(outputs):
+    """``find_glyphs`` must silently skip unrecognised scripts. A crash
+    here would mean a single malformed output in an attacker-supplied tx
+    aborts inspection of the whole transaction."""
+    inspector = GlyphInspector()
+    try:
+        result = inspector.find_glyphs(outputs)
+    except ValidationError:
+        # find_glyphs is documented to *not* raise ValidationError — it
+        # swallows them per-output. If one escapes, treat as failure too.
+        joined = b"".join(s for _, s in outputs)
+        pytest.fail(
+            f"find_glyphs raised ValidationError (should be silently skipped) "
+            f"on inputs {[(s, b.hex()) for s, b in outputs]}\n  joined={joined.hex()}"
+        )
+    except Exception as exc:
+        joined = b"".join(s for _, s in outputs)
+        _fail_unexpected("find_glyphs", exc, joined)
+        return
+    assert isinstance(result, list)
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# 5. _inspect_script — top-level CLI/browser script dispatch
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+@given(
+    script_hex=st.text(
+        alphabet="0123456789abcdef",
+        min_size=50,
+        max_size=2_048,
+    ).filter(lambda s: len(s) % 2 == 0)
+)
+@settings(max_examples=_budget(300), suppress_health_check=[HealthCheck.too_slow])
+def test_inspect_script_only_validation_error(script_hex):
+    """``_inspect_script`` runs the whole P2PKH / OP_RETURN / NFT / FT /
+    mutable / commit-NFT / commit-FT / dMint dispatch. Every classifier
+    must either claim the bytes or the function returns ``unknown`` —
+    the only allowed exception is ``ValidationError`` (raised when the
+    hex itself is malformed, which we exclude by construction here, but
+    keep the assertion to document the contract)."""
+    try:
+        result = _inspect_script(script_hex)
+    except ValidationError:
+        return
+    except Exception as exc:
+        _fail_unexpected("_inspect_script", exc, script_hex)
+        return
+    assert isinstance(result, dict)
+    assert "type" in result
+    assert "length" in result
+
+
+@given(
+    # Use uppercase / mixed / odd-length / non-hex to exercise the front
+    # door's hex validation branch.
+    bad_hex=st.one_of(
+        st.text(alphabet="0123456789ABCDEFXG", min_size=50, max_size=200),
+        st.text(min_size=50, max_size=100),  # arbitrary unicode
+    )
+)
+@settings(max_examples=_budget(200), suppress_health_check=[HealthCheck.too_slow])
+def test_inspect_script_rejects_bad_hex_with_validation_error(bad_hex):
+    """Anything that isn't valid lowercase hex must surface as
+    ``ValidationError``, not a ``ValueError`` from ``bytes.fromhex``."""
+    try:
+        _inspect_script(bad_hex)
+    except ValidationError:
+        pass
+    except Exception as exc:
+        # Allow successful classification if Hypothesis happens to produce
+        # all-lowercase even-length hex — only a non-ValidationError
+        # exception is a bug.
+        _fail_unexpected("_inspect_script (bad hex)", exc, bad_hex)
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# 6. _classify_input — top-level inspect classifier
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+@given(s=st.text(min_size=0, max_size=400))
+@settings(max_examples=_budget(400), suppress_health_check=[HealthCheck.too_slow])
+def test_classify_input_only_validation_error(s):
+    """``_classify_input`` is the entry point users hit when they paste
+    *anything* into ``pyrxd glyph inspect``. It must classify or refuse
+    cleanly — never raise a non-``ValidationError`` exception that would
+    surface as an opaque traceback."""
+    try:
+        result = _classify_input(s)
+    except ValidationError:
+        return
+    except Exception as exc:
+        _fail_unexpected("_classify_input", exc, s)
+        return
+    assert isinstance(result, tuple) and len(result) == 2
+    form, normalised = result
+    assert form in {"txid", "contract", "outpoint", "script"}
+    assert isinstance(normalised, str)
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# 7. GlyphRef.from_bytes / from_contract_hex
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+@given(data=st.binary(min_size=0, max_size=128))
+@settings(max_examples=_budget(200), suppress_health_check=[HealthCheck.too_slow])
+def test_glyphref_from_bytes_only_validation_error(data):
+    """``GlyphRef.from_bytes`` requires exactly 36 bytes. Anything else
+    must raise ``ValidationError`` (the txid embedded inside is decoded
+    via ``Txid()`` which itself raises ``ValidationError``)."""
+    try:
+        GlyphRef.from_bytes(data)
+    except ValidationError:
+        pass
+    except Exception as exc:
+        _fail_unexpected("GlyphRef.from_bytes", exc, data)
+
+
+@given(s=st.text(min_size=0, max_size=200))
+@settings(max_examples=_budget(300), suppress_health_check=[HealthCheck.too_slow])
+def test_glyphref_from_contract_hex_only_validation_error(s):
+    """``GlyphRef.from_contract_hex`` validates length and hex shape.
+    Any non-72-char or non-hex input must raise ``ValidationError``,
+    never ``ValueError`` from a deeper ``bytes.fromhex``."""
+    try:
+        GlyphRef.from_contract_hex(s)
+    except ValidationError:
+        pass
+    except Exception as exc:
+        _fail_unexpected("GlyphRef.from_contract_hex", exc, s)
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# 8. Round-trip: build_mutable_scriptsig → push-data walker recovers CBOR
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+@given(
+    cbor_bytes=st.binary(min_size=1, max_size=200),
+    operation=st.sampled_from(["mod", "sl"]),
+    contract_output_index=st.integers(min_value=0, max_value=1024),
+    ref_hash_index=st.integers(min_value=0, max_value=1024),
+    ref_index=st.integers(min_value=0, max_value=1024),
+    token_output_index=st.integers(min_value=0, max_value=1024),
+)
+@settings(max_examples=_budget(200), suppress_health_check=[HealthCheck.too_slow])
+def test_build_mutable_scriptsig_roundtrip_extracts_cbor(
+    cbor_bytes,
+    operation,
+    contract_output_index,
+    ref_hash_index,
+    ref_index,
+    token_output_index,
+):
+    """A mutable-NFT scriptSig built by ``build_mutable_scriptsig`` must
+    feed back through the inspector's push-data walker and yield items
+    whose 2nd entry is the original CBOR. The walker rejects malformed
+    CBOR via ``decode_payload`` (returning ``None``); we don't require
+    successful CBOR decode here — we require the walker to find the
+    ``gly`` marker and try to decode the payload that follows. That tests
+    the structural contract between builder and parser."""
+    scriptsig = build_mutable_scriptsig(
+        operation=operation,
+        cbor_bytes=cbor_bytes,
+        contract_output_index=contract_output_index,
+        ref_hash_index=ref_hash_index,
+        ref_index=ref_index,
+        token_output_index=token_output_index,
+    )
+
+    inspector = GlyphInspector()
+    # Walk the push-data manually so we can assert structural recovery
+    # *without* requiring the random CBOR bytes to decode to a valid
+    # GlyphMetadata. Mirrors the inspector's own walker.
+    pos = 0
+    items: list[bytes] = []
+    while pos < len(scriptsig):
+        op = scriptsig[pos]
+        pos += 1
+        if 1 <= op <= 75:
+            items.append(scriptsig[pos : pos + op])
+            pos += op
+        elif op == 0x4C:
+            n = scriptsig[pos]
+            pos += 1
+            items.append(scriptsig[pos : pos + n])
+            pos += n
+        elif op == 0x4D:
+            n = int.from_bytes(scriptsig[pos : pos + 2], "little")
+            pos += 2
+            items.append(scriptsig[pos : pos + n])
+            pos += n
+        else:
+            break
+
+    assert b"gly" in items, "gly marker not found in built scriptsig"
+    gly_idx = items.index(b"gly")
+    assert gly_idx + 1 < len(items), "no item after gly marker"
+    assert items[gly_idx + 1] == cbor_bytes, "cbor bytes not recovered"
+
+    # And the public API contract: never raises.
+    try:
+        inspector.extract_reveal_metadata(scriptsig)
+    except Exception as exc:
+        _fail_unexpected("extract_reveal_metadata (round-trip)", exc, scriptsig)

--- a/tests/test_fuzz_parsers.py
+++ b/tests/test_fuzz_parsers.py
@@ -83,6 +83,7 @@ def test_decode_payload_only_validation_error(data):
     try:
         decode_payload(data)
     except ValidationError:
+        # expected: parser converted a malformed input cleanly
         pass
     except Exception as exc:
         _fail_unexpected("decode_payload", exc, data)
@@ -114,6 +115,7 @@ def test_dmint_from_script_only_validation_error(data):
     try:
         DmintState.from_script(data)
     except ValidationError:
+        # expected: parser converted a malformed input cleanly
         pass
     except Exception as exc:
         _fail_unexpected("DmintState.from_script", exc, data)
@@ -133,6 +135,7 @@ def test_dmint_from_script_v2_prefix_only_validation_error(height_push, tail):
     try:
         DmintState.from_script(data)
     except ValidationError:
+        # expected: parser converted a malformed input cleanly
         pass
     except Exception as exc:
         _fail_unexpected("DmintState.from_script (v2-prefix)", exc, data)
@@ -204,6 +207,7 @@ def test_find_glyphs_never_raises_on_arbitrary_scripts(outputs):
             f"find_glyphs raised ValidationError (should be silently skipped) "
             f"on inputs {[(s, b.hex()) for s, b in outputs]}\n  joined={joined.hex()}"
         )
+        return  # unreachable (pytest.fail raises) — proves `result` is bound below
     except Exception as exc:
         joined = b"".join(s for _, s in outputs)
         _fail_unexpected("find_glyphs", exc, joined)
@@ -258,6 +262,7 @@ def test_inspect_script_rejects_bad_hex_with_validation_error(bad_hex):
     try:
         _inspect_script(bad_hex)
     except ValidationError:
+        # expected: parser rejected malformed hex at the boundary
         pass
     except Exception as exc:
         # Allow successful classification if Hypothesis happens to produce
@@ -305,6 +310,7 @@ def test_glyphref_from_bytes_only_validation_error(data):
     try:
         GlyphRef.from_bytes(data)
     except ValidationError:
+        # expected: parser rejected malformed ref bytes at the boundary
         pass
     except Exception as exc:
         _fail_unexpected("GlyphRef.from_bytes", exc, data)
@@ -319,6 +325,7 @@ def test_glyphref_from_contract_hex_only_validation_error(s):
     try:
         GlyphRef.from_contract_hex(s)
     except ValidationError:
+        # expected: parser rejected malformed contract hex at the boundary
         pass
     except Exception as exc:
         _fail_unexpected("GlyphRef.from_contract_hex", exc, s)


### PR DESCRIPTION
## Summary

Adds a fuzz-testing layer over the **inspect-tool parser surface** — the code paths that consume *fully attacker-supplied* input: block-explorer pastes, ElectrumX responses, hostile reveal scriptSigs.

Every fuzz target asserts the same trust-boundary contract:

> Return a structured value, or raise `ValidationError`. Any other exception type (`IndexError`, `struct.error`, `cbor2.CBORDecodeError`, `ValueError`, `TypeError`) is a bug — the parser leaking its internal failure mode past its boundary.

That's exactly the bug class that broke the inspect tool's browser flow before the boundary was hardened: a bare `cbor2.CBORDecodeError` escaping `decode_payload` slipped past a caller's `except ValidationError`.

## Two complementary engines

| Engine | Where | What |
|--------|-------|------|
| **Hypothesis** (random + shrinking) | `tests/test_fuzz_parsers.py` | 8 targets, 15 tests. Counterexamples print the offending bytes/hex for reproduction. |
| **atheris** (coverage-guided libFuzzer) | `scripts/fuzz_atheris/harness_*.py` | 5 harnesses, one per parser, instrumenting only `pyrxd.glyph.*` to keep mutation feedback focused. |

### Hypothesis targets (`tests/test_fuzz_parsers.py`)

1. `decode_payload` — CBOR decode boundary
2. `DmintState.from_script` — variable-length opcode walker
3. `GlyphInspector.extract_reveal_metadata` — push-data walker (documented "never raises")
4. `GlyphInspector.find_glyphs` — script classifier dispatch
5. `_inspect_script` — CLI/browser inspect dispatch
6. `_classify_input` — top-level inspect classifier
7. `GlyphRef.from_bytes` / `from_contract_hex` — fixed-shape ref decoders
8. round-trip: `build_mutable_scriptsig` → push-data walker recovers the embedded CBOR

## Supporting infrastructure

- **`tests/conftest.py`** — registers Hypothesis `deep` (25k examples) and `overnight` (250k examples) profiles, selected via `HYPOTHESIS_PROFILE`. Falls back cleanly if Hypothesis isn't installed.
- **`scripts/fuzz_deep.sh`** — re-runs the Hypothesis suite at a scaled budget (`quick` / `deep` / `overnight`).
- **`scripts/fuzz_overnight.sh`** — Hypothesis deep lane + all 5 atheris harnesses in parallel; exits non-zero if any lane finds a crash.

## Deliberately NOT in `task ci`

These are stress runs, not per-commit gates — adding them to taskipy would tempt routine use and make CI slow. `testpaths = "tests"` already keeps pytest from collecting the atheris harnesses under `scripts/`. The 15 Hypothesis tests *do* run in the normal suite at CI budget (~1.5 s).

atheris is **not pinned** in `pyproject.toml` — it's a one-off dev tool. `pip install atheris` when you want to run the coverage-guided harnesses.

## Test plan

- [x] `python3 -m pytest tests/test_fuzz_parsers.py` — 15 passed at CI budget
- [x] `bash -n` syntax-checks both shell scripts
- [x] `ruff check` + `ruff format --check` clean on all 8 files
- [x] Pre-push hook: full suite green, lint clean
- [ ] CI on this PR