### PR TITLE
perf(tests): pre-mine SPV synthetic-block PoW headers → 52x test speedup

### DIFF
--- a/scripts/gen-spv-test-fixtures.py
+++ b/scripts/gen-spv-test-fixtures.py
@@ -1,0 +1,160 @@
+"""Pre-mine PoW headers for the SPV test suite's synthetic-block tests.
+
+The two slow tests in ``tests/test_spv.py`` (``test_builder_full_success_synthetic_block``
+and ``test_builder_rejects_insufficient_payment``) need a header whose
+double-SHA256 hash beats a real difficulty target. Mining one in-process
+takes ~5-30s each, dominating the entire pyrxd test suite (~33s).
+
+This script grinds the headers once and saves the nonces (plus the full
+header bytes for verification) to a JSON fixture committed under
+``tests/fixtures/spv_synthetic_headers.json``. The test class loads from
+that fixture on every run; mining only runs as a fallback when the
+fixture is missing or no longer satisfies the verifier.
+
+Regenerate manually with:
+
+    python scripts/gen-spv-test-fixtures.py
+
+Each (satoshis, hash20) tuple in :data:`FIXTURES_TO_GENERATE` produces
+one fixture entry. Add entries here if the test suite gains new
+synthetic-block tests with different inputs.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import sys
+import time
+from pathlib import Path
+
+# Import grinder + verifier from pyrxd source. Run this script from the
+# repo root with the dev venv active.
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
+from pyrxd.security.errors import SpvVerificationError
+from pyrxd.spv import verify_header_pow
+
+# Match exactly the static parameters used by tests/test_spv.py:
+#   - version = 0x20000000 (LE)
+#   - prev / anchor = b"\x99" * 32
+#   - nbits = 0x1d7fffff (LE: ff ff 7f 1d) — large target, exponent 0x1d
+#   - time = 0
+#   - merkle_root = hash256(b"\xab"*32 || hash256(raw_tx))
+HEADER_VERSION = b"\x00\x00\x00\x20"
+HEADER_ANCHOR = b"\x99" * 32
+HEADER_NBITS = b"\xff\xff\x7f\x1d"
+HEADER_TIME = b"\x00\x00\x00\x00"
+
+MERKLE_SIBLING_LE = b"\xab" * 32
+
+
+def hash256(data: bytes) -> bytes:
+    return hashlib.sha256(hashlib.sha256(data).digest()).digest()
+
+
+def p2pkh_output(satoshis: int, hash20: bytes) -> bytes:
+    """Match tests/test_spv.py:_p2pkh_output exactly."""
+    if len(hash20) != 20:
+        raise ValueError(f"hash20 must be 20 bytes, got {len(hash20)}")
+    # value (8 bytes LE) + script_len + OP_DUP OP_HASH160 <push 20> <pkh> OP_EQUALVERIFY OP_CHECKSIG
+    script = b"\x76\xa9\x14" + hash20 + b"\x88\xac"
+    return satoshis.to_bytes(8, "little") + bytes([len(script)]) + script
+
+
+def build_raw_tx(satoshis: int, hash20: bytes) -> tuple[bytes, bytes]:
+    """Build the synthetic raw tx + compute its txid_le. Mirrors test helper."""
+    payment_output = p2pkh_output(satoshis, hash20)
+    raw_tx = (
+        b"\x01\x00\x00\x00"  # version
+        + b"\x01"  # 1 input
+        + b"\x00" * 32  # prev txid
+        + b"\xff\xff\xff\xff"  # prev vout
+        + b"\x00"  # empty scriptSig
+        + b"\xff\xff\xff\xff"  # sequence
+        + b"\x01"  # 1 output
+        + payment_output
+        + b"\x00\x00\x00\x00"  # locktime
+    )
+    return raw_tx, hash256(raw_tx)
+
+
+def grind_header(merkle_root_le: bytes, max_tries: int = 100_000_000) -> tuple[bytes, int]:
+    """Grind a nonce until the header passes the verifier. Returns (header, nonce)."""
+    base = HEADER_VERSION + HEADER_ANCHOR + merkle_root_le + HEADER_TIME + HEADER_NBITS
+    for nonce in range(max_tries):
+        header = base + nonce.to_bytes(4, "little")
+        h = hash256(header)
+        # Fast gate before the full verifier: last 3 LE bytes must be 0
+        # (PoW target has 3 leading-zero BE bytes for exponent 0x1d / mantissa 0x7fffff)
+        if h[29] == 0 and h[30] == 0 and h[31] == 0:
+            try:
+                verify_header_pow(header)
+                return header, nonce
+            except SpvVerificationError:
+                continue
+    raise RuntimeError(f"could not grind header in {max_tries} tries")
+
+
+# All (satoshis, hash20_hex) tuples used by synthetic-block tests today.
+# Keep this in sync with tests/test_spv.py call sites of _build_synthetic_proof_inputs.
+FIXTURES_TO_GENERATE: list[tuple[int, str]] = [
+    (5000, "77" * 20),  # test_builder_full_success_synthetic_block + 2 sibling tests
+    (500, "77" * 20),  # test_builder_rejects_insufficient_payment
+]
+
+OUTPUT_PATH = Path(__file__).resolve().parents[1] / "tests" / "fixtures" / "spv_synthetic_headers.json"
+
+
+def main() -> None:
+    out: dict = {
+        "_meta": {
+            "generated_by": "scripts/gen-spv-test-fixtures.py",
+            "purpose": (
+                "Pre-mined PoW headers for tests/test_spv.py synthetic-block tests. "
+                "Saves ~33s on every test run. Regenerate if SPV protocol or verifier "
+                "semantics change."
+            ),
+            "header_params": {
+                "version_le_hex": HEADER_VERSION.hex(),
+                "anchor_hex": HEADER_ANCHOR.hex(),
+                "nbits_le_hex": HEADER_NBITS.hex(),
+                "time_le_hex": HEADER_TIME.hex(),
+                "merkle_sibling_le_hex": MERKLE_SIBLING_LE.hex(),
+            },
+            "fixture_count": len(FIXTURES_TO_GENERATE),
+        },
+        "fixtures": [],
+    }
+
+    for satoshis, hash20_hex in FIXTURES_TO_GENERATE:
+        hash20 = bytes.fromhex(hash20_hex)
+        _raw_tx, txid_le = build_raw_tx(satoshis, hash20)
+        merkle_root_le = hash256(MERKLE_SIBLING_LE + txid_le)
+
+        print(f"grinding (satoshis={satoshis}, hash20={hash20_hex})...", flush=True)
+        t0 = time.time()
+        header, nonce = grind_header(merkle_root_le)
+        dt = time.time() - t0
+        print(f"  found nonce={nonce} in {dt:.1f}s", flush=True)
+
+        out["fixtures"].append(
+            {
+                "satoshis": satoshis,
+                "hash20_hex": hash20_hex,
+                "nonce": nonce,
+                "header_hex": header.hex(),
+                "header_hash256_le_hex": hash256(header).hex(),
+                "grind_seconds": round(dt, 2),
+            }
+        )
+
+    OUTPUT_PATH.parent.mkdir(parents=True, exist_ok=True)
+    OUTPUT_PATH.write_text(json.dumps(out, indent=2) + "\n")
+    print(f"\nwrote {OUTPUT_PATH}")
+    print(
+        f"  {len(out['fixtures'])} fixtures, total grind time: {sum(f['grind_seconds'] for f in out['fixtures']):.1f}s"
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/fixtures/spv_synthetic_headers.json
+++ b/tests/fixtures/spv_synthetic_headers.json
@@ -1,0 +1,32 @@
+{
+  "_meta": {
+    "generated_by": "scripts/gen-spv-test-fixtures.py",
+    "purpose": "Pre-mined PoW headers for tests/test_spv.py synthetic-block tests. Saves ~33s on every test run. Regenerate if SPV protocol or verifier semantics change.",
+    "header_params": {
+      "version_le_hex": "00000020",
+      "anchor_hex": "9999999999999999999999999999999999999999999999999999999999999999",
+      "nbits_le_hex": "ffff7f1d",
+      "time_le_hex": "00000000",
+      "merkle_sibling_le_hex": "abababababababababababababababababababababababababababababababab"
+    },
+    "fixture_count": 2
+  },
+  "fixtures": [
+    {
+      "satoshis": 5000,
+      "hash20_hex": "7777777777777777777777777777777777777777",
+      "nonce": 28660750,
+      "header_hex": "0000002099999999999999999999999999999999999999999999999999999999999999995293517966b2cf8713ece2f0ab446007bac9afd5cfd7b7a25bec699f6b3da60c00000000ffff7f1d0e54b501",
+      "header_hash256_le_hex": "40aadadf6a3cb26c71f4e054fb6f93b386a38e1a0c94ca3222b9c8497c000000",
+      "grind_seconds": 14.78
+    },
+    {
+      "satoshis": 500,
+      "hash20_hex": "7777777777777777777777777777777777777777",
+      "nonce": 6392320,
+      "header_hex": "0000002099999999999999999999999999999999999999999999999999999999999999999addc2307316820425c1c7bebe0e78b378db321d0a6b9fbef63cced37c90980a00000000ffff7f1d008a6100",
+      "header_hash256_le_hex": "1b30e65480f537973771b8e059e62b38666ecd54879ec2bc3ff62e014d000000",
+      "grind_seconds": 3.42
+    }
+  ]
+}

--- a/tests/test_spv.py
+++ b/tests/test_spv.py
@@ -738,7 +738,10 @@ class TestSpvProofBuilder:
         target_BE = 0x000000_7fffff_00..00 — hash_BE first 3 bytes must be 0
         (equivalently hash_LE last 3 bytes must be 0), so probability 1/2^24.
         Fast-path: hash directly with hashlib and only call the full verifier
-        on matches. This finishes within ~5 seconds on CPython.
+        on matches. This finishes within ~5-30s on CPython, so the test class
+        loads pre-mined headers from a fixture file (see :meth:`_load_pow_fixture`)
+        and only falls back to this grinder if the fixture is missing or no
+        longer satisfies the verifier.
         """
         time_field = b"\x00\x00\x00\x00"
         base = version + prev + merkle_le + time_field + nbits
@@ -755,8 +758,47 @@ class TestSpvProofBuilder:
                     continue
         raise RuntimeError("could not grind header in 100M tries")
 
+    @staticmethod
+    def _load_pow_fixture(satoshis: int, hash20: bytes) -> bytes | None:
+        """Return a pre-mined header for (satoshis, hash20) if available.
+
+        Loads from ``tests/fixtures/spv_synthetic_headers.json`` (generated
+        by ``scripts/gen-spv-test-fixtures.py``). Each fixture entry is
+        re-verified against the current PoW verifier before use — if the
+        verifier semantics changed, the fixture is silently ignored and
+        the caller falls back to in-process grinding.
+
+        Returns ``None`` if no fixture exists for the requested inputs OR
+        if the fixture header no longer satisfies the verifier.
+        """
+        import json
+        from pathlib import Path
+
+        fixture_path = Path(__file__).parent / "fixtures" / "spv_synthetic_headers.json"
+        if not fixture_path.exists():
+            return None
+        try:
+            data = json.loads(fixture_path.read_text())
+        except (json.JSONDecodeError, OSError):
+            return None
+
+        hash20_hex = hash20.hex()
+        for entry in data.get("fixtures", []):
+            if entry.get("satoshis") == satoshis and entry.get("hash20_hex") == hash20_hex:
+                header = bytes.fromhex(entry["header_hex"])
+                # Re-verify against the current verifier — if PoW semantics
+                # changed since the fixture was generated, fall through to
+                # grinding so the test still runs (just slowly).
+                try:
+                    verify_header_pow(header)
+                    return header
+                except SpvVerificationError:
+                    return None
+        return None
+
     # Class-level cache of ground synthetic headers, keyed by (satoshis, hash20).
-    # Each grind takes ~5s on CPython; cache avoids repeat work across tests.
+    # In normal use this stays empty — the fixture loader catches everything.
+    # Cache + grinder are kept as a fallback for inputs not in the fixture.
     _synthetic_cache: dict = {}
 
     def _build_synthetic_proof_inputs(
@@ -796,7 +838,20 @@ class TestSpvProofBuilder:
 
         anchor = b"\x99" * 32
         nbits = b"\xff\xff\x7f\x1d"  # large target, exponent 0x1d
-        header = self._grind_header(b"\x00\x00\x00\x20", anchor, merkle_root_le, nbits)
+        # Prefer the pre-mined fixture (saves ~33s per test run); fall back
+        # to in-process grinding if no fixture matches these inputs.
+        header = self._load_pow_fixture(satoshis, hash20)
+        if header is None:
+            import warnings
+
+            warnings.warn(
+                f"no pre-mined PoW header for (satoshis={satoshis}, "
+                f"hash20={hash20.hex()}) — falling back to in-process grind "
+                f"(~5-30s). Regenerate fixture via "
+                f"`python scripts/gen-spv-test-fixtures.py`.",
+                stacklevel=2,
+            )
+            header = self._grind_header(b"\x00\x00\x00\x20", anchor, merkle_root_le, nbits)
         result = (
             txid_be_hex,
             raw_tx.hex(),


### PR DESCRIPTION
## Summary

Two SPV proof-builder tests need a header whose double-SHA256 hash beats a real PoW difficulty target. Mining the header in-process took **~33s combined** — that's been the longest test in the suite for a while.

This PR pre-mines the two needed headers once and saves them to a committed fixture file. The test class loads from the fixture on every run; the existing in-process grinder stays as a fallback.

## Before / after

| Scope | Before | After | Δ |
|---|---|---|---|
| `tests/test_spv.py` | 33.82s | **0.65s** | **52x faster** |
| Full pyrxd suite | 85.67s | 32.34s | ~2.6x faster |
| `test_builder_full_success_synthetic_block` | 27.1s | <0.01s | — |
| `test_builder_rejects_insufficient_payment` | 6.0s | <0.01s | — |

All 2885 tests still pass. No semantic changes.

## How it works

- `scripts/gen-spv-test-fixtures.py` (new, ~150 LOC) replicates the test's synthetic-block construction exactly, grinds a valid PoW header for each `(satoshis, hash20)` pair the suite uses, and writes the result to `tests/fixtures/spv_synthetic_headers.json` (~1.5 KB).
- `_build_synthetic_proof_inputs` now calls `_load_pow_fixture(satoshis, hash20)` first. If a matching entry exists AND still passes the current `verify_header_pow`, the header is used directly. Otherwise the existing grinder runs as a fallback with a `UserWarning` telling the user to regenerate.
- The fixture loader re-verifies each entry on load. If PoW semantics ever change, the stale fixture is silently ignored and the grinder fires — no coordinated regen-then-merge needed.

## Why this pattern

Same shape as the Photonic-vectors bridge script in PR #106 (`scripts/gen-photonic-vectors/`): pre-compute expensive deterministic test data, commit the result, validate against the real implementation on every test run.

## To regenerate

```bash
python scripts/gen-spv-test-fixtures.py
```

Add entries to `FIXTURES_TO_GENERATE` in that script if new synthetic-block tests need different inputs.

## Test plan

- [x] `tests/test_spv.py` — 73/73 pass in 0.65s
- [x] Full pyrxd regression — 2885/2885 pass in 32.34s, no new test failures, no new warnings
- [x] Fallback path — temporarily renaming the fixture file forces the grinder, the test still passes (just slow), with the documented UserWarning
- [x] Lint + format clean (no `--no-verify` needed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)