### PR TITLE
ci(trufflehog): wire defense-in-depth secret scanner (closes #21)

### DIFF
--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -1,0 +1,66 @@
+# gitleaks — defense-in-depth secret scanner.
+#
+# pyrxd has `detect-secrets` as a pre-commit hook (per #17), but a
+# contributor without pre-commit installed — or one who runs
+# `--no-verify` — bypasses local checks entirely. CI is the only
+# enforcement point we can trust for outside contributors and for
+# our own moments of haste. See issue #21 for the full rationale.
+#
+# Config lives in `.gitleaks.toml` at repo root: `useDefault = true`
+# plus a small scoped allowlist for well-known published test
+# vectors (BIP-32, secp256k1 RFC-6979) that the default ruleset
+# misclassifies as generic API keys. Do NOT extend that allowlist
+# without reviewing each rule.
+
+name: Gitleaks
+
+on:
+  # PR-scan: every PR gets a fresh secret scan against its diff +
+  # whatever's in the worktree. Blocks merge if a secret is found.
+  pull_request:
+    branches: [main]
+  # Push-scan: catches anything that lands on main directly (admin
+  # override of branch protection, etc.).
+  push:
+    branches: [main]
+  # Weekly full-history audit. The PR/push scans only cover the
+  # current head; a scheduled run re-scans the whole git history,
+  # catching anything that slipped in before this workflow existed
+  # or before a new rule was added to the default ruleset.
+  # Staggered from CodeQL (06:00) and Scorecard (07:00) to avoid
+  # competing for runner capacity.
+  schedule:
+    - cron: "0 8 * * 1"
+
+permissions:
+  contents: read
+
+# Cancel in-flight runs when a new commit lands on the same branch/PR.
+# Matches the cancellation policy in ci.yml / codeql.yml / lint.yml /
+# osv-scanner.yml (per #89). Free Actions minutes are not free.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  scan:
+    name: Scan for leaked secrets
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          # Full history for the weekly scheduled scan; the PR/push
+          # scans don't strictly need it but the action handles
+          # incremental scans efficiently either way.
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Gitleaks scan
+        uses: gitleaks/gitleaks-action@ff98106e4c7b2bc287b24eaf42907196329070c7  # v2.3.9
+        env:
+          # The action publishes Gitleaks ORG-tier license info to
+          # GITLEAKS_LICENSE; we don't have one (free OSS use) and
+          # the action runs without it for public repos. No secret
+          # required for our use case.
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/trufflehog.yml
+++ b/.github/workflows/trufflehog.yml
@@ -1,4 +1,4 @@
-# gitleaks — defense-in-depth secret scanner.
+# trufflehog — defense-in-depth secret scanner.
 #
 # pyrxd has `detect-secrets` as a pre-commit hook (per #17), but a
 # contributor without pre-commit installed — or one who runs
@@ -6,13 +6,20 @@
 # enforcement point we can trust for outside contributors and for
 # our own moments of haste. See issue #21 for the full rationale.
 #
-# Config lives in `.gitleaks.toml` at repo root: `useDefault = true`
-# plus a small scoped allowlist for well-known published test
-# vectors (BIP-32, secp256k1 RFC-6979) that the default ruleset
-# misclassifies as generic API keys. Do NOT extend that allowlist
-# without reviewing each rule.
+# Why trufflehog and not gitleaks: gitleaks-action@v2 requires a paid
+# license key (`GITLEAKS_LICENSE`) for any repository owned by a
+# GitHub *organization*, including ours. The gitleaks CLI is MIT but
+# the official action wrapper is paywalled for orgs. trufflehog
+# (trufflesecurity/trufflehog) has equivalent scanning, fully OSS,
+# no license requirement, and is already used by sibling repos in
+# the MudwoodLabs org (e.g. radiant-glyph-guide).
+#
+# The `.gitleaks.toml` config at repo root remains in place because
+# pre-commit's local `detect-secrets` + `gitleaks` hooks still read
+# it. trufflehog has its own ruleset baked into the binary and
+# does not require a config file for the defense-in-depth use case.
 
-name: Gitleaks
+name: trufflehog
 
 on:
   # PR-scan: every PR gets a fresh secret scan against its diff +
@@ -26,11 +33,12 @@ on:
   # Weekly full-history audit. The PR/push scans only cover the
   # current head; a scheduled run re-scans the whole git history,
   # catching anything that slipped in before this workflow existed
-  # or before a new rule was added to the default ruleset.
+  # or before a new rule was added to trufflehog's default ruleset.
   # Staggered from CodeQL (06:00) and Scorecard (07:00) to avoid
   # competing for runner capacity.
   schedule:
     - cron: "0 8 * * 1"
+  workflow_dispatch:
 
 permissions:
   contents: read
@@ -50,17 +58,18 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
-          # Full history for the weekly scheduled scan; the PR/push
-          # scans don't strictly need it but the action handles
+          # Full history for the weekly scheduled scan. The PR/push
+          # scans don't strictly need it but trufflehog handles
           # incremental scans efficiently either way.
           fetch-depth: 0
           persist-credentials: false
 
-      - name: Gitleaks scan
-        uses: gitleaks/gitleaks-action@ff98106e4c7b2bc287b24eaf42907196329070c7  # v2.3.9
-        env:
-          # The action publishes Gitleaks ORG-tier license info to
-          # GITLEAKS_LICENSE; we don't have one (free OSS use) and
-          # the action runs without it for public repos. No secret
-          # required for our use case.
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Trufflehog scan
+        uses: trufflesecurity/trufflehog@37b77001d0174ebec2fcca2bd83ff83a6d45a3ab  # v3.95.3
+        with:
+          # --results=verified,unknown — flag verified leaks (real
+          # credentials confirmed by the issuer's API) and unknown
+          # matches (pattern matches that couldn't be auto-verified).
+          # Skips unverified because that bucket is mostly noise from
+          # documentation examples and test vectors.
+          extra_args: --results=verified,unknown


### PR DESCRIPTION
## Summary

\`pyrxd\` has \`detect-secrets\` as a pre-commit hook (per #17), but a contributor without \`pre-commit\` installed — or one who runs \`--no-verify\` — bypasses local checks entirely. CI is the only enforcement point we can trust. \`.gitleaks.toml\` was configured in the repo root for some time but never wired into a workflow. This PR adds the workflow.

## What ships

\`.github/workflows/gitleaks.yml\` — single-job workflow that runs \`gitleaks/gitleaks-action@v2.3.9\` (SHA-pinned per the repo's existing convention).

Three triggers:

- **\`pull_request\`** — fresh secret scan on every PR (the primary value: blocks merge if a secret slips into a diff).
- **\`push\` to main** — catches anything that lands on main directly (admin override of branch protection, force-push by maintainer, etc.).
- **Weekly \`schedule\`** — full-history audit. PR/push scans only cover the current head; a scheduled run re-scans the whole git history, catching anything that slipped in before this workflow existed or before a new rule was added to the default ruleset. Mondays 08:00 UTC, staggered from CodeQL (06:00) and Scorecard (07:00).

Plus the standard pyrxd CI hygiene already in every other workflow:

- Concurrency cancellation on push/PR refresh (per #89).
- SHA-pinned action with version comment.
- \`permissions: contents: read\` only.
- \`persist-credentials: false\` on checkout.

## What does NOT change

- \`.gitleaks.toml\` is unmodified — it already does the right thing (\`useDefault = true\` + scoped allowlist for well-known published test vectors like the BIP-32 reference vectors).
- \`detect-secrets\` pre-commit hook stays in place — it remains the first line of defense; gitleaks-in-CI is defense-in-depth, not a replacement.

## Test plan

- [x] YAML syntax validates (\`python3 -c \"import yaml; yaml.safe_load(...)\"\`)
- [x] Workflow file follows the existing pattern (SHA-pinned action, version comment, concurrency block)
- [ ] CI on this PR runs the workflow against the PR head — that's the real first test