### PR TITLE
docs: remove local-path + private-project leaks from tracked docs

### DIFF
--- a/docs/brainstorms/2026-05-07-dmint-integration-brainstorm.md
+++ b/docs/brainstorms/2026-05-07-dmint-integration-brainstorm.md
@@ -206,4 +206,4 @@ future. No chain query needed to confirm.
 - [`docs/dmint-research-mainnet.md`](../dmint-research-mainnet.md) — live V1 contract decode + mint trace
 - [`src/pyrxd/glyph/dmint.py`](../../src/pyrxd/glyph/dmint.py) — current implementation
 - [`src/pyrxd/glyph/builder.py:291`](../../src/pyrxd/glyph/builder.py#L291) — `prepare_dmint_deploy`
-- External: `/home/eric/apps/Pinball/glyph-miner` — fast miner project (not pyrxd)
+- External: the `glyph-miner` project — fast miner reference (not pyrxd)

--- a/docs/brainstorms/2026-05-08-dmint-v1-deploy-m2-brainstorm.md
+++ b/docs/brainstorms/2026-05-08-dmint-v1-deploy-m2-brainstorm.md
@@ -98,9 +98,10 @@ against captured mainnet bytes**.
 V1 deploy is the most byte-intricate part of the protocol (multi-
 output commit, ref-seed derivation, parallel contract reveal, CBOR
 metadata). It's exactly the surface most likely to bite us if we
-infer instead of read. Photonic's TS source is the canonical
-authority for "what does the live ecosystem expect" (per memory:
-`feedback_photonic_canonical_reference.md`).
+infer instead of read. Per the project convention, Photonic's TS
+source is the default reference for "what does the live ecosystem
+expect" — deviate explicitly, with a documented reason, only when
+Photonic is wrong.
 
 Rejected:
 - **Approach 2 (Implement-first)**: violates the M1 lesson. Almost

--- a/docs/dmint-research-mainnet.md
+++ b/docs/dmint-research-mainnet.md
@@ -14,7 +14,7 @@ without decoding the token's reveal CBOR payload.
 
 ## 1. Discovery method
 
-- **MCP tool list** (`/home/eric/apps/radiant-mcp-server/src/index.ts`,
+- **MCP tool list** (`radiant-mcp-server`, `src/index.ts`
   lines 486–547): the MCP exposes `radiant_get_dmint_contracts` /
   `radiant_get_dmint_contract`, which call ElectrumX RPC methods
   `dmint.get_contracts` etc. Probing the public server
@@ -266,7 +266,7 @@ contract's lifetime.
   human-readable token name and the declared `diff`/`numContracts`. Not
   blocking for Python builder validation but would be nice to pull.
 - **Cannot distinguish V1 vs V2 encoding from the guide alone.** The
-  guide (`/home/eric/apps/radiant-glyph-guide/README.md` §dMint) and
+  guide (`radiant-glyph-guide` README §dMint) and
   photonic-wallet (`dMintScript` in `packages/lib/src/script.ts`) ship
   the **V2** 10-state-item layout. The live contracts here are the
   **V1** 3-state-item layout. A Python builder needs both code paths
@@ -293,13 +293,13 @@ contract's lifetime.
 
 ## Files referenced in this report
 
-- Full node on VPS: `ssh ericadmin@89.117.20.219 -- sudo docker exec
-  radiant-mainnet radiant-cli …` at tip = block 422,868.
-- Photonic-wallet reference: `/tmp/photonic-wallet/packages/lib/src/script.ts`
-  (lines 440–766) and `.../lib/src/mint.ts` (lines 388–460).
-- MCP tool surface: `/home/eric/apps/radiant-mcp-server/src/index.ts`
+- Full node on a private VPS: `radiant-cli` queries against a
+  self-hosted Radiant Core mainnet node, at tip = block 422,868.
+- Photonic-wallet reference: `packages/lib/src/script.ts`
+  (lines 440–766) and `packages/lib/src/mint.ts` (lines 388–460).
+- MCP tool surface: `radiant-mcp-server`, `src/index.ts`
   (lines 486–547).
-- Glyph v2 guide (protocol context): `/home/eric/apps/radiant-glyph-guide/README.md`
+- Glyph v2 guide (protocol context): `radiant-glyph-guide` README
   (lines 1310–1330 for protocol-ID table, 2820–2845 for V2 notes).
 - Local helper scripts used to pull the data: `/tmp/decode_script.py`
   (byte decoder), `/tmp/fetch_scripts.py`, `/tmp/trace_mint.py`,

--- a/docs/plans/2026-05-07-feat-dmint-v1-mint-and-reference-miner-plan.md
+++ b/docs/plans/2026-05-07-feat-dmint-v1-mint-and-reference-miner-plan.md
@@ -346,8 +346,8 @@ yet — adding it before someone asks is YAGNI.
 Generalize [`verify_sha256d_solution` at dmint.py:466](../../src/pyrxd/glyph/dmint.py#L466)
 to take a keyword-only `nonce_width: Literal[4, 8] = 8` (preserves V2
 default; new V1 callers pass `nonce_width=4`). Confirmed equivalence
-with glyph-miner reference at
-`/home/eric/apps/Pinball/glyph-miner/src/miner.ts:494-508`: target check
+with the glyph-miner reference at
+`glyph-miner` `src/miner.ts:494-508`: target check
 is `hash[0..4] == 0x00000000 AND be_u64(hash[4..12]) < target`.
 
 ### C. Synthetic-then-real acceptance proof
@@ -479,7 +479,7 @@ difficulty without explicit opt-in.
 - **Mining is offline.** No network calls inside `mine_solution`. The
   preimage-target shim protocol is local-only (subprocess stdin/stdout),
   not a network endpoint.
-- **License attribution.** glyph-miner is MIT (`/home/eric/apps/Pinball/glyph-miner/LICENSE`).
+- **License attribution.** glyph-miner is MIT (see its `LICENSE`).
   pyrxd is Apache 2.0. Compatible. If specific algorithm code is ported
   (e.g. midstate-precompute pattern), preserve the MIT header per file
   or add to NOTICE. Not a legal opinion.
@@ -550,9 +550,9 @@ difficulty without explicit opt-in.
 
 ### Dependencies
 
-- VPS Radiant node at `89.117.20.219` for `testmempoolaccept`
+- A self-hosted Radiant full node for `testmempoolaccept`
   (existing — already used by deploy-integration tests).
-- `glyph-miner` project at `/home/eric/apps/Pinball/glyph-miner` for
+- the `glyph-miner` project for
   the optional fast-mining path. Not a hard dependency for shipping
   M1, but a cross-check during real-mint testing.
 
@@ -669,7 +669,7 @@ Acceptance: both guards in place. Test confirms the
 
 ### External references
 
-- `/home/eric/apps/Pinball/glyph-miner/` (MIT) — authoritative V1 mining algorithm
+- `glyph-miner` (MIT) — authoritative V1 mining algorithm
   - `src/pow.ts` L11–18 — preimage construction
   - `src/miner.ts` L283–311 — midstate precompute
   - `src/miner.ts` L494–508 — target check (BE)

--- a/docs/plans/2026-05-08-feat-dmint-v1-deploy-plan.md
+++ b/docs/plans/2026-05-08-feat-dmint-v1-deploy-plan.md
@@ -253,7 +253,7 @@ Three hard constraints from cross-tool research:
 1. **Contracts MUST live at consecutive vouts** of the reveal tx
    (vout[0..N-1]). glyph-miner discovers parallel contracts by
    incrementing vout from `firstRef`; non-consecutive layout
-   silently undercounts ([glyph-miner deployments.ts:207-219](file:///home/eric/apps/Pinball/glyph-miner/src/deployments.ts)).
+   silently undercounts (glyph-miner `src/deployments.ts:207-219`).
 
 2. **CBOR `p` must equal `[1, 4]`** (FT + DMINT markers); CBOR `v`
    field must be **omitted** for V1 (emitting `v: 2` would mis-
@@ -318,9 +318,9 @@ isn't available; specifically read:
   "Photonic Divergence" section of the research doc, naming which
   Photonic file/line and value differ from mainnet, and the reason
   pyrxd will prefer mainnet. This prevents future review rounds from
-  re-litigating the same discrepancies (per the
-  feedback_photonic_canonical_reference.md memory: "deviate
-  explicitly when Photonic isn't the best answer").
+  re-litigating the same discrepancies — the project convention is to
+  treat Photonic as the default reference but deviate explicitly,
+  with a documented reason, when Photonic isn't the best answer.
 
 **Phase 2a exit criteria** (Phase 2a is done when ALL are met):
 - [x] "snk" 35-output discrepancy reconciled with documented explanation
@@ -828,14 +828,12 @@ bugs found here are fixed in M2.1.
 
 ## Dependencies & Prerequisites
 
-- VPS Radiant node at `89.117.20.219` (existing, used by M1 deploy
+- A self-hosted Radiant full node (existing, used by M1 deploy
   integration tests)
 - ElectrumX mainnet endpoint for chain walking in Phase 2a
-- Photonic Wallet TS source (re-clone if `/tmp/photonic-wallet/` is
-  no longer cached)
-- glyph-miner at `/home/eric/apps/Pinball/glyph-miner/` (already
-  present from M1)
-- RXinDexer at `/home/eric/apps/Pinball/RXinDexer/` (already present)
+- Photonic Wallet TS source (clone locally if not already cached)
+- glyph-miner (already cloned locally from M1)
+- RXinDexer (already cloned locally)
 
 ## Risk Analysis & Mitigation
 
@@ -852,7 +850,7 @@ bugs found here are fixed in M2.1.
 - **R2: glyph-miner refuses to mine pyrxd-deployed contracts** for a
   shape reason we missed. Manual acceptance gate fails.
   - *Mitigation*: Phase 2a includes reading glyph-miner's
-    `parseDmintScript` ([glyph.ts:277-322](file:///home/eric/apps/Pinball/glyph-miner/src/glyph.ts))
+    `parseDmintScript` (glyph-miner `src/glyph.ts:277-322`)
     and asserting our contract output script byte-for-byte matches
     `V1_BYTECODE_PART_B`. Plus the consecutive-vouts requirement is
     a hard test gate.
@@ -966,17 +964,20 @@ Every critical gap from the SpecFlow analysis is addressed:
 - [`src/pyrxd/glyph/dmint.py:352-504`](../../src/pyrxd/glyph/dmint.py#L352) — M1 V1 builders
 - [`src/pyrxd/glyph/dmint.py:2156`](../../src/pyrxd/glyph/dmint.py#L2156) — `find_dmint_funding_utxo` (pattern to mirror)
 - [`tests/test_dmint_deploy_integration.py:355-545`](../../tests/test_dmint_deploy_integration.py#L355) — VPS testmempoolaccept harness
-- [Memory: Photonic is the canonical reference](file:///home/eric/.claude/projects/-home-eric-apps-pyrxd/memory/feedback_photonic_canonical_reference.md)
+- Project convention — Photonic's TypeScript source is the default
+  reference for protocol questions, but pyrxd deviates explicitly
+  (with a documented reason) when Photonic is buggy, outdated, or
+  worse-engineered than the alternative.
 
 ### External
 
-- glyph-miner (MIT) at `/home/eric/apps/Pinball/glyph-miner/`:
+- glyph-miner (MIT):
   - `src/dmint-api.ts:309-342` — RXinDexer-driven discovery
   - `src/deployments.ts:90-98, 207-219` — fallback URL + per-token
     enumeration via consecutive vouts
   - `src/glyph.ts:103-105, 265, 277-322, 391-441` — V1 contract-script
     parser (the "what bytes glyph-miner actually checks")
-- RXinDexer at `/home/eric/apps/Pinball/RXinDexer/`:
+- RXinDexer:
   - `indexer/parser.py:540-542` — auto-discovery via
     `detect_token_from_script`
   - `indexer/script_utils.py:262-373` — V1+V2 dMint contract parser

--- a/docs/plans/2026-05-11-first-real-v1-dmint-deploy.md
+++ b/docs/plans/2026-05-11-first-real-v1-dmint-deploy.md
@@ -160,9 +160,9 @@ Token metadata:
 ### Phase 4 — dry-run
 
 ```bash
-cd /home/eric/apps/pyrxd/.worktrees/feat/dmint-v1-deploy
+# from the repo root (or the relevant worktree)
 DRY_RUN=1 GLYPH_WIF=<test-wif> \
-  /home/eric/apps/pyrxd/.venv/bin/python examples/dmint_v1_deploy_demo.py
+  .venv/bin/python examples/dmint_v1_deploy_demo.py
 ```
 
 Expected output:
@@ -183,7 +183,7 @@ to verify:
 ```bash
 DRY_RUN=0 I_UNDERSTAND_THIS_IS_REAL=yes \
   GLYPH_WIF=<test-wif> \
-  /home/eric/apps/pyrxd/.venv/bin/python examples/dmint_v1_deploy_demo.py
+  .venv/bin/python examples/dmint_v1_deploy_demo.py
 ```
 
 Demo:

--- a/docs/plans/2026-05-11-ship-parallel-miner-plan.md
+++ b/docs/plans/2026-05-11-ship-parallel-miner-plan.md
@@ -365,7 +365,7 @@ tests pass, the miner cannot embed a wrong nonce.
   template for new contrib tests.
 
 ### External
-- `glyph-miner` at `/home/eric/apps/Pinball/glyph-miner/` — the
+- the `glyph-miner` project — the
   fast-but-divergence-risk alternative.
 
 ### Files to be created

--- a/docs/radiant-core-wallet-research.md
+++ b/docs/radiant-core-wallet-research.md
@@ -10,7 +10,7 @@ already cover what users need? Specifically: can someone running a node use
 
 ## Method
 
-Live queries against the mainnet full node at `89.117.20.219` (Radiant Core, version 200300, tip 424872 at time of probe). All queries were read-only RPC calls. No funds moved, no wallet state changed.
+Live queries against a self-hosted Radiant Core mainnet full node (version 200300, tip 424872 at time of probe). All queries were read-only RPC calls. No funds moved, no wallet state changed.
 
 ## Findings
 

--- a/scripts/check-no-private-links.py
+++ b/scripts/check-no-private-links.py
@@ -1,10 +1,22 @@
 #!/usr/bin/env python3
-"""Check that tracked markdown/rst files don't link to gitignored paths.
+"""Check that tracked markdown/rst files don't leak private paths.
 
-Catches the failure mode where AI-generated documentation (or careless
-manual edits) reference files in private directories like ``docs/design/``.
-Such links would be broken in any clone of the repo and leak the
-existence of private files via the link text.
+Two checks, both run on every invocation:
+
+1. **Private-path links** — a markdown/RST link whose target resolves
+   to a ``.gitignore``-matched path (e.g. ``docs/design/``). Such links
+   break in any clone and leak the existence of private files via the
+   link text.
+2. **Bare home-directory paths** — an absolute ``/home/<user>/`` or
+   ``/Users/<user>/`` path *anywhere* in the doc body: link, prose, or
+   code block. These leak the author's username and local layout,
+   break in every other clone, and — when they point into a sibling
+   project — leak that project's existence. Username-agnostic forms
+   like ``~/.pyrxd/config.toml`` are NOT flagged: that's the correct
+   way to document a home-relative path.
+
+Both catch the same failure mode: AI-generated documentation (or
+careless manual edits) referencing local-only paths.
 
 Usage
 -----
@@ -14,7 +26,7 @@ Usage
 Exit codes
 ----------
     0  no leaks found (or no tracked files to check)
-    1  one or more tracked files link to a gitignored path
+    1  one or more tracked files leak a private path (either check)
     2  invocation error (not in a git repo, dependencies missing, etc.)
 
 Design notes
@@ -32,6 +44,11 @@ Design notes
   ``[text](path)`` and bare ``](path)`` forms. URLs (``http://``,
   ``https://``, ``mailto:``) are skipped — only relative/absolute
   filesystem paths are checked
+- The home-path check deliberately does NOT flag ``~/...`` (tilde-home,
+  username-agnostic), ``/root/...`` (no username embedded), or
+  ``/tmp/...`` (scratch paths carry no username and are a normal way to
+  describe a throwaway clone or fixture dump). Only paths with a
+  concrete username — ``/home/<user>/`` or ``/Users/<user>/`` — leak
 """
 
 from __future__ import annotations
@@ -50,6 +67,24 @@ _REFERENCE_LINK_RE = re.compile(r"^\s*\[[^\]]+\]:\s+(\S+)", re.MULTILINE)
 # Match RST hyperlinks: `text <target>`_ and .. _name: target
 _RST_INLINE_RE = re.compile(r"`[^`]+\s+<([^>]+)>`_")
 _RST_TARGET_RE = re.compile(r"^\.\.\s+_[^:]+:\s+(\S+)", re.MULTILINE)
+
+# Match absolute home-directory paths with a *concrete username baked
+# in* — anywhere in prose, not just inside link syntax. These leak the
+# author's username and local directory layout, break in every other
+# clone, and (when they point into a sibling private project) leak that
+# project's existence. The link-target checks above only catch the
+# `](path)` form; this catches the rest. A ``file://`` prefix is
+# matched too, so ``file:///home/alice/...`` is caught.
+#
+# Matches: /home/<user>/..., /Users/<user>/...
+#
+# Deliberately does NOT match:
+#   - ~/... (tilde-home) — username-agnostic; the *correct* way to
+#     document a home-relative path like ``~/.pyrxd/config.toml``
+#   - /root/... — no username embedded; rare and not a personal leak
+#   - /tmp/... — scratch paths carry no username and are a normal way
+#     to describe a throwaway clone or fixture dump
+_HOME_PATH_RE = re.compile(r"(?:file://)?/(?:home|Users)/[^/\s]+/[^\s`)\"'<>]+")
 
 
 def git_ls_files(repo_root: Path) -> list[Path]:
@@ -106,6 +141,21 @@ def extract_links(content: str, suffix: str) -> list[str]:
     return links
 
 
+def find_home_paths(content: str) -> list[str]:
+    """Find absolute home-directory paths with a baked-in username.
+
+    Returns the matched path strings (with any ``file://`` prefix
+    intact, so the report shows exactly what's in the file). Unlike
+    the link-target checks, this scans the *whole* document body — a
+    leak in a fenced code block or a plain prose mention counts.
+
+    Only ``/home/<user>/`` and ``/Users/<user>/`` match; ``~/``,
+    ``/root/`` and ``/tmp/`` are intentionally not flagged (see the
+    module docstring for why).
+    """
+    return _HOME_PATH_RE.findall(content)
+
+
 def looks_like_url(target: str) -> bool:
     """Skip http/https/mailto/data/git URLs — only filesystem paths matter."""
     return target.startswith(("http://", "https://", "mailto:", "data:", "git@", "ftp://"))
@@ -158,9 +208,7 @@ def check_ignored(repo_root: Path, paths: list[Path]) -> set[Path]:
         check=False,  # exit 1 is normal (means "no ignored files in input")
     )
     if result.returncode not in (0, 1):
-        raise RuntimeError(
-            f"git check-ignore failed with exit code {result.returncode}: {result.stderr}"
-        )
+        raise RuntimeError(f"git check-ignore failed with exit code {result.returncode}: {result.stderr}")
     return {Path(line) for line in result.stdout.splitlines() if line}
 
 
@@ -199,6 +247,7 @@ def main() -> int:
         print(f"Scanning {len(docs)} tracked doc files for private-path links...")
 
     leaks: list[tuple[Path, str, Path]] = []  # (source_file, raw_target, resolved_path)
+    home_path_leaks: list[tuple[Path, str]] = []  # (source_file, matched_path)
 
     for doc in docs:
         full_path = repo_root / doc
@@ -208,6 +257,11 @@ def main() -> int:
             if args.verbose:
                 print(f"  skip {doc}: {exc}")
             continue
+
+        # Check 2: bare home-directory paths anywhere in the doc body.
+        # Runs regardless of whether the doc has any link syntax.
+        for matched in find_home_paths(content):
+            home_path_leaks.append((doc, matched))
 
         targets = extract_links(content, doc.suffix)
         if not targets:
@@ -233,7 +287,10 @@ def main() -> int:
             if resolved in ignored:
                 leaks.append((doc, raw_target, resolved))
 
+    failed = False
+
     if leaks:
+        failed = True
         print("error: tracked docs link to gitignored (private) paths:", file=sys.stderr)
         print("", file=sys.stderr)
         for source, target, resolved in leaks:
@@ -247,10 +304,34 @@ def main() -> int:
             "link. See docs/CONTRIBUTING.md for the docs-publication convention.",
             file=sys.stderr,
         )
+
+    if home_path_leaks:
+        failed = True
+        if leaks:
+            print("", file=sys.stderr)
+        print(
+            "error: tracked docs contain bare home-directory paths:",
+            file=sys.stderr,
+        )
+        print("", file=sys.stderr)
+        for source, matched in home_path_leaks:
+            print(f"  {source}", file=sys.stderr)
+            print(f"    path: {matched}", file=sys.stderr)
+            print("", file=sys.stderr)
+        print(
+            "An absolute /home/<user>/ or /Users/<user>/ path leaks the author's\n"
+            "username and local layout, breaks in every other clone, and if it\n"
+            "points into a sibling project leaks that project's existence.\n"
+            "Rewrite as a repo-relative path, a bare project/file reference, or a\n"
+            "username-agnostic ~/ path. See docs/CONTRIBUTING.md.",
+            file=sys.stderr,
+        )
+
+    if failed:
         return 1
 
     if args.verbose:
-        print(f"OK — {len(docs)} tracked doc files, no leaks to private paths.")
+        print(f"OK — {len(docs)} tracked doc files, no private-path links and no bare home-directory paths.")
     return 0
 
 


### PR DESCRIPTION
## Summary

Scrubs every author-specific absolute path from tracked documentation, and **hardens the link checker** so this class of leak is caught mechanically going forward.

All of the leaked content was **pre-existing on `origin/main`** — surfaced while adding `.claude/` to `.gitignore` (which made the existing `file://` link into `~/.claude/` resolve as a private-path link).

## What leaked

| Leak | Where | Severity |
|------|-------|----------|
| `file://` markdown link into the author's private `~/.claude/` memory dir | `docs/plans/2026-05-08-feat-dmint-v1-deploy-plan.md` | Links a private dir; broken in every clone |
| 2 prose mentions of that private memory filename | brainstorm + plan | Names a private file |
| ~15 `/home/eric/apps/...` absolute paths across **6 docs** | plans, brainstorms, research docs | Leaks username + local layout; several point into sibling projects (`radiant-mcp-server`, `radiant-glyph-guide`) and the **private `Pinball/` project group** (`glyph-miner`, `RXinDexer`) |
| VPS IP `89.117.20.219` in **4 docs** | research + plans | Infrastructure exposure; one line was `ssh ericadmin@<ip> -- sudo docker exec ...` |

## How it's fixed

Each reference is rewritten to a **repo-relative path**, a **bare project/file reference** (the projects themselves are public — only the `/home/eric/apps/` prefix leaked), or a **generic placeholder**. The substance — which file, which line range, which convention — is fully preserved; only the machine-specific prefix is removed.

`/tmp/...` scratch paths are left as-is — they carry no username.

## Checker hardening — `scripts/check-no-private-links.py`

The original checker only caught the markdown-link form `](path)`. The `/home/eric/` *prose* mentions slipped through. New second check:

- Scans the **whole doc body** for bare `/home/<user>/` and `/Users/<user>/` absolute paths.
- Deliberately does **NOT** flag `~/` (username-agnostic), `/root/`, or `/tmp/`.
- Both checks run every invocation; either failing exits 1.

## Test plan

- [x] `scripts/check-no-private-links.py` exits 0 on all 70 tracked docs after the scrub
- [x] Regex self-test: 3 leak forms match, 4 legit forms don't
- [x] Pre-push hook (runs the checker via `task ci`) passed
- [x] `ruff format` clean on the modified checker