### PR TITLE
fix(docs): resolve stranded merge conflict markers in tutorials TOC

### DIFF
--- a/docs/tutorials/index.md
+++ b/docs/tutorials/index.md
@@ -7,27 +7,21 @@ fungible token, run a Gravity swap.
 ```{toctree}
 :maxdepth: 1
 
-<<<<<<< docs/tutorial-glyph-nft-mint
 mint-a-glyph-nft
-=======
 mint-a-glyph-ft
->>>>>>> main
 ```
 
 ## Available now
 
-<<<<<<< docs/tutorial-glyph-nft-mint
 - **[Mint a Glyph NFT](mint-a-glyph-nft.md)** — author CBOR metadata,
   build a commit transaction, wait for confirmation, build the reveal,
   and broadcast. Uses a synthetic key by default so you can run every
   step before you have a funded wallet; flip to a real WIF at the end.
-=======
 - **[Mint a Glyph FT](mint-a-glyph-ft.md)** — start-to-finish: design a
   fungible token, build the commit + reveal transactions with
   `GlyphBuilder.prepare_commit` and `prepare_ft_deploy_reveal`, and
   broadcast a single 75-byte FT output carrying the full premine
   supply. DRY_RUN by default; opt in to broadcast.
->>>>>>> main
 
 ## Coming soon
 


### PR DESCRIPTION
## Summary

The squash-merge of [PR #81](https://github.com/MudwoodLabs/pyrxd/pull/81) (\`docs(tutorials): mint a Glyph NFT\`) on top of the earlier \`mint-a-glyph-ft\` commit landed with **unresolved merge conflict markers** committed directly into \`docs/tutorials/index.md\` — six lines of \`<<<<<<<\`, \`=======\`, and \`>>>>>>>\` markers across the \`{toctree}\` directive and the "Available now" bullet list.

The Sphinx docs build did not error on these markers (the docs CI has been green on every commit since #81), but **the published docs site has been missing tutorial entries** since #81 merged — \`{toctree}\` directives silently truncate at unrecognized content, so the TOC has been broken for several days.

## Impact

1. **Published docs broken** — the [Tutorials index](https://mudwoodlabs.github.io/pyrxd/tutorials/) page renders without working entries for NFT and FT tutorials.
2. **Tutorial PRs blocked** — every subsequent tutorial PR sees a \`CONFLICTING\` state because the merge base is before the broken commit:
   - [#82](https://github.com/MudwoodLabs/pyrxd/pull/82) — inspect tutorial
   - [#85](https://github.com/MudwoodLabs/pyrxd/pull/85) — dMint claim tutorial
   - [#87](https://github.com/MudwoodLabs/pyrxd/pull/87) — first-tx tutorial

Once this fix lands, each of those three PRs can rebase on the new main and resolve their own TOC additions cleanly (each adds one line to the toctree + one bullet to the "Available now" list).

## Resolution

Keep both tutorial entries. Both \`mint-a-glyph-nft.md\` and \`mint-a-glyph-ft.md\` exist as tracked files on main; the TOC just needs to reference them both. Removed the six conflict marker lines, kept all the prose content from both sides of the conflict (the markers split the TOC into "NFT half" and "FT half" — the correct merge is the union).

## Verification

- [x] \`grep '^<<<<<<<\\|^=======$\\|^>>>>>>>' docs/tutorials/index.md\` returns nothing
- [x] File parses as valid Markdown / myST
- [x] Pre-push hook (full suite + lint) passed clean
- [ ] CI on this PR

## Followup

After this lands, I'll rebase #82, #85, #87 against the new main. Should be mechanical (each adds one toctree line + one bullet without conflict).