### PR TITLE
perf(ci): halve the test job — memoize SPV header grind, cache deps, drop redundant run

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,16 @@ jobs:
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6
         with:
           python-version: ${{ matrix.python-version }}
+      # Cache Poetry's downloads + resolved virtualenv, keyed on the lock file,
+      # so `poetry install --sync` skips re-downloading/rebuilding native wheels
+      # on every run. A cache miss just falls back to a normal cold install.
+      - name: Cache Poetry packages
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830  # v4
+        with:
+          path: ~/.cache/pypoetry
+          key: poetry-${{ runner.os }}-py${{ matrix.python-version }}-${{ hashFiles('poetry.lock') }}
+          restore-keys: |
+            poetry-${{ runner.os }}-py${{ matrix.python-version }}-
       - name: Install Poetry
         # Hash-pinned via ci/poetry-pin.txt. Closes the OpenSSF Scorecard
         # / CodeQL PinnedDependenciesID alert. See ci/README.md for how
@@ -41,12 +51,13 @@ jobs:
         run: pip install -r ci/poetry-pin.txt --require-hashes
       - name: Install dependencies
         run: poetry install --sync --no-interaction
-      - name: Run tests
-        run: poetry run pytest tests/ -v --tb=short
+      # The full-suite coverage run below is the canonical pass/fail gate. A
+      # separate non-coverage `pytest tests/` run was redundant (same tests) and
+      # re-ran the slowest tests a second time, so it was dropped.
       - name: Security module coverage (must be 100%)
         run: poetry run pytest tests/security/ -o "addopts=" --cov=pyrxd.security --cov-fail-under=100
-      - name: Overall coverage (must be 85%)
-        run: poetry run pytest tests/ -o "addopts=" --cov=pyrxd --cov-fail-under=85
+      - name: Tests + overall coverage (must be 85%)
+        run: poetry run pytest tests/ -o "addopts=" --cov=pyrxd --cov-fail-under=85 --tb=short
       - name: Bandit security scan
         run: poetry run bandit -r src/ -c pyproject.toml
       - name: Type check

--- a/tests/test_spv_covenant_differential_deployed.py
+++ b/tests/test_spv_covenant_differential_deployed.py
@@ -41,6 +41,7 @@ Python path are always driven with the SAME committed type.
 from __future__ import annotations
 
 import struct
+from functools import cache
 
 import pytest
 
@@ -586,6 +587,11 @@ def test_header_nbits_exponent_ceiling_divergence_needs_regtest():
 # =========================================================================== MERKLE walk
 
 
+# Expensive: grinds a ~24-bit-target block header in pure Python (~13s/call).
+# Every caller passes identical args, so memoize to grind once per
+# (payment_spk, n_levels) instead of once per test. Returns only immutable
+# bytes/str, so sharing one cached tuple across tests is safe.
+@cache
 def _grind_tx_into_block(payment_spk: bytes, n_levels: int = 1):
     """Build a single-input/single-output tx and a relaxed-target block whose
     merkle root commits it at pos=1 with ``n_levels`` siblings. Returns


### PR DESCRIPTION
Speeds up the `test (3.12)` CI job (8m40s on the last docs-only PR) via three independent, low-risk changes. Profiled with `pytest --durations` first — these target the measured hot spots, not guesses.

## What was slow (measured)
- **~64% of raw suite time was 3 tests** in `tests/test_spv_covenant_differential_deployed.py` — each calls `_grind_tx_into_block`, which **mines a ~24-bit-target block header in pure Python** (`for nonce in range(50M)` double-SHA256), ~13s each. All three grind the *identical* header.
- **CI ran the full suite twice** — a plain `pytest tests/ -v` step plus the `--cov-fail-under=85` step run the same tests, so the slow grind ran ~4× per job.
- **No dependency cache** — `poetry install --sync` did a cold native-wheel build every run.

## Changes
1. **`perf(test)`** — `@functools.cache` on `_grind_tx_into_block`. The file drops from ~40s → **~13.5s** (verified locally: first grind 13.5s, the other two are sub-ms cache hits). Pure perf; the function returns only immutable bytes/str so sharing the cached result is safe. 38 passed / 2 skipped / 1 xfailed, ruff clean.
2. **`perf(ci)` — drop the redundant plain run.** The `--cov-fail-under=85` step already executes the whole suite; the separate non-coverage `pytest tests/ -v` was a duplicate pass. **Coverage gates unchanged** (only the `--cov` runs ever measured coverage).
3. **`perf(ci)` — cache Poetry.** `actions/cache` (hash-pinned to v4 `0057852…`, matching the repo's OpenSSF-Scorecard pinning convention) keyed on `poetry.lock`, caching `~/.cache/pypoetry`. Cache miss falls back to a cold install.

Net: the 3 grind tests go from ~4 runs/job to 1, and dep install is cached. The real validation is this PR's own CI run.

Docs/infra + test-perf only — no `src/` changes, no behavioural change to any test.