### PR TITLE
fix(check-no-private-links): narrow username class so doc placeholders pass

### DIFF
--- a/scripts/check-no-private-links.py
+++ b/scripts/check-no-private-links.py
@@ -76,15 +76,22 @@ _RST_TARGET_RE = re.compile(r"^\.\.\s+_[^:]+:\s+(\S+)", re.MULTILINE)
 # `](path)` form; this catches the rest. A ``file://`` prefix is
 # matched too, so ``file:///home/alice/...`` is caught.
 #
-# Matches: /home/<user>/..., /Users/<user>/...
+# Matches: /home/<concrete-user>/..., /Users/<concrete-user>/...
+# where the username segment is constrained to characters POSIX
+# usernames actually use ([a-zA-Z0-9._-]).
 #
 # Deliberately does NOT match:
+#   - Documentation placeholders: /home/<user>/..., /home/$USER/...
+#     — the angle-bracket / shell-var glyphs aren't valid POSIX
+#     usernames, so the narrowed character class skips them. Security
+#     playbooks describing the leak pattern itself can therefore use
+#     ``/home/<user>/...`` freely without tripping the checker.
 #   - ~/... (tilde-home) — username-agnostic; the *correct* way to
 #     document a home-relative path like ``~/.pyrxd/config.toml``
 #   - /root/... — no username embedded; rare and not a personal leak
 #   - /tmp/... — scratch paths carry no username and are a normal way
 #     to describe a throwaway clone or fixture dump
-_HOME_PATH_RE = re.compile(r"(?:file://)?/(?:home|Users)/[^/\s]+/[^\s`)\"'<>]+")
+_HOME_PATH_RE = re.compile(r"(?:file://)?/(?:home|Users)/[a-zA-Z0-9._-]+/[^\s`)\"'<>]+")
 
 
 def git_ls_files(repo_root: Path) -> list[Path]:


### PR DESCRIPTION
## Summary

The hardened home-path check from [PR #100](https://github.com/MudwoodLabs/pyrxd/pull/100) used \`[^/\s]+\` for the username segment, which matched **any** non-slash/non-whitespace character. That swept up documentation placeholders like \`/home/<user>/...\` and \`/home/<user>/apps/…\` that appear in the security playbook ([PR #101](https://github.com/MudwoodLabs/pyrxd/pull/101)) describing the very leak pattern this check targets.

The result: post-PR-100/101 main fails its own checker.

## Fix

Narrowed the username class to \`[a-zA-Z0-9._-]+\` — the character set POSIX usernames actually use.

## Verification (self-test)

Real leaks still match:

| Input | Behavior |
|---|---|
| \`/home/eric/apps/foo\` | match (leak) |
| \`file:///home/alice/.claude/\` | match (leak) |
| \`/Users/bob/code/thing\` | match (leak) |
| \`/home/jane-doe/x\` | match (leak — hyphen valid in usernames) |
| \`/home/user_name/y\` | match (leak — underscore valid) |

Documentation placeholders no longer match:

| Input | Behavior |
|---|---|
| \`/home/<user>/...\` | skip (\`<\` not in username class) |
| \`/home/<user>/apps/…\` | skip |
| \`/home/$USER/foo\` | skip (\`$\` not in class) |

Plus running the checker against current \`origin/main\` returns exit 0 (was exit 1 before this fix).

## Inline-comment update

The regex's comment block now calls out the placeholder exemption explicitly, so the next person editing the regex doesn't re-widen it back to \`[^/\s]+\`.

## Test plan

- [x] Regex self-test (8 cases — 5 leaks match, 3 placeholders don't)
- [x] \`scripts/check-no-private-links.py\` exits 0 against current main
- [x] Pre-push hook (full suite + lint) passed clean
- [ ] CI on this PR