### PR TITLE
docs: security review playbook + /security-panel multi-reviewer skill

### DIFF
--- a/.claude/skills/security-panel/SKILL.md
+++ b/.claude/skills/security-panel/SKILL.md
@@ -1,0 +1,286 @@
+---
+name: security-panel
+description: Spawn a fan-out of 8 specialised reviewer subagents in parallel against a chosen scope (branch diff, path, or PR). Synthesizes findings into a severity-bucketed report. Use for pre-release audits, risky refactors, or feature reviews touching wire formats / trust boundaries. NOT for routine per-commit reviews — burns tokens.
+---
+
+# /security-panel — multi-reviewer fan-out
+
+A high-leverage, **high-cost** technique. Eight specialised review
+subagents run in parallel against the same target, each focused on
+its own dimension. The orchestrating Claude instance synthesizes
+their reports into a single severity-bucketed summary.
+
+See `docs/security-review-playbook.md` §4 for what this technique
+caught in pyrxd's 0.5.0 audit (V2 reward-shape bug, broad-except
+leak, missing FT golden vector, V2 quarantine recommendation).
+
+## When to use this
+
+* Pre-release audit before tagging a version.
+* A risky refactor across many files (10+).
+* New features touching wire formats or trust boundaries.
+* Any change where the cost of a bug is high and the diff is large
+  enough that single-reviewer fatigue is real.
+
+## When NOT to use this
+
+* Per-commit reviews on routine PRs — burns tokens for low marginal
+  value.
+* Documentation-only PRs — use `every-style-editor` alone.
+* Mechanical chores (linting, dep bumps, CI config).
+* Single-finding deep dives — use the `security-review` skill (the
+  "no finding without a working exploit" workflow); that's the
+  depth-first complement to this breadth-first fan-out.
+
+## Workflow
+
+### Step 1 — Ask for scope
+
+Use **AskUserQuestion** to clarify what to review. Do not assume
+defaults; the scope choice drives every subsequent prompt.
+
+```
+Question: "What's the scope of this review?"
+Header: "Review scope"
+Options:
+  1. Current branch diff (git diff origin/main...HEAD)
+  2. A specific PR — collect findings against PR head vs. base
+  3. A path or file glob (e.g. src/pyrxd/glyph/dmint.py)
+  4. Whole repo — first-audit-of-a-new-repo mode (heavy)
+```
+
+If they pick option 2, ask for the PR number. If option 3, ask for
+the path. If option 4, confirm the cost — whole-repo mode is roughly
+8× the token cost of a per-PR fan-out and should only be used at
+first-audit-of-a-new-repo intake.
+
+### Step 2 — Materialize the target context
+
+Once scope is chosen, gather the actual content the reviewers will
+read. Don't just hand them a path — hand them the diff or file
+content directly:
+
+* **Branch diff**: `git diff origin/main...HEAD` (or whatever the
+  default branch is — check first).
+* **PR**: `gh pr view <num> --json files,title,body` for metadata,
+  then `gh pr diff <num>` for the diff.
+* **Path**: `cat` the file(s) up to a reasonable size limit (~50 KB
+  per reviewer is plenty).
+* **Whole repo**: `git ls-files | head -200` for orientation, then
+  let each reviewer fetch what it needs from its own context. This
+  is the only mode that doesn't pre-bundle content.
+
+Cap the per-reviewer context window: if the diff exceeds ~20 KB,
+prefer summarizing per-area rather than dumping everything to all 8.
+A reviewer with a 200 KB diff produces shallow output.
+
+### Step 3 — Pick the language slot
+
+Six of the eight reviewers are language-agnostic. The seventh slot
+is language-specific. Detect the dominant language from the scope:
+
+| Dominant language | Use |
+|---|---|
+| Python | `compound-engineering:review:kieran-python-reviewer` |
+| TypeScript / JavaScript | `compound-engineering:review:kieran-typescript-reviewer` |
+| Ruby on Rails | `compound-engineering:review:kieran-rails-reviewer` (or `dhh-rails-reviewer` for opinionated Rails idiom) |
+| Other / mixed | Skip this slot; you'll have 7 reviewers instead of 8 |
+
+### Step 4 — Spawn all 8 reviewers in ONE message
+
+Critical: make all 8 `Agent` tool calls **in a single response so
+they run concurrently**. Sequential spawning is roughly 5× slower
+with no quality benefit.
+
+The standard roster:
+
+1. **`compound-engineering:review:security-sentinel`** — auth,
+   input validation, hardcoded secrets, OWASP top-10 patterns
+2. **`compound-engineering:review:pattern-recognition-specialist`**
+   — anti-patterns, naming inconsistencies, duplication
+3. **`compound-engineering:review:architecture-strategist`** —
+   layering, coupling, abstraction boundaries
+4. **`compound-engineering:review:code-simplicity-reviewer`** —
+   YAGNI violations, premature abstraction
+5. **`compound-engineering:review:performance-oracle`** —
+   algorithmic complexity, hot-path issues
+6. **`compound-engineering:review:data-integrity-guardian`** —
+   migrations, transactions, persistent state, privacy
+7. **Language-specific quality reviewer** (per Step 3)
+8. **`general-purpose` with red-team prompt** — there is no dedicated
+   red-team reviewer. Use the prompt template below.
+
+### Red-team prompt template (slot 8)
+
+The `general-purpose` agent gets this prompt verbatim, with the
+target diff/content interpolated where indicated:
+
+```
+You are a red-team reviewer. Your job is to find ways a hostile
+caller could violate the assumptions the code makes about its
+inputs, its environment, or its callers.
+
+Specifically:
+- What invariants does the code rely on without checking?
+- What inputs has the author assumed are "trusted" but actually
+  cross a trust boundary?
+- What error paths leak information (timing, error messages,
+  exception types) that a caller could exploit?
+- What's the worst thing a malicious caller could do here that
+  the author probably didn't think about?
+
+For each finding, output:
+  Severity: critical | high | medium | low
+  Location: file:line
+  Finding: one-sentence description
+  Why it matters: the concrete attack or exposure
+  Suggested fix: one sentence
+
+If you find no exploitable assumptions, say so explicitly — "no
+red-team findings on this scope" is a valid answer. Do NOT
+manufacture findings to fill quota.
+
+Report in under 400 words.
+
+TARGET:
+[interpolate the scope content here]
+```
+
+### Step 5 — Per-reviewer prompts
+
+Each compound-engineering reviewer has its own built-in prompt; pass
+it the target content and add one project-specific framing line.
+Standard scaffold:
+
+```
+TARGET FOR REVIEW: [scope description]
+
+[diff or file content, capped at ~20 KB]
+
+Constraints:
+- Report findings in under 400 words.
+- Use severity buckets: critical | high | medium | low | info.
+- For each finding: location (file:line), one-sentence description,
+  why it matters, suggested fix.
+- If you find nothing in your dimension, say so explicitly — "no
+  findings on this scope from a [security|architecture|etc.]
+  perspective" is a valid answer.
+```
+
+The under-400-words cap is load-bearing — without it, a single
+reviewer's report blows out the synthesis step's context budget.
+
+### Step 6 — Synthesize
+
+Once all 8 reviewers return, produce a single report with this
+structure:
+
+```
+# Security panel review — [scope]
+
+## Findings by severity
+
+### Critical (N findings)
+- [file:line] [reviewer] — [one-sentence description]
+  - Why: [reviewer's "why it matters" line]
+  - Fix: [reviewer's suggested fix]
+  - Consensus: [N of 8 reviewers flagged this, or "one-reviewer-only"]
+
+### High (N findings)
+[...]
+
+### Medium / Low / Info
+[truncate if long; show top 5 of each]
+
+## Cross-reviewer agreement
+
+- N findings flagged by ≥ 3 reviewers (consensus signal — fix first)
+- N findings flagged by exactly 1 reviewer (verify or defer)
+
+## What no reviewer flagged
+
+[Optional: areas of the scope that received no findings — sometimes
+worth noting "the parser was unanimously found clean", sometimes
+worth noting "no reviewer covered the new CBOR path", which is a
+gap.]
+
+## Suggested next actions
+
+[Concrete recommendations, ordered by severity. Don't pad — if 3
+findings are critical and 2 are medium, list 5 actions.]
+```
+
+**Consensus tagging is the highest-value output.** A finding flagged
+by 3+ reviewers in different dimensions (e.g. security + simplicity
++ architecture all flagging the same broad `except Exception`) is
+almost always real. A finding flagged by exactly one reviewer
+deserves a second look — could be insight, could be noise.
+
+### Step 7 — Offer next actions
+
+After the report, use **AskUserQuestion** to offer follow-up:
+
+```
+Options:
+  1. Fix the critical findings now (I'll start with the highest-
+     consensus one).
+  2. Open a tracking issue for each high+critical finding and defer.
+  3. Run the depth-first `/security-review` skill on a specific
+     finding to develop a working exploit PoC.
+  4. Done — report only, no action.
+```
+
+## Cost estimate
+
+A single panel run against a ~2 000-line diff is roughly:
+
+- 8 parallel agent runs
+- ~5 000 tokens prompt per reviewer + their reasoning context
+- ~400 tokens output per reviewer
+- Plus the synthesis step
+
+Total: tens of thousands of tokens. Budget accordingly. This is
+appropriate for pre-release audits and risky refactors, not for
+routine PR review.
+
+## Anti-patterns
+
+* **Don't run the full panel on every PR.** Trains the team to
+  ignore findings ("noise"). Reserve for moments where signal-to-
+  noise actually warrants it.
+* **Don't sequence the reviewers.** All 8 in parallel in one message
+  or you've thrown away most of the speed advantage.
+* **Don't let a reviewer write 2 000 words.** The 400-word cap is
+  load-bearing for synthesis. Re-prompt if a reviewer overruns.
+* **Don't manufacture consensus.** If only one reviewer flags a
+  finding, label it "one-reviewer-only" — don't promote it to
+  "consensus" because three reviewers happened to mention the same
+  file. Consensus means *the same finding*, not *the same file*.
+
+## Porting to another Radiant repo
+
+The skill is project-local (lives in `.claude/skills/security-panel/`
+in pyrxd). To port:
+
+1. Copy `.claude/skills/security-panel/` to the target repo.
+2. Adjust the language-slot mapping in Step 3 if the target is in a
+   different language than pyrxd.
+3. Adjust the default scope check in Step 1 if the target's default
+   branch isn't `main`.
+4. Test it once on a known PR before relying on it for an audit.
+
+The compound-engineering reviewer subagents are user-global (not
+per-repo), so they're available in any working directory without
+extra setup.
+
+## See also
+
+* `docs/security-review-playbook.md` §4 — what this technique
+  caught in pyrxd's 0.5.0 audit, in case-study form.
+* `~/.claude/skills/security-review/SKILL.md` — the depth-first
+  "no finding without a working exploit" complement to this skill.
+  Use it after `/security-panel` finds something worth exploiting
+  for proof.
+* `scripts/check-no-private-links.py` — the mechanical leak-check
+  that runs in `task ci`; complements §4 by catching the leak class
+  that human reviewers consistently miss.

--- a/docs/security-review-playbook.md
+++ b/docs/security-review-playbook.md
@@ -1,0 +1,481 @@
+# Security review playbook
+
+A working notebook of the techniques that found **real bugs** in
+pyrxd's 0.5.0 and 0.5.1 release cycles — not a generic methodology.
+Each section names the technique, the actual finding it produced, and
+the cases where it applies vs. where it doesn't.
+
+Use this when starting a review on pyrxd itself, or as a reference
+when bootstrapping a review of a sibling project in the Radiant
+ecosystem.
+
+## Scope and limits
+
+This document captures **what worked on pyrxd** between roughly
+2026-04-29 (0.2.0) and 2026-05-14 (0.5.1). It is biased toward:
+
+* Wire-format builders that emit bytes the rest of the ecosystem
+  parses.
+* Parsers that consume attacker-supplied input (block-explorer
+  pastes, ElectrumX responses, hostile reveal scriptSigs).
+* Library code shipped to PyPI under MIT/Apache — the audience is
+  downstream SDK consumers, not end users.
+
+It is **not** a comprehensive Radiant-ecosystem methodology. If your
+target is a frontend wallet, an indexer, or pure tooling without
+on-chain serialization, only a subset of the techniques here will
+apply. The "When it applies / when it doesn't" subsection of each
+case study calls that out.
+
+## Per-repo intake checklist
+
+Before picking which techniques to run on a new repo, answer five
+questions. The Yes answers map to the case studies below.
+
+| Question | If yes → | If no → |
+|---|---|---|
+| Does the repo emit bytes that another implementation has to parse (transactions, contracts, CBOR, BIP-32 paths)? | §1 golden-vector pinning | Skip §1 |
+| Is there a canonical reference implementation in another language? | §2 cross-implementation byte-diff | Skip §2; §1 carries the load alone |
+| Does the repo expose any parser to attacker-controlled input? | §3 trust-boundary fuzz contract | Skip §3 |
+| Is the repo about to ship a release with non-trivial new surface? | §4 multi-reviewer panel | Optional |
+| Is the repo public? | §5 mechanical leak-checking | Skip §5 (private repos still benefit but the urgency is lower) |
+
+If you got at most one Yes, this playbook isn't the right tool —
+spawn the `security-sentinel` reviewer alone via the `/security-panel`
+skill (see `.claude/skills/security-panel.md`) and call it.
+
+If you got three or more, run them in the order listed: §1 builds the
+golden vectors §2 will diff against; §3 hardens the parser side; §4
+fans the multi-reviewer panel out across the cleaned tree; §5 is the
+mechanical guard that runs in CI from then on.
+
+---
+
+## §1 — Golden-vector pinning against mainnet
+
+**What it does.** For every wire-format builder, capture real
+on-chain bytes for a known-good transaction and assert
+`build(...) == GOLDEN`.
+
+**What it found.** Two critical bugs that 49 round-trip tests missed:
+
+1. **M1 V1 dMint mint scriptSig push convention.** Pre-0.5.0,
+   `build_mint_scriptsig` pushed `<inputHash> <outputHash> <nonce>
+   <0x00>` (72 bytes total). The canonical mainnet convention is
+   `<0x04 nonce(4)> <0x20 inputHash(32)> <0x20 outputHash(32)>
+   <0x00>` — same length, different push order. The old shape
+   produced mint transactions the covenant rejects 100% of the time.
+   M1 had never successfully spent a mainnet contract until this
+   bug was found by walking real bytes against the builder's output.
+   Verified fixed at txid `c9fdcd34…e530`.
+2. **V2 mint reward output emitted plain P2PKH at vout[1].** The
+   covenant requires the same 75-byte FT-wrapped reward as V1
+   (`build_dmint_v1_ft_output_script`). Caught pre-V2-mainnet-deploy
+   when the audit panel walked the V2 builder against the V1 golden.
+   Would have been a 100% rejection on every V2 mint.
+
+**Why round-trip tests miss this.** `assert parse(build(x)) == x`
+proves the builder and parser are self-consistent. Both can harbor
+**coordinated bugs** invisible to every round-trip assertion —
+they were authored from the same flawed mental model. Real-world
+example here: the M1 builder *and* the M1 parser agreed on the wrong
+push order. Mainnet didn't.
+
+**Where pyrxd carries this.** Six golden-vector test classes pin
+every wire-format builder pyrxd ships:
+
+| Builder | Test class | Mainnet ref |
+|---|---|---|
+| `build_ft_locking_script` (75 B) | `TestFtLockingScriptMainnetGolden` | RBG transfer `ac7f1f70…0ae4` |
+| `build_nft_locking_script` (63 B) | `TestNftLockingScriptMainnetGolden` | Glyph NFT `27390efa…be7e` |
+| `build_commit_locking_script` (75 B, FT + NFT) | `TestCommitLockingScriptMainnetGolden` | GLYPH deploy `a443d9df…878b` |
+| `decode_payload` + `build_reveal_scriptsig_suffix` (65 569 B w/ embedded PNG) | `TestCborPayloadMainnetGolden` | GLYPH reveal `b965b32d…9dd6` |
+| `build_dmint_v1_contract_script` (241 B) | `TestV1GoldenVectorGlyphPattern` | GLYPH deploy reveal vout 0 |
+| `build_mint_scriptsig` (72 B) + 4-output mint shape | `TestCovenantShape` | snk `146a4d68…f3c` + PXD `c9fdcd34…e530` |
+
+**Mechanics — how to add one in roughly 20 minutes.**
+
+1. Find a mainnet transaction known to use the format you're building.
+   For Glyph/dMint, the [Radiant Glyph Guide][rgg]'s §17 has a
+   table; otherwise `gh api repos/<org>/<repo>/contents/...` against a
+   working implementation's test fixtures, or `getrawtransaction`
+   against your full node.
+2. Fetch the raw tx hex; extract the specific output (or scriptsig)
+   bytes you want to pin. For payloads >a few kB, check them in as a
+   binary fixture under `tests/fixtures/` (see `glyph_reveal_cbor.bin`
+   for the canonical example).
+3. Write one test class that asserts:
+   - `build(...) == captured_bytes` (the core assertion)
+   - The captured bytes pass your own classifier (round-trips with
+     the parser side, but the *baseline* truth is the on-chain bytes,
+     not the round-trip)
+   - `extract_*(captured_bytes)` recovers the inputs (proves bytes
+     and parser agree)
+
+The test file in `tests/test_glyph_dmint.py::TestCommitLockingScriptMainnetGolden`
+is a good template — 79 lines, three assertions, no dependencies
+beyond the builder itself.
+
+**When it applies.** Any function whose output is a byte string
+another implementation must parse. Bonus when the on-chain consumers
+are covenant-driven (Radiant covenants reject byte-shape mismatches
+100% of the time — silent corruption is impossible, but so is
+"works on testnet").
+
+**When it doesn't.** Pure business logic, frontend rendering,
+tooling without serialization, RPC client wrappers that round-trip
+JSON unmodified. Don't manufacture golden vectors where there is no
+canonical wire format to pin against.
+
+**Anti-pattern to avoid.** Don't write goldens against your own
+testnet broadcasts. The point is *independent ground truth* — bytes
+emitted by a different implementation (Photonic, glyph-miner,
+Photonic Wallet, etc.) on mainnet. A self-loop test pinning your own
+output against your own output is just a slower round-trip test.
+
+[rgg]: https://github.com/MudwoodLabs/radiant-glyph-guide
+
+---
+
+## §2 — Cross-implementation byte-diff
+
+**What it does.** Diff your builder's output against the canonical
+reference implementation, at the byte level, with the explicit rule:
+"Photonic (or whatever the reference is) is the default; deviate
+explicitly and document the reason when the reference is wrong."
+
+**What it found.** The audit pattern that catches the bugs §1's
+golden vectors only catch retrospectively (after they ship to
+mainnet). Used during 0.4.0 → 0.5.0 to validate the V1 deploy and
+V1 mint flows before the first mainnet broadcast.
+
+The rule cuts both ways:
+- The Photonic V1 mint scriptSig push order is what pyrxd had to
+  match — pyrxd had it wrong, Photonic had it right.
+- Photonic's `parseDmintScript` ships as V2-only in master — but
+  the live ecosystem runs V1. pyrxd correctly deviated and
+  documented `docs/dmint-research-photonic-deploy.md` §7 explaining
+  why.
+
+**Where pyrxd records the diff convention.** Two places, both
+public-tracked:
+
+- `docs/dmint-research-photonic-deploy.md` — per-decision table:
+  Photonic file/line, what value Photonic emits, what pyrxd emits,
+  and the reason for any divergence.
+- `docs/dmint-research-photonic.md` — the same for the broader
+  Photonic source-tree walk.
+
+**Mechanics.** Read the reference implementation *with the goal of
+emitting matching bytes* — not "understand the protocol." Capture
+each builder call and decode call as a row in a divergence table:
+
+| Photonic file:line | Photonic emits | pyrxd emits | Match? | Reason if not |
+|---|---|---|---|---|
+| `script.ts:152-213` (ftCommitScript) | `aa20<hash>88…` | `aa20<hash>88…` | ✓ | — |
+| `script.ts:704-766` (dMintScript) | V2 9-state-item layout | V1 3-state-item layout | ✗ | Photonic master ships V2-only emit; live chain runs V1 |
+
+The act of filling the table *is* the audit. Each "match" row is a
+no-op confirmation; each "no match" row is either a real divergence
+(documented) or a bug (fix and re-row).
+
+**When it applies.** Protocols with a canonical reference
+implementation in another language. For Radiant: Photonic Wallet
+(Glyph/dMint/WAVE), glyph-miner (dMint mining), RXinDexer (indexer
+classifiers). For other ecosystems: BIP-32 reference vectors, the
+Bitcoin Core RPC reference, etc.
+
+**When it doesn't.** Protocols with no second implementation, or
+where the second implementation is *itself* a fork of yours. Then §1
+golden vectors against on-chain bytes are the strongest baseline you
+can write.
+
+**The deferral rule.** Don't write a divergence row that says
+"Photonic does X, we'll do Y because X is suboptimal" without
+mainnet evidence. Either:
+
+1. Find an on-chain transaction emitted by a *third* implementation
+   that agrees with X — Photonic is right, you match.
+2. Find an on-chain transaction emitted by a third implementation
+   that agrees with Y — Photonic is wrong (or outdated), document
+   and deviate.
+3. Neither exists — the protocol surface isn't validated; **don't
+   ship it**, mark experimental, defer to a future release where one
+   side has been validated.
+
+The V2 dMint reward bug was caught by exactly this rule: pyrxd's
+V2 path matched Photonic's V2 emit, but no V2 contract has been
+deployed to mainnet → no third-party validation possible → the V2
+path is now quarantined behind `V2UnvalidatedWarning` (see §6 below
+for how this connects to release hygiene).
+
+---
+
+## §3 — Trust-boundary fuzz contract
+
+**What it does.** For every parser that consumes attacker-supplied
+input, assert one specific contract:
+
+> Return a structured value, or raise one specific exception type.
+> Any other exception type is a bug — the parser leaking its
+> internal failure mode past its trust boundary.
+
+**What it found.** A `cbor2.CBORDecodeError` escaping `decode_payload`
+that slipped past the inspect-tool's `except ValidationError`
+handler. The inspect tool's browser flow crashed instead of cleanly
+classifying the input as malformed. Fix was a one-line wrap inside
+`decode_payload`; without the fuzz test, the bug would have only
+been visible to a user who happened to paste exactly the wrong
+bytes.
+
+**Where pyrxd carries this.** `tests/test_fuzz_parsers.py` ships
+eight Hypothesis targets, all asserting the same contract via the
+shared `_fail_unexpected()` helper:
+
+```python
+def _fail_unexpected(target: str, exc: BaseException, raw: bytes | str) -> None:
+    payload = raw.hex() if isinstance(raw, (bytes, bytearray)) else repr(raw)
+    pytest.fail(
+        f"{target} raised unexpected {type(exc).__name__}: {exc}\n"
+        f"  input ({len(raw)}): {payload}"
+    )
+```
+
+The eight targets:
+
+1. `decode_payload` — CBOR decode boundary
+2. `DmintState.from_script` — variable-length opcode walker
+3. `GlyphInspector.extract_reveal_metadata` — push-data walker
+4. `GlyphInspector.find_glyphs` — script classifier dispatch
+5. `_inspect_script` — CLI/browser inspect dispatch
+6. `_classify_input` — top-level inspect classifier
+7. `GlyphRef.from_bytes` / `from_contract_hex` — fixed-shape ref
+   decoders
+8. Round-trip: `build_mutable_scriptsig` → push-data walker recovers
+   the embedded CBOR (proves builder and parser agree on the
+   structural contract, separate from the byte-shape contract §1
+   covers)
+
+Plus five atheris coverage-guided harnesses under
+`scripts/fuzz_atheris/`, hitting the same surface with libFuzzer
+mutation feedback.
+
+**Mechanics — adding a fuzz target.**
+
+1. Identify the parser function that consumes attacker input. "Where
+   does untrusted bytes/text first cross into your code?" — that's
+   the boundary.
+2. Write one `@given(data=st.binary(...))` decorator + a try/except
+   asserting the contract:
+
+```python
+@given(data=st.binary(min_size=0, max_size=1024))
+@settings(max_examples=_budget(400), suppress_health_check=[HealthCheck.too_slow])
+def test_my_parser_only_validation_error(data):
+    try:
+        my_parser(data)
+    except ValidationError:
+        # expected: parser converted a malformed input cleanly
+        pass
+    except Exception as exc:
+        _fail_unexpected("my_parser", exc, data)
+```
+
+3. Run at CI budget (~1.5 s for 400 examples). If it finds a
+   counterexample, the failure message prints the offending bytes
+   hex-encoded — paste it into a reproduction unit test before
+   fixing the parser.
+
+**When it applies.** Any parser at a trust boundary: HTTP request
+handlers, RPC dispatchers, file-format readers, script walkers,
+CBOR/JSON/protobuf decoders. Anywhere the input is "whatever the
+attacker decided to send."
+
+**When it doesn't.** Internal-only parsers consuming data your own
+code wrote three lines earlier. The trust boundary is *external
+input* — fuzzing your own serialization round-trip is a §1
+golden-vector concern, not a §3 fuzz concern.
+
+**Cost.** The Hypothesis suite runs in ~1.5 s at CI budget (400
+examples per target). The atheris harnesses are overnight-run
+material — invoke via `scripts/fuzz_overnight.sh` against an 8-core
+box. Don't put atheris on the per-commit CI path.
+
+**Anti-pattern.** A `try/except: pass` with no comment looks like a
+broad swallow even when it's correct. Either add a comment naming
+the expected contract (`# expected: parser converted a malformed
+input cleanly`) or pin the exception type tightly. CodeQL's
+`py/empty-except` rule will flag the comment-less form.
+
+---
+
+## §4 — Multi-reviewer panel
+
+**What it does.** Spawn a fan-out of specialised reviewer subagents
+in parallel against the same target (a PR, a branch's diff, or a
+specific path). Each reviewer focuses on its own dimension —
+security, architecture, simplicity, performance, etc. — and returns
+a short report. You synthesize.
+
+**What it found.** Almost everything in the 0.5.0 audit pass: the
+V2 reward-shape bug (red-team chain-conformance reviewer),
+unnecessary V2 surface that turned into the `V2UnvalidatedWarning`
+quarantine (architecture-strategist), the broad-except leak that
+turned into §3 (security-sentinel + pattern-recognition-specialist),
+the missing FT golden vector (pattern-recognition-specialist).
+0.5.0's CHANGELOG attributes findings to specific reviewers.
+
+**The roster.** Eight slots, three are language-specific. For a
+Python repo:
+
+| Slot | Reviewer | What it catches |
+|---|---|---|
+| Security | `compound-engineering:review:security-sentinel` | Auth, input validation, secrets, OWASP top-10 patterns |
+| Pattern recognition | `compound-engineering:review:pattern-recognition-specialist` | Anti-patterns, naming inconsistencies, duplication |
+| Architecture | `compound-engineering:review:architecture-strategist` | Layering, coupling, abstraction boundaries |
+| Simplicity | `compound-engineering:review:code-simplicity-reviewer` | YAGNI violations, premature abstraction |
+| Performance | `compound-engineering:review:performance-oracle` | Algorithmic complexity, hot-path issues |
+| Data integrity | `compound-engineering:review:data-integrity-guardian` | Migrations, transactions, persistent state |
+| Language quality | `compound-engineering:review:kieran-python-reviewer` (or `kieran-typescript-reviewer`, `kieran-rails-reviewer`) | Idiomatic patterns, type safety, maintainability |
+| Red team | `general-purpose` with a red-team prompt | Adversarial mindset; "what's the worst thing a hostile caller could do here?" |
+
+There is **no dedicated red-team reviewer**; the eighth slot is a
+`general-purpose` agent given a red-team-styled prompt. Lean
+heavily on "what assumptions does this code make about its caller
+that an attacker could violate?"
+
+**Where pyrxd carries this.** As a Claude skill at
+`.claude/skills/security-panel.md` (this PR adds it). Invoke with
+`/security-panel`; it prompts for scope (current branch diff, a
+specific path, or a PR number) then fans the eight reviewers out in
+parallel.
+
+**Mechanics.** The skill instructs the orchestrating Claude
+instance to make **eight `Agent` tool calls in a single message** so
+they run concurrently. Each agent gets a prompt scoped to its
+dimension plus the same target description. The skill defines an
+output schema — each reviewer returns under 400 words; the
+orchestrator synthesizes findings into a single report with severity
+buckets (critical / high / medium / low / info) and a "consensus
+vs. one-reviewer-only" tag on each finding.
+
+**When it applies.** Pre-release audits. Risky refactors. New
+features touching wire formats or trust boundaries. Any change where
+the cost of a bug is high and the diff is large enough that single-
+reviewer fatigue is a real risk.
+
+**When it doesn't.** Per-commit reviews on a routine PR — you'll
+burn tokens for low marginal value. Documentation-only PRs (run
+`every-style-editor` alone). Mechanical chores (linting, dep bumps,
+CI config tweaks).
+
+**Cost.** Each reviewer agent is a full Claude run with its own
+context. Eight in parallel on a 2 000-line diff is roughly the
+token cost of a heavy investigation. Budget accordingly.
+
+**Anti-pattern: reviewer overload.** Running the full panel on
+every PR trains the team to ignore reviewer findings ("noise"). Save
+it for the moments where the signal-to-noise actually warrants it.
+
+---
+
+## §5 — Mechanical leak-checking
+
+**What it does.** A `task ci` check that scans every tracked
+markdown/RST file for two leak classes:
+
+1. **Markdown link targets pointing into `.gitignore`d paths**
+   (`[text](docs/design/foo.md)` when `docs/design/` is private).
+   Such links break in every clone and leak the existence of
+   private files via the link text.
+2. **Absolute home-directory paths with a baked-in username**
+   (`/home/<user>/...` or `/Users/<user>/...`) anywhere in doc
+   body, link or prose or fenced code block. These leak the
+   author's username and local layout. When they point into a
+   sibling private project, they leak that project's existence
+   too.
+
+**What it found.** A single grep at the end of the 0.5.1 release
+sprint surfaced **18 leaks across 6 tracked docs** that had been
+public on `origin/main` for over a week:
+
+- One `file://` markdown link directly into the author's private
+  `~/.claude/` auto-memory directory.
+- Two prose mentions of that private memory file's name.
+- About fifteen `/home/<user>/apps/…` paths, several pointing into
+  a private sibling-project group (leaking the existence of those
+  private projects via the path name alone).
+- A VPS IP and a full `ssh ericadmin@<ip> -- sudo docker exec ...`
+  line — username + IP + the fact the VPS runs docker as sudo.
+
+Every leak was old. None had been caught by review. None had been
+caught by CI. The mechanical scan ran in 60 ms.
+
+**Where pyrxd carries this.** `scripts/check-no-private-links.py`.
+Two checks, both run on every invocation:
+
+1. Link-target check — link is gitignored.
+2. Home-path regex check — `/home/<user>/...` or
+   `/Users/<user>/...` in any tracked doc.
+
+Wired into `task ci` so the pre-push hook catches new leaks before
+they reach `origin`. The hardened version was deliberately narrow:
+it does **not** flag `~/...` (username-agnostic — the correct way
+to document `~/.pyrxd/config.toml`), `/root/...` (no username),
+or `/tmp/...` (scratch paths carry no user identity).
+
+**Mechanics — porting to another repo.** The script is portable
+as-is. Drop `scripts/check-no-private-links.py` into the target
+repo, add it to `task ci` (or whatever the equivalent test
+runner is), and add a `.gitignore` block for repo-specific private
+paths (most repos want at least `.claude/`, `.worktrees/`,
+`logs/`). Done.
+
+**When it applies.** Every public repo. Even when the techniques in
+§1–§4 don't fit (frontend-only, doc-only), this one always does.
+
+**When it doesn't.** Truly-private internal repos where there's no
+publication surface at all. Even then, the discipline pays off if
+you ever consider opening the repo later.
+
+**Anti-pattern.** Methodology theatre — adding a "Security
+Checklist" markdown file that nobody reads is worse than nothing,
+because it creates the appearance of coverage. The mechanical
+check, in CI, is the only form that catches the next leak.
+
+---
+
+## What this playbook is NOT
+
+Worth being explicit, because it's tempting to over-read the success
+of one release cycle as a general methodology:
+
+* **Not a substitute for a deep-review pass on a new repo.** The
+  techniques here found bugs on a *familiar* codebase. The first
+  pass on an unfamiliar repo should still be the multi-reviewer
+  panel from §4, not the playbook in isolation.
+* **Not a guarantee.** Six golden vectors caught two on-chain-
+  rejection bugs. They would not have caught a covert ECDSA-nonce
+  reuse, a timing side-channel, or a logic error in the wallet's
+  coin-selection. Different attack classes need different lenses.
+* **Not stable.** This document will go stale. Re-derive the
+  techniques from the next release cycle's *actual* findings; don't
+  preserve sections out of habit.
+
+## Update protocol
+
+Add a new case study when:
+
+* A specific technique finds a real bug that the other techniques in
+  this playbook would have missed.
+* You ship a security fix and want the lesson to compound.
+
+Remove or rewrite a case study when:
+
+* It no longer reflects the actual workflow.
+* The technique it documents is now mechanical (lives in `task ci`
+  rather than in human review).
+* A subsequent finding contradicts it.
+
+The point is the case studies, not the index. Length is fine as long
+as every section names a real finding.


### PR DESCRIPTION
## Summary

Two deliverables, one PR, captured for **re-use across the Radiant ecosystem** as you start security/red-team reviews on sibling repos.

### 1. `docs/security-review-playbook.md` (~480 lines)

Case-study format — the **five techniques that found real bugs** in pyrxd's 0.5.0 → 0.5.1 release cycle, with the specific findings each technique produced and "when it applies / when it doesn't" guidance:

| § | Technique | What it caught |
|---|---|---|
| §1 | Golden-vector pinning against mainnet | M1 V1 mint scriptSig push convention; V2 reward-shape bug |
| §2 | Cross-implementation byte-diff | The "Photonic as default reference, deviate explicitly" rule |
| §3 | Trust-boundary fuzz contract | `cbor2.CBORDecodeError` leaking past `except ValidationError` (crashed inspect-tool browser flow) |
| §4 | Multi-reviewer panel | The 8-reviewer fan-out from the 0.5.0 audit (V2 reward bug, broad-except leak, missing FT golden, V2 quarantine recommendation) |
| §5 | Mechanical leak-checking | The 18 leaks across 6 docs that PR #100 surfaces |

Plus: per-repo intake checklist (5 questions → which techniques apply), anti-patterns, update protocol, and an explicit "what this is NOT" framing to avoid methodology theatre.

### 2. `.claude/skills/security-panel/SKILL.md` (~290 lines)

A project-local Claude skill that operationalises §4 — fans **8 specialised reviewer subagents out in parallel** against a chosen scope:

- 6 compound-engineering reviewers (security-sentinel, pattern-recognition-specialist, architecture-strategist, code-simplicity-reviewer, performance-oracle, data-integrity-guardian)
- 1 language-specific reviewer (kieran-python / kieran-typescript / kieran-rails / dhh-rails)
- 1 red-team prompt against `general-purpose` (no dedicated red-team reviewer exists; the prompt template is in the skill)

The skill **asks for scope on every invocation** (branch diff, path, PR number, or whole-repo) so the user makes a deliberate choice each time. Includes consensus tagging in the synthesis step (3+ reviewers flagging the same finding = consensus signal; 1 reviewer = "verify or defer").

**Project-local on purpose** so the skill travels with pyrxd; the "Porting to another Radiant repo" subsection of the skill covers how to copy it to a sibling repo.

### Verification

- [x] All 10 named subagents (8 standard + 2 Ruby alternates) verified present in `~/.claude/plugins/cache/.../compound-engineering/.../agents/review/`
- [x] Both files leak-clean (no `/home/<user>/` or `/Users/<user>/` paths — uses `/home/<user>/...` placeholder where the §5 case study describes the leak pattern)
- [x] All markdown fenced code blocks balanced
- [x] Pre-push hook (full suite + lint) passed clean

### Notes on sequencing

This PR depends on **no other open PR**. It pairs naturally with [PR #100](https://github.com/MudwoodLabs/pyrxd/pull/100) (which hardens `check-no-private-links.py`) — the playbook's §5 describes the post-PR-#100 state. Merging this before #100 just means a reader's view of §5 momentarily describes a future state; merging #100 first reads in the natural order.