### PR TITLE
fix(miner): terminate parallel-miner workers on every exit path

### DIFF
--- a/src/pyrxd/contrib/miner/parallel.py
+++ b/src/pyrxd/contrib/miner/parallel.py
@@ -26,7 +26,10 @@ from __future__ import annotations
 import hashlib
 import multiprocessing as mp
 import os
+import signal
 import time
+from collections.abc import Iterator
+from contextlib import contextmanager
 from dataclasses import dataclass
 
 from .protocol import MAX_SHA256D_TARGET, MineExhausted, MineSuccess
@@ -133,28 +136,35 @@ def mine(params: MineParams) -> MineSuccess | MineExhausted:
     # attempts_counter: aggregate across workers. "Q" same rationale.
     attempts_counter = ctx.Value("Q", 0)
 
-    procs = []
+    procs: list[mp.process.BaseProcess] = []
     started = time.monotonic()
-    for worker_id in range(params.n_workers):
-        p = ctx.Process(
-            target=_worker,
-            args=(
-                params.preimage,
-                params.target,
-                params.nonce_width,
-                worker_id,  # start
-                params.nonce_max,  # stop
-                params.n_workers,  # stride
-                found_event,
-                found_value,
-                attempts_counter,
-            ),
-        )
-        p.start()
-        procs.append(p)
+    # All worker management runs under _ensure_workers_terminated so that
+    # any exit path — normal return, exception, SIGTERM, SIGINT, KeyboardInterrupt —
+    # leaves no orphaned worker processes consuming CPU after this function returns.
+    # Historically (pre-2026-05) this code only used `p.join()`; a pytest crash
+    # or timeout during mine() would orphan up to N workers that continued
+    # grinding until they hit nonce_max, eating cores indefinitely.
+    with _ensure_workers_terminated(procs):
+        for worker_id in range(params.n_workers):
+            p = ctx.Process(
+                target=_worker,
+                args=(
+                    params.preimage,
+                    params.target,
+                    params.nonce_width,
+                    worker_id,  # start
+                    params.nonce_max,  # stop
+                    params.n_workers,  # stride
+                    found_event,
+                    found_value,
+                    attempts_counter,
+                ),
+            )
+            p.start()
+            procs.append(p)
 
-    for p in procs:
-        p.join()
+        for p in procs:
+            p.join()
 
     elapsed = time.monotonic() - started
 
@@ -168,6 +178,62 @@ def mine(params: MineParams) -> MineSuccess | MineExhausted:
         attempts=attempts_counter.value,
         elapsed_s=elapsed,
     )
+
+
+# Grace period for cooperative shutdown after found_event is set.
+# Workers poll the event every `check_interval` hashes (~256 hashes in
+# the current impl), so this should be near-instantaneous in practice.
+_WORKER_TERMINATE_GRACE_S = 1.0
+# Hard kill grace after SIGTERM. If a worker is in a tight C loop and
+# ignores SIGTERM, SIGKILL after this.
+_WORKER_KILL_GRACE_S = 0.5
+
+
+@contextmanager
+def _ensure_workers_terminated(
+    procs: list[mp.process.BaseProcess],
+) -> Iterator[None]:
+    """Guarantee every spawned worker is reaped before this context exits.
+
+    Catches every interrupt path that can leak workers:
+
+    1. Normal completion — procs already joined; terminate() is a no-op.
+    2. Unhandled exception inside the with-block — terminate + join all.
+    3. KeyboardInterrupt (Ctrl-C) — same as above.
+    4. SIGTERM delivered to the parent (pytest --timeout, OOM killer,
+       `kill <pid>`) — restored signal handler triggers cleanup via
+       a raised KeyboardInterrupt-style interrupt, then we cascade
+       terminate() to children.
+
+    The SIGTERM handler is installed only for the duration of the
+    context and is restored afterward, so we don't pollute callers'
+    signal handling.
+    """
+
+    # Install a SIGTERM handler that cascades to children. SIGINT
+    # (Ctrl-C) already raises KeyboardInterrupt which the finally
+    # block catches; SIGTERM by default just kills the process
+    # without finally running, so we explicitly handle it.
+    def _sigterm_to_keyboard_interrupt(_signum: int, _frame: object) -> None:
+        raise KeyboardInterrupt("SIGTERM received — terminating mine() workers")
+
+    previous_handler = signal.signal(signal.SIGTERM, _sigterm_to_keyboard_interrupt)
+    try:
+        yield
+    finally:
+        # Restore the caller's SIGTERM handler before doing the cleanup
+        # work itself, so a second SIGTERM during cleanup behaves
+        # normally rather than recursing.
+        signal.signal(signal.SIGTERM, previous_handler)
+        for p in procs:
+            if p.is_alive():
+                p.terminate()
+        for p in procs:
+            p.join(_WORKER_TERMINATE_GRACE_S)
+            if p.is_alive():
+                # Worker ignored SIGTERM — escalate to SIGKILL.
+                p.kill()
+                p.join(_WORKER_KILL_GRACE_S)
 
 
 def default_n_workers() -> int:

--- a/tests/contrib/test_miner_parallel.py
+++ b/tests/contrib/test_miner_parallel.py
@@ -257,3 +257,243 @@ class TestDefaultNWorkers:
         """Some sandboxed environments make os.cpu_count() return None.
         The helper must still produce a usable integer ≥ 1."""
         assert default_n_workers() >= 1
+
+
+# ---------------------------------------------------------------------------
+# Orphan-prevention regression tests
+#
+# Historical bug (saved in pyrxd memory as
+# `project_orphan_workers_diagnostic`): pytest crashes or timeouts during
+# mine() left up to N worker processes orphaned, each grinding to nonce_max
+# at 99.9% CPU until they finished naturally. Fix: mine() now uses
+# _ensure_workers_terminated to guarantee cleanup on any exit path.
+#
+# These tests spawn mine() in a SEPARATE subprocess so we can simulate
+# interruption mid-mine and then assert that no grandchildren survived.
+# ---------------------------------------------------------------------------
+
+
+def _run_long_mine_in_subprocess() -> None:
+    """Entry point used by the orphan-prevention tests.
+
+    Starts mine() with a huge nonce_max so it WOULD run for a long time.
+    The parent kills this subprocess; the orphan-prevention machinery in
+    mine() must terminate all workers before this process dies.
+    """
+    from pyrxd.contrib.miner.parallel import MineParams, mine
+
+    mine(
+        MineParams(
+            preimage=bytes.fromhex("ab" * 64),
+            target=1,  # impossibly tight → workers will grind to nonce_max
+            nonce_width=8,
+            n_workers=2,
+            # 2^40 nonces × 2 workers — would take hours without cleanup.
+            nonce_max=2**40,
+        )
+    )
+
+
+def _run_short_mine_in_subprocess() -> None:
+    """Entry point: mine() that exhausts naturally in milliseconds.
+
+    Used by the baseline orphan test to verify that even a clean,
+    non-interrupted mine() reaps its workers before returning.
+    """
+    from pyrxd.contrib.miner.parallel import MineParams, mine
+
+    mine(
+        MineParams(
+            preimage=bytes.fromhex("ab" * 64),
+            target=0x7FFFFFFFFFFFFFFF,
+            nonce_width=4,
+            n_workers=2,
+            nonce_max=256,
+        )
+    )
+
+
+class TestOrphanPrevention:
+    """Regression tests for the parallel-miner orphan-worker leak.
+
+    Pattern: spawn a python subprocess that runs mine() with an impossible
+    target + huge nonce_max. Send the subprocess a signal (SIGTERM /
+    SIGINT). After the subprocess exits, confirm no grandchild Python
+    processes remain.
+    """
+
+    @staticmethod
+    def _spawn_mine_subprocess() -> mp.process.BaseProcess:
+        """Spawn _run_long_mine_in_subprocess in a fresh process."""
+        ctx = mp.get_context("spawn")
+        p = ctx.Process(target=_run_long_mine_in_subprocess)
+        p.start()
+        return p
+
+    @staticmethod
+    def _wait_for_workers_to_start(parent_pid: int, want: int = 2, timeout_s: float = 5.0) -> None:
+        """Block until ``parent_pid`` has at least ``want`` python children."""
+        import time
+
+        deadline = time.monotonic() + timeout_s
+        while time.monotonic() < deadline:
+            n = TestOrphanPrevention._count_python_children(parent_pid)
+            if n >= want:
+                return
+            time.sleep(0.05)
+        raise AssertionError(f"timed out waiting for {want} workers under PID {parent_pid}")
+
+    @staticmethod
+    def _count_python_children(parent_pid: int) -> int:
+        """Count direct children of parent_pid via /proc.
+
+        Uses /proc/<pid>/task/<pid>/children which is a file (not a dir)
+        containing space-separated child PIDs.
+        """
+        try:
+            with open(f"/proc/{parent_pid}/task/{parent_pid}/children") as f:
+                content = f.read().strip()
+        except (FileNotFoundError, PermissionError):
+            return 0
+        if not content:
+            return 0
+        return len(content.split())
+
+    @staticmethod
+    def _direct_children(parent_pid: int) -> list[int]:
+        """Return the direct child PIDs of parent_pid."""
+        try:
+            with open(f"/proc/{parent_pid}/task/{parent_pid}/children") as f:
+                content = f.read().strip()
+        except (FileNotFoundError, PermissionError):
+            return []
+        if not content:
+            return []
+        return [int(s) for s in content.split()]
+
+    @staticmethod
+    def _pid_alive(pid: int) -> bool:
+        """True iff /proc/<pid> exists AND the process is not a zombie.
+
+        Zombies still show in /proc until reaped, but they're not consuming
+        CPU. Treat them as dead for the orphan-detection purpose: the
+        original bug was workers eating 99.9% CPU, which zombies don't.
+        """
+        try:
+            with open(f"/proc/{pid}/status") as f:
+                status = f.read()
+        except (FileNotFoundError, PermissionError):
+            return False
+        state_line = next((ln for ln in status.split("\n") if ln.startswith("State:")), "")
+        if not state_line:
+            return False
+        # 'Z' = zombie. Anything else (R, S, D, T, t, X) we treat as alive.
+        return "Z" not in state_line.split(":", 1)[1]
+
+    def test_normal_completion_leaves_no_orphans(self):
+        """Sanity baseline: a tiny mine() that exhausts naturally leaves
+        no orphans after the subprocess exits.
+
+        Why a subprocess and not an in-process mine()? Running mine()
+        in-process makes the workers direct children of the pytest
+        runner, which also spawns its own helpers (xdist, coverage,
+        plugin processes). Diffing /proc children before/after picks
+        up those unrelated helpers as false positives. A subprocess
+        gives us a clean parent boundary.
+        """
+        import time
+
+        ctx = mp.get_context("spawn")
+        p = ctx.Process(target=_run_short_mine_in_subprocess)
+        p.start()
+        worker_pids: list[int] = []
+        try:
+            # Workers appear, then the tiny nonce_max=256 sweep exhausts
+            # in <100ms. Race: workers may have already exited by the
+            # time we read /proc/<p.pid>/task/.../children. That's fine
+            # — if worker_pids is empty we just have nothing to check.
+            self._wait_for_workers_to_start(p.pid, want=1, timeout_s=5.0)
+            worker_pids = self._direct_children(p.pid)
+        except AssertionError:
+            # Workers came and went before we could observe them — that
+            # IS the happy path for natural completion. Fall through and
+            # let p.join() confirm clean exit.
+            pass
+
+        p.join(timeout=10.0)
+        assert not p.is_alive(), "mine() subprocess did not exit cleanly"
+        assert p.exitcode == 0, f"subprocess exit code {p.exitcode}"
+
+        time.sleep(0.25)
+        survivors = [pid for pid in worker_pids if self._pid_alive(pid)]
+        assert not survivors, f"normal mine() leaked workers: {sorted(survivors)}"
+
+    def test_sigterm_terminates_all_workers(self):
+        """The regression test for the original bug.
+
+        Pattern: capture the worker PIDs while the parent is still alive
+        (so /proc/<parent>/task/<parent>/children is still readable), THEN
+        send SIGTERM to the parent. After the parent exits, the workers
+        get re-parented to init (PID 1) — we can't find them by walking
+        from the dead parent, so we have to remember who they were.
+        """
+        import os
+        import signal as signal_mod
+        import time
+
+        p = self._spawn_mine_subprocess()
+        worker_pids: list[int] = []
+        try:
+            self._wait_for_workers_to_start(p.pid, want=2, timeout_s=5.0)
+            worker_pids = self._direct_children(p.pid)
+            assert len(worker_pids) >= 2, f"expected ≥2 workers under parent {p.pid}, got {worker_pids}"
+
+            os.kill(p.pid, signal_mod.SIGTERM)
+            p.join(timeout=5.0)
+            assert not p.is_alive(), "mine() subprocess did not exit within 5s of SIGTERM"
+
+            # Give the OS up to 1s to fully reap children.
+            time.sleep(1.0)
+            survivors = [pid for pid in worker_pids if self._pid_alive(pid)]
+            assert not survivors, f"SIGTERM left {len(survivors)} orphan workers behind: {survivors}"
+        finally:
+            if p.is_alive():
+                p.kill()
+                p.join(timeout=2.0)
+            for orphan in worker_pids:
+                if self._pid_alive(orphan):
+                    try:
+                        os.kill(orphan, signal_mod.SIGKILL)
+                    except ProcessLookupError:
+                        pass
+
+    def test_keyboard_interrupt_terminates_all_workers(self):
+        """Same as SIGTERM but via SIGINT (Ctrl-C / KeyboardInterrupt)."""
+        import os
+        import signal as signal_mod
+        import time
+
+        p = self._spawn_mine_subprocess()
+        worker_pids: list[int] = []
+        try:
+            self._wait_for_workers_to_start(p.pid, want=2, timeout_s=5.0)
+            worker_pids = self._direct_children(p.pid)
+            assert len(worker_pids) >= 2
+
+            os.kill(p.pid, signal_mod.SIGINT)
+            p.join(timeout=5.0)
+            assert not p.is_alive()
+
+            time.sleep(1.0)
+            survivors = [pid for pid in worker_pids if self._pid_alive(pid)]
+            assert not survivors, f"SIGINT left {len(survivors)} orphan workers behind: {survivors}"
+        finally:
+            if p.is_alive():
+                p.kill()
+                p.join(timeout=2.0)
+            for orphan in worker_pids:
+                if self._pid_alive(orphan):
+                    try:
+                        os.kill(orphan, signal_mod.SIGKILL)
+                    except ProcessLookupError:
+                        pass


### PR DESCRIPTION
## Summary

- `mine()` in `src/pyrxd/contrib/miner/parallel.py` spawned N multiprocessing workers and joined them in a bare loop with no `try/finally`. Any non-natural exit (SIGTERM from `pytest-timeout`/OOM kill/`kill <pid>`, unhandled exception, KeyboardInterrupt) left the workers grinding to `nonce_max` (up to `2**40` for V2) under init/systemd-user. Observed twice in the wild on this machine as 15+ orphan workers at 99.9% CPU each.
- Wrap the spawn-and-join block in a new `_ensure_workers_terminated` context manager that installs a SIGTERM handler (raises `KeyboardInterrupt` so SIGTERM funnels into the same cleanup path as Ctrl-C), then on exit `terminate()` → `join(1.0s)` → `kill()` + `join(0.5s)` for any worker that ignored SIGTERM. Restores the caller's SIGTERM handler before running cleanup, so a second SIGTERM during shutdown behaves normally instead of recursing.
- Adds three regression tests in `TestOrphanPrevention`. The SIGTERM test was verified to FAIL against pre-fix main (2 orphan workers survived) and PASS against the fix.

## Test plan

- [x] `pytest tests/contrib/test_miner_parallel.py` — 16/16 pass on the fix
- [x] Confirmed `test_sigterm_terminates_all_workers` FAILS against pre-fix `parallel.py` (the bug is real; the test catches it)
- [x] Full test suite: 3019 passed, 12 skipped via pre-push hook
- [x] `ruff check` + `ruff format --check` clean

## Test-pattern note

The tests use a "capture worker PIDs before parent dies" pattern: when the parent exits, workers are re-parented to init/systemd-user and the parent's `/proc/<pid>/task/...` is gone, so walking from the dead parent finds nothing. You have to remember which PIDs you were watching before the signal is sent.