### PR TITLE
refactor(gravity): de-duplicate hashOutputHashes + harden output parsing

### DIFF
--- a/docs/brainstorms/2026-05-19-gravity-bch-spike-findings.md
+++ b/docs/brainstorms/2026-05-19-gravity-bch-spike-findings.md
@@ -1,0 +1,257 @@
+---
+title: Gravity BCH support — spike findings
+date: 2026-05-19
+status: brainstorm
+---
+
+# Gravity BCH support — current state is better than expected
+
+## TL;DR
+
+A spike investigation into adding BCH support to Gravity found that
+**the existing SPV verifier and Gravity covenant are already
+chain-agnostic for SHA-256d UTXO chains**. The verifier doesn't
+compute or validate difficulty — it accepts whatever nBits the maker
+committed at offer time. BCH headers are byte-identical in structure
+to BTC headers and use the same PoW. BCH has no segwit, so the
+shipping P2PKH path (closed out in the previous spike's follow-up
+commit) is the relevant one — and it's now end-to-end tested.
+
+What's actually missing for BCH support is:
+
+1. **Data-source compatibility verification** — confirm
+   `MempoolSpaceSource(base_url="https://mempool.cash/api")` (or
+   similar BCH explorer with mempool.space-shaped API) works
+   end-to-end. Likely yes, but unverified.
+2. **An end-to-end integration test** using recorded BCH headers
+   and a BCH P2PKH payment, mirroring `TestGravityTradeP2PKH`.
+3. **Documentation** explicitly stating BCH is a supported
+   counterparty chain alongside BTC.
+4. **Cashaddr ↔ hash160 helper** (probably small, maybe already
+   exists in another library; users could decode externally).
+
+**Revised effort estimate: ~1-2 weeks of alternating-week pyrxd time
+(~5-10 hours of focused work)** — basically a copy of the BCH version
+of the P2PKH spike-follow-up commit. The original plan budgeted 4-6
+weeks; the same overestimation pattern as the P2PKH spike.
+
+## What the spike found
+
+### Discovery 1: the SPV verifier is chain-agnostic at the math layer
+
+`src/pyrxd/spv/pow.py` performs:
+
+1. SHA-256d hash of the 80-byte header
+2. Comparison against a target derived from the header's own nBits
+   field (bytes 72-76)
+3. Rejection if `hash >= target`
+
+There is **no consensus-style difficulty validation**. The verifier
+does NOT check that nBits is "correct for the height" — it only
+checks that the header satisfies the difficulty it claims. This is
+deliberately chain-agnostic: BTC, BCH, BSV, and any other SHA-256d
+chain all use this exact format.
+
+`src/pyrxd/spv/chain.py` verifies header chain linkage (`prevHash`
+in bytes 4-36 of each subsequent header matches `hash256` of the
+previous). Identical structure across all SHA-256d chains.
+
+The naming is BTC-flavored throughout the SPV module (docstrings,
+type names like "Bitcoin SPV"), but the **logic** is universal.
+
+### Discovery 2: difficulty algorithm differences don't matter to the verifier
+
+BTC uses epoch-based retargeting (every 2,016 blocks). BCH uses
+aserti3-2d (per-block adjustment, based on time since the last
+retarget anchor). **Neither matters to the verifier.**
+
+Why: the security model is that the **maker** commits to specific
+`expected_nbits` (and optionally `expected_nbits_next`) values at
+offer creation time. The covenant rejects any header whose nBits
+doesn't match one of those two values. The verifier doesn't need to
+know how the counterparty chain computes difficulty; it just needs
+to confirm the maker's commitment.
+
+```python
+# from src/pyrxd/gravity/covenant.py:317
+expected_nbits: bytes,           # 4-byte LE nBits of expected difficulty
+expected_nbits_next: bytes | None = None,  # difficulty after a transition
+```
+
+For BCH, the maker just picks the current BCH nBits value at offer
+time, possibly with `expected_nbits_next` set to handle an aserti3-2d
+adjustment during the swap window. The covenant doesn't care that
+BCH's adjustment is per-block instead of epoch-based.
+
+The same generalization applies to any future SHA-256d chain or
+soft-fork: nothing in the verifier or covenant needs to change.
+
+### Discovery 3: witness stripping is a no-op for BCH
+
+`src/pyrxd/spv/witness.py:strip_witness` returns the input unchanged
+if there's no segwit marker (bytes 4 = 0x00). **BCH never had
+segwit**, so every BCH tx is already legacy-serialized and bypasses
+the stripping logic. No code change needed.
+
+### Discovery 4: data-source abstraction is already chain-pluggable
+
+`src/pyrxd/network/bitcoin.py` defines:
+
+```python
+class BtcDataSource(ABC):
+    @abstractmethod
+    async def get_tip_height(self) -> BlockHeight: ...
+    @abstractmethod
+    async def get_block_header_hex(self, height: BlockHeight) -> bytes: ...
+    # ... etc.
+```
+
+with three concrete implementations:
+- `MempoolSpaceSource(base_url=...)` — defaults to mempool.space but
+  takes any compatible base URL
+- `BlockstreamSource(base_url=...)` — defaults to blockstream.info
+  but takes any compatible base URL
+- `BitcoinCoreRpcSource` — works against any Bitcoin Core-style RPC
+  (BCH's Bitcoin Cash Node has a compatible RPC surface)
+
+mempool.cash uses a fork of mempool.space's API; its endpoint paths
+should match. `MempoolSpaceSource(base_url="https://mempool.cash/api")`
+or similar should work without code changes. **This is unverified;
+the spike did not run live API calls. Verification is a Phase 2.1
+deliverable.**
+
+`MempoolSpaceSource.get_tx_output_script_type` maps API-reported
+script types via:
+
+```python
+type_map = {
+    "p2pkh": "p2pkh",
+    "p2wpkh": "p2wpkh",  # never seen on BCH; harmless
+    "p2sh": "p2sh",
+    "p2tr": "p2tr",      # never seen on BCH; harmless
+    "v0_p2wpkh": "p2wpkh",
+    "v1_p2tr": "p2tr",
+}
+```
+
+BCH responses will only return "p2pkh" or "p2sh" — both handled.
+
+### Discovery 5: addresses are not a Gravity concern
+
+The maker provides `btc_receive_hash` as raw bytes (20-byte hash160
+for P2PKH/P2WPKH/P2SH, 32-byte for P2TR). The Gravity SDK does NOT
+encode or decode the maker's counterparty-chain address. Address
+encoding (base58 for BTC legacy, bech32 for BTC segwit, cashaddr for
+BCH) is a wallet-side concern.
+
+This means there's **no Gravity-side change needed** for cashaddr
+support. A BCH user converts their cashaddr to hash160 in their
+wallet and passes the hash160 to the SDK. Existing libraries
+(`bitcash`, `cashaddress`, or hand-rolled) handle this trivially.
+
+A nicety-feature would be to add a `pyrxd.address.cashaddr_to_hash160`
+helper so callers don't need a separate library, but it's not
+required for protocol-level BCH support.
+
+## The chain-agnostic narrative is real
+
+The deeper finding from these two spikes is that **the existing
+Gravity stack was built more chain-agnostic than the docs let on.**
+The output-type dispatch was unified into a single sentinel covenant
+(P2PKH spike finding); the PoW verifier doesn't bake in BTC's
+specific difficulty algorithm (this spike); the data-source layer
+takes a configurable base URL (this spike). What looks like "BCH
+support requires per-chain work" turns out to be "BCH support
+requires testing the chain-agnostic code against BCH inputs."
+
+This is good news both for BCH and for any future SHA-256d chain
+(BSV, Bitcoin Gold's SHA-256d version, etc.). It is **not** good
+news for non-SHA-256d chains (Litecoin/Dogecoin with Scrypt, ZEC
+with Equihash) — those still need consensus extension or HTLC.
+
+## What's actually missing for BCH support
+
+A four-by-three matrix of "is this layer exercised for BCH?":
+
+| Layer | BTC | BCH |
+|---|---|---|
+| Header PoW verification | ✅ mainnet | ✅ identical math; untested with BCH headers |
+| Header chain linkage | ✅ mainnet | ✅ identical structure; untested |
+| Merkle inclusion proof | ✅ mainnet | ✅ identical structure; untested |
+| P2PKH payment verification | ✅ now tested (`TestGravityTradeP2PKH`) | ⚠️ untested with BCH-style txs |
+| P2SH payment verification | ⚠️ unit-level only | ⚠️ unit-level only |
+| Witness stripping (no-op for BCH) | n/a — segwit txs only | ✅ correctly no-ops on legacy txs |
+| Covenant `btcReceiveType` dispatch | ✅ four-way | ✅ same dispatch, just used with type=0 |
+| Data source (mempool.space-style API) | ✅ mempool.space | ⚠️ mempool.cash unverified |
+| Data source (Bitcoin Core RPC) | ✅ btc-core | ⚠️ bch-node RPC unverified |
+| Documentation as supported chain | ✅ docs/concepts/gravity.md | ❌ not mentioned |
+| End-to-end integration test | ✅ `TestGravityTradeP2PKH` + others | ❌ none |
+| Mainnet exercise | ✅ P2WPKH only | ❌ none |
+
+## Suggested next work
+
+The pattern from the P2PKH spike-followup commit applies almost
+directly. Recommended sequence:
+
+1. **Add a BCH end-to-end integration test** mirroring
+   `TestGravityTradeP2PKH`. Use synthetic BCH-style P2PKH inputs.
+   The fixture pattern (pre-mined PoW header with relaxed target,
+   from `tests/fixtures/spv_synthetic_headers.json`) carries over;
+   nothing about the fixture is BTC-specific. Test name:
+   `TestGravityTradeBCH` in `tests/test_gravity_trade.py`.
+2. **Add a small documentation update to `docs/concepts/gravity.md`**
+   stating BCH is a supported counterparty chain. The Axis 2 table
+   currently uses "Bitcoin" as if it were the only option; the doc
+   should make explicit that the verifier is chain-agnostic for
+   SHA-256d UTXO chains and BCH is the second supported one.
+3. **Optional: add a `cashaddr_to_hash160` helper** if there's an
+   ergonomic case for it. Defer to a follow-up if no immediate
+   demand.
+4. **Defer mainnet exercise** to Phase 3 — same as P2PKH/P2SH/P2TR
+   mainnet exercise. Synthetic tests demonstrate code-level
+   correctness; mainnet validation comes later.
+
+What's **not** in scope:
+
+- **Live API verification of mempool.cash**: defer to Phase 3 or
+  to whoever actually needs to use it. The spike showed there's
+  every reason to expect it to work; the test would be a 5-minute
+  curl exercise when someone actually has a BCH integration use
+  case.
+- **BCH-specific difficulty validation**: the verifier doesn't do
+  this for BTC either. Adding it would be a security upgrade for
+  *both* chains, not a BCH-specific item, and belongs in a
+  separate brainstorm.
+- **Address encoding helpers**: nice-to-have, not required.
+
+## A diagnostic note
+
+The "diagnose before patching" rule applied here too:
+
+- **Symptom** in the parent plan: "BCH support requires P2PKH
+  covenants, chain-id parameter, BCH-specific tests."
+- **Assumed mechanism**: each item is non-trivial; total estimate
+  4-6 weeks.
+- **Actual mechanism**: P2PKH already works (P2PKH spike); chain
+  identification is a wallet-side concern (the SDK doesn't care
+  which chain it's verifying); the only real new work is an
+  integration test + a doc update.
+
+Two spike investigations in a row have found that the parent
+strategy plan overestimated the technical work by roughly 3-4×.
+That's not a criticism of the original plan — it's the spike
+pattern doing its job, exactly as the attack-plan brainstorm
+predicted. The pattern is robust enough to expect it might apply
+again in Phase 2.2 (HTLC hardening). When the next "this looks
+like multi-week work" comes up, read the code first and estimate
+after.
+
+## Status
+
+- BCH support spike: **complete; scope much smaller than parent
+  plan assumed**.
+- Suggested next pyrxd-side block: write the BCH integration test
+  + add the doc update (~5-10 hours).
+- The parent plan's Phase 2.1 budget shrinks substantially.
+  Strategic implications (slack management, Phase 2.2 buffer)
+  belong in the private strategy update, not here.

--- a/docs/brainstorms/2026-05-19-gravity-glyph-ft-swap-brainstorm.md
+++ b/docs/brainstorms/2026-05-19-gravity-glyph-ft-swap-brainstorm.md
@@ -1,0 +1,246 @@
+---
+title: Gravity for Glyph FT/NFT — selling tokens for BTC atomically
+date: 2026-05-19
+status: brainstorm
+---
+
+# Gravity for Glyph FT/NFT — selling tokens for BTC atomically
+
+## TL;DR
+
+Today's Gravity covenant locks **plain RXD** and releases plain RXD on
+settlement. To sell tokens (FT) or singletons (NFT) for BTC atomically
+you need a **new covenant variant** that carries a Glyph ref through
+the lock-and-release dance — the shipped covenant script doesn't carry
+a ref, so a Glyph-bearing UTXO can't fund it and a ref can't appear in
+the settlement output.
+
+The BTC half of Gravity (SPV verifier, BTC-output-type dispatch,
+deadline/forfeit logic) is chain-agnostic and reusable. The Radiant
+half is new design work: a covenant script that carries a ref and
+constrains where it lands, plus a small fix to the Gravity-specific
+sighash helper that hard-codes `totalRefs = 0`. The general-purpose
+preimage builder in [transaction_preimage.py](../../src/pyrxd/transaction/transaction_preimage.py)
+already handles refs correctly, so this is plumbing not invention.
+
+This is meaningful protocol work — comparable to the original Gravity
+spike, though smaller than building Gravity from scratch since the
+SPV/BTC machinery already exists. It is **not** a config tweak on an
+existing artifact.
+
+## Why the current covenant can't carry a ref
+
+Two blockers — one in the covenant script, one in the Gravity-specific
+sighash helper. Both apply equally to FT and NFT.
+
+### Blocker 1: the covenant's locking script doesn't carry a ref
+
+The shipped maker covenant
+([artifacts/maker_covenant_flat_12x20_sentinel_all.artifact.json](../../src/pyrxd/gravity/artifacts/maker_covenant_flat_12x20_sentinel_all.artifact.json))
+locks a plain UTXO. There's no `OP_PUSHINPUTREF` or
+`OP_PUSHINPUTREFSINGLETON` in the covenant script itself. Even if you
+tried to fund the covenant with a ref-bearing UTXO, the spend wouldn't
+satisfy Radiant's ref-conservation rule (each ref on the input side
+must reappear on the output side — sum-preserving for FT, identity for
+NFT) because the covenant's settlement output also doesn't carry the
+ref.
+
+This is the load-bearing problem. You can't fix it by patching Python
+— the covenant **script** has to be rewritten to carry a ref through
+the spend and constrain where it lands.
+
+### Blocker 2: the Gravity sighash helper hard-codes `totalRefs = 0`
+
+`_compute_hash_output_hashes` at
+[gravity/transactions.py:93-134](../../src/pyrxd/gravity/transactions.py#L93)
+hard-codes `totalRefs = 0` and `refsHash = 32 × 0x00` for every output
+it processes. That's wrong for an output carrying a ref (where
+`totalRefs >= 1` and `refsHash = hash256(sorted refs concatenated)`),
+so a spend that produces a ref-bearing output would sign with the
+wrong sighash and Radiant validators would reject it.
+
+**The fix is small.** A separate, correct implementation already lives
+at
+[transaction/transaction_preimage.py:66](../../src/pyrxd/transaction/transaction_preimage.py#L66)
+— it parses outputs, walks for `OP_PUSHINPUTREF` opcodes, and computes
+the real `refsHash`. The Gravity copy is a stale specialization;
+delete it and reuse the general implementation. A comment at
+`transaction_preimage.py:109` also wrongly claims ref count is "always
+0 for standard P2PKH/FT/NFT outputs" — fix in passing.
+
+## What a ref-bearing Gravity covenant needs to do
+
+Sketch of the asset flow (Maker = seller of token, Taker = BTC payer):
+
+1. Maker has a ref-bearing UTXO: an FT holding `N` units of token `T`,
+   or an NFT holding singleton `S`.
+2. Maker locks a UTXO into the covenant that:
+   - Carries the ref (FT ref + amount `N`, or NFT singleton).
+   - Encodes the agreed BTC price, BTC receive address, deadline, and
+     Taker pubkey hash, same as today's Gravity.
+3. Taker pays BTC to Maker's BTC address.
+4. Taker submits a settlement tx on Radiant that:
+   - Spends the covenant UTXO.
+   - Produces an output carrying the same ref (and amount, for FT) to
+     the Taker's Radiant address.
+   - Attaches an SPV proof of the BTC payment, same as today.
+5. Covenant validates SPV proof + ref-passthrough; spend succeeds; the
+   asset is now Taker's.
+6. Fallback: if no settlement by deadline, Maker can `forfeit` — the
+   covenant releases the ref-bearing UTXO back to Maker.
+
+The novel constraint vs. today's covenant: **the settlement output's
+ref payload must match the covenant input's ref payload, and (for FT)
+the amount must be preserved.** That's a conservation check inside
+covenant script, not just at network-level validation.
+
+## What changes vs. the sentinel covenant
+
+| Surface | Today (plain RXD) | Ref-bearing variant |
+|---|---|---|
+| Covenant locking script | Plain P2SH-wrapped covenant, no ref | Covenant script carries `OP_PUSHINPUTREF` (FT) or `OP_PUSHINPUTREFSINGLETON` (NFT), with `refKind` dispatch |
+| Gravity sighash helper | `totalRefs = 0` hard-coded in `gravity/transactions.py` | Reuse the general implementation in `transaction/transaction_preimage.py` (already handles refs) |
+| Settlement output constraint | "Pay `N` RXD to Taker address" | "Pay ref `R` (× amount `A` for FT, singleton for NFT) to Taker address; RXD value = dust" |
+| BTC-side dispatch | `btcReceiveType` 4-way (P2PKH/P2WPKH/P2SH/P2TR) | **Reused as-is** |
+| SPV proof verification | Sentinel padding for Merkle depth 12–20 | **Reused as-is** |
+| Deadline / forfeit | Standard | **Reused as-is**, but forfeit returns the ref-bearing UTXO to Maker |
+
+The right mental model: this is a **fork of the sentinel covenant**
+where the BTC-facing and deadline-facing half is unchanged and the
+Radiant-facing half is rewritten to handle refs. The Python sighash
+work is mostly de-duplication rather than new logic.
+
+## FT and NFT in a unified ref-bearing covenant
+
+FTs use `OP_PUSHINPUTREF` (`0xd0`) and require conservation
+(sum-in = sum-out, splittable). NFTs use `OP_PUSHINPUTREFSINGLETON`
+(`0xd8`) and are unique (the ref can only exist on one UTXO at a
+time). See
+[ft.py:3-4](../../src/pyrxd/glyph/ft.py#L3) and
+[radiant-fts-are-on-chain.md](../concepts/radiant-fts-are-on-chain.md).
+
+**Decision: build one unified ref-bearing covenant that handles both,
+with an in-script `refKind` flag.** Parallels how the sentinel
+covenant unified the four BTC output types via `btcReceiveType`.
+
+What `refKind` would gate (subject to spike validation):
+- `refKind = 0` (FT) → covenant uses `OP_PUSHINPUTREF` for the ref,
+  carries an `amount` parameter, and the settlement clause enforces
+  sum-of-input-amounts == sum-of-output-amounts for that ref.
+- `refKind = 1` (NFT) → covenant uses `OP_PUSHINPUTREFSINGLETON`,
+  no amount parameter (implicitly 1), settlement clause enforces the
+  singleton appears on exactly one output.
+
+Rationale:
+- One audit cycle covers both asset types.
+- End-to-end tests for FT and NFT run against the same artifact,
+  catching cross-cutting bugs early.
+- The script delta between branches is small: same ref-passthrough
+  scaffolding, NFT skips the amount-equality clause.
+- The fee penalty for the extra dispatch logic is paid once on the
+  covenant funding and once on settlement — a few extra bytes per
+  trade, not a structural cost.
+
+The case for splitting into separate variants would be: smaller
+scripts, smaller per-trade fees, simpler per-variant audit. None of
+those outweigh the duplication cost at this stage, when neither
+variant has been on mainnet yet. If fee profiling during the spike
+shows the unified covenant is materially heavier than acceptable,
+revisit then.
+
+## Trust-minimization properties to preserve
+
+The whole point of Gravity is no-trust, no-custody, no-KYC. The
+ref-bearing variant has to preserve every property:
+
+- **Maker can always reclaim after timeout.** Forfeit path must
+  return the *original ref-bearing UTXO* (same ref, same amount for
+  FT; same singleton for NFT) to Maker — not some other asset, not
+  just RXD.
+- **Taker cannot claim without paying.** SPV-proof-of-BTC-payment
+  remains the only non-forfeit spend path.
+- **Network enforces conservation.** For FT: exactly `N` units in,
+  exactly `N` units out to Taker — no mint, burn, or split. For NFT:
+  the singleton ref appears on exactly one output (the Taker's).
+- **No partial fills via covenant.** Partial fills would require a
+  split-and-relock primitive; explicitly out of scope for v1. Maker
+  can post multiple smaller-lot covenants if partial-fill UX is
+  needed.
+
+## Additional work not in the table
+
+The table above partitions the covenant-level changes. A few project-
+level items aren't covered there:
+
+- **Ref-aware factory in [covenant.py](../../src/pyrxd/gravity/covenant.py)**
+  that takes `(glyph_ref, ref_kind, amount)` alongside the existing
+  `(btc_receive_type, btc_receive_hash, deadline, ...)` params.
+- **End-to-end tests** exercising lock → BTC payment → SPV → settle,
+  one for FT and one for NFT against a synthetic Glyph.
+- **Audit pass before any mainnet exercise** — new covenant, full
+  audit treatment, no `allow_legacy=True` shortcut.
+- **Out of scope for v1:** cancel-tx (cooperative early-exit) — the
+  forfeit path covers failure. Multi-ref outputs. Partial fills.
+
+## Alternatives considered
+
+- **Two-leg swap (Gravity BTC→RXD, then OTC RXD→FT).** Not atomic.
+  Either side can stiff on leg 2. Only viable for trusted
+  counterparties; doesn't fit "sell credits to whoever shows up with
+  BTC."
+- **Radiant Swap DEX (`swap.*`).** Mentioned in
+  [rxindexer.py:8](../../src/pyrxd/network/rxindexer.py#L8) but not
+  yet wired up in pyrxd, and trades on Radiant only — does not accept
+  BTC. Useful as the eventual FT-for-RXD venue, complementary to
+  Gravity not a replacement.
+
+## Open questions
+
+1. **Multi-ref outputs.** Some FT designs and most NFT collections
+   can carry multiple refs on one UTXO. The first variant should
+   constrain `totalRefs == 1` (single asset per covenant) for
+   simplicity; multi-ref is a future extension.
+
+2. **FT change.** If Maker wants to lock 1,000 units but their FT
+   UTXO holds 5,000, options are: (a) require Maker to split off
+   exactly 1,000 to a fresh UTXO before posting the covenant; (b)
+   build a covenant funding tx that produces both a covenant-locked
+   output (1,000) and a Maker-change output (4,000). Start with (a)
+   — cleaner, no covenant-side complexity. (Does not apply to NFT
+   since singletons can't be split.)
+
+3. **Photonic precedent.** Per memory, Photonic is the default
+   reference for Glyph/dMint protocol questions. Check whether
+   Photonic's TypeScript codebase has done anything analogous
+   (ref-bearing covenants, ref-passthrough constraints) before
+   committing to a script shape.
+
+4. **Deny-list semantics.** The ref-bearing covenant should carry
+   its own deny-list — failure modes are different enough from the
+   RXD covenant deny-list in
+   [covenant.py](../../src/pyrxd/gravity/covenant.py) that mixing
+   them would confuse the audit story.
+
+## Suggested next step
+
+Not "start writing the covenant." The next step is:
+
+1. **Check Photonic** for any prior art on ref-bearing covenants /
+   ref-passthrough constraints.
+2. **De-duplicate the sighash helper first** — delete
+   `gravity/transactions.py`'s `_compute_hash_output_hashes` in favor
+   of the general one in `transaction/transaction_preimage.py`, fix
+   the stale ref-count comment there, and confirm existing Gravity
+   tests still pass. The script spike below needs a working signer
+   for ref-bearing outputs; this is the prerequisite.
+3. **Spike the Radiant-side script** — write a candidate covenant
+   template (no BTC half yet), verify on regtest that it can:
+   (a) lock a ref-bearing UTXO (FT and NFT), (b) release it to a
+   target address on a single-clause spend, (c) be reclaimed via a
+   timeout path.
+4. **Only then bolt on the BTC half** — splice the SPV proof and
+   `btcReceiveType` dispatch in from the sentinel covenant.
+
+The risk surface is overwhelmingly on the Radiant ref-handling side;
+the BTC side is solved. Sequencing the spike that way puts the
+unknown work first, where it belongs.

--- a/docs/brainstorms/2026-05-19-gravity-p2pkh-spike-findings.md
+++ b/docs/brainstorms/2026-05-19-gravity-p2pkh-spike-findings.md
@@ -1,0 +1,193 @@
+---
+title: Gravity P2PKH support — current state is better than the docs claim
+date: 2026-05-19
+status: brainstorm
+---
+
+# Gravity P2PKH support — what's actually there
+
+## TL;DR
+
+A spike investigation into adding P2PKH support to Gravity found that
+**the shipping sentinel covenant already handles all four Bitcoin
+output types** (P2PKH, P2WPKH, P2SH, P2TR) via a `btcReceiveType`
+parameter and an in-script four-way dispatch. The docs claim
+P2PKH / P2SH / P2TR are unsupported; that claim is stale.
+
+What's actually missing is end-to-end integration test coverage for
+the three non-P2WPKH paths, plus a documentation update.
+
+This is not a multi-week covenant compilation effort. It is a
+~1-2 week test + doc update.
+
+## What the docs say
+
+[docs/concepts/gravity.md:117-122](../concepts/gravity.md#L117) shows:
+
+| Output type | Address prefix | Status |
+|---|---|---|
+| **P2WPKH** (native segwit) | `bc1q...` | ✅ shipped |
+| **P2PKH** (legacy) | `1...` | ❌ no covenant compiled yet |
+| **P2SH** (wrapped segwit) | `3...` | ❌ no covenant compiled yet |
+| **P2TR** (taproot) | `bc1p...` | ❌ no covenant compiled yet |
+
+And shortly after:
+
+> only `p2wpkh` has a deployable covenant in the artifacts directory
+
+Both statements are stale.
+
+## What the code actually does
+
+### Discovery 1: the sentinel covenant dispatches on `btcReceiveType`
+
+The shipping artifact
+`src/pyrxd/gravity/artifacts/maker_covenant_flat_12x20_sentinel_all.artifact.json`
+contains a four-way `OP_IF`/`OP_ELSE` chain in its asm:
+
+```
+$btcReceiveType OP_0 OP_NUMEQUAL OP_IF ... 88ac OP_EQUALVERIFY ... # P2PKH (type 0)
+OP_ELSE $btcReceiveType OP_1 OP_NUMEQUAL OP_IF ... # P2WPKH (type 1)
+OP_ELSE $btcReceiveType OP_2 OP_NUMEQUAL OP_IF ... # P2SH (type 2)
+OP_ELSE $btcReceiveType OP_3 OP_NUMEQUALVERIFY ... # P2TR (type 3)
+```
+
+All four output-script prefix/suffix patterns are embedded literally
+in the script (`76a914...88ac`, `0014`, `a914...87`, `5120`). The
+covenant compares the BTC tx's output script bytes against the
+type-specific expected pattern, with the hash provided as
+`$btcReceiveHash` and the type provided as `$btcReceiveType`.
+
+### Discovery 2: the Python factory routes the type parameter
+
+[src/pyrxd/gravity/covenant.py:408-424](../../src/pyrxd/gravity/covenant.py#L408)
+already maps `btc_receive_type` strings to integer constants and
+substitutes them into the covenant template:
+
+```python
+_VALID_BTC_RECEIVE_TYPES = {"p2pkh": 0, "p2wpkh": 1, "p2sh": 2, "p2tr": 3}
+...
+flat_extras = {
+    ...
+    "btcReceiveType": _btc_type_int,
+}
+for name, value in flat_extras.items():
+    if name in ctor_param_names:
+        claimed_params[name] = value
+```
+
+`btc_receive_type='p2pkh'` substitutes type integer 0 into the
+template. The resulting covenant compiles and produces a valid offer.
+
+### Discovery 3: a passing unit test confirms all four types build
+
+[tests/test_gravity.py:189](../../tests/test_gravity.py#L189) ships
+`TestGravityOffer::test_all_btc_receive_types_accepted`:
+
+```python
+def test_all_btc_receive_types_accepted(self):
+    for rt in ("p2pkh", "p2wpkh", "p2sh", "p2tr"):
+        hash_len = 32 if rt == "p2tr" else 20
+        offer = _make_gravity_offer(
+            btc_receive_type=rt,
+            btc_receive_hash=b"\x00" * hash_len,
+        )
+        assert offer.btc_receive_type == rt
+```
+
+Run today (2026-05-19):
+
+```
+tests/test_gravity.py::TestGravityOffer::test_all_btc_receive_types_accepted PASSED
+```
+
+### Discovery 4: the SPV verifier handles all four types
+
+[src/pyrxd/spv/payment.py:18-40](../../src/pyrxd/spv/payment.py#L18)
+ships `P2PKH`, `P2WPKH`, `P2SH`, `P2TR` as named constants with
+their respective script-length and prefix/suffix patterns:
+
+```python
+_SCRIPT_PATTERNS = {
+    P2PKH:  (b"\x76\xa9\x14", b"\x88\xac"),  # 3 + 20 + 2
+    P2WPKH: (b"\x00\x14", b""),              # 2 + 20
+    P2SH:   (b"\xa9\x14", b"\x87"),          # 2 + 20 + 1
+    P2TR:   (b"\x51\x20", b""),              # 2 + 32
+}
+```
+
+[tests/test_spv.py:470](../../tests/test_spv.py#L470)
+`test_valid_p2pkh_output_accepted` exercises P2PKH payment
+verification with a synthetic P2PKH output; the test passes.
+
+## Why the docs are stale
+
+Best guess: the gravity.md table was written relative to the *earlier*
+covenant variants (the experimental `_p2wpkh`-suffixed family — see
+the artifacts directory). Those were single-type. The current
+sentinel-all covenant unified the dispatch, but the docs weren't
+updated to reflect that consolidation.
+
+The `_p2wpkh` suffix on those older artifacts is a historical naming
+artifact, not an indication that the shipping `flat_12x20_sentinel_all`
+is single-type.
+
+## What's actually missing
+
+A four-by-four matrix of "is this layer exercised end-to-end?":
+
+| Layer | P2WPKH | P2PKH | P2SH | P2TR |
+|---|---|---|---|---|
+| Covenant artifact (substitute params) | ✅ tested | ✅ builds | ✅ builds | ✅ builds |
+| Covenant validation (deny-list check) | ✅ | ✅ | ✅ | ✅ |
+| SPV verifier (script parser) | ✅ tested | ✅ tested | ✅ tested | ✅ tested |
+| Maker offer build | ✅ tested | ✅ tested | ✅ tested | ✅ tested |
+| Maker fund-tx broadcast | ✅ mainnet | ⚠️ untested | ⚠️ untested | ⚠️ untested |
+| Taker BTC payment + SPV proof | ✅ mainnet | ⚠️ untested | ⚠️ untested | ⚠️ untested |
+| Finalize tx on Radiant | ✅ mainnet | ⚠️ untested | ⚠️ untested | ⚠️ untested |
+| End-to-end test with recorded BTC blocks | ✅ | ❌ | ❌ | ❌ |
+| Documentation in gravity.md | ✅ | ❌ wrong | ❌ wrong | ❌ wrong |
+
+The gap is **end-to-end integration testing** and **documentation
+update**. The on-chain mainnet validation for P2WPKH demonstrates the
+covenant works correctly on the network; the same path should work for
+the other three types, but it has never been *demonstrated* end-to-end
+with recorded BTC blocks containing the relevant payment shape.
+
+## Suggested next work
+
+1. **Update `docs/concepts/gravity.md`** — fix the Axis 2 table and
+   the "only p2wpkh has a deployable covenant" sentence to reflect
+   that `flat_12x20_sentinel_all` supports all four types via the
+   `btcReceiveType` parameter, and that what's missing is end-to-end
+   test coverage for the three non-P2WPKH paths.
+2. **Add an end-to-end P2PKH integration test** — use a recorded BTC
+   block containing a P2PKH payment and exercise the full Maker-locks
+   → Taker-pays → finalize flow against the covenant. Reuses the
+   existing P2WPKH integration test pattern. Estimated ~150-300 LOC
+   of test code.
+3. **Mark P2PKH as `experimental` in any user-facing status** — not
+   "production-ready" until the end-to-end test exists and a small
+   mainnet exercise demonstrates the covenant accepts real P2PKH
+   payments.
+4. **Repeat for P2SH and P2TR** in subsequent work, in priority order
+   based on actual demand. P2SH is likely the next-most-valuable
+   because wrapped-segwit addresses are still common in older
+   wallets; P2TR is the future-facing case.
+
+## A diagnostic note
+
+The "diagnose before patching" rule applied here:
+
+- **Symptom** the docs reported: "P2PKH not supported in Gravity."
+- **Assumed mechanism** (from gravity.md): "need to compile a separate
+  P2PKH covenant variant."
+- **Actual mechanism**: the covenant already supports all four types;
+  what's missing is test coverage + a doc update.
+
+The original framing — "compile a new variant" — would have been ~4-5
+weeks of unnecessary work duplicating something the sentinel covenant
+already does. Spike-testing before committing to the framing caught
+this. The pattern generalizes: when a doc claims a capability is
+missing and the work to add it looks substantial, check the *current*
+code state before estimating effort against the doc.

--- a/docs/brainstorms/2026-05-19-gravity-ref-covenant-design.md
+++ b/docs/brainstorms/2026-05-19-gravity-ref-covenant-design.md
@@ -1,0 +1,288 @@
+---
+title: Ref-bearing Gravity covenant — Phase 2 design (post adversarial review)
+date: 2026-05-19
+status: design — REVISED after divergent review panel (2026-05-20); see Review Outcome
+---
+
+# Ref-bearing Gravity covenant — Phase 2 design
+
+**Purpose.** Concrete covenant design for FT-for-BTC swaps, written
+*before* compiling any bytecode so it can take the adversarial-review
+checkpoint the plan
+([2026-05-19-feat-gravity-ref-bearing-covenant-plan.md](../plans/2026-05-19-feat-gravity-ref-bearing-covenant-plan.md),
+Phase 2) requires. Grounded in the real sentinel covenant asm and the
+shipped FT/NFT script builders — not in inference.
+
+## Review Outcome (divergent panel, 2026-05-20)
+
+Four reviewers (security-sentinel, architecture-strategist,
+code-simplicity, Radiant-script correctness) reviewed this design
+**independently** before any bytecode. They converged on one root cause
+and several structural improvements. Verdict: **the design's threat
+handling was incomplete in a CRITICAL way** — the first draft asserted
+only `output[0]`'s bytecode and left every other output unconstrained.
+That single under-constraint enables three exploitable attacks. The
+two "open questions" the first draft *flagged* were not open; they were
+live. Revised mandates below.
+
+### CRITICAL — the covenant must constrain the WHOLE transaction, not just output[0]
+
+The first draft asserted `OP_0 OP_OUTPUTBYTECODE OP_EQUALVERIFY` and
+`OP_0 OP_OUTPUTVALUE >= dust`. That is insufficient. Three attacks, one
+root cause:
+
+1. **Output-count blindness.** Nothing constrains `OP_TXOUTPUTCOUNT`;
+   the spender controls outputs[1..n].
+2. **Multi-ref smuggling (was "open question #2" — it is live).** Maker
+   funds with two refs (sold ref R + valuable piggyback R2). Radiant
+   ref-conservation forces R2 onto *some* output; the covenant pins
+   only output[0]=R, so the Maker routes R2 to a Maker-controlled
+   output[1]. Taker pays BTC, gets R; Maker keeps R2.
+3. **FT value-splitting (was "open question #1" — it is live, and
+   consensus does NOT cover it).** Radiant FT conservation sums value
+   across **all** outputs sharing the FT script
+   ([glyph/script.py:53-54,70](../../src/pyrxd/glyph/script.py#L53):
+   "R can split"). Lock N units; settle by sending Taker output[0] = 1
+   unit (passes bytecode match + dust) and Maker output[1] = N−1 units
+   under the same FT script. `sum_in == sum_out` holds globally; the
+   covenant is satisfied; the Taker is shorted N−1.
+
+**Mandated fixes (must be in-script AND proven to REJECT the negative
+case on regtest before any byte is trusted):**
+
+- `OP_TXOUTPUTCOUNT <n> OP_NUMEQUALVERIFY` — pin the exact output count.
+- `OP_0 OP_OUTPUTVALUE <lockedFtUnits> OP_NUMEQUALVERIFY` — **exact** FT
+  value to the Taker, not `>= dust`. (FT units are the output's photon
+  value under the FT script.)
+- A single-input-ref assertion (`OP_REFDATASUMMARY_UTXO` /
+  `refoutputcount`-style — exact opcode TBD on regtest) so a
+  multi-ref funding UTXO cannot settle.
+
+This reverses the first draft's FT-amount simplification: **the exact
+amount check is required after all**, because consensus governs only
+the aggregate, never output[0]'s share. The `lockedFtUnits` value
+must therefore be bound into the covenant (constructor param or
+asserted equal to the input value).
+
+### Structural improvements (adopted)
+
+- **FT-only v1.** Drop NFT from v1 (Simplicity + others). NFT is a
+  second script layout, compile, regtest trail, and audit surface that
+  does not serve the "sell credits/tokens" need. Ship FT; NFT is a
+  near-mechanical repeat when a real NFT-sale need appears.
+- **Build-time template source, not three forked artifacts**
+  (Architecture). The security rejection of `refKind` dispatch was
+  about *runtime* selectability, not *build-time* templating. Keep one
+  human-audited template source with a single substituted
+  `<<OUTPUT_CLAUSE>>` region; emit distinct artifacts from it. Avoids
+  triplicate drift (a sentinel SPV fix would otherwise need 3× hand-
+  application + re-audit).
+- **`glyphRef` needs a new `_FIXED_LENGTHS` entry = 36** (Architecture).
+  It is NOT "like btcReceiveHash" (that's 32-byte Sha256). Declared as
+  plain `bytes` it would skip length validation
+  ([covenant.py:217,247](../../src/pyrxd/gravity/covenant.py#L217)) and
+  a 35/37-byte ref would silently produce an on-chain-rejected
+  covenant. Add `GlyphRef: 36` to the loader.
+- **Drop subaddress derivation; reject duplicate BTC addresses in the
+  off-chain verifier instead** (Simplicity). `glyphRef` is already in
+  the P2SH hash, so the covenant address is already offer-unique. The
+  SPV-reuse risk is purely off-chain (a verifier crediting one BTC
+  payment to two offers sharing a receive address). An off-chain
+  duplicate-address check is less machinery than a key-derivation
+  scheme and gives the same property. (Security flagged nonce-
+  uniqueness as a HIGH gap in the derivation approach — dropping it
+  removes the gap.)
+- **Share the FT fingerprint constant** between the covenant template
+  generator and `glyph/script.py` (Architecture) so a Glyph version
+  bump breaks loudly at build, not silently on-chain.
+- **Spike-harness builder is allowed before the production builder**
+  (Architecture) — you need *some* tx to submit to regtest. The
+  "no Python builders until conservation proven" gate applies to the
+  *shipped* builders; a disposable spike harness to produce the
+  regtest spend is fine and necessary.
+
+The body below is the original draft, retained for the construction
+detail; read it through the lens of the mandates above.
+
+---
+
+**Single review question this doc must survive:** *what does shipping
+this normalize, and what is the day-1 attack?*
+
+## Context the design rests on (verified, with sources)
+
+1. **The sentinel covenant already constructs its settlement output
+   compositionally and asserts it by introspection** — it does not use
+   `hashOutputs`. From the real artifact asm
+   (`maker_covenant_flat_12x20_sentinel_all`, finalize branch):
+
+   ```
+   76a914 $takerRadiantPkh OP_CAT 88ac OP_CAT     # build P2PKH scriptPubKey
+   OP_0 OP_OUTPUTBYTECODE OP_EQUALVERIFY           # assert output[0] == it
+   OP_0 OP_OUTPUTVALUE $totalPhotonsInOutput OP_GREATERTHANOREQUAL OP_VERIFY
+   ```
+
+   The forfeit branch is structurally identical, swapping `$makerPkh`
+   for `$takerRadiantPkh` and gating on
+   `$claimDeadline OP_CHECKLOCKTIMEVERIFY OP_DROP`:
+
+   ```
+   $claimDeadline OP_CHECKLOCKTIMEVERIFY OP_DROP
+   76a914 $makerPkh OP_CAT 88ac OP_CAT
+   OP_0 OP_OUTPUTBYTECODE OP_EQUALVERIFY
+   OP_0 OP_OUTPUTVALUE $totalPhotonsInOutput OP_GREATERTHANOREQUAL
+   ```
+
+2. **The FT/NFT locking scripts are fixed-shape with one variable
+   field (the 36-byte ref).** From `glyph/script.py`:
+
+   - **FT (75 bytes):** `76a914 <pkh:20> 88ac` `bd` `d0` `<ref:36>`
+     `dec0e9aa76e378e4a269e69d`
+     (P2PKH + `OP_STATESEPARATOR` + `OP_PUSHINPUTREF` + ref + 12-byte
+     FT conservation fingerprint)
+   - **NFT (63 bytes):** `d8` `<ref:36>` `7576a914 <pkh:20> 88ac`
+     (`OP_PUSHINPUTREFSINGLETON` + ref + `OP_DROP OP_DUP` + P2PKH tail)
+
+3. **Photonic has no transfer/swap covenant to copy** (see
+   [spike-findings addendum](2026-05-19-gravity-ref-covenant-spike-findings.md)).
+   dMint's self-rebuild (`require(output.stateScript == rebuilt_bytes)`)
+   is the closest mechanism; ref-to-arbitrary-destination is novel.
+
+## The design
+
+Two separate artifacts (`maker_covenant_ft_v1`, `maker_covenant_nft_v1`)
+per the plan's security decision. Each is a fork of the sentinel
+covenant where **only the constructed-output bytecode changes** —
+everything BTC-facing (SPV proof, `btcReceiveType` dispatch,
+sentinel-padded Merkle depth, `claimDeadline`) is reused verbatim.
+
+### New constructor param
+
+Add `glyphRef` (36 bytes) to the constructor, substituted into the hex
+template exactly like `btcReceiveHash`. **This binds the ref into the
+P2SH redeem-script hash** — the offer's identity includes the exact ref
+being sold (Security #1: ref substitution is impossible because a
+different ref produces a different P2SH address).
+
+FT also adds `ftAmount`? **No — see the FT-amount decision below.**
+
+### Settlement clause (FT)
+
+Replace the sentinel's P2PKH-output construction with the FT script
+construction, then assert by introspection as today:
+
+```
+76a914 $takerRadiantPkh OP_CAT 88ac OP_CAT      # P2PKH prefix  (unchanged)
+bd OP_CAT                                        # + OP_STATESEPARATOR
+d0 OP_CAT                                        # + OP_PUSHINPUTREF
+$glyphRef OP_CAT                                 # + the locked ref (constructor param)
+dec0e9aa76e378e4a269e69d OP_CAT                  # + FT conservation fingerprint
+OP_0 OP_OUTPUTBYTECODE OP_EQUALVERIFY            # assert output[0] == the FT script
+OP_0 OP_OUTPUTVALUE <dust> OP_GREATERTHANOREQUAL OP_VERIFY
+```
+
+The settlement output is now a 75-byte FT output to the Taker's PKH
+carrying the locked ref. RXD value drops to dust (the value side is no
+longer the asset; the ref is).
+
+### Settlement clause (NFT)
+
+Same shape, NFT script layout:
+
+```
+d8 $glyphRef OP_CAT                              # OP_PUSHINPUTREFSINGLETON + ref
+7576a914 OP_CAT $takerRadiantPkh OP_CAT 88ac OP_CAT
+OP_0 OP_OUTPUTBYTECODE OP_EQUALVERIFY
+OP_0 OP_OUTPUTVALUE <dust> OP_GREATERTHANOREQUAL OP_VERIFY
+```
+
+(Exact CAT ordering and minimal-push encoding of the literal opcode
+bytes is a compile detail to validate on regtest; the structure is what
+matters for review.)
+
+### Forfeit clause (FT and NFT)
+
+Identical change: the sentinel forfeit builds `76a914 $makerPkh 88ac`;
+the ref version builds the **same FT/NFT script but to `$makerPkh`**, so
+the reclaimed UTXO carries the original ref back to the Maker. Gated by
+`$claimDeadline OP_CHECKLOCKTIMEVERIFY` unchanged.
+
+This satisfies the trust property "forfeit returns the *original*
+ref-bearing UTXO" — the reclaimed output is constructed to carry the
+same `$glyphRef`.
+
+## How the four threats are handled
+
+| Threat | Handling in this design |
+|---|---|
+| **Ref substitution (Security #1)** | `glyphRef` is a constructor param → baked into the P2SH hash. A different ref ⇒ different covenant address ⇒ Maker never funded it. The settlement clause constructs the expected output from `$glyphRef`, so the Taker cannot redirect a different ref. |
+| **Multi-ref smuggling (Security #2, Critical)** | The settlement/forfeit output bytecode is asserted *exactly* (`OP_EQUALVERIFY` on full scriptPubKey), so the output carries exactly the one constructed ref. **Open question:** does asserting output[0]'s bytecode also need an explicit ref-*count* constraint on the spend to stop a *second* smuggled ref riding a different output? Radiant ref-conservation should force any input ref onto an output, so a smuggled funding ref must appear somewhere — needs an explicit `refoutputcount`-style check or a total-outputs constraint. **MUST resolve on regtest before shipping.** |
+| **SPV proof reuse across offers (Security #5, Critical)** | Subaddress derivation: `btcReceiveHash` derived from `(makerPkh, glyphRef, nonce)` so each offer's BTC receive address is unique → one BTC payment proves exactly one covenant. (Chosen over OP_RETURN to avoid excluding consumer BTC wallets.) |
+| **refKind branch confusion (Security #6)** | Eliminated by construction: two separate artifacts, no in-script `refKind` dispatch, no selectable branch. |
+
+## The FT-amount decision (important)
+
+**The FT amount is NOT carried in the ref or in a covenant param.**
+Per the Photonic finding (`fungible.rxd`), Radiant FT conservation is a
+**consensus-level value check** — `codeScriptValueSum(inputs) >=
+codeScriptValueSum(outputs)` for outputs sharing the FT code-script
+hash. The FT "amount" is the UTXO's photon value under the FT script,
+not a separate field.
+
+Consequence for the covenant: by constructing the exact FT output
+script (which includes the FT fingerprint) and asserting it via
+`OP_OUTPUTBYTECODE`, **the covenant pins the ref and the script shape;
+Radiant consensus pins the amount conservation.** This means:
+
+- The plan's `FtAmount`/`amount` constructor param and the
+  `sum-in == sum-out` *in-script* check are likely **unnecessary** —
+  consensus already enforces it. This simplifies the covenant.
+- **Open question to confirm on regtest:** does locking N FT units into
+  the covenant and asserting the FT output script guarantee the Taker
+  receives exactly N, or could a malicious settlement split value? The
+  `OP_OUTPUTVALUE >= dust` check governs RXD, not FT units. Need to
+  verify the FT-fingerprint consensus check covers this. **This is the
+  single most important thing to validate before writing the builder.**
+
+If consensus does NOT fully cover it, fall back to an explicit
+in-script value assertion. Either way, this is a regtest question, not
+a design-by-inference question.
+
+## What stays exactly as the sentinel covenant
+
+- SPV proof verification (block headers, Merkle proof, sentinel padding
+  depth 12–20)
+- `btcReceiveType` four-way dispatch (P2PKH/P2WPKH/P2SH/P2TR)
+- `btcChainAnchor`, `expectedNBits`, `expectedNBitsNext` PoW binding
+- `claimDeadline` + `OP_CHECKLOCKTIMEVERIFY` forfeit gate
+- The P2SH-wrapping and `CovenantArtifact` substitution machinery
+
+## Open questions to resolve on regtest (before bytecode is "done")
+
+1. **FT conservation coverage** (above) — does asserting the FT output
+   script + consensus conservation guarantee the Taker gets exactly the
+   locked amount? *Highest priority.*
+2. **Multi-ref smuggling** — is exact-output-bytecode assertion
+   sufficient, or is an explicit ref-count constraint needed?
+3. **Minimal-push encoding** of the literal opcode bytes (`bd`, `d0`,
+   `d8`, the fingerprint) inside `OP_CAT` chains — confirm the compiler
+   emits them as data pushes, not as executed opcodes.
+4. **Script size / fee** — measure both artifacts vs sentinel; confirm
+   ≤ 1.5× gate.
+5. **`OP_OUTPUTBYTECODE` on a ref-bearing output** — never exercised by
+   the sentinel covenant; confirm the node accepts the spend
+   (`testmempoolaccept`) before any golden-byte fixture is trusted.
+
+## Recommended sequence (unchanged from plan, now concrete)
+
+1. **Adversarial review of THIS doc** (the checkpoint) — answer the
+   single review question above.
+2. Draft FT template → compile → regtest lock/release/forfeit →
+   resolve open questions 1–3.
+3. Repeat for NFT.
+4. Benchmark (open question 4), record in spike-findings.
+5. Only then bolt on the BTC half (Phase 4) and write Python builders.
+
+**Do not write the Python tx builders or the BTC half until the FT
+conservation question (1) is answered on a real regtest spend.** That
+is the load-bearing unknown; everything downstream depends on it.

--- a/docs/brainstorms/2026-05-19-gravity-ref-covenant-spike-findings.md
+++ b/docs/brainstorms/2026-05-19-gravity-ref-covenant-spike-findings.md
@@ -1,0 +1,208 @@
+---
+title: Gravity ref-bearing covenant — spike-first findings revise the estimate
+date: 2026-05-19
+status: brainstorm
+---
+
+# Gravity ref-bearing covenant — spike-first findings
+
+## Why this spike
+
+The plan
+[2026-05-19-feat-gravity-ref-bearing-covenant-plan.md](../plans/2026-05-19-feat-gravity-ref-bearing-covenant-plan.md)
+carried a 9–12 week estimate, much of it derived from the brainstorm's
+reading of the *intent* of `gravity/transactions.py` rather than from
+reading the actual shipping covenant script. Per
+[spike-first-then-convergent-design-divergent-review-panels.md](../solutions/design-decisions/spike-first-then-convergent-design-divergent-review-panels.md),
+doc/inference-derived estimates in this codebase have run 3–4× high
+three times in a row because the code generalized past its docs. This
+spike reads the current code before trusting the number.
+
+**This is read-only findings.** No code written; no estimate is
+"approved" — it is revised against what the code actually does.
+
+## What the code actually does
+
+### Finding 1: the settlement output is built compositionally, via introspection — not value-only
+
+The sentinel covenant
+(`maker_covenant_flat_12x20_sentinel_all.artifact.json`, contract
+`MakerCovenantFlat12x20`) constrains the settlement output like this
+(from the artifact `asm`, finalize branch tail):
+
+```
+76a914 $takerRadiantPkh OP_CAT 88ac OP_CAT
+OP_0 OP_OUTPUTBYTECODE OP_EQUALVERIFY
+OP_0 OP_OUTPUTVALUE $totalPhotonsInOutput OP_GREATERTHANOREQUAL OP_VERIFY
+```
+
+It **builds the expected output scriptPubKey byte-by-byte with
+`OP_CAT`** (`76a914` + taker PKH + `88ac` = a plain P2PKH), then
+asserts that output 0's actual bytecode equals it via
+`OP_OUTPUTBYTECODE OP_EQUALVERIFY`, and that output 0's value clears
+`totalPhotonsInOutput` via `OP_OUTPUTVALUE`.
+
+The `asm` uses `OP_CAT` **260 times** and `OP_HASH256` 53 times — this
+is already a covenant that assembles scripts and hashes
+compositionally. It is **not** a value-only covenant that would need
+new machinery to describe a ref-bearing output.
+
+**Implication:** adding a ref to the settlement output is *additive*
+work in an existing pattern — CAT the FT/NFT epilogue into the
+expected-output construction — not a from-scratch output-description
+system. The brainstorm's framing ("the covenant script has no way to
+carry a ref") was directionally true (the bytes aren't there today)
+but over-stated the *difficulty* (the construction mechanism is).
+
+### Finding 2: the FT/NFT epilogues are small, fixed, and already built in Python
+
+[glyph/script.py:build_ft_locking_script](../../src/pyrxd/glyph/script.py#L135):
+
+```python
+p2pkh = b"\x76\xa9\x14" + owner_pkh + b"\x88\xac"          # 25 bytes
+epilogue = b"\xbd\xd0" + ref.to_bytes() + b"\xde\xc0\xe9\xaa\x76\xe3\x78\xe4\xa2\x69\xe6\x9d"
+# = OP_STATESEPARATOR OP_PUSHINPUTREF <36-byte ref> <12-byte FT fingerprint>
+# total script = 75 bytes
+```
+
+So the FT settlement output the covenant must assert is just the
+existing P2PKH construction (`76a914 <takerPkh> 88ac`) **plus a
+fixed 50-byte epilogue** where only the 36-byte ref is a parameter.
+`build_nft_locking_script` exists too (63-byte singleton). The covenant
+change is: CAT `bd d0 <glyph_ref> dec0e9aa76e378e4a269e69d` after the
+P2PKH for the FT artifact (and the singleton variant for NFT).
+
+### Finding 3: ref-parsing is shipped and tested — not new work
+
+`_get_push_refs` ([transaction_preimage.py:18](../../src/pyrxd/transaction/transaction_preimage.py#L18))
+already parses both `OP_PUSHINPUTREF` (`0xd0`) and
+`OP_PUSHINPUTREFSINGLETON` (`0xd8`), and is tested at
+[tests/test_preimage.py:34-79](../../tests/test_preimage.py#L34) for
+FT, NFT, multi-ref, and empty-script cases. The general
+`_compute_hash_output_hashes` ([transaction_preimage.py:66](../../src/pyrxd/transaction/transaction_preimage.py#L66))
+already computes the correct `refsHash`. The Phase-1 de-dup is real
+but small, and the "new ref-aware sighash code path" the plan worried
+about is **already written and covered**.
+
+### Finding 4: the constructor already has 10 params and a four-way BTC dispatch
+
+The sentinel constructor:
+
+```
+makerPkh, takerRadiantPkh, btcReceiveHash, btcReceiveType, btcSatoshis,
+btcChainAnchor, expectedNBits, expectedNBitsNext, claimDeadline,
+totalPhotonsInOutput
+```
+
+Adding `glyph_ref` (and, for FT, `amount`) is one or two more
+constructor params substituted the same way `btcReceiveHash` is —
+the substitution machinery in
+[covenant.py:203-267](../../src/pyrxd/gravity/covenant.py#L203)
+handles it with no structural change.
+
+## What this does NOT make free
+
+Unlike the BCH case (where the SPV verifier was already chain-agnostic
+and the work was *zero*), the ref-bearing covenant still needs genuine
+new work:
+
+1. **The settlement output now carries a ref, so it is no longer a
+   plain P2PKH.** The taker receives an FT/NFT output, which means the
+   covenant's `totalPhotonsInOutput` check must coexist with a
+   dust-value ref output — different value semantics.
+2. **Ref-conservation is a consensus rule the covenant must not
+   violate.** The covenant builds the *expected* output bytecode; the
+   network separately enforces that input refs == output refs. The
+   covenant and the consensus rule must agree, or the spend is
+   rejected. This is the genuine design risk and still needs regtest
+   validation.
+3. **The two Critical security findings stand** (multi-ref smuggling,
+   SPV proof reuse) — those are about *what the covenant must
+   additionally constrain*, and the introspection mechanism makes them
+   *expressible* (`OP_OUTPUTBYTECODE` can assert the full ref-bearing
+   script, including that there's exactly one ref) but someone still
+   has to write and audit those clauses.
+4. **`OP_OUTPUTBYTECODE` on a ref-bearing output is a script path the
+   sentinel covenant has never exercised.** Regtest validation is
+   still required — Finding 1 says the *mechanism* exists, not that
+   the *specific spend* has been proven.
+
+## Revised estimate
+
+| Phase | Plan estimate | Spike-revised | Why |
+|---|---|---|---|
+| 1 — sighash de-dup | 3–5 days | **1–2 days** | `_get_push_refs` + correct `_compute_hash_output_hashes` already shipped and tested; de-dup is small. Regtest harness still needed but lighter than feared. |
+| 2 — covenant spike | 2–3 weeks | **1–2 weeks** | Output construction mechanism (`OP_CAT` + `OP_OUTPUTBYTECODE`) already exists; work is additive (CAT the epilogue) not from-scratch. Ref-conservation regtest validation is the real unknown and keeps this from collapsing further. |
+| 3 — types + validator | 5–7 days | **5–7 days** | Unchanged — Python type discipline + opcode-stream validator + property tests are real work regardless of covenant findings. |
+| 4 — BTC half + builders | 2–3 weeks | **1.5–2 weeks** | Builders extend an existing introspection-output pattern; golden-byte regtest gate unchanged. |
+| 5 — e2e + red-team | 2–3 weeks | **2–3 weeks** | Unchanged — the test surface is the test surface; security findings stand. |
+| 6 — async verifier | 5–7 days | **5–7 days** | Unchanged. |
+| 7 — audit + docs | 1 week | **1 week** | Unchanged. |
+| **Total** | **9–12 weeks** | **~6.5–9 weeks** | |
+
+The collapse is real but **smaller than the doc's headline 3–4×
+cases**, and that is the honest finding: this is not the BCH situation
+where the work was already done. The covenant genuinely needs new
+ref-bearing clauses and regtest proof of ref-conservation. What the
+spike corrects is the *framing* — "build a new output-description
+system" → "extend an existing compositional-output covenant" — which
+takes ~2.5–3 weeks off the estimate, mostly in Phases 1, 2, and 4.
+
+## What did NOT change
+
+- The split FT/NFT artifact decision (security) stands.
+- Both Critical security findings stand and still gate Phase 4→5.
+- The golden-byte regtest gate (anti-synthetic-divergence) stands —
+  in fact Finding 4 makes it *more* important: `OP_OUTPUTBYTECODE` on
+  a ref output is unexercised, so synthetic round-trip would be
+  exactly the trap the dMint incidents warn about.
+
+## Phase-2 addendum (2026-05-19): Photonic prior-art check
+
+Read the Photonic Wallet TypeScript source (a local checkout of the
+public `photonic-wallet` repo) for ref-bearing covenant prior art.
+Findings:
+
+- **Photonic has no transfer / swap / escrow covenant.** Its only
+  ref-bearing covenant is the self-rebuilding dMint `powmint.rxd`,
+  which preserves refs by byte-slicing its own state script forward
+  (`bytes newState = 0x04 + bytes4(newHeight) +
+  tx.inputs[...].stateScript.split(5)[1]; require(tx.outputs[i].stateScript
+  == newState)` — powmint.rxd:49) and counts ref outputs via
+  `refOutputCount(tokenRef)` / `codeScriptCount()` introspection
+  (powmint.rxd:42).
+- **Its FT/NFT scripts are passive.** `ftScript` / `nftScript`
+  (script.ts:245-263) push the ref but do **not** enforce "this output
+  carries this ref"; ref conservation is enforced by the *receiver's*
+  covenant at consensus level, not by the sender. `swap.ts` is
+  UI-level pre-signed-tx logic, **not** a locked covenant.
+
+**Implication — the Gravity pattern is novel.** Locking a ref-bearing
+UTXO and enforcing on settlement that the ref flows to a *specific
+Taker destination* via a script we construct
+(`require(tx.outputs[k].lockingBytecode == <constructed bytes incl.
+ref>)`) is **not** something Photonic exemplifies. The closest
+mechanism is dMint's `require(output.stateScript == rebuilt_bytes)`,
+which — combined with Finding 1 (the sentinel covenant already CATs
+output scripts and asserts them via `OP_OUTPUTBYTECODE`) — makes the
+construction feasible. But there is no battle-tested precedent for
+*ref-to-arbitrary-destination*, so:
+
+- The external-audit gate (already in the plan) is **non-negotiable**,
+  not a recommendation.
+- The golden-byte + `testmempoolaccept` gates matter even more — this
+  is genuinely new bytecode, not a variant of a proven shape.
+
+The construction primitive to use: build the expected Taker output
+bytecode in-script by CATing `<ftScript/nftScript bytes with the
+locked ref spliced in>`, then `OP_<k> OP_OUTPUTBYTECODE OP_EQUALVERIFY`
+— mirroring the sentinel covenant's existing P2PKH-output assertion,
+extended to carry the ref opcode + 36-byte ref + FT fingerprint.
+
+## Recommended next step
+
+The plan estimates were updated to the spike-revised column. Phase 2
+proceeds: draft the FT + NFT covenant templates (Radiant-only, no BTC
+half yet), validate lock → release → forfeit against the mainnet node
+on `tr`, and record benchmark vectors. Ref-conservation validation on
+a real spend remains the dominant unknown.

--- a/docs/concepts/gravity.md
+++ b/docs/concepts/gravity.md
@@ -110,25 +110,57 @@ depth from 12 through 20 now works with one covenant.
 
 ### Axis 2: Bitcoin output type
 
-The `_p2wpkh` variants only accept payment to native-segwit BTC
-addresses (the `bc1q...` ones). A complete Gravity rollout would
-also support:
+The older `_p2wpkh`-suffixed covenant variants (visible in the
+artifacts directory) only accepted payment to native-segwit BTC
+addresses. **The shipping `maker_covenant_flat_12x20_sentinel_all`
+covenant unified the dispatch** and accepts all four standard
+Bitcoin output types via in-script branching on a `btcReceiveType`
+parameter (0=P2PKH, 1=P2WPKH, 2=P2SH, 3=P2TR). The covenant compares
+the BTC tx's output script bytes against the type-specific expected
+pattern (e.g. `76 a9 14 <hash> 88 ac` for P2PKH, `00 14 <hash>` for
+P2WPKH, etc.), with the hash supplied as `btcReceiveHash` and the
+type supplied as `btcReceiveType`.
 
-| Output type | Address prefix | Status |
-|---|---|---|
-| **P2WPKH** (native segwit) | `bc1q...` | ✅ shipped |
-| **P2PKH** (legacy) | `1...` | ❌ no covenant compiled yet |
-| **P2SH** (wrapped segwit) | `3...` | ❌ no covenant compiled yet |
-| **P2TR** (taproot) | `bc1p...` | ❌ no covenant compiled yet |
+| Output type | Address prefix | Covenant support | End-to-end test |
+|---|---|---|---|
+| **P2WPKH** (native segwit) | `bc1q...` | ✅ shipped | ✅ mainnet-proven |
+| **P2PKH** (legacy) | `1...` | ✅ shipped | ✅ synthetic (`TestGravityTradeP2PKH`) |
+| **P2SH** (wrapped segwit) | `3...` | ✅ shipped | ⚠️ unit-level only |
+| **P2TR** (taproot) | `bc1p...` | ✅ shipped | ⚠️ unit-level only |
 
-The SDK's API in `pyrxd/gravity/covenant.py` already declares
-``_VALID_BTC_RECEIVE_TYPES = {"p2pkh": 0, "p2wpkh": 1, "p2sh": 2,
-"p2tr": 3}`` — but only `p2wpkh` has a deployable covenant in the
-artifacts directory. If a maker wants to receive BTC at a taproot
-address, the SDK currently has no covenant to use.
+What "covenant support ✅ shipped" means concretely:
+- The Python factory in `pyrxd/gravity/covenant.py` substitutes the
+  type integer into the covenant template via
+  `_VALID_BTC_RECEIVE_TYPES = {"p2pkh": 0, "p2wpkh": 1, "p2sh": 2, "p2tr": 3}`.
+- `tests/test_gravity.py::TestGravityOffer::test_all_btc_receive_types_accepted`
+  asserts `build_gravity_offer` produces a valid offer for all four
+  types.
+- The SPV verifier in `pyrxd/spv/payment.py` parses all four output
+  script formats; `tests/test_spv.py` exercises each at the unit
+  level.
 
-This is one of the main directions covenant work needs to go: extend
-the audited+sentinel pattern to the other three output types.
+What "end-to-end test ⚠️ unit-level only" means for P2SH and P2TR:
+- The covenant artifact, factory, and SPV verifier all handle these
+  types correctly at the unit level.
+- A full Maker-locks → Taker-pays → finalize integration test using
+  the real `SpvProofBuilder.build()` pipeline against a synthetic
+  P2SH-paying or P2TR-paying BTC transaction has not yet been
+  written. The P2PKH analogue
+  (`tests/test_gravity_trade.py::TestGravityTradeP2PKH`) is the
+  pattern to copy when adding them.
+- A small-amount mainnet exercise against a real P2PKH / P2SH / P2TR
+  payment has not yet been performed for these types. Mainnet-proven
+  status applies only to P2WPKH today.
+
+### History note: why the docs previously said otherwise
+
+An earlier version of this document claimed only P2WPKH was
+supported. That was accurate relative to the older single-type
+covenant variants (`maker_covenant_unified_p2wpkh`, the experimental
+`flat_*_p2wpkh` lineage) but became stale when the sentinel-all
+covenant landed and unified the dispatch. The `_p2wpkh` suffix on
+older artifacts is a historical naming artifact, not a current
+limitation of the shipping covenant.
 
 ### Axis 3: Security upgrades over time
 
@@ -178,8 +210,12 @@ versions:
 1. **Audit + ship the depth-branched variants.** Smaller covenants
    mean lower fees on each spend; might be useful for high-frequency
    makers.
-2. **Compile P2PKH / P2SH / P2TR variants.** Each new output type is
-   a separate sentinel-style covenant; the pattern carries over.
+2. **End-to-end integration tests + mainnet exercise for P2SH / P2TR.**
+   The shipping sentinel covenant already supports all four output
+   types via in-script dispatch (see Axis 2 above); what's missing is
+   integration test coverage and a small-amount mainnet exercise for
+   the two output types still marked ⚠️ unit-level only. P2PKH was
+   closed out in this category in 2026-05; P2SH and P2TR remain.
 3. **Independent security audit of the entire Gravity surface.**
    Self-audit found and fixed the issues in the deny-list above; an
    external audit is the next step before any Gravity claims should

--- a/docs/concepts/gravity.md
+++ b/docs/concepts/gravity.md
@@ -1,8 +1,11 @@
 # Gravity: cross-chain atomic swaps
 
-**Audience:** developers integrating cross-chain BTC↔RXD swaps via
-`pyrxd.gravity`, and anyone who's seen the phrase "sentinel-artifact
-path mainnet-proven" and wondered what it actually means.
+**Audience:** developers integrating cross-chain swaps via
+`pyrxd.gravity` between RXD and a SHA-256d UTXO chain (BTC is
+mainnet-proven; BCH is supported; see § Supported counterparty
+chains for the full picture), and anyone who's seen the phrase
+"sentinel-artifact path mainnet-proven" and wondered what it
+actually means.
 
 **Status:** sentinel-path swaps proven on mainnet. Other covenant
 variants are experimental and not yet validated for real funds.
@@ -32,6 +35,53 @@ The conceptual lineage runs through Bitcoin's HTLCs (Lightning), the
 Decred / Litecoin atomic swap work, and SPV-anchored DeFi
 constructions on Bitcoin Cash. Gravity is the Radiant-specific
 expression of that pattern.
+
+## Supported counterparty chains
+
+Gravity's SPV verifier is chain-agnostic for **SHA-256d UTXO chains**
+by deliberate design. The verifier checks proof-of-work as
+`hash < target` against the header's own nBits — it does not compute
+or validate difficulty algorithm transitions. As long as the maker
+commits to the right `expected_nbits` at offer time, the verifier
+accepts any chain of headers satisfying those nBits.
+
+| Chain | Counterparty role | Status |
+|---|---|---|
+| **Bitcoin (BTC)** | proven on mainnet | ✅ shipping |
+| **Bitcoin Cash (BCH)** | verifier accepts real mainnet headers | ✅ ready; integration tests in `tests/test_spv.py::TestBchMainnetFixtures` |
+| **Bitcoin SV (BSV)** | same SHA-256d format | ⚠️ untested; should work with no code changes |
+| Other SHA-256d UTXO chains | same SHA-256d format | ⚠️ untested |
+
+What "ready" means for BCH:
+
+- Real BCH mainnet block headers (840000 + 840001) pass the
+  unmodified `verify_header_pow` and `verify_chain` (with
+  `chain_anchor` binding).
+- The shipping `maker_covenant_flat_12x20_sentinel_all` covenant
+  supports BCH-style payments (P2PKH is the primary type since BCH
+  has no segwit; P2SH is the secondary type for multisig flows).
+- The `MempoolSpaceSource` data-source class accepts a configurable
+  `base_url`, so a caller can construct
+  `MempoolSpaceSource(base_url="https://mempool.cash/api")` or a
+  similar BCH-side explorer endpoint without code changes. Live API
+  compatibility has not been verified end-to-end.
+- BCH cashaddr encoding is wallet-side, not Gravity-side. The maker
+  provides raw `hash160` bytes; address-format handling stays at
+  the wallet layer.
+
+What's **not** supported, and would require more than a parameter
+change:
+
+- **Non-SHA-256d chains** (Litecoin/Dogecoin use Scrypt; Zcash uses
+  Equihash; Monero uses RandomX). The SPV verifier's PoW check
+  hardcodes SHA-256d. Verifying these chains' PoW on Radiant would
+  require new RadiantScript opcodes (a consensus extension) or a
+  different cross-chain protocol altogether (such as HTLC + adaptor
+  signatures, which doesn't require on-chain PoW verification).
+
+The asymmetric design of Gravity (counterparty chain doesn't need to
+know Gravity exists; only Radiant verifies the proof) is preserved
+for all supported chains.
 
 ## What a covenant is
 

--- a/docs/plans/2026-05-19-feat-gravity-ref-bearing-covenant-plan.md
+++ b/docs/plans/2026-05-19-feat-gravity-ref-bearing-covenant-plan.md
@@ -1,0 +1,990 @@
+---
+title: Ref-bearing Gravity covenant — atomic Glyph FT/NFT ↔ BTC swaps
+type: feat
+date: 2026-05-19
+status: draft
+---
+
+# Ref-bearing Gravity covenant — atomic Glyph FT/NFT ↔ BTC swaps
+
+## Overview
+
+Today's Gravity covenant family swaps **plain RXD for BTC** atomically and
+trust-minimized. This plan adds a new covenant variant — the
+**ref-bearing covenant** — that lets a Maker offer Glyph fungible tokens
+(FT) or NFT singletons in exchange for BTC, with the same trust
+properties: no custody, no exchange, no KYC, covenant-enforced timeout
+and forfeit.
+
+The variant is a **fork of the shipping sentinel covenant** that keeps
+the entire BTC-facing half (SPV verifier, four-way BTC output-type
+dispatch, sentinel-padded Merkle depth handling, deadline mechanics)
+and rewrites the Radiant-facing half to carry a Glyph ref through
+lock-and-release. The plan ships **two separate covenant artifacts**
+— `maker_covenant_ft_v1.artifact.json` (FT, uses `OP_PUSHINPUTREF`)
+and `maker_covenant_nft_v1.artifact.json` (NFT singleton, uses
+`OP_PUSHINPUTREFSINGLETON`).
+
+The brainstorm at
+[docs/brainstorms/2026-05-19-gravity-glyph-ft-swap-brainstorm.md](../brainstorms/2026-05-19-gravity-glyph-ft-swap-brainstorm.md)
+originally committed to a unified in-script `refKind` dispatch.
+Security and architecture review during plan refinement reversed that
+decision: FT (`0xd0`) and NFT (`0xd8`) are different opcodes with
+different conservation semantics (sum-in == sum-out vs. singleton
+identity), not output-format variants like `btcReceiveType`. Two
+artifacts means two smaller audit surfaces, no branch-selection
+attack class (Security Sentinel rated this High severity), and the
+ability to deny-list one variant without affecting the other. The
+unified-covenant idea remains under "Future Considerations" if a
+future audit shows the maintenance overhead of two artifacts
+outweighs the security partitioning.
+
+This plan turns the brainstorm direction into phased, reviewable,
+auditable work.
+
+## Problem Statement
+
+**Concrete user need:** "I want to sell credits/tokens (FT) or a unique
+collectible (NFT) for BTC without trusting a custodian, without an
+exchange, and without forcing the buyer through KYC."
+
+**Why this isn't doable today:**
+
+1. The shipping maker covenant
+   ([gravity/artifacts/maker_covenant_flat_12x20_sentinel_all.artifact.json](../../src/pyrxd/gravity/artifacts/maker_covenant_flat_12x20_sentinel_all.artifact.json))
+   builds its settlement output as a plain P2PKH (`76a914 <takerPkh>
+   88ac`, asserted via `OP_OUTPUTBYTECODE`) with no ref bytes.
+   Funding it with a ref-bearing UTXO violates Radiant's
+   ref-conservation rule (each ref on the input must reappear on an
+   output); the funding tx is rejected. **Note (per
+   [spike-findings](../brainstorms/2026-05-19-gravity-ref-covenant-spike-findings.md)):
+   the covenant already constructs output scripts compositionally with
+   `OP_CAT`, so adding a ref is additive work in an existing pattern —
+   not a from-scratch output-description system.**
+
+2. The Gravity-specific sighash helper
+   `_compute_hash_output_hashes` at
+   [gravity/transactions.py:93-134](../../src/pyrxd/gravity/transactions.py#L93)
+   hard-codes `totalRefs = 0` and `refsHash = 32 × 0x00` for every
+   output it processes. Even if the covenant script carried a ref,
+   signed spends would produce the wrong sighash for ref-bearing
+   outputs and get rejected by validators.
+
+**The alternatives don't meet the user need:**
+
+- **Off-chain custodian** — defeats the trust property.
+- **Two-leg swap (Gravity BTC→RXD, then OTC RXD→FT)** — not atomic;
+  either side can stiff on leg 2.
+- **Radiant Swap DEX (`swap.*`)** — referenced at
+  [rxindexer.py:8](../../src/pyrxd/network/rxindexer.py#L8) but trades
+  on Radiant only; does not accept BTC.
+
+## Proposed Solution
+
+Build **two separate ref-bearing covenant artifacts** — one for FT,
+one for NFT singleton. Each carries the same SPV/BTC half as the
+sentinel covenant; the Radiant half differs in opcode and
+conservation discipline.
+
+| Artifact | Asset | Opcode | Conservation rule |
+|---|---|---|---|
+| `maker_covenant_ft_v1` | FT | `OP_PUSHINPUTREF` (`0xd0`) | Settlement output carries the same ref + same amount; sum-in == sum-out enforced by Radiant ref-conservation |
+| `maker_covenant_nft_v1` | NFT singleton | `OP_PUSHINPUTREFSINGLETON` (`0xd8`) | Settlement output carries the singleton on exactly one output; no amount field |
+
+A discriminated-union API in Python:
+
+- `RefKind(IntEnum)` — `FT = 0`, `NFT = 1` (boundary conversion only;
+  the artifact name carries the discrimination at script level).
+- `FtAmount = NewType("FtAmount", int)` — prevents accidentally
+  mixing FT units with photons/satoshis at type-check time.
+- `GravityFTOffer` and `GravityNFTOffer` — distinct frozen
+  dataclasses, both extend a shared `_BaseGravityOffer` (extracted
+  from today's `GravityOffer.__post_init__` validators).
+
+The covenant flow mirrors today's Gravity:
+
+1. Maker locks a ref-bearing UTXO into the covenant (ref + amount for
+   FT; ref alone for NFT).
+2. Taker pays BTC to Maker's BTC address.
+3. Taker (or anyone with the SPV proof) submits a settlement tx that
+   spends the covenant UTXO, produces a ref-bearing output to Taker,
+   and attaches the SPV proof.
+4. Covenant validates SPV proof + ref-passthrough + amount
+   conservation; spend succeeds; asset is now Taker's.
+5. Fallback: if no settlement by deadline, Maker can `forfeit` to
+   reclaim the original ref-bearing UTXO.
+
+## Technical Approach
+
+### Architecture
+
+**File-level partition** of new vs reused code:
+
+| Component | Status | Path |
+|---|---|---|
+| SPV proof builder/verifier | Reused as-is | [src/pyrxd/spv/](../../src/pyrxd/spv/) |
+| BTC output-type dispatch (P2PKH/P2WPKH/P2SH/P2TR) | Reused as-is | covenant script param `btcReceiveType` |
+| Sentinel-padded Merkle proof handling (depth 12–20) | Reused as-is | covenant script |
+| Sighash helper (correct, ref-aware) | Reused (de-dup target) | [transaction_preimage.py:66](../../src/pyrxd/transaction/transaction_preimage.py#L66) |
+| Sighash helper (stale, hardcoded) | **Delete** | [gravity/transactions.py:93-134](../../src/pyrxd/gravity/transactions.py#L93) |
+| Deny-list / artifact loader | Extend | [gravity/covenant.py:59-76](../../src/pyrxd/gravity/covenant.py#L59) |
+| `_LAZY_EXPORTS` | Extend | [src/pyrxd/__init__.py](../../src/pyrxd/__init__.py), [gravity/__init__.py](../../src/pyrxd/gravity/__init__.py) |
+| Ref-bearing covenant templates (NEW) | **Two new artifacts** | `gravity/artifacts/maker_covenant_ft_v1.artifact.json`, `gravity/artifacts/maker_covenant_nft_v1.artifact.json` |
+| Shared offer base + ref-bearing types (NEW) | **New** | `gravity/types.py` (extend with `_BaseGravityOffer`, `RefKind`, `FtAmount`, `GravityFTOffer`, `GravityNFTOffer`) |
+| Ref-bearing factory (NEW) | **New** | `gravity/ref/covenant.py` |
+| Ref-bearing tx builders (NEW) | **New** | `gravity/ref/transactions.py` |
+| Funding-input pre-flight validator (NEW) | **New** | `gravity/ref/validation.py` (opcode-stream walker, never byte-scan) |
+| Taker offer-verification API (NEW, async) | **New** | `gravity/ref/verify.py` |
+| End-to-end + red-team tests (NEW) | **New** | `tests/test_gravity_ref.py`, `test_gravity_ref_trade.py`, `test_gravity_ref_red_team.py`, `test_gravity_ref_verify.py` |
+
+### Implementation Phases
+
+The phases are sequenced so each one ends in a green `task ci`, no
+partial states leaking into main. Phase boundaries are also natural
+PR boundaries.
+
+---
+
+#### Phase 1: Sighash de-duplication (foundation)
+
+**Goal:** delete the duplicate `_compute_hash_output_hashes` in
+`gravity/transactions.py` and reuse the correct one in
+`transaction_preimage.py`. Existing Gravity tests must still pass
+byte-for-byte (the two implementations are equivalent for the
+`totalRefs=0` path that today's Gravity uses).
+
+**Tasks:**
+
+- [ ] Decide adapter shape:
+  - **Option A:** reconstruct `TransactionOutput` instances at the
+    Gravity call site in `_sign_radiant_p2sh_input`
+    ([gravity/transactions.py:170](../../src/pyrxd/gravity/transactions.py#L170))
+    and call the general helper.
+  - **Option B:** extract the byte-stream parsing loop in
+    `gravity/transactions.py:106-124` into a shared helper that calls
+    `_get_push_refs` from `transaction_preimage.py:18`.
+  - **Recommendation:** B — closer to the brainstorm's "delete the
+    duplicate" intent, no object reconstruction overhead.
+- [x] Implement chosen adapter; delete the Gravity `_compute_hash_output_hashes`. **Done 2026-05-19:** chose a cleaner variant of Option A — the adapter parses `outputs_serialized` via the existing `TransactionOutput.from_hex` reader and delegates to the general impl. No new byte-parser written; reuses two already-tested primitives. ([gravity/transactions.py:96](../../src/pyrxd/gravity/transactions.py#L96))
+- [x] Fix the stale comment at
+  [transaction_preimage.py:109](../../src/pyrxd/transaction/transaction_preimage.py#L109)
+  that incorrectly claims ref count is "always 0 for standard
+  P2PKH/FT/NFT outputs." **Done 2026-05-19.**
+- [x] Add `TestSighashBackcompat` golden-vector regression test.
+  **Done 2026-05-19** — placed in `tests/test_gravity.py` (not
+  `test_gravity_trade.py`; that's where the pure-function builder tests
+  live). Golden vectors are inline module constants captured from the
+  pre-refactor impl, parameterized, asserted byte-identical. Also added
+  `test_ft_output_now_computes_real_refshash` (proves the FT path no
+  longer hashes as totalRefs=0) and `test_malformed_trailing_bytes_rejected`.
+- [ ] **DEFERRED to Phase 2: adversarial sighash vectors for `totalRefs >= 1`
+  sourced from a confirmed broadcast.** These need a real ref-bearing
+  Gravity covenant spend, which doesn't exist until Phase 2. Partial
+  coverage landed now: `test_ft_output_now_computes_real_refshash`
+  exercises the `totalRefs=1` path with a synthetic FT script, and the
+  refactored adapter was run live against the real on-chain ref output
+  in mainnet tx `dac1e2df...` (8104 confs, 1 ref) — confirming the
+  ref-aware path runs on real consensus bytes. Full sort-order /
+  dedup / mixed-opcode regtest fixtures come with the Phase 2 covenant.
+- [x] Confirm `tests/test_gravity_trade.py::TestGravityTradeP2PKH` and
+  `TestGravityTradeFinalize` still pass. **Done — 199 passed across
+  gravity + preimage + trade + red-team suites.**
+- [x] Confirm `tests/test_preimage.py::TestComputeHashOutputHashes` (mainnet
+  tx `dac1e2df...` pinned vectors) still passes. **Done.**
+
+**Success criteria:**
+- [x] Gravity + preimage + trade + red-team suites green (199 passed). `task ci` not yet run end-to-end on this branch — pending before PR.
+- [x] Coverage for `gravity/transactions.py` holds (91%); the refactored adapter is exercised by the new tests.
+- [x] Live cross-check against the mainnet node on `tr`: refactored adapter ran on the real on-chain ref-bearing output in tx `dac1e2df...` (8104 confs).
+- [ ] One PR. Title: `refactor(gravity): de-duplicate _compute_hash_output_hashes`. (Regtest fixture-capture harness deferred with the Phase-2 covenant work — see deferred item above.)
+
+**Estimated effort:** 1–2 days (spike-revised down from 3–5: the
+ref-aware `_get_push_refs` + `_compute_hash_output_hashes` are already
+shipped and tested at
+[tests/test_preimage.py:34-79](../../tests/test_preimage.py#L34), so
+the de-dup is small; regtest harness setup is lighter than feared).
+See [spike-findings](../brainstorms/2026-05-19-gravity-ref-covenant-spike-findings.md).
+
+---
+
+#### Phase 2: Photonic prior-art check + Radiant-side script spike
+
+**Goal:** establish whether Photonic (the canonical Glyph reference per
+[CLAUDE.md memory](../../docs/concepts/gravity.md)) has prior art on
+ref-bearing covenants, then spike a **Radiant-only** covenant script
+that carries a ref through lock and release (no BTC half yet).
+
+**Tasks:**
+
+- [ ] Read Photonic's TypeScript codebase for any ref-bearing covenant
+  / ref-passthrough constraint patterns. Document findings in a new
+  brainstorm at `docs/brainstorms/2026-05-MM-gravity-ref-spike-findings.md`.
+- [ ] Draft **two candidate covenant templates** — one for FT, one
+  for NFT. Required clauses for each:
+  - Settlement clause: covenant **constructor params** include
+    `glyph_ref` (substituted into the hex template like
+    `btcReceiveHash` — this binds the ref into the P2SH hash;
+    Security #1). The clause builds the settlement output script with
+    the locked ref opcode and ref bytes, pushes expected amount (FT)
+    or just the singleton (NFT), enforces conservation.
+  - Forfeit clause: pop expected reclaim signature, verify against
+    Maker pubkey, build reclaim output with the same ref
+    opcode/bytes and amount.
+  - **Critical (Security #2):** Both templates must independently
+    enforce `totalRefs == 1` on settlement output and forfeit output
+    so a Python-bypassing Maker who funds with a multi-ref UTXO
+    cannot smuggle an extra ref through. Python pre-flight (Phase 3)
+    is not sufficient on its own.
+  - **Critical (Security #5):** The covenant must bind the BTC
+    payment to **offer-unique** data. Today's sentinel covenant
+    binds to `(btcReceiveHash, btcReceiveType, btcSatoshis)`; two
+    concurrent ref-bearing offers from the same Maker to the same
+    BTC address satisfy each others' SPV proofs. **Mitigation:
+    subaddress derivation.** Each offer's `btcReceiveHash` is
+    derived from `(maker_pubkey_hash, glyph_ref, nonce)` so each
+    offer has a fresh receiving address. Rationale: any BTC wallet
+    that can send to an address can pay (no OP_RETURN authoring
+    requirement → no Taker funnel cost). Maker key management
+    overhead is small — Makers already manage pubkey rotation.
+    Phase 2 spike validates the derivation scheme; if it proves
+    impractical, fall back to OP_RETURN-carrying-P2SH-hash with a
+    documented Taker-wallet-compatibility note.
+  - **No `refKind` in-script dispatch.** Templates compile separately;
+    the artifact name and constructor params discriminate.
+- [ ] Compile candidate to `*.artifact.json` shape matching
+  [gravity/artifacts/maker_offer.artifact.json](../../src/pyrxd/gravity/artifacts/maker_offer.artifact.json):
+  `{version, compilerVersion, contract, abi, asm, hex}` with
+  `<paramName>` placeholders for substitution.
+- [ ] Drive the spike on regtest (per memory:
+  [Radiant Core (current) not radiant-node (old)](../../docs/concepts/gravity.md)).
+  Validate:
+  - (a) lock a 75-byte FT UTXO and a 63-byte NFT singleton UTXO into
+    the covenant; both funding txs accepted by Radiant validators.
+  - (b) release each via a single-clause spend to a target address;
+    ref appears on the output, conservation holds.
+  - (c) reclaim via timeout (block-height bound); ref returns to Maker.
+- [ ] Document attempted designs that didn't work in the spike-findings
+  brainstorm (follows the
+  [2026-05-19-gravity-p2pkh-spike-findings.md](../brainstorms/2026-05-19-gravity-p2pkh-spike-findings.md)
+  precedent).
+
+**Success criteria:**
+- Spike-findings brainstorm published.
+- Two working artifact drafts (regtest-validated, **not** mainnet-ready,
+  **not** shipped under `gravity/artifacts/` yet — live in a scratch
+  location).
+- **Benchmark vector table in the brainstorm** (Performance #1 + #2):
+  - Sentinel covenant settlement bytes (baseline).
+  - FT covenant settlement bytes.
+  - NFT covenant settlement bytes.
+  - FT funding tx size; NFT funding tx size.
+  - Per-trade fee in photons at the project's documented relay floor
+    (cite the floor constant, don't invent a number).
+- **Absolute acceptance gates (replace the original 30% threshold):**
+  - Settlement tx ≤ 1.5× sentinel settlement tx size.
+  - FT funding tx ≤ 1.5× sentinel funding tx size.
+  - Per-trade Taker-paid fee ≤ documented "acceptable swap fee"
+    constant (TBD in spike if no such constant exists; needs Maker/
+    Taker UX context).
+- **Adversarial review checkpoint** (per `expert-panel-pivot` lesson,
+  scaled down): one half-day red-team pass on the artifact draft
+  before Phase 4 begins. Single question: "what does shipping this
+  normalize, and what's the day-1 attack?" Findings recorded in the
+  spike-findings brainstorm.
+
+**Estimated effort:** 1–2 weeks (spike-revised down from 2–3). The
+sentinel covenant already constructs settlement-output scripts
+compositionally with `OP_CAT` (260× in the asm) and asserts them via
+`OP_OUTPUTBYTECODE`/`OP_OUTPUTVALUE` — so carrying a ref is *additive*
+(CAT the FT/NFT epilogue into the expected-output construction), not a
+from-scratch output-description system. The remaining dominant unknown
+is regtest validation that ref-conservation and the covenant's
+expected-output assertion agree — that is what keeps this from
+collapsing further. Two artifacts still add time vs. one. See
+[spike-findings](../brainstorms/2026-05-19-gravity-ref-covenant-spike-findings.md).
+
+---
+
+#### Phase 3: Funding-input pre-flight validation + type discipline
+
+**Goal:** before any covenant code can sign a funding tx, the Python
+must verify the source UTXO matches what the covenant expects. This
+prevents a class of "mis-funded covenant" bugs that lock assets until
+deadline with no recovery.
+
+**Tasks (type discipline):**
+
+- [ ] Extract `_BaseGravityOffer` in `src/pyrxd/gravity/types.py` — a
+  `@dataclass(frozen=True, slots=True, kw_only=True)` holding the
+  BTC + deadline + Taker fields shared across plain-RXD, FT, and
+  NFT offers. Move the shared `__post_init__` validation logic from
+  today's `GravityOffer` ([types.py:60-80](../../src/pyrxd/gravity/types.py#L60))
+  into the base.
+- [ ] `GravityOffer` (existing) extends `_BaseGravityOffer`. Add a
+  no-op subclass-specific `__post_init__` if any plain-RXD-only
+  validation exists.
+- [ ] `GravityFTOffer` extends `_BaseGravityOffer`. Fields: `glyph_ref:
+  GlyphRef`, `amount: FtAmount`. Frozen, slots, kw_only.
+- [ ] `GravityNFTOffer` extends `_BaseGravityOffer`. Field:
+  `glyph_ref: GlyphRef`. No amount.
+- [ ] `RefKind(IntEnum)` in `types.py`: `FT = 0`, `NFT = 1`. Used at
+  the script-boundary; out-of-range becomes free `ValueError` via
+  `RefKind(value)`.
+- [ ] `FtAmount = NewType("FtAmount", int)` in `types.py`. Prevents
+  unit confusion with photons/satoshis at type-check time. Zero
+  runtime cost.
+
+**Tasks (validators — opcode-stream walker, no byte-scan):**
+
+- [ ] New subpackage `src/pyrxd/gravity/ref/` with `validation.py`:
+  - `_validate_ft_funding_input(utxo, expected_ref, expected_amount)`
+    — parses 75-byte FT locking script (per
+    [glyph/script.py:135](../../src/pyrxd/glyph/script.py#L135))
+    by **walking the opcode stream** (skip push payloads per the
+    canonical walker at `glyph/dmint.py:1513`). Bare-byte scans are
+    prohibited — cite
+    [funding-utxo-byte-scan-dos.md](../solutions/logic-errors/funding-utxo-byte-scan-dos.md)
+    in the module docstring. Asserts ref bytes match
+    `expected_ref.to_bytes()` and FT amount matches.
+  - `_validate_nft_funding_input(utxo, expected_ref)` — same shape
+    for 63-byte NFT singleton script
+    ([glyph/script.py:127](../../src/pyrxd/glyph/script.py#L127)).
+  - Both prefixed `_` (private) per existing helper-privacy
+    convention in `gravity/transactions.py` (`_varint`,
+    `_validate_txid`, etc.). Callers go through the factory.
+  - Error messages follow the
+    [covenant.py:249-253](../../src/pyrxd/gravity/covenant.py#L249)
+    triad: `f"<field> must be <expected>; got <actual>. <consequence>"`.
+
+**Tasks (factories — two, not one):**
+
+- [ ] In `src/pyrxd/gravity/ref/covenant.py`:
+  - `build_gravity_ft_offer(glyph_ref, amount, btc_receive_type,
+    btc_receive_hash, deadline, ...) -> GravityFTOffer`
+  - `build_gravity_nft_offer(glyph_ref, btc_receive_type,
+    btc_receive_hash, deadline, ...) -> GravityNFTOffer`
+- [ ] Each factory loads its specific artifact name
+  (`maker_covenant_ft_v1` or `maker_covenant_nft_v1`) and calls the
+  matching pre-flight validator. Cross-kind loading raises
+  `ValidationError`.
+
+**Tests (consolidated — `tests/test_gravity_ref.py`, validators + types
+together per Kieran #9):**
+
+- [ ] `TestFundingInputMismatch` — wrong ref, wrong amount, multi-ref
+  UTXO, non-FT locking script, wrong-kind UTXO (NFT into FT
+  validator).
+- [ ] `TestArtifactKindIsolation` — `build_gravity_ft_offer` rejects
+  the NFT artifact name; vice versa.
+- [ ] `TestFundingDenyListFalsePositive` (per
+  [funding-utxo-byte-scan-dos.md](../solutions/logic-errors/funding-utxo-byte-scan-dos.md)):
+  construct a legitimate 75-byte FT funding script where the 20-byte
+  miner P2PKH payload happens to contain bytes in the `0xD0–0xD8`
+  ref-opcode range. Validator must accept. Document the
+  false-positive rate in the test docstring (target: 0%).
+- [ ] **Hypothesis property tests** (per
+  [fuzzing-strategy-graduated-approach.md](../solutions/design-decisions/fuzzing-strategy-graduated-approach.md)):
+  `tests/property/test_ref_validation_robustness.py` —
+  `validate_ft_funding_input(arbitrary_bytes_as_script)` and
+  `validate_nft_funding_input(...)` never raise anything but
+  `ValidationError`. ~50 LOC, runs in existing pytest.
+- [ ] `TestRefKindIntEnumBoundaries` — `RefKind(2)` raises `ValueError`;
+  free out-of-range rejection.
+- [ ] `TestFtAmountTypeDiscipline` — at the mypy/pyright level, passing
+  a `Photons` or bare `int` where `FtAmount` is expected fails (test
+  enforced via the type-check CI step).
+
+**Success criteria:**
+- `task ci` green. `coverage-security` 100% on `gravity/ref/validation.py`.
+- New types exposed via `_LAZY_EXPORTS` in
+  [src/pyrxd/__init__.py](../../src/pyrxd/__init__.py) under a new
+  `# Gravity — ref-bearing` section comment, alphabetical:
+  `GravityFTOffer`, `GravityNFTOffer`, `RefKind`,
+  `build_gravity_ft_offer`, `build_gravity_nft_offer`,
+  `verify_ref_offer` (Phase 6). Validators stay unexported (private
+  per convention).
+- `src/pyrxd/gravity/__init__.py` updates its eager `__all__` list
+  (not lazy — different mechanism from the top-level init, per
+  Pattern Recognition).
+- One PR. Title: `feat(gravity): add ref-bearing offer types + funding
+  pre-flight validator`.
+
+**Estimated effort:** 5–7 days (up from 3–5 due to the additional
+property tests and shared-base extraction).
+
+---
+
+#### Phase 4: Bolt on the BTC half — full covenant + tx builders
+
+**Goal:** splice the SPV proof + `btcReceiveType` dispatch from the
+sentinel covenant into the Phase-2 Radiant-side spike. Produce a
+shippable artifact.
+
+**Tasks:**
+
+- [ ] Merge the SPV-proof clauses from the sentinel covenant
+  ([gravity/artifacts/maker_covenant_flat_12x20_sentinel_all.artifact.json](../../src/pyrxd/gravity/artifacts/maker_covenant_flat_12x20_sentinel_all.artifact.json))
+  into both Phase-2 ref-bearing templates. The sentinel-padded
+  Merkle-depth handling (depth 12–20) is reused verbatim.
+- [ ] `btcReceiveType` four-way dispatch (P2PKH/P2WPKH/P2SH/P2TR)
+  reused verbatim.
+- [ ] Final artifacts ship at:
+  - `src/pyrxd/gravity/artifacts/maker_covenant_ft_v1.artifact.json`
+  - `src/pyrxd/gravity/artifacts/maker_covenant_nft_v1.artifact.json`
+- [ ] Tx builders in `src/pyrxd/gravity/ref/transactions.py`:
+  - `build_ft_maker_offer_tx(...)` / `build_nft_maker_offer_tx(...)`
+    — Maker funds the covenant with a ref-bearing UTXO.
+  - `build_ft_finalize_tx(...)` / `build_nft_finalize_tx(...)` —
+    Taker (or anyone) settles with SPV proof; output carries the ref
+    to Taker.
+  - `build_ft_forfeit_tx(...)` / `build_nft_forfeit_tx(...)` — Maker
+    reclaims after deadline.
+  - **No `cancel_tx`** — out of v1 scope per brainstorm; forfeit
+    covers failure.
+- [ ] Pre-broadcast validator (scoped per Simplicity #5 — a thin
+  check, not a full simulator): "does each input ref appear on
+  exactly one output of expected kind." Reject locally with a clear
+  error before broadcast. Prevents the "tx rejected by validators,
+  assets stalled to deadline" failure for the common pre-flight
+  bugs. **Add Hypothesis property tests** on this validator (same
+  graduated-fuzzing pattern as Phase 3).
+- [ ] **Typed exception discipline** (per
+  [dmint-v1-mint-scriptsig-divergence.md](../solutions/logic-errors/dmint-v1-mint-scriptsig-divergence.md)):
+  introduce or reuse a `PolicyRejection` exception type for tx
+  rejections that surface from regtest/mainnet. Ensure ElectrumX
+  `code 1` rejections are *not* reclassified as `NetworkError` (this
+  masked a critical V1 dMint bug for weeks).
+
+**Tests (in `tests/test_gravity_ref.py`):**
+
+- [ ] Class-per-builder: `TestBuildFTMakerOfferTx`,
+  `TestBuildFTFinalizeTx`, `TestBuildFTForfeitTx`, and the three NFT
+  analogs. Mirrors
+  [tests/test_gravity.py::TestBuildFinalizeTx](../../tests/test_gravity.py#L93).
+- [ ] `TestRefArtifactSubstitution` — verify `<paramName>`
+  placeholders substitute correctly for `glyph_ref` and `amount`
+  params in both artifacts.
+
+**Tests (golden bytes from real regtest — per
+[dmint-v1-mint-shape-mismatch.md](../solutions/logic-errors/dmint-v1-mint-shape-mismatch.md)):**
+
+- [ ] `TestRefArtifactGoldenVectors` (**mandatory before merge**):
+  For each of the six builders (FT and NFT × offer/finalize/forfeit),
+  capture byte-for-byte expected output from a **regtest broadcast
+  that actually confirmed** during Phase 2 validation. Assert
+  `tx.serialize() == _REGTEST_CONFIRMED_BYTES_<TX>` with the regtest
+  txid and block height cited in the test fixture. **No builder
+  lands without an externally-confirmed byte fixture** — synthetic
+  round-trip through pyrxd's own parser does not satisfy this gate.
+- [ ] `testmempoolaccept` gate: every settlement and forfeit tx
+  produced by the new builders must be accepted by a real Radiant
+  Core regtest node via `testmempoolaccept` (or actual broadcast +
+  confirmation) before the PR can merge. The pre-broadcast validator
+  is informational only; it does not satisfy this gate.
+
+**Success criteria:**
+- `task ci` green.
+- Both artifacts load via `CovenantArtifact.load("maker_covenant_ft_v1")`
+  and `CovenantArtifact.load("maker_covenant_nft_v1")`.
+- Golden byte vectors checked in; each cites a regtest txid + block
+  height in the fixture file.
+- `testmempoolaccept` evidence checked in (regtest run logs or CI
+  artifact).
+- One PR. Title: `feat(gravity): ship ref-bearing covenant artifacts + tx builders`.
+
+**Estimated effort:** 1.5–2 weeks (spike-revised down from 2–3:
+builders extend the existing introspection-output pattern rather than
+inventing one). The golden-byte regtest gate is unchanged — and
+**more** important per the spike: `OP_OUTPUTBYTECODE` on a ref-bearing
+output is a script path the sentinel covenant has never exercised, so
+synthetic round-trip would be exactly the dMint trap. See
+[spike-findings](../brainstorms/2026-05-19-gravity-ref-covenant-spike-findings.md).
+
+---
+
+#### Phase 5: End-to-end + red-team test coverage
+
+**Goal:** match or exceed the existing Gravity test discipline. The
+brainstorm called out
+[tests/test_gravity_trade.py::TestGravityTradeP2PKH](../../tests/test_gravity_trade.py#L945)
+as the pattern to copy — full lock → BTC payment → SPV → settle, no
+verifier mocking, real `SpvProofBuilder.build()` against a synthetic
+BTC tx and pre-mined PoW header.
+
+**Tasks (end-to-end, in `tests/test_gravity_ref_trade.py`):**
+
+- [ ] `TestGravityFTTrade` — clone the P2PKH pattern, swap in the FT
+  covenant. Full lock → BTC payment → SPV → settle. Synthetic BTC
+  tx, pre-mined header from
+  `tests/fixtures/spv_synthetic_headers.json` (extend the fixture if
+  needed; pre-generated and committed, per
+  [test_gravity_trade.py:912-917](../../tests/test_gravity_trade.py#L912)).
+- [ ] `TestGravityNFTTrade` — same shape for NFT singleton.
+- [ ] `TestGravityFTForfeit` and `TestGravityNFTForfeit` — deadline
+  expiry, Maker reclaims.
+- [ ] `TestThirdPartySettlement` — anyone with the SPV proof can
+  settle (today's Gravity property must survive in the ref variant).
+
+**Tasks (red-team, in a new dedicated file
+`tests/test_gravity_ref_red_team.py` mirroring
+[tests/test_gravity_red_team.py](../../tests/test_gravity_red_team.py)):**
+
+- [ ] `TestRefArtifactTampering` — byte mutation of both artifacts;
+  deny-list bypass attempts; ASCII reinjection.
+- [ ] `TestRefArtifactOutpointBinding` (per Security Sentinel
+  cross-cutting recommendation): verify each settlement proof is
+  consumed atomically with the covenant input — no replay against a
+  re-funded covenant at the same P2SH hash (relevant to
+  `dmint-deploy-reveal-hashlock-reuse.md` learning).
+- [ ] `TestRefBoundToP2SHHash` (Security #1): mutate `glyph_ref` in
+  the substituted hex bytes; assert P2SH hash changes. Confirms the
+  ref is a covenant constructor param, not a witness.
+- [ ] `TestRefParamEncodingEdges`:
+  - Wrong-length `glyph_ref` (not 36 bytes)
+  - `amount = 0` (rejected at factory; FT only)
+  - `amount = 2^64 - 1` (uint64 boundary; serializes; presumably fails
+    conservation at settlement — assert behavior)
+  - `RefKind(2)` raises `ValueError` (IntEnum boundary)
+- [ ] `TestMultiRefSourceRejected` (Security #2 — Critical): funding
+  UTXO carries multiple refs.
+  - Part A: Python pre-flight rejects.
+  - Part B (**bypass the validator, fund directly**): the covenant
+    **script itself** must reject. If script-level rejection cannot
+    be confirmed via regtest broadcast, Phase 2 design did not
+    satisfy Security #2 and must be revisited.
+- [ ] `TestSPVProofReuseAcrossOffers` (Security #5 — Critical): two
+  Maker offers with the same `(btcReceiveHash, btcReceiveType,
+  btcSatoshis)`. Submit the same SPV proof to both settlement
+  attempts. Expected behavior depends on Phase 2's chosen
+  mitigation; the test asserts only-one settles.
+- [ ] `TestRefSortOrderConsensus` — uses two refs that sort
+  differently than declaration order. Sighash uses sorted order
+  ([transaction_preimage.py:80-91](../../src/pyrxd/transaction/transaction_preimage.py#L80));
+  the script-level constraint must read refs in the same order.
+- [ ] `TestSettlementAmountSplit` — settlement tx tries to split N
+  into two outputs (Taker + attacker). Rejected by ref-conservation.
+- [ ] `TestSingletonDuplicationAttempt` — settlement tx tries to
+  produce NFT singleton on two outputs. Rejected.
+- [ ] `TestRefSubstitution` — settlement output carries a different
+  ref of the same kind. Rejected.
+- [ ] `TestSourceRefBurnedPreSettlement` — source ref destroyed
+  post-funding (some FTs have admin burn keys). Verify forfeit still
+  works (it returns the locked UTXO; the ref's external state
+  doesn't affect that).
+- [ ] `TestSettlementReorgAcrossDeadline` — settlement tx reorgs out
+  near deadline; forfeit races re-confirmation. Document expected
+  behavior.
+- [ ] `TestForfeitFeeStarvation` (Security #4): Maker's only
+  fee-bearing UTXO is double-spent by attacker at deadline; verify
+  forfeit can be funded from any UTXO (covenant must not require a
+  specific fee source).
+- [ ] `TestDuplicateOfferDisambiguation`
+  ([dmint-deploy-reveal-hashlock-reuse.md](../solutions/logic-errors/dmint-deploy-reveal-hashlock-reuse.md)):
+  two identical-param offers from the same Maker produce identical
+  P2SH script hashes. Verifier must disambiguate by funding outpoint,
+  not by scripthash history ordering.
+- [ ] `TestPolicyRejectionSurfaced`
+  ([dmint-v1-mint-scriptsig-divergence.md](../solutions/logic-errors/dmint-v1-mint-scriptsig-divergence.md)):
+  when the covenant rejects a malformed witness/scriptSig, the
+  resulting error is a typed `PolicyRejection`, not a generic
+  `NetworkError`. ElectrumX `code 1` reclassification masked a
+  critical V1 dMint bug.
+
+**Tasks (CLI surface, in
+[wallet_cmds.py](../../src/pyrxd/cli/wallet_cmds.py)):**
+
+- [ ] One `gravity-ref` command group with subcommands `offer`,
+  `settle`, `forfeit` (per Simplicity #6). Each subcommand must show
+  the human-readable ref + amount + deadline before signing —
+  surfaces the Maker/Taker pre-confirmation UX gap from SpecFlow.
+
+**Success criteria:**
+- `task ci` green. `coverage-overall` ≥85% maintained.
+- Both end-to-end FT and NFT trades demonstrably work against
+  synthetic BTC + pre-mined PoW headers.
+- All Critical-rated security tests pass (`TestMultiRefSourceRejected`
+  Part B and `TestSPVProofReuseAcrossOffers` are blockers).
+- Red-team coverage at least matches the existing Gravity red-team
+  test count proportional to the covenant surface.
+
+**Estimated effort:** 2–3 weeks.
+
+---
+
+#### Phase 6: Taker verification API + cross-feature integration
+
+**Goal:** SpecFlow surfaced this as the brainstorm's biggest gap — a
+Taker has no first-class API for verifying what they're buying before
+paying BTC. Build it as a first-class deliverable.
+
+**Tasks (verifier — async, per Kieran #5):**
+
+- [ ] New module `src/pyrxd/gravity/ref/verify.py`:
+  - `async def verify_ref_offer(offer, *, funding_outpoint,
+    expected_ref, expected_amount=None, resolver, btc_confirmations=N)
+    -> VerifyResult` — Taker-side check.
+  - **Takes a specific funding outpoint** (`txid:vout`) rather than
+    searching by scripthash — per
+    [dmint-deploy-reveal-hashlock-reuse.md](../solutions/logic-errors/dmint-deploy-reveal-hashlock-reuse.md):
+    a Maker reposting the same offer produces an identical P2SH
+    hash, so "find the offer by scripthash" is ambiguous.
+  - Calls `RxinDexerClient.glyph_get_token(ref)` and/or
+    `glyph_get_metadata(ref)`
+    ([rxindexer.py:120,133](../../src/pyrxd/network/rxindexer.py#L120))
+    to fetch token metadata (decimals, ticker, supply where
+    available). **The original plan referenced a non-existent
+    `glyph_resolve` method — corrected by Performance Oracle.**
+  - Confirms covenant `glyph_ref` matches `expected_ref`; confirms
+    covenant `amount` (FT) matches `expected_amount`.
+  - Returns a **structured `VerifyResult` dataclass** (Security #8):
+    `verified: bool`, `warnings: list[str]`, `failure_reason: str |
+    None`. **Raises** on missing metadata (fail-closed, never returns
+    a falsy "verified=False" that callers might misinterpret as
+    "verification ran cleanly and the offer is bad" vs. "verification
+    couldn't complete").
+  - Requires `btc_confirmations >= N` confirmations of the funding
+    tx (Security #7). N parameterized; documented default.
+  - **In-process TTL cache** (Performance #5): 60-second TTL keyed by
+    ref bytes — token metadata is near-immutable.
+  - **Latency budget:** ≤ 500ms p95 for a single offer verification.
+- [ ] **Phantom-metadata warning** (Security UX): when the resolver
+  shows the same `btcReceiveHash` on another live ref-bearing offer,
+  the result includes a warning (`VerifyResult.warnings`). Documented
+  in [docs/red-team-checklist.md](../red-team-checklist.md) as a
+  Taker-visible risk; out of v1 enforcement scope.
+
+**Tests (in `tests/test_gravity_ref_verify.py`):**
+
+- [ ] `@pytest.mark.asyncio` on every test. Async resolver fixture.
+- [ ] `TestVerifyRefOffer` — happy path, ref mismatch, amount
+  mismatch, missing metadata (must **raise**, not return falsy),
+  outpoint-not-found.
+- [ ] `TestVerifyRefOfferDoesNotReturnFalsy` (Security #8 hardening):
+  assert the API contract that catching exceptions and proceeding is
+  documented as a security bug.
+- [ ] `TestVerifyRefOfferCacheTTL` — second call within 60s hits
+  cache; after TTL, network roundtrip again.
+- [ ] `TestVerifyRefOfferConcurrentOfferWarning` — two live offers
+  share `btcReceiveHash`; warning surfaced.
+
+**Scope cuts from original plan:**
+
+- ~~`verify_ref_offer_via_wave`~~ dropped — WAVE deferred per
+  [wave-protocol-deferred-until-consumer.md](../solutions/design-decisions/wave-protocol-deferred-until-consumer.md);
+  no concrete consumer needs it in this plan. Listed under Future
+  Considerations.
+- ~~Glyph inspector integration~~ deferred to a separate post-merge
+  follow-up issue. Different file
+  ([inspect.js](../inspect_static/inspect/inspect.js)), different
+  reviewer attention, different risk profile (per Simplicity #4).
+  Filed as a tracked follow-up before this plan closes.
+
+**Success criteria:**
+- `task ci` green.
+- All async tests pass with `pytest-asyncio`.
+- One PR. Title: `feat(gravity): async Taker-side ref-offer verification API`.
+
+**Estimated effort:** 5–7 days (smaller after WAVE + inspector cuts).
+
+---
+
+#### Phase 7: Audit pass + deny-list seeding
+
+**Goal:** before any mainnet exercise, the ref-bearing covenant gets a
+full audit treatment.
+
+**Tasks:**
+
+- [ ] **This audit pass is `audit 06`** — one greater than the most
+  recent `audit 05-F-N` series at
+  [gravity/trade.py:19,23,182](../../src/pyrxd/gravity/trade.py#L19).
+  Use hyphenated form: `audit 06-S1`, `audit 06-F-1`, ... matching
+  the most recent convention. Findings recorded inline at point of
+  enforcement.
+- [ ] Create `docs/audits/` directory (does not exist yet) and add
+  a top-of-file audit index in `gravity/ref/covenant.py` mapping
+  `audit 06 → docs/audits/2026-MM-DD-ref-covenant-audit.md` (one new
+  file; ~1 page summary of audit findings + dispositions).
+  Otherwise future readers see `audit 06-S3` and have to grep.
+- [ ] Extend [gravity/covenant.py:59-76](../../src/pyrxd/gravity/covenant.py#L59)
+  deny-list with ref-bearing entries. **Use a `[ref-v1] ` reason
+  prefix** on the existing `_BANNED_NAMES` / `_BANNED_BYTECODE_SHA256`
+  dicts (per Simplicity #3) — separate dicts would be premature
+  partitioning for ~1 entry. The prefix supports the same audit
+  story with `grep '\[ref-v1\]'`.
+- [ ] If the unified `refKind` dispatch design surfaces during audit
+  (since the plan reversed away from it), add an explicit deny-list
+  entry for it with reason: `[ref-v1] in-script refKind dispatch —
+  branch-confusion attack class; split FT/NFT preferred (audit 06-S2)`.
+- [ ] If the audit surfaces any attempted-and-rejected designs from
+  Phase 2's spike, add them to the deny-list with reasons.
+- [ ] **External audit is a hard gate**, not a recommendation, for
+  any mainnet exercise of the ref-bearing variant (Security
+  cross-cutting recommendation). NFT-irreversibility raises the bar
+  above the plain-RXD covenant. Per
+  [docs/concepts/gravity.md:219-222](../concepts/gravity.md#L219).
+  Plan-of-plan follow-up; this plan ships through internal audit
+  only, no mainnet activation.
+
+**Tasks (documentation):**
+
+- [ ] Update [docs/concepts/gravity.md](../concepts/gravity.md):
+  - Add a new section on ref-bearing covenants (FT + NFT support).
+  - Status table: shipping (RXD), shipping with limits (ref v1, FT
+    tested on mainnet at small amount, NFT not yet).
+  - Open-amount and partial-fill limitations called out.
+- [ ] CHANGELOG entry under unreleased "Added" section, citing the new
+  artifact and Taker-verification API.
+- [ ] Small-amount mainnet exercise after audit (separate task post-audit,
+  not in this plan).
+
+**Success criteria:**
+- Internal audit signed off.
+- Deny-list extended.
+- Docs updated.
+- One PR. Title: `chore(gravity): ref covenant audit pass + deny-list +
+  docs`.
+
+**Estimated effort:** 1 week.
+
+## Alternative Approaches Considered
+
+| Alternative | Why rejected |
+|---|---|
+| **Off-chain custodian** | Defeats Gravity's trust property. |
+| **Two-leg swap (Gravity BTC→RXD, then RXD→FT)** | Not atomic; either side can stiff on leg 2. Only viable for trusted counterparties. |
+| **Radiant Swap DEX (`swap.*`)** | Trades on Radiant only; does not accept BTC. Complementary to Gravity, not a replacement. |
+| **Unified `refKind`-dispatched covenant** | The brainstorm's original direction. Rejected during plan review: FT (`0xd0`) and NFT (`0xd8`) are different opcodes with different conservation semantics, not output-format variants like `btcReceiveType`. In-script dispatch creates a branch-confusion attack class (Security: High). Future-consolidation option if measured data eventually shows the split's maintenance cost outweighs the security partitioning. |
+| **OP_RETURN-carrying-P2SH-hash for SPV proof binding** | Strongest cryptographic binding (one BTC tx → one covenant), but excludes Taker wallets that can't author OP_RETURN payloads (most consumer mobile wallets). Subaddress derivation chosen instead; OP_RETURN remains a fallback if subaddress derivation proves impractical in the Phase 2 spike. |
+| **Patch existing sentinel covenant in-place** | Would break the mainnet-proven RXD path. New artifact preserves the existing one untouched. |
+| **Generalize the sighash helper to accept either bytes or list** | Adds a union type to a security-critical function; harder to audit. Cleaner to extract the byte-stream parser and reuse `_get_push_refs`. |
+
+## Acceptance Criteria
+
+### Functional Requirements
+
+- [ ] **FT swap end-to-end:** Maker locks 1,000 FT units; Taker pays BTC;
+  Taker settles; 1,000 units land on Taker's Radiant address; FT
+  conservation holds on every output.
+- [ ] **NFT swap end-to-end:** Maker locks NFT singleton; Taker pays BTC;
+  Taker settles; singleton appears on Taker's address; no
+  duplication.
+- [ ] **Forfeit:** if deadline passes without settlement, Maker reclaims
+  the original ref-bearing UTXO (ref + amount intact for FT; singleton
+  intact for NFT).
+- [ ] **Third-party settlement:** anyone holding the SPV proof can
+  submit the settlement tx; today's Gravity property survives.
+- [ ] **Pre-flight validation:** Maker cannot fund the covenant with a
+  wrong-kind or wrong-ref UTXO; the factory rejects before signing.
+- [ ] **Taker verification:** `verify_ref_offer` confirms ref, amount,
+  and (where available) token metadata before Taker pays.
+
+### Non-Functional Requirements
+
+- [ ] **Fee profile:** FT and NFT covenant script size + settlement
+  tx size each measured against the sentinel covenant (absolute
+  byte counts, not just ratios). Targets:
+  - Settlement tx ≤ 1.5× sentinel settlement tx size
+  - Funding tx ≤ 1.5× sentinel funding tx size
+  - Per-trade Taker-paid fee documented in spike-findings brainstorm
+- [ ] **Sighash backcompat:** existing plain-RXD Gravity trades produce
+  identical sighash bytes after Phase 1 de-duplication (parameterized
+  golden vector test) **and** new adversarial vectors for `totalRefs
+  >= 1` produce correct sighashes (validated against regtest
+  broadcasts, not just round-trip).
+- [ ] **No `allow_legacy=True` shortcut:** the new artifacts get the
+  full audit treatment and clean deny-list.
+- [ ] **Coverage:** `coverage-security` 100% on new modules
+  (`gravity/ref/validation.py`, `gravity/ref/covenant.py`,
+  `gravity/ref/verify.py`); `coverage-overall` ≥85%.
+- [ ] **Async discipline:** `verify_ref_offer` is `async def`;
+  validators stay sync (local-only parsing).
+- [ ] **Type discipline:** `RefKind(IntEnum)` boundary at script
+  layer; `FtAmount = NewType("FtAmount", int)` prevents unit confusion
+  with photons/satoshis; mypy/pyright enforced in CI.
+
+### Quality Gates
+
+- [ ] `task ci` green at the end of each phase. Pre-push hook
+  installed (per
+  [local-ci-parity-via-task-ci-and-pre-push-hook.md](../solutions/integration-issues/local-ci-parity-via-task-ci-and-pre-push-hook.md));
+  no `--no-verify` pushes except WIP.
+- [ ] Conventional Commits with DCO sign-off
+  ([CONTRIBUTING.md:130-142](../../CONTRIBUTING.md#L130)).
+- [ ] Internal audit signed off (Phase 7). External audit is a hard
+  gate before any mainnet exercise (post-plan).
+- [ ] Documentation in
+  [docs/concepts/gravity.md](../concepts/gravity.md) updated to
+  reflect ref-bearing variant status.
+- [ ] Brainstorm spike-findings doc published (Phase 2).
+- [ ] Both Critical-severity security tests pass
+  (`TestMultiRefSourceRejected` Part B script-level enforcement, and
+  `TestSPVProofReuseAcrossOffers`).
+
+## Success Metrics
+
+| Metric | Measurement | Target |
+|---|---|---|
+| FT swap demonstrably atomic | End-to-end test green | Yes |
+| NFT swap demonstrably atomic | End-to-end test green | Yes |
+| Trust properties preserved | Red-team test suite passes (Critical-rated tests are blockers) | Yes |
+| Settlement tx size | Byte count vs sentinel | ≤ 1.5× sentinel |
+| Funding tx size | Byte count vs sentinel | ≤ 1.5× sentinel |
+| Per-trade Taker-paid fee | Photons at documented relay floor | Documented in spike-findings brainstorm |
+| Sighash backcompat | Golden vector regression test | Byte-identical |
+| Mainnet small-amount exercise (post-audit) | Out of plan scope; tracked separately | Successful settlement on real BTC+RXD |
+
+## Dependencies & Prerequisites
+
+- **Radiant Core (current fork) on regtest** for the Phase 2 spike.
+  Per memory:
+  [project_radiant_core_current_repo](../../docs/concepts/gravity.md).
+- **RXinDexer client** wired up for the Phase 6 Taker verification API
+  ([rxindexer.py](../../src/pyrxd/network/rxindexer.py) has `glyph_*`
+  RPCs; `swap_*` family is documented but not yet implemented and is
+  not needed for this plan).
+- **Existing SPV proof builder + sentinel covenant** unchanged; this
+  plan adds alongside, does not modify.
+- **Photonic codebase access** for the Phase 2 prior-art check.
+
+## Risk Analysis & Mitigation
+
+| Risk | Likelihood | Impact | Mitigation |
+|---|---|---|---|
+| **Synthetic round-trip tests mask on-chain divergence (recurring dMint failure mode, 2× in 2026-05)** | High | High | Phase 4 golden-byte fixtures from real regtest broadcasts + `testmempoolaccept` gate; no builder merges on round-trip-through-own-parser alone |
+| **Multi-ref smuggling at funding (Security Critical)** | Medium | High | Script-level `totalRefs==1` enforcement in Phase 2 templates; both Python pre-flight + script-level red-team tests in Phase 5 |
+| **SPV proof reuse across concurrent offers (Security Critical)** | Medium | High (NFT) | Phase 2 spike chooses offer-binding mitigation (subaddress derivation, OP_RETURN, or doc-only); Phase 5 `TestSPVProofReuseAcrossOffers` |
+| Two artifacts duplicate audit attention | Low | Medium | Internal audit (Phase 7) covers both; external audit (post-plan) is a hard gate before mainnet |
+| Photonic has no prior art and Radiant-side script needs more design iteration than budgeted | Medium | Medium | Phase 2 is the bounded high-risk phase; extend the spike if needed before committing to Phase 4 |
+| Sighash de-dup breaks plain-RXD Gravity trades silently | Low | High | Phase 1 golden vector regression test (multi-scenario, parameterized); byte-identical assertion; **adversarial vectors for `totalRefs >= 1`** added in this revision |
+| Internal audit surfaces structural issues post-Phase-4 | Medium | High | Audit is Phase 7, before mainnet — discovery here defers mainnet exercise, doesn't break shipped code |
+| Maker funds a covenant with a wrong-kind artifact and assets stall to deadline | Low | High | Phase 3 funding-input pre-flight validator + artifact-kind isolation tests |
+| BTC reorg vanishes a confirmed payment, NFT-side loss is irreversible (vs RXD fungibility) | Low | High (NFT) | Document recommendation for deeper BTC confirmation count for high-value ref-bearing offers (parameter `btc_confirmations` in `verify_ref_offer`); out of v1 enforcement scope |
+| Squatted ticker / phantom metadata fools Taker | Medium | Medium | Phase 6 verification API fails closed on missing metadata; doc note in red-team checklist; full provenance enforcement is post-v1 |
+| ElectrumX reclassifies `code 1` policy rejection as `NetworkError` (recurring V1 dMint failure mode) | Low | High | Phase 4 typed `PolicyRejection`; Phase 5 `TestPolicyRejectionSurfaced` red-team test |
+
+## Resource Requirements
+
+- **One implementer** with familiarity with: Radiant script,
+  BIP143-style sighash extension, the existing Gravity codebase, FT/NFT
+  conservation rules.
+- **Audit pair** (internal) for Phase 7; should not be the implementer.
+- **Regtest Radiant Core node** for Phase 2 spike validation.
+- **Total estimated effort:** ~6.5–9 weeks across all phases
+  (spike-revised from 9–12 — see
+  [spike-findings](../brainstorms/2026-05-19-gravity-ref-covenant-spike-findings.md)).
+  Phase breakdown: Phase 1 — 1–2 days (sighash de-dup; ref-parsing
+  already shipped); Phase 2 — 1–2 weeks (additive covenant work on an
+  existing compositional-output pattern; ref-conservation regtest
+  validation is the dominant unknown); Phase 3 — 5–7 days (type
+  discipline + opcode-stream validator + property tests); Phase 4 —
+  1.5–2 weeks (BTC half + golden-byte regtest fixtures +
+  `testmempoolaccept` gate); Phase 5 — 2–3 weeks (end-to-end +
+  red-team); Phase 6 — 5–7 days (async verifier); Phase 7 — 1 week
+  (audit + docs). The collapse is real but smaller than the
+  spike-first doc's headline 3–4× cases — this is genuinely new
+  ref-bearing covenant work, not (like the BCH case) work the existing
+  design had already done.
+
+## Future Considerations
+
+Out of scope for v1 but design-aware:
+
+- **Unified `refKind`-dispatched covenant.** Plan default is split
+  FT/NFT artifacts (security: avoids branch-confusion attack class).
+  A future consolidation into one artifact with in-script `refKind`
+  dispatch could reduce maintenance overhead, but only after measured
+  data shows the split's audit/maintenance cost outweighs the
+  security partitioning. External audit gate.
+- **Multi-ref outputs.** Some FT designs and most NFT collections
+  carry multiple refs per UTXO. v1 constrains `totalRefs == 1`; v2
+  could relax.
+- **Partial fills.** Would require a split-and-relock primitive. v1
+  Maker can post multiple smaller-lot covenants instead.
+- **Cancel-tx (cooperative early-exit).** Brainstorm dropped from v1;
+  forfeit covers the failure path. Add later if Maker UX demands it.
+- **WAVE-name first-class offers** (`verify_ref_offer_via_wave`).
+  Cut from Phase 6 per WAVE-deferred policy. Trigger to revisit:
+  a concrete downstream consumer needs Wave name → ref → offer
+  lookup.
+- **Glyph inspector integration.** Pattern-match the new covenants'
+  P2SH hashes in `docs/inspect_static/inspect/inspect.js`. Separate
+  follow-up issue.
+- **Reclaim-to-new-address forfeit.** For NFTs where the original
+  Maker reclaim key may be compromised, a future cancel-tx could allow
+  reclaim-to-different-address with two-of-two Maker+Taker signatures.
+- **External audit.** Per
+  [docs/concepts/gravity.md:219](../concepts/gravity.md#L219), external
+  audit is a **hard gate** for any mainnet exercise of the ref-bearing
+  variant (NFT-irreversibility raises the bar). Plan-of-plan
+  follow-up.
+
+## Documentation Plan
+
+| Doc | Update |
+|---|---|
+| [docs/concepts/gravity.md](../concepts/gravity.md) | New "ref-bearing covenant" section; status table; v1 limitations |
+| [docs/red-team-checklist.md](../red-team-checklist.md) | New red-team categories: multi-ref smuggling, SPV proof reuse across offers, sort-order consensus, phantom metadata, duplicate-offer disambiguation |
+| [docs/brainstorms/2026-05-MM-gravity-ref-spike-findings.md](../brainstorms/) | New (Phase 2 deliverable) |
+| [docs/audits/2026-MM-DD-ref-covenant-audit.md](../audits/) | New (Phase 7 deliverable, audit 06 index target) |
+| [CHANGELOG.md](../../CHANGELOG.md) | Unreleased "Added" entries for FT/NFT artifacts + Taker verification API |
+| `examples/gravity_ref_ft_demo.py` (new) | Runnable FT swap demo, mirrors `examples/gravity_swap_demo.py` |
+| ~~`examples/gravity_ref_nft_demo.py`~~ | Deferred to post-merge follow-up (per Simplicity #7) — NFT differs from FT by parameter choice, not by demo shape |
+
+## References & Research
+
+### Internal References
+
+- **Brainstorm:** [docs/brainstorms/2026-05-19-gravity-glyph-ft-swap-brainstorm.md](../brainstorms/2026-05-19-gravity-glyph-ft-swap-brainstorm.md)
+- **Existing Gravity overview:** [docs/concepts/gravity.md](../concepts/gravity.md)
+- **Sighash de-dup targets:**
+  [transaction_preimage.py:66](../../src/pyrxd/transaction/transaction_preimage.py#L66)
+  (correct, reuse) and
+  [gravity/transactions.py:93](../../src/pyrxd/gravity/transactions.py#L93) (delete)
+- **FT/NFT script construction:**
+  [glyph/script.py:127,135](../../src/pyrxd/glyph/script.py#L127),
+  [glyph/ft.py:91-328](../../src/pyrxd/glyph/ft.py#L91)
+- **GlyphRef:** [glyph/types.py:32-95](../../src/pyrxd/glyph/types.py#L32)
+- **End-to-end test pattern:**
+  [tests/test_gravity_trade.py::TestGravityTradeP2PKH at line 945](../../tests/test_gravity_trade.py#L945)
+- **Red-team test pattern:**
+  [tests/test_gravity_red_team.py:143-501](../../tests/test_gravity_red_team.py#L143)
+- **Sighash mainnet vectors:**
+  [tests/test_preimage.py::TestComputeHashOutputHashes](../../tests/test_preimage.py)
+  pinned against tx `dac1e2dfed64fbfd0f0fe6b925e144cfc32ef76803abc7a6a4058406d707b407`
+- **Covenant loader + deny-list:** [gravity/covenant.py:59-194](../../src/pyrxd/gravity/covenant.py#L59)
+- **Lazy public API:** [src/pyrxd/__init__.py](../../src/pyrxd/__init__.py),
+  [gravity/__init__.py](../../src/pyrxd/gravity/__init__.py)
+- **WAVE resolver:** [glyph/wave.py:206-264](../../src/pyrxd/glyph/wave.py#L206)
+- **Photonic reference:** `docs/dmint-research-photonic.md` §2.1 (ref-preservation pattern)
+
+### Conventions
+
+- **Commit style:** Conventional Commits, ≤72 char subject, DCO sign-off
+  ([CONTRIBUTING.md:130-142](../../CONTRIBUTING.md#L130))
+- **CI gate:** `task ci`; coverage gates `coverage-security` (100%) and
+  `coverage-overall` (≥85%) ([CONTRIBUTING.md:62-74](../../CONTRIBUTING.md#L62))
+- **Audit citations:** inline `audit NN-SX` / `audit NN-F-N` (hyphenated)
+  comments at point of enforcement. Existing audits: `04`, `05`. **This
+  plan reserves `audit 06`** for its Phase-7 audit pass. Top-of-file
+  index in `gravity/ref/covenant.py` maps `audit 06 → docs/audits/...`.
+- **Brainstorm/plan naming:** `YYYY-MM-DD-<topic>-{brainstorm,plan}.md`
+
+### Related Work
+
+- [docs/brainstorms/2026-05-19-gravity-bch-spike-findings.md](../brainstorms/2026-05-19-gravity-bch-spike-findings.md) — BCH-support spike (informs the SPV reuse story)
+- [docs/brainstorms/2026-05-19-gravity-p2pkh-spike-findings.md](../brainstorms/2026-05-19-gravity-p2pkh-spike-findings.md) — P2PKH support, informed BTC-output dispatch reuse
+- [docs/dmint-followup.md](../dmint-followup.md), [docs/threat-model.md](../threat-model.md), [docs/red-team-checklist.md](../red-team-checklist.md) — adjacent security context
+
+### Institutional learnings applied (recurring failure modes prevented)
+
+- [docs/solutions/design-decisions/spike-first-then-convergent-design-divergent-review-panels.md](../solutions/design-decisions/spike-first-then-convergent-design-divergent-review-panels.md) — read current code before trusting doc-derived estimates; run a divergent review pass to prune over-design. **Applied:** divergent review = the 6-reviewer deepen pass; spike-first = [2026-05-19-gravity-ref-covenant-spike-findings.md](../brainstorms/2026-05-19-gravity-ref-covenant-spike-findings.md), which revised the estimate from 9–12 to ~6.5–9 weeks after reading the actual covenant asm.
+- [docs/solutions/logic-errors/dmint-v1-mint-shape-mismatch.md](../solutions/logic-errors/dmint-v1-mint-shape-mismatch.md) — synthetic round-trip passed; real bytes diverged. **Applied:** Phase 4 golden-byte fixtures from real regtest broadcasts.
+- [docs/solutions/logic-errors/dmint-v1-mint-scriptsig-divergence.md](../solutions/logic-errors/dmint-v1-mint-scriptsig-divergence.md) — `code 1` reclassified as `NetworkError` masked critical bug. **Applied:** Phase 4 typed `PolicyRejection`; Phase 5 `TestPolicyRejectionSurfaced`.
+- [docs/solutions/logic-errors/funding-utxo-byte-scan-dos.md](../solutions/logic-errors/funding-utxo-byte-scan-dos.md) — bare-byte deny-list rejected ~51% of legitimate inputs. **Applied:** Phase 3 opcode-stream walker (no byte-scan); `TestFundingDenyListFalsePositive`.
+- [docs/solutions/logic-errors/dmint-v1-classifier-gap.md](../solutions/logic-errors/dmint-v1-classifier-gap.md) — synthetic V2 fixtures passed; mainnet inspection failed. **Applied:** Glyph inspector integration deferred + requires real-bytes fixture when it lands.
+- [docs/solutions/logic-errors/dmint-deploy-reveal-hashlock-reuse.md](../solutions/logic-errors/dmint-deploy-reveal-hashlock-reuse.md) — reused hashlocks confuse scripthash-history walkers. **Applied:** Phase 6 `verify_ref_offer` takes funding outpoint, not scripthash; `TestDuplicateOfferDisambiguation`.
+- [docs/solutions/design-decisions/fuzzing-strategy-graduated-approach.md](../solutions/design-decisions/fuzzing-strategy-graduated-approach.md) — graduated Hypothesis → Atheris → OSS-Fuzz strategy. **Applied:** Stage-1 Hypothesis property tests on funding validators (Phase 3) and pre-broadcast validator (Phase 4).
+- [docs/solutions/design-decisions/wave-protocol-deferred-until-consumer.md](../solutions/design-decisions/wave-protocol-deferred-until-consumer.md) — WAVE deferred until concrete consumer. **Applied:** `verify_ref_offer_via_wave` cut from Phase 6.
+- [docs/solutions/design-decisions/expert-panel-pivot-before-coding.md](../solutions/design-decisions/expert-panel-pivot-before-coding.md) — pre-implementation expert review prevented coding the wrong primitive. **Applied:** half-day adversarial review checkpoint between Phase 2 spike and Phase 4 implementation.
+- [docs/solutions/integration-issues/local-ci-parity-via-task-ci-and-pre-push-hook.md](../solutions/integration-issues/local-ci-parity-via-task-ci-and-pre-push-hook.md) — pre-push hook required for CI parity. **Applied:** Quality Gates section.

--- a/docs/solutions/design-decisions/spike-first-then-convergent-design-divergent-review-panels.md
+++ b/docs/solutions/design-decisions/spike-first-then-convergent-design-divergent-review-panels.md
@@ -1,0 +1,342 @@
+---
+title: Spike-first estimation and convergent-then-divergent panels — reading current code cut three estimates 3-4x and a divergent review cut one plan 75%
+date: 2026-05-19
+problem_type: design_decision
+component: design-process
+symptoms:
+  - About to commit multi-week effort against an estimate derived from documentation, with no one having read the current shipping code first
+  - Documentation describes a capability gap ("no covenant compiled yet", "verifier not chain-agnostic") that may reflect an older generation of the code than what now ships
+  - A complex design has been blessed by a panel of domain experts, but every expert added their own preferred abstraction and the proposed effort keeps growing
+  - A "what should we build" panel produced strong consensus and no one is asking "did we propose too much, or the wrong shape?"
+  - Repeated pattern of estimates landing 3-4x over the eventual real cost once the code is actually inspected
+  - Security gaps (a bypassable defense, a recursion bug, a masking exception handler) sitting undetected inside a design that passed convergent expert agreement
+severity: high
+status: solved
+related_prs: []
+tags:
+  - design-decisions
+  - process-patterns
+  - estimation
+  - spike-first
+  - expert-panel
+  - convergent-divergent-review
+  - docs-drift
+  - pre-implementation-review
+  - over-design
+  - red-team
+---
+
+## Summary
+
+Two reinforcing process techniques, discovered by applying them
+repeatedly in one working session:
+
+1. **Spike-first estimation** — read the *current* code before
+   trusting any estimate derived from documentation. Three times in
+   a row, doc-derived estimates were 3-4× too high because the code
+   had quietly generalized past its docs.
+
+2. **Convergent design panel, then divergent review panel** — a
+   panel run to answer "what should we build?" reliably over-builds,
+   because each expert adds the abstraction their domain prizes.
+   Following it with a panel of reviewers who *disagree with each
+   other* ("did we overbuild, get the shape wrong, or under-secure?")
+   cut one plan from a 95-145 hour scope to ~32 hours — while *also*
+   catching security defects the convergent panel had approved.
+
+This entry is a **see also / extension** of
+[expert-panel-pivot-before-coding.md](./expert-panel-pivot-before-coding.md),
+which establishes "run an expert panel before coding." This doc adds
+two things that doc does not cover: (a) spike-test the resulting
+*estimates* against the actual code, and (b) run a *second, divergent*
+panel to prune the first panel's output. It deliberately does not
+re-derive the panel-composition material — reference that doc for it.
+
+## Root Cause Analysis
+
+Documentation captures a snapshot of the code's *intent at authoring
+time*, but a maturing codebase generalizes underneath it. When
+[docs/concepts/gravity.md](../../concepts/gravity.md) said "no covenant
+compiled yet" for P2PKH/P2SH/P2TR, that was true the day it was
+written — but the team later unified dispatch into the shipping
+`maker_covenant_flat_12x20_sentinel_all` covenant, which now branches
+on a `btcReceiveType` parameter (0=P2PKH, 1=P2WPKH, 2=P2SH, 3=P2TR)
+covering all four output types in one script. The doc never lied; it
+just aged. The asymmetry matters: docs are updated when someone
+*notices* drift, while code generalizes whenever an engineer reaches
+for the cleanest abstraction to close an unrelated ticket. So the gap
+between "what the doc claims the code can do" and "what the code can
+actually do" almost always runs in one direction — the code can do
+*more* than the doc admits. Estimating against the doc therefore
+systematically over-estimates, and the error compounds with codebase
+maturity: the more refactoring cycles a module has survived, the more
+capability has quietly accreted past its last doc update. The SPV
+verifier is the extreme case — it was *never* BTC-specific.
+`verify_header_pow` checks `hash < target` against the target derived
+from the header's own nBits and never computes the difficulty
+algorithm, so it was chain-agnostic for any SHA-256d UTXO chain from
+day one. The "add BCH support" estimate was budgeting for work the
+original design had already made unnecessary.
+
+A single convergent design panel over-builds for a structurally
+similar reason: every expert is incentivized to contribute, and the
+only contribution an expert can make is to add something. Put five
+domain specialists in a room asking "what should we build?" and each
+one adds the abstraction their domain prizes — a state-machine
+sub-state model, a journal+snapshot persistence layer, a per-chain
+finality-policy interface, a multi-source quorum primitive. Each is
+individually defensible; summed, they produced a 95-145 hour plan.
+Convergence on "yes, build it all" is not validation — it is the
+absence of anyone whose job is to say no. Worse, agreement creates a
+false sense of rigor that *hides* gaps: five people enthusiastically
+designing new machinery all assumed the existing primitives were
+sound, so nobody checked that the existing parameter object actually
+enforced its own timelock-ordering invariant (it did not). Adding-mode
+and checking-mode are different cognitive postures, and a panel
+staffed entirely for the first cannot perform the second.
+
+## Solution
+
+### Part 1 — Spike before you estimate
+
+Before committing multi-week effort to any task whose scope is
+inferred from documentation, design notes, or a status table, run a
+time-boxed spike: a few hours reading the *current* code path the
+task touches, ending in a short findings brainstorm (kept in
+`docs/brainstorms/`) that revises the estimate against reality.
+
+The spike is read-then-write: open the actual implementation, find
+the cheapest existing test that would already exercise the "missing"
+capability (a `test_all_btc_receive_types_accepted` test already
+proved offers build for all four BTC output types), and if the
+capability seems present, write one confirming test and watch it
+pass.
+
+Signals that demand a spike before estimating:
+- The doc uses status language ("not yet", "no X compiled",
+  "experimental") rather than pointing at code.
+- The doc is older than the module's last refactor.
+- The task is phrased as "add support for X" where X is a sibling of
+  something already supported.
+- The estimate is large and round (4-6 weeks) — round numbers are
+  usually doc-derived guesses, not decomposed work.
+
+Across three consecutive cases this turned 4-5 weeks into ~1 week,
+and 4-6 weeks into ~1-2 weeks.
+
+### Part 2 — Convergent panel, then divergent review panel
+
+Run a *convergent* multi-expert panel ("what should we build?") when
+the problem is genuinely cross-domain and you need coverage — staff
+it with one specialist per affected domain so no blind spot goes
+unrepresented. (See
+[expert-panel-pivot-before-coding.md](./expert-panel-pivot-before-coding.md)
+for how to compose and read such a panel.)
+
+Then, before writing any code, run a *divergent* review panel ("did
+we overbuild, get the shape wrong, or under-secure?"). Staff it with
+reviewers who answer to different masters — architecture strategy,
+code-simplicity, language-idiom, and adversarial security — and
+explicitly do *not* require them to agree. Disagreement is the
+feature: when the simplicity reviewer wants to delete the persistence
+layer and the security reviewer wants to harden it, you are forced to
+make the trade-off *explicitly* instead of defaulting to "build
+both."
+
+The economics are decisive. The divergent review costs roughly 30
+minutes wall-clock (panels run in parallel) plus ~60 minutes of
+synthesis, and in the documented case it cut the plan from 95-145h to
+~32h — about 70 hours of code never written — *while also* catching
+three concrete defects the convergent panel had sailed past (see
+Evidence). One hour of review to avoid seventy hours of construction
+is the cheapest leverage in the workflow; run it on every
+convergent-panel output as a matter of course.
+
+A key mechanical detail: reviewers must write their reviews
+**independently, without seeing each other's first**. Parallelism
+prevents anchoring; the value of the panel is in the *independence*
+of the perspectives. Synthesize afterward.
+
+## Code / Evidence
+
+The most convincing artifact is real chain headers passing the
+*unmodified* SPV verifier. BCH block 840000 and BTC block 840000 are
+unrelated blocks on different chains with different version bits,
+nBits, and merkleroots — yet both verify against the same code,
+because that code never validates the difficulty algorithm at all:
+
+```python
+# tests/test_spv.py — TestBchMainnetFixtures (real BCH mainnet headers)
+def test_bch_block_840000_pow_valid(self):
+    header = bytes.fromhex(BCH_BLOCK_840000)
+    hash_le = verify_header_pow(header)              # src/pyrxd/spv/pow.py, unchanged
+    assert hash_le[::-1].hex() == \
+        "000000000000000000b3cfd73dbd87c5e6cae26d89a5956ee78193733f61340e"
+```
+
+`verify_header_pow` (`src/pyrxd/spv/pow.py:25`) only builds the target
+from the header's own nBits and does an 8-chunk big-endian
+`hash < target` comparison; `verify_chain` (`src/pyrxd/spv/chain.py:22`)
+only checks `header[i].prevHash == hash256(header[i-1])`. Neither
+references BTC's epoch retargeting or BCH's aserti3-2d difficulty
+algorithm — so the "add BCH support" work was already done by the
+original chain-agnostic design.
+
+The three estimate revisions:
+
+| Item | Doc-derived estimate | Post-spike estimate |
+|------|----------------------|---------------------|
+| P2PKH support in Gravity covenant | 4-5 weeks | ~1 week (e2e test + doc fix) |
+| BCH support in Gravity | 4-6 weeks | ~1-2 weeks (verifier already chain-agnostic) |
+| A complex hardening design | 95-145h (convergent plan) | ~32h (after divergent review) |
+
+The divergent review panel also surfaced three defects the convergent
+design panel missed (illustrating that adding-mode review cannot
+substitute for checking-mode review):
+
+1. A parameter dataclass documented a load-bearing ordering invariant
+   in a comment but had no `__post_init__` enforcing it — the defense
+   was bypassable.
+2. A nonce-derivation helper recursed with identical arguments
+   (`return _derive_nonce(...) + 1`) — non-terminating in principle,
+   "works" only because the triggering condition is astronomically
+   improbable.
+3. An `except Exception: continue` poller handler that would have
+   swallowed the exact transaction-receipt error the whole design
+   existed to detect.
+
+## Related Documentation
+
+- [expert-panel-pivot-before-coding.md](./expert-panel-pivot-before-coding.md)
+  — The adjacent prior pattern: run a convergent expert panel *before*
+  coding, and read cross-discipline objections as a signal to pivot
+  the primitive. **This entry extends it** with spike-first estimate
+  calibration and a second divergent pruning panel; it does not
+  re-derive the panel-composition material.
+- [../../brainstorms/2026-05-19-gravity-p2pkh-spike-findings.md](../../brainstorms/2026-05-19-gravity-p2pkh-spike-findings.md)
+  — First concrete spike artifact. Found the gravity.md
+  "P2PKH/P2SH/P2TR unsupported" claim stale; collapsed an estimated
+  ~4-5 week effort to ~1 week.
+- [../../brainstorms/2026-05-19-gravity-bch-spike-findings.md](../../brainstorms/2026-05-19-gravity-bch-spike-findings.md)
+  — Second spike artifact, run immediately after the first. Found the
+  SPV verifier already chain-agnostic; documents the parent plan
+  overestimating ~3-4× *twice in a row* — the load-bearing evidence
+  that spike-first estimation is a repeatable corrective, not a
+  one-off.
+- [../../concepts/gravity.md](../../concepts/gravity.md) — The stale
+  doc that drove both spikes. Concrete example of the failure mode the
+  pattern guards against: estimating against a doc's stated capability
+  gap rather than against the actual code state.
+- [fuzzing-strategy-graduated-approach.md](./fuzzing-strategy-graduated-approach.md)
+  — Sibling "how much engineering to commit" process decision
+  (graduated, evidence-driven escalation).
+- [wave-protocol-deferred-until-consumer.md](./wave-protocol-deferred-until-consumer.md)
+  — Same family of "the code is further along than the framing
+  suggests; re-estimate before building" reasoning, applied to
+  deferral.
+
+## Prevention & Best Practices
+
+The two techniques only compound value if they become reflexes rather
+than heroics. The goal is to make "read the code before you trust the
+estimate" and "never ship a convergent panel's output unchallenged"
+the default path of least resistance.
+
+### Triggers / checklist
+
+**Spike before estimating when ANY of these hold:**
+- The estimate is derived from a doc, design note, or ticket rather
+  than from reading the implementing code.
+- The codebase is fast-moving (recent commits to the relevant module).
+- The estimate exceeds ~1 day, or the work is "add support for X"
+  where X might already be covered by a more general existing
+  mechanism.
+- Anyone says "this is basically a rewrite of…" or "we'll need a new
+  abstraction for…".
+
+**Run a convergent design panel (one specialist per affected domain,
+"what to build") when:**
+- The decision is hard to reverse (wire format, schema, public API,
+  trust boundary).
+- The problem is genuinely under-specified and you want broad
+  coverage of approaches before committing.
+
+**Always follow with a divergent review panel (reviewers who disagree,
+"did we overbuild / wrong shape / under-secure") when:**
+- You ran a convergent panel. The two go together — a convergent
+  panel that isn't challenged is a liability, not a plan.
+- The plan's total estimate jumped after combining each expert's
+  preferred abstraction.
+- The change touches security, money, or untrusted input.
+
+### Anti-patterns to avoid
+
+- **Trusting a doc-derived estimate in a fast-moving codebase.** Docs
+  lag code. Treat any unspiked, doc-sourced number as an upper bound,
+  not a forecast.
+- **Treating a convergent panel's output as a final plan.** Five
+  experts each adding their preferred abstraction reliably
+  over-builds. The convergent output is a menu, not an order.
+- **Running only one panel when the decision warrants both.** A lone
+  convergent panel over-builds; a lone divergent panel may critique a
+  shape no one defended well.
+- **Letting reviewers see each other's reviews before writing.** This
+  anchors them into agreement and destroys the disagreement that makes
+  the divergent panel valuable. Independent first, synthesize after.
+- **Skipping the spike because "I already know this code."** If you
+  knew it, the doc-derived estimate would already match reality. Spend
+  the 30 minutes.
+
+### Lightweight spike report template
+
+Keep it to six fields, ~half a page:
+
+1. **Claim under test** — the symptom or scope as stated in the
+   plan/doc.
+2. **Assumed mechanism** — what the doc implies must be built.
+3. **Actual mechanism (in code)** — what the code already does, with
+   `file:line` evidence for each load-bearing claim.
+4. **Gap** — what genuinely remains vs. what the doc assumed.
+5. **Revised estimate** — new number, plus the multiple vs. the
+   original.
+6. **Risks / unknowns** — anything the spike could NOT confirm by
+   reading code (label clearly as unverified).
+
+Every quantitative claim must cite its source — a `file:line`, a test
+run, or an explicit "ESTIMATED" tag. No blended guesses.
+
+### How to know the pattern is working
+
+Leading indicators, not lagging vanity metrics:
+- **Estimates revised down after spikes** — track the spike multiple.
+  A healthy habit regularly surfaces 2-4× overestimates; if spikes
+  never change the number, you're spiking work you already understand
+  (overhead) or rubber-stamping.
+- **Divergent panels produce genuine disagreement** — reviewers land
+  on materially different verdicts before synthesis. Unanimous "looks
+  good" rounds are a smell.
+- **Un-built code** — count the abstractions the convergent panel
+  proposed that the divergent panel cut and that were never missed.
+  That delta (here, 95-145h → ~32h) is the pattern paying for itself.
+- **Security gaps caught by the divergent panel, not in production** —
+  the review panel found gaps the design panel missed; that's the
+  safety dividend.
+
+### When NOT to use it
+
+The pattern has real overhead — two panels plus a spike can cost more
+than the work. Skip it for:
+- **Small, reversible changes** — config tweaks, copy edits, internal
+  refactors with full test coverage.
+- **Well-understood, stable code** — if the module hasn't moved and
+  you've read it recently, doc and code agree; a spike adds nothing.
+- **Time-critical hotfixes** — incident response wants one competent
+  reviewer and a fast path. Schedule the deeper review as follow-up if
+  the fix touched a trust boundary.
+- **Trivial estimates** — sub-hour, single-file work where being wrong
+  by 3× is still cheap.
+
+Rule of thumb: the heavier the irreversibility and the staler your
+knowledge of the code, the more of this pattern you apply. For
+everything else, a quick estimate or a single review is the correct,
+honest choice.

--- a/src/pyrxd/gravity/transactions.py
+++ b/src/pyrxd/gravity/transactions.py
@@ -20,6 +20,9 @@ import time
 from pyrxd.security.errors import ValidationError
 from pyrxd.security.secrets import PrivateKeyMaterial
 from pyrxd.spv.proof import SpvProof
+from pyrxd.transaction.transaction_output import TransactionOutput
+from pyrxd.transaction.transaction_preimage import _compute_hash_output_hashes as _general_hash_output_hashes
+from pyrxd.utils import Reader
 
 from .codehash import (
     compute_p2sh_address_from_redeem,
@@ -93,45 +96,30 @@ def _push_data(data: bytes) -> bytes:
 def _compute_hash_output_hashes(outputs_serialized: bytes) -> bytes:
     """Compute Radiant's ``hashOutputHashes`` from serialized outputs.
 
-    For each output:
-        summary = value(8 LE) + hash256(scriptPubKey)(32) + totalRefs(4 LE) + refsHash(32)
+    Parses the wire-serialized outputs (``value(8 LE) + varint(len) + script``
+    repeated) into :class:`TransactionOutput` objects and delegates to the
+    canonical, ref-aware implementation in
+    :func:`pyrxd.transaction.transaction_preimage._compute_hash_output_hashes`.
 
-    For plain P2PKH / P2SH outputs (no ``OP_PUSHINPUTREF``):
-        totalRefs = 0, refsHash = b'\x00' * 32  (32 zero bytes — per Radiant source, NOT hash256(b''))
-
-    ``hashOutputHashes = hash256(concatenated summaries)``
+    This module previously carried its own copy that hard-coded
+    ``totalRefs = 0`` for every output. That was correct only for the
+    plain-RXD covenant outputs Gravity produced at the time, but would
+    silently sign the wrong sighash for any ref-bearing (FT/NFT) output
+    — the exact divergence the ref-bearing covenant work needs fixed. The
+    general implementation walks the script for ``OP_PUSHINPUTREF`` /
+    ``OP_PUSHINPUTREFSINGLETON`` and computes the real ``refsHash``; it is
+    pinned against a confirmed mainnet reveal tx in ``tests/test_preimage.py``
+    and produces byte-identical output to the old copy for the
+    ``totalRefs = 0`` case (see ``tests/test_gravity.py::TestSighashBackcompat``).
     """
-    ZERO_REFS_HASH = b"\x00" * 32  # uint256 zero — used when totalRefs == 0 (per Radiant source)
-
-    pos = 0
-    summaries: list[bytes] = []
-    while pos < len(outputs_serialized):
-        value = int.from_bytes(outputs_serialized[pos : pos + 8], "little")
-        pos += 8
-        # Read varint for script length
-        first = outputs_serialized[pos]
-        if first < 0xFD:
-            script_len = first
-            pos += 1
-        elif first == 0xFD:
-            script_len = int.from_bytes(outputs_serialized[pos + 1 : pos + 3], "little")
-            pos += 3
-        else:
-            raise ValidationError("output script too large for hashOutputHashes")
-        if pos + script_len > len(outputs_serialized):
-            raise ValidationError("outputs_serialized truncated reading script")
-        script = outputs_serialized[pos : pos + script_len]
-        pos += script_len
-
-        summary = (
-            value.to_bytes(8, "little")
-            + hash256(script)
-            + (0).to_bytes(4, "little")  # totalRefs = 0 (no glyph refs in covenant outputs)
-            + ZERO_REFS_HASH
-        )
-        summaries.append(summary)
-
-    return hash256(b"".join(summaries))
+    reader = Reader(outputs_serialized)
+    outputs: list[TransactionOutput] = []
+    while not reader.eof():
+        output = TransactionOutput.from_hex(reader)
+        if output is None:  # malformed / truncated output record
+            raise ValidationError("outputs_serialized is truncated or malformed")
+        outputs.append(output)
+    return _general_hash_output_hashes(outputs)
 
 
 def _sign_radiant_p2sh_input(  # nosec B107 -- no hardcoded credentials

--- a/src/pyrxd/transaction/transaction_output.py
+++ b/src/pyrxd/transaction/transaction_output.py
@@ -47,5 +47,14 @@ class TransactionOutput:
             if script_length is None:
                 raise ValueError("failed to read script length")
             locking_script_bytes = stream.read_bytes(script_length)
+            # read_bytes returns however many bytes are left at EOF, not an error.
+            # A varint that over-claims the script length must NOT yield a valid
+            # output with a silently truncated script — that would corrupt any
+            # hash computed over these bytes (e.g. Radiant's hashOutputHashes).
+            if len(locking_script_bytes) != script_length:
+                raise ValueError(
+                    f"truncated output script: varint claims {script_length} bytes, "
+                    f"only {len(locking_script_bytes)} available"
+                )
             return TransactionOutput(locking_script=Script(locking_script_bytes), satoshis=satoshis)
         return None

--- a/src/pyrxd/transaction/transaction_preimage.py
+++ b/src/pyrxd/transaction/transaction_preimage.py
@@ -106,7 +106,11 @@ def _preimage(
 
     Identical to Bitcoin SV BIP143 except field 8 (hashOutputHashes) is
     inserted before hashOutputs. This extra field hashes each output's value,
-    script hash, and ref count (always 0 for standard P2PKH/FT/NFT outputs).
+    script hash, ref count, and (when refs are present) the hash of the
+    sorted+deduplicated refs. The ref count is 0 only for plain outputs
+    (e.g. P2PKH); FT outputs carry one ``OP_PUSHINPUTREF`` and NFT singletons
+    one ``OP_PUSHINPUTREFSINGLETON``, so their ref count is >= 1 — see
+    ``_compute_hash_output_hashes`` / ``_get_push_refs`` above.
 
      1. nVersion (4-byte LE)
      2. hashPrevouts (32-byte hash)

--- a/tests/test_gravity.py
+++ b/tests/test_gravity.py
@@ -754,3 +754,69 @@ class TestGravityModuleImports:
             build_forfeit_tx,
             compute_p2sh_code_hash,
         )
+
+
+def _ser_output(value: int, script: bytes) -> bytes:
+    """Wire-serialize one output: value(8 LE) + 1-byte len + script."""
+    return value.to_bytes(8, "little") + bytes([len(script)]) + script
+
+
+_P2PKH_AA = bytes.fromhex("76a914" + "aa" * 20 + "88ac")
+_P2PKH_BB = bytes.fromhex("76a914" + "bb" * 20 + "88ac")
+# FT locking script shape: P2PKH + OP_STATESEPARATOR OP_PUSHINPUTREF <36B ref> <12B FT fingerprint>
+_FT_OUTPUT = (
+    bytes.fromhex("76a914" + "cc" * 20 + "88ac") + b"\xbd\xd0" + bytes(36) + bytes.fromhex("dec0e9aa76e378e4a269e69d")
+)
+
+
+class TestSighashBackcompat:
+    """Regression guard for the Phase-1 de-duplication of
+    ``_compute_hash_output_hashes``.
+
+    The Gravity-specific copy (which hard-coded ``totalRefs = 0``) was deleted
+    in favor of the canonical ref-aware implementation in
+    ``pyrxd.transaction.transaction_preimage``. These golden vectors were
+    captured from the OLD implementation *before* the refactor; the de-dup must
+    reproduce them byte-for-byte for the ``totalRefs = 0`` path that plain-RXD
+    Gravity uses today. See
+    docs/plans/2026-05-19-feat-gravity-ref-bearing-covenant-plan.md (Phase 1).
+    """
+
+    # Golden vectors captured from the pre-refactor _compute_hash_output_hashes.
+    GOLDEN = {
+        "single_p2pkh": (
+            _ser_output(546, _P2PKH_AA),
+            "42053adc8c31d4299864f45101c180c7397471cd13b2ac0451217754649b33cf",
+        ),
+        "two_p2pkh": (
+            _ser_output(1000, _P2PKH_AA) + _ser_output(2000, _P2PKH_BB),
+            "0aec905422816fe9325e8fa82f37f2ef0a8dd78fde9a9f5518ba34c315dbe0d8",
+        ),
+    }
+
+    @pytest.mark.parametrize("scenario", list(GOLDEN.keys()))
+    def test_totalrefs0_byte_identical_to_pre_refactor(self, scenario):
+        from pyrxd.gravity.transactions import _compute_hash_output_hashes
+
+        outputs_serialized, expected = self.GOLDEN[scenario]
+        assert _compute_hash_output_hashes(outputs_serialized).hex() == expected
+
+    def test_ft_output_now_computes_real_refshash(self):
+        """The whole point of the de-dup: a ref-bearing output must NOT hash as
+        totalRefs=0. The old Gravity copy produced a wrong (zeros) refsHash for
+        FT outputs; the canonical impl walks OP_PUSHINPUTREF and computes the
+        real one. Assert the FT result differs from the equivalent plain-P2PKH
+        result (i.e. the ref is actually accounted for)."""
+        from pyrxd.gravity.transactions import _compute_hash_output_hashes
+
+        ft = _compute_hash_output_hashes(_ser_output(546, _FT_OUTPUT))
+        # A plain output of the same value but no ref must hash differently.
+        plain = _compute_hash_output_hashes(_ser_output(546, _P2PKH_AA))
+        assert ft != plain
+
+    def test_malformed_trailing_bytes_rejected(self):
+        from pyrxd.gravity.transactions import _compute_hash_output_hashes
+
+        blob = _ser_output(546, _P2PKH_AA) + b"\xff\xff"  # garbage tail
+        with pytest.raises(ValidationError):
+            _compute_hash_output_hashes(blob)

--- a/tests/test_gravity.py
+++ b/tests/test_gravity.py
@@ -801,22 +801,67 @@ class TestSighashBackcompat:
         outputs_serialized, expected = self.GOLDEN[scenario]
         assert _compute_hash_output_hashes(outputs_serialized).hex() == expected
 
-    def test_ft_output_now_computes_real_refshash(self):
-        """The whole point of the de-dup: a ref-bearing output must NOT hash as
-        totalRefs=0. The old Gravity copy produced a wrong (zeros) refsHash for
-        FT outputs; the canonical impl walks OP_PUSHINPUTREF and computes the
-        real one. Assert the FT result differs from the equivalent plain-P2PKH
-        result (i.e. the ref is actually accounted for)."""
+    def test_ft_output_computes_real_refshash_golden(self):
+        """The point of the de-dup: a ref-bearing output must hash with the REAL
+        refsHash, not the old hard-coded zeros. Pin the FT result to a golden
+        value captured from the canonical (ref-aware) impl. A bare ``ft != plain``
+        check is too weak — two different scripts differ in the script-hash term
+        regardless of refsHash, so it could pass even if refsHash were still
+        zeroed. This golden pins the ref accounting itself."""
         from pyrxd.gravity.transactions import _compute_hash_output_hashes
 
-        ft = _compute_hash_output_hashes(_ser_output(546, _FT_OUTPUT))
-        # A plain output of the same value but no ref must hash differently.
-        plain = _compute_hash_output_hashes(_ser_output(546, _P2PKH_AA))
-        assert ft != plain
+        result = _compute_hash_output_hashes(_ser_output(546, _FT_OUTPUT)).hex()
+        assert result == "c1e66ffcb9c4ced99641614ff23ccb185cbe1c721ebded2eeb9cc2b622609605"
 
-    def test_malformed_trailing_bytes_rejected(self):
+    def test_large_script_0xfd_varint_boundary(self):
+        """A script >= 0xFD bytes uses a 2-byte varint length prefix. Golden
+        captured from the canonical impl — locks the varint-boundary path the
+        old hand-rolled parser handled explicitly."""
         from pyrxd.gravity.transactions import _compute_hash_output_hashes
 
-        blob = _ser_output(546, _P2PKH_AA) + b"\xff\xff"  # garbage tail
+        big_script = b"\x6a" + b"\x4c\xfa" + bytes(250)  # OP_RETURN OP_PUSHDATA1 250 <250> = 253 bytes
+        blob = (546).to_bytes(8, "little") + b"\xfd" + len(big_script).to_bytes(2, "little") + big_script
+        assert (
+            _compute_hash_output_hashes(blob).hex()
+            == "98ba70b21fcac18a6e6ef8c7232b945856455b028e6e62b8ad845f8f7dd86600"
+        )
+
+    def test_empty_outputs_blob(self):
+        """Empty input must not crash (no IndexError on the empty-list path)."""
+        from pyrxd.gravity.transactions import _compute_hash_output_hashes
+
+        # hash256(b"") — the well-defined hash of zero outputs.
+        assert _compute_hash_output_hashes(b"").hex() == (
+            "5df6e0e2761359d30a8275058e299fcc0381534545f55cf43e41983f5d4c9456"
+        )
+
+    def test_trailing_garbage_rejected(self):
+        """A trailing fragment that can't form a full output record must raise,
+        not be silently ignored."""
+        from pyrxd.gravity.transactions import _compute_hash_output_hashes
+
+        blob = _ser_output(546, _P2PKH_AA) + b"\xff\xff"  # 2 trailing bytes
+        with pytest.raises(ValidationError):
+            _compute_hash_output_hashes(blob)
+
+    def test_overlong_script_length_rejected(self):
+        """An output whose script-length varint OVER-CLAIMS must raise — not
+        produce a hash over a silently truncated script. This is the signing-path
+        regression guard: the old hand-rolled parser caught it explicitly and the
+        from_hex-based adapter must too."""
+        from pyrxd.gravity.transactions import _compute_hash_output_hashes
+
+        # Claims a 25-byte script but provides only 13 bytes.
+        blob = (546).to_bytes(8, "little") + bytes([25]) + bytes.fromhex("76a914" + "aa" * 10)
+        with pytest.raises(ValidationError):
+            _compute_hash_output_hashes(blob)
+
+    def test_midstream_truncation_rejected(self):
+        """A valid first output followed by a truncated second output must raise,
+        not hash only the first and silently drop the corrupt tail."""
+        from pyrxd.gravity.transactions import _compute_hash_output_hashes
+
+        truncated_second = (1000).to_bytes(8, "little") + bytes([25]) + bytes.fromhex("76a914aa")
+        blob = _ser_output(546, _P2PKH_AA) + truncated_second
         with pytest.raises(ValidationError):
             _compute_hash_output_hashes(blob)

--- a/tests/test_gravity_trade.py
+++ b/tests/test_gravity_trade.py
@@ -868,21 +868,21 @@ def _build_p2pkh_spv_proof(hash160: bytes, satoshis: int):
     tests/fixtures/spv_synthetic_headers.json (the test_spv.py fixture).
     Returns the verified SpvProof.
     """
-    from pyrxd.spv.proof import CovenantParams, SpvProofBuilder
     from pyrxd.spv.pow import hash256
+    from pyrxd.spv.proof import CovenantParams, SpvProofBuilder
 
     # Minimal raw tx: 1 input (any prevout, empty scriptSig), 1 P2PKH output.
     payment_output = _p2pkh_output_bytes(satoshis, hash160)
     raw_tx = (
-        b"\x01\x00\x00\x00"      # version 1
-        + b"\x01"                 # 1 input
-        + b"\x00" * 32            # prev txid (any)
-        + b"\xff\xff\xff\xff"     # prev vout
-        + b"\x00"                 # empty scriptSig
-        + b"\xff\xff\xff\xff"     # sequence
-        + b"\x01"                 # 1 output
+        b"\x01\x00\x00\x00"  # version 1
+        + b"\x01"  # 1 input
+        + b"\x00" * 32  # prev txid (any)
+        + b"\xff\xff\xff\xff"  # prev vout
+        + b"\x00"  # empty scriptSig
+        + b"\xff\xff\xff\xff"  # sequence
+        + b"\x01"  # 1 output
         + payment_output
-        + b"\x00\x00\x00\x00"     # locktime
+        + b"\x00\x00\x00\x00"  # locktime
     )
     assert len(raw_tx) > 64, "raw_tx must be > 64 bytes (Merkle forgery defense)"
 
@@ -918,9 +918,7 @@ def _build_p2pkh_spv_proof(hash160: bytes, satoshis: int):
 
     # Sanity: the fixture header's merkle root must match our synthetic tx.
     header = bytes.fromhex(header_hex)
-    assert header[36:68] == merkle_root_le, (
-        "fixture header merkle root does not match synthetic tx — fixture is stale"
-    )
+    assert header[36:68] == merkle_root_le, "fixture header merkle root does not match synthetic tx — fixture is stale"
 
     params = CovenantParams(
         btc_receive_hash=hash160,

--- a/tests/test_gravity_trade.py
+++ b/tests/test_gravity_trade.py
@@ -837,3 +837,192 @@ class TestResolveBtcTxHeight:
         assert int(height) == 12345
         btc.get_tip_height.assert_not_awaited()
         btc.get_raw_tx.assert_not_awaited()
+
+
+# ---------------------------------------------------------------------------
+# End-to-end P2PKH integration: real SPV proof + finalize tx assembly
+#
+# These tests close the loop on P2PKH support by exercising the *real*
+# SpvProofBuilder pipeline (no mocking the verifier) against a synthetic
+# P2PKH-paying BTC transaction, then running build_finalize_tx on the
+# resulting verified proof. Together they demonstrate the full
+# Maker-locks-RXD -> Taker-pays-BTC-to-P2PKH -> finalize-on-Radiant flow
+# works end-to-end with the shipping sentinel covenant artifact.
+#
+# Pre-mined PoW headers are loaded from tests/fixtures/spv_synthetic_headers.json
+# (the same fixture pre-mined for TestSpvProofBuilder in test_spv.py).
+# ---------------------------------------------------------------------------
+
+
+def _p2pkh_output_bytes(value_sats: int, hash160: bytes) -> bytes:
+    """Build a serialized P2PKH output: value(8 LE) + len(1) + script(25)."""
+    assert len(hash160) == 20
+    script = b"\x76\xa9\x14" + hash160 + b"\x88\xac"  # OP_DUP OP_HASH160 <20> OP_EQUALVERIFY OP_CHECKSIG
+    return value_sats.to_bytes(8, "little") + bytes([len(script)]) + script
+
+
+def _build_p2pkh_spv_proof(hash160: bytes, satoshis: int):
+    """Build a fully-verified SpvProof for a synthetic P2PKH payment.
+
+    Reuses the pre-mined PoW headers from
+    tests/fixtures/spv_synthetic_headers.json (the test_spv.py fixture).
+    Returns the verified SpvProof.
+    """
+    from pyrxd.spv.proof import CovenantParams, SpvProofBuilder
+    from pyrxd.spv.pow import hash256
+
+    # Minimal raw tx: 1 input (any prevout, empty scriptSig), 1 P2PKH output.
+    payment_output = _p2pkh_output_bytes(satoshis, hash160)
+    raw_tx = (
+        b"\x01\x00\x00\x00"      # version 1
+        + b"\x01"                 # 1 input
+        + b"\x00" * 32            # prev txid (any)
+        + b"\xff\xff\xff\xff"     # prev vout
+        + b"\x00"                 # empty scriptSig
+        + b"\xff\xff\xff\xff"     # sequence
+        + b"\x01"                 # 1 output
+        + payment_output
+        + b"\x00\x00\x00\x00"     # locktime
+    )
+    assert len(raw_tx) > 64, "raw_tx must be > 64 bytes (Merkle forgery defense)"
+
+    txid_le = hash256(raw_tx)
+    txid_be_hex = txid_le[::-1].hex()
+    # Output is at: 4(version) + 1(input count) + 36(prevout) + 1(scriptSig len) + 0(scriptSig) + 4(sequence) + 1(output count)
+    output_offset = 4 + 1 + 36 + 1 + 0 + 4 + 1
+    assert raw_tx[output_offset : output_offset + 8] == satoshis.to_bytes(8, "little")
+
+    # Synthetic Merkle proof: tx at position 1, single sibling (coinbase at pos 0).
+    sibling_le = b"\xab" * 32
+    sibling_be_hex = sibling_le[::-1].hex()
+    merkle_root_le = hash256(sibling_le + txid_le)
+
+    anchor = b"\x99" * 32
+    # Load the pre-mined header for (satoshis, hash160) from the shared fixture.
+    import json
+    from pathlib import Path
+
+    fixture_path = Path(__file__).parent / "fixtures" / "spv_synthetic_headers.json"
+    fixture = json.loads(fixture_path.read_text())
+    header_hex: str | None = None
+    for entry in fixture.get("fixtures", []):
+        if entry.get("satoshis") == satoshis and entry.get("hash20_hex") == hash160.hex():
+            header_hex = entry["header_hex"]
+            break
+    if header_hex is None:
+        pytest.skip(
+            f"No pre-mined PoW header in fixture for satoshis={satoshis}, "
+            f"hash160={hash160.hex()}. Regenerate via "
+            f"scripts/gen-spv-test-fixtures.py."
+        )
+
+    # Sanity: the fixture header's merkle root must match our synthetic tx.
+    header = bytes.fromhex(header_hex)
+    assert header[36:68] == merkle_root_le, (
+        "fixture header merkle root does not match synthetic tx — fixture is stale"
+    )
+
+    params = CovenantParams(
+        btc_receive_hash=hash160,
+        btc_receive_type="p2pkh",
+        btc_satoshis=satoshis,
+        chain_anchor=anchor,
+        anchor_height=100_000,
+        merkle_depth=1,
+    )
+    builder = SpvProofBuilder(params)
+    proof = builder.build(
+        txid_be=txid_be_hex,
+        raw_tx_hex=raw_tx.hex(),
+        headers_hex=[header_hex],
+        merkle_be=[sibling_be_hex],
+        pos=1,
+        output_offset=output_offset,
+    )
+    return proof
+
+
+class TestGravityTradeP2PKH:
+    """End-to-end P2PKH path: real SPV proof + finalize tx assembly.
+
+    Closes the loop on the spike finding in
+    docs/brainstorms/2026-05-19-gravity-p2pkh-spike-findings.md — the
+    shipping sentinel covenant supports all four BTC output types via
+    in-script dispatch on btcReceiveType, but the only path previously
+    exercised end-to-end (real SPV builder + real finalize-tx build) was
+    P2WPKH. These tests demonstrate P2PKH works end-to-end on the same
+    code path.
+    """
+
+    HASH160 = b"\x77" * 20  # matches the pre-mined fixture entries
+    SATOSHIS = 5000
+
+    def test_real_spv_proof_p2pkh_builds(self):
+        """SpvProofBuilder.build() produces a valid SpvProof for a P2PKH payment."""
+        proof = _build_p2pkh_spv_proof(self.HASH160, self.SATOSHIS)
+        assert proof.covenant_params.btc_receive_type == "p2pkh"
+        assert proof.covenant_params.btc_receive_hash == self.HASH160
+        assert proof.covenant_params.btc_satoshis == self.SATOSHIS
+        # The proof's raw_tx should be the witness-stripped form (here: identical,
+        # since the synthetic tx is legacy-only with no segwit marker).
+        assert b"\x76\xa9\x14" + self.HASH160 + b"\x88\xac" in proof.raw_tx
+
+    def test_real_p2pkh_proof_drives_finalize_tx(self):
+        """build_finalize_tx accepts a real P2PKH SpvProof and produces a valid tx."""
+        proof = _build_p2pkh_spv_proof(self.HASH160, self.SATOSHIS)
+
+        # Use the same synthetic claimed_redeem_hex pattern as the existing
+        # P2WPKH tests in test_gravity.py::TestBuildFinalizeTx — the redeem
+        # script bytes are not exercised by finalize-tx assembly (only the
+        # length is used for serialization), so the same fake works here.
+        result = build_finalize_tx(
+            spv_proof=proof,
+            claimed_redeem_hex="ab" * 50,
+            funding_txid="cd" * 32,
+            funding_vout=0,
+            funding_photons=1_000_000,
+            to_address="1BgGZ9tcN4rm9KBzDn7KprQz87SZ26SAMH",
+            fee_sats=1_000,
+        )
+
+        # Functional assertions
+        assert isinstance(result, FinalizeResult)
+        assert result.tx_hex
+        bytes.fromhex(result.tx_hex)  # valid hex
+        assert len(result.txid) == 64
+        assert result.output_photons == 999_000
+        assert result.fee_sats == 1_000
+
+    def test_real_p2pkh_finalize_scriptsig_contains_p2pkh_evidence(self):
+        """The serialized finalize tx must embed the P2PKH-shape raw_tx in scriptSig.
+
+        The covenant's on-chain verification will parse the rawTx push from the
+        scriptSig and re-check the output type. This test confirms the raw_tx
+        bytes carrying a P2PKH script (76 a9 14 <hash> 88 ac) survive into the
+        finalize tx unchanged.
+        """
+        proof = _build_p2pkh_spv_proof(self.HASH160, self.SATOSHIS)
+        result = build_finalize_tx(
+            spv_proof=proof,
+            claimed_redeem_hex="ab" * 50,
+            funding_txid="cd" * 32,
+            funding_vout=0,
+            funding_photons=1_000_000,
+            to_address="1BgGZ9tcN4rm9KBzDn7KprQz87SZ26SAMH",
+            fee_sats=1_000,
+        )
+        raw = bytes.fromhex(result.tx_hex)
+        # The P2PKH script prefix + hash160 + suffix must appear verbatim in
+        # the serialized finalize tx (it's part of the raw_tx push in scriptSig).
+        p2pkh_script = b"\x76\xa9\x14" + self.HASH160 + b"\x88\xac"
+        assert p2pkh_script in raw
+
+    def test_p2pkh_offer_carries_correct_receive_type(self):
+        """A GravityOffer built with btc_receive_type='p2pkh' round-trips correctly.
+
+        Demonstrates the Python factory path documented as missing in the
+        stale gravity.md Axis 2 table is in fact working.
+        """
+        offer = make_offer(btc_receive_type="p2pkh", btc_receive_hash=self.HASH160)
+        assert offer.btc_receive_type == "p2pkh"
+        assert offer.btc_receive_hash == self.HASH160

--- a/tests/test_spv.py
+++ b/tests/test_spv.py
@@ -245,6 +245,137 @@ class TestMainnetFixtures:
         assert root == header[36:68]
 
 
+# --------------------------------------------------------------------------- BCH mainnet fixtures
+
+# Real BCH mainnet block 840000 + 840001 headers, sourced from haskoin.com/bch
+# API on 2026-05-19. BCH headers are byte-identical in format to BTC headers
+# (80 bytes: version + prevhash + merkleroot + time + bits + nonce, all LE
+# except hashes which are BE-display reversed to LE on the wire) — and use
+# the same SHA-256d PoW. These fixtures demonstrate the existing SPV verifier
+# accepts real BCH mainnet headers without modification, closing out the
+# Phase 2.1 spike finding (the verifier is chain-agnostic for SHA-256d UTXO
+# chains).
+#
+# BCH 840000 BE hash: 000000000000000000b3cfd73dbd87c5e6cae26d89a5956ee78193733f61340e
+# BCH 840001 BE hash: 000000000000000000e782c9c56bfb1d4f03c44374215a3729338cb9fe60bb21
+BCH_BLOCK_840000 = (
+    "00e0012094e6544f1722e1334febbdc91ef3f72e9589970b527da300000000000000"
+    "00000d63386da1b39df5f4e962dcbc1b2bd105b2da298313ba621f7e1834d28d9246f"
+    "bdb0d66fb980118afb88c0e"
+)
+BCH_BLOCK_840001 = (
+    "000000200e34613f739381e76e95a5896de2cae6c587bd3dd7cfb3000000000000000"
+    "000567d79f4090127afb6b0b58e471cf4217f0ebf52650adb20e3e17f3a13044f367b"
+    "de0d66ea9a01186abe35f6"
+)
+
+
+class TestBchMainnetFixtures:
+    """Byte-for-byte tests against real BCH mainnet blocks 840000 and 840001.
+
+    These tests close out the Phase 2.1 spike finding documented in
+    docs/brainstorms/2026-05-19-gravity-bch-spike-findings.md: the existing
+    SPV verifier and Gravity covenant are already chain-agnostic for
+    SHA-256d UTXO chains. BCH and BTC headers share the exact same 80-byte
+    structure and SHA-256d PoW; the verifier doesn't compute or validate
+    difficulty (it only confirms hash < target derived from the header's
+    own nBits), so BCH's aserti3-2d DAA vs. BTC's epoch retargeting makes
+    no difference to it.
+
+    Notably, BCH 840000 and BTC 840000 are unrelated blocks at the same
+    height on different chains, with different version bits, nBits, and
+    merkleroots — yet both pass the same verifier with no changes.
+    """
+
+    BCH_840000_BE_HASH = "000000000000000000b3cfd73dbd87c5e6cae26d89a5956ee78193733f61340e"
+    BCH_840001_BE_HASH = "000000000000000000e782c9c56bfb1d4f03c44374215a3729338cb9fe60bb21"
+    BCH_839999_BE_HASH = "000000000000000000a37d520b9789952ef7f31ec9bdeb4f33e122174f54e694"
+
+    def test_bch_block_840000_pow_valid(self) -> None:
+        """Real BCH mainnet block 840000 must pass the SPV verifier's PoW check unmodified."""
+        header = bytes.fromhex(BCH_BLOCK_840000)
+        hash_le = verify_header_pow(header)
+        assert len(hash_le) == 32
+        hash_be = hash_le[::-1].hex()
+        assert hash_be == self.BCH_840000_BE_HASH
+
+    def test_bch_block_840001_pow_valid(self) -> None:
+        """Real BCH mainnet block 840001 must pass the SPV verifier's PoW check unmodified."""
+        header = bytes.fromhex(BCH_BLOCK_840001)
+        hash_le = verify_header_pow(header)
+        hash_be = hash_le[::-1].hex()
+        assert hash_be == self.BCH_840001_BE_HASH
+
+    def test_bch_block_840000_tampered_nonce_fails(self) -> None:
+        """Tampered BCH 840000 (zero'd nonce) must fail PoW. Sanity check that the
+        verifier isn't just accepting anything BCH-shaped."""
+        tampered = bytes.fromhex(BCH_BLOCK_840000[:-8] + "00000000")
+        with pytest.raises(SpvVerificationError):
+            verify_header_pow(tampered)
+
+    def test_bch_chain_840000_to_840001_valid(self) -> None:
+        """Consecutive BCH mainnet chain must verify against the unmodified verify_chain."""
+        headers = [bytes.fromhex(BCH_BLOCK_840000), bytes.fromhex(BCH_BLOCK_840001)]
+        hashes = verify_chain(headers)
+        assert len(hashes) == 2
+        # Hashes returned in LE; check the BE-reversed matches the known mainnet values.
+        assert hashes[0][::-1].hex() == self.BCH_840000_BE_HASH
+        assert hashes[1][::-1].hex() == self.BCH_840001_BE_HASH
+
+    def test_bch_chain_with_anchor_to_839999_valid(self) -> None:
+        """BCH chain verifies with a chain_anchor binding to block 839999's hash.
+
+        This is the audit 05-F-3 defense exercise applied to BCH: the maker
+        commits to a specific BCH anchor block (839999 in this case) and the
+        verifier rejects any chain whose first header doesn't link to it.
+        """
+        headers = [bytes.fromhex(BCH_BLOCK_840000), bytes.fromhex(BCH_BLOCK_840001)]
+        chain_anchor = bytes.fromhex(self.BCH_839999_BE_HASH)[::-1]  # LE
+        hashes = verify_chain(headers, chain_anchor=chain_anchor)
+        assert len(hashes) == 2
+
+    def test_bch_chain_wrong_anchor_rejected(self) -> None:
+        """Wrong chain_anchor must reject a BCH chain (same defense as BTC)."""
+        headers = [bytes.fromhex(BCH_BLOCK_840000), bytes.fromhex(BCH_BLOCK_840001)]
+        wrong_anchor = b"\x00" * 32
+        with pytest.raises(SpvVerificationError, match="anchor"):
+            verify_chain(headers, chain_anchor=wrong_anchor)
+
+    def test_bch_chain_840001_before_840000_fails(self) -> None:
+        """Out-of-order BCH chain must fail (link broken)."""
+        headers = [bytes.fromhex(BCH_BLOCK_840001), bytes.fromhex(BCH_BLOCK_840000)]
+        with pytest.raises(SpvVerificationError):
+            verify_chain(headers)
+
+    def test_bch_block_840000_nbits_value(self) -> None:
+        """Document and check the actual BCH 840000 nBits value.
+
+        BCH 840000 nBits == 0x180198fb (BE) — different from BTC 840000's
+        nBits at the same height because the chains have evolved
+        independently since the 2017 fork. This is the value a Maker would
+        need to commit to expected_nbits when offering a BCH-side payment
+        proof anchored at height 840000.
+        """
+        header = bytes.fromhex(BCH_BLOCK_840000)
+        # nBits at bytes 72..76, LE on the wire
+        nbits_le = header[72:76]
+        assert nbits_le.hex() == "fb980118"  # LE encoding of 0x180198fb
+
+    def test_bch_block_840000_distinct_from_btc_block_840000(self) -> None:
+        """BCH 840000 and BTC 840000 are different chains' blocks at the same height.
+
+        Confirms these tests are exercising the BCH chain, not accidentally
+        re-running BTC tests. The block hashes differ because the chains
+        diverged at the 2017 fork.
+        """
+        bch_header = bytes.fromhex(BCH_BLOCK_840000)
+        btc_header = bytes.fromhex(BLOCK_840000)
+        assert bch_header != btc_header
+        # Both pass their respective PoW checks against the same unmodified verifier.
+        verify_header_pow(bch_header)
+        verify_header_pow(btc_header)
+
+
 # --------------------------------------------------------------------------- PoW details
 
 


### PR DESCRIPTION
## Summary

Phase 1 of the ref-bearing Gravity covenant work (see `docs/plans/2026-05-19-feat-gravity-ref-bearing-covenant-plan.md`). Two commits:

1. **`refactor(gravity)`** — Delete the Gravity-specific `_compute_hash_output_hashes`, which hard-coded `totalRefs=0` for every output. It was correct only for plain-RXD covenant outputs and would have signed an invalid sighash for any ref-bearing (FT/NFT) output. Replaced with a thin adapter that parses the wire-serialized outputs via `TransactionOutput.from_hex` and delegates to the canonical, ref-aware impl in `transaction_preimage.py` (already pinned against a confirmed mainnet reveal tx).

2. **`fix(transaction)`** — `from_hex` accepted truncated output scripts silently (`Reader.read_bytes` returns short at EOF without erroring), so an over-claiming script-length varint produced a valid `TransactionOutput` over corrupt bytes — and thus a `hashOutputHashes` over corrupt data. Restore the old hand-rolled parser's explicit truncation guard at the parser layer. **Found by technical review of commit 1.**

## Why

The hard-coded `totalRefs=0` blocks the ref-bearing covenant work: FT/NFT outputs carry `OP_PUSHINPUTREF`/`OP_PUSHINPUTREFSINGLETON` and must hash with a real `refsHash`. This de-dup unblocks that while preserving exact behavior for today's plain-RXD path.

## Testing

- **Byte-identical** to the pre-refactor impl for the `totalRefs=0` path — golden vectors captured *before* the refactor, asserted *after* (`TestSighashBackcompat`).
- New edge-case coverage: golden-pinned FT `refsHash`, 0xFD varint-length boundary, empty blob, trailing garbage, **over-long script length**, **mid-stream truncation**.
- Cross-checked live against the real on-chain ref-bearing output in mainnet tx `dac1e2df...` (8104 confs) — the ref-aware path runs correctly on real consensus bytes.
- `task ci` green: 3042 passed, 12 skipped; lint, format, mypy, coverage gates (security 100%, overall ≥85%) all pass.

## Scope

Pure refactor + parser hardening. No covenant scripts, no new public API. Subsequent phases (ref-bearing covenant artifacts, tx builders, Taker verification) build on this.