### PR TITLE
chore(lint): clean up pre-existing ruff errors in docs + scripts

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -3,6 +3,7 @@
 Builds the public-facing docs at https://pyrxd.readthedocs.io. Favours
 clarity and zero-warning builds over feature breadth.
 """
+
 from __future__ import annotations
 
 import os
@@ -19,7 +20,7 @@ author = "Mudwood Labs"
 copyright = f"{datetime.now().year}, {author}"
 
 # Read the version from the package itself so docs and code never drift.
-from pyrxd import __version__ as _pyrxd_version  # noqa: E402
+from pyrxd import __version__ as _pyrxd_version
 
 version = _pyrxd_version
 release = _pyrxd_version

--- a/docs/inspect_static/inspect/glue.py
+++ b/docs/inspect_static/inspect/glue.py
@@ -362,13 +362,9 @@ def _hint_for(form: str) -> str:
     """A one-line follow-up hint per failed-form."""
     return {
         "contract": (
-            "Glyph contract ids are 72 hex characters: "
-            "<32-byte txid in display order><4-byte vout in big endian>"
+            "Glyph contract ids are 72 hex characters: <32-byte txid in display order><4-byte vout in big endian>"
         ),
-        "outpoint": (
-            "Outpoints look like '<64-char-txid>:<vout-int>' "
-            "— check your colon and length"
-        ),
+        "outpoint": ("Outpoints look like '<64-char-txid>:<vout-int>' — check your colon and length"),
         "script": (
             "Scripts are hex-encoded locking-script bytes. "
             "P2PKH is 25 bytes (50 hex chars); FT is 75 bytes (150 hex chars)."

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -162,6 +162,10 @@ ignore = [
     "S",      # examples use test keys / hardcoded WIFs intentionally
     "E402",   # examples may reorder imports for narrative clarity
 ]
+"scripts/**" = [
+    "S603",   # subprocess call with non-shell args: dev scripts trust their own argv
+    "S607",   # partial executable path: `git`, `python3` etc. resolved via PATH at dev time
+]
 "docs/conf.py" = ["E", "F", "I"]
 
 [tool.ruff.lint.isort]

--- a/scripts/check-no-private-links.py
+++ b/scripts/check-no-private-links.py
@@ -158,9 +158,7 @@ def check_ignored(repo_root: Path, paths: list[Path]) -> set[Path]:
         check=False,  # exit 1 is normal (means "no ignored files in input")
     )
     if result.returncode not in (0, 1):
-        raise RuntimeError(
-            f"git check-ignore failed with exit code {result.returncode}: {result.stderr}"
-        )
+        raise RuntimeError(f"git check-ignore failed with exit code {result.returncode}: {result.stderr}")
     return {Path(line) for line in result.stdout.splitlines() if line}
 
 

--- a/scripts/vendor-confusables.py
+++ b/scripts/vendor-confusables.py
@@ -117,9 +117,9 @@ def _fetch_and_verify(version: str, *, update_hash: bool) -> tuple[str, str, str
                 f"compromised upstream mirror or a TLS MITM. Investigate\n"
                 f"before proceeding."
             )
-        print(f"  pinned SHA matches — proceeding", file=sys.stderr)
+        print("  pinned SHA matches — proceeding", file=sys.stderr)
     else:
-        print(f"  --update-hash: skipping pin verification", file=sys.stderr)
+        print("  --update-hash: skipping pin verification", file=sys.stderr)
     return data.decode("utf-8"), url, sha
 
 
@@ -284,6 +284,7 @@ def _emit(mappings: dict[int, str], unicode_version: str, source_url: str) -> st
     ]
     for source_cp in sorted(mappings.keys()):
         target = mappings[source_cp]
+
         # Render the target as a Python string literal. Avoid emitting
         # raw non-ASCII codepoints into the source file — keeps the
         # generated module 7-bit clean and easier to grep. Use
@@ -367,7 +368,7 @@ def main() -> int:
     print(f"  parsed {len(mappings):,} raw mappings (Unicode {unicode_version})", file=sys.stderr)
     if args.update_hash:
         print(
-            f"\n  After verifying the diff, update _PINNED_SHA256 in this script to:",
+            "\n  After verifying the diff, update _PINNED_SHA256 in this script to:",
             file=sys.stderr,
         )
         print(f"      {sha}", file=sys.stderr)


### PR DESCRIPTION
## Summary

Clears the 11 pre-existing `ruff check` errors that were blocking
`task ci` and the pre-push hook. Net change: **13 inserted / 13 deleted**
across 5 files. No behaviour change.

## What was wrong

| Count | Rule | File | Fix |
|---|---|---|---|
| 1 | RUF100 | `docs/conf.py` | Removed unused `# noqa: E402` (E402 already in per-file-ignores) |
| 3 | F541 | `scripts/vendor-confusables.py` | Dropped `f` prefix from f-strings without placeholders |
| 3+4 | S603/S607 | `scripts/check-no-private-links.py` | Added `scripts/**` per-file-ignore for these two rules — legitimate `subprocess.run(["git", ...])` in a dev script |

Also ran `ruff format` to pick up two files that had drifted from
format-clean state (`docs/conf.py`, `docs/inspect_static/inspect/glue.py`).

## Why the per-file-ignore for `scripts/**` rather than per-line noqa

`check-no-private-links.py` has 7 separate subprocess calls. Adding
`# noqa: S603, S607` to each would be noisier than the configuration
change, and the same reasoning applies uniformly across the scripts
directory: dev tooling trusts its own argv and resolves `git` / `python3`
from PATH at dev time. The pattern matches the existing `tests/**` and
`examples/**` ignores in shape.

## Test plan

- [x] `ruff check .` → All checks passed
- [x] `ruff format --check .` → 185 files already formatted
- [x] `pytest tests/` → 2844 passed, 12 skipped
- [x] `task ci` (via pre-push hook) → all checks pass cleanly

## Impact

Unblocks the pre-push hook for future PRs — PR #102 had to ship with
`--no-verify` because of these. After this lands, normal `git push`
works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)