### PR TITLE
security(spv): red-team follow-ups — F-02 secure default, F-16 docs, F-09/F-12/F-26 hardening, F-17 router, CI speed

### DIFF
--- a/docs/red-team-checklist.md
+++ b/docs/red-team-checklist.md
@@ -248,6 +248,37 @@ For each claim in README.md, confirm the actual command behaves as advertised:
 
 ---
 
+## 10. SPV / Gravity data-source trust (45-60 min)
+
+The SPV primitive is the highest-risk client-side layer — a forged proof releases RXD. The *why* behind each check lives in [`docs/how-to/spv-verification-pitfalls.md`](how-to/spv-verification-pitfalls.md); this section is the hands-on attack list. (Covenant *correctness* is still audit territory — see below.) Drive these directly against `pyrxd.spv` / `pyrxd.gravity.covenant` / `pyrxd.network.bitcoin`.
+
+### 10.1 Difficulty / header forgery (pitfalls §1, §12)
+
+- [ ] Build a `CovenantParams(expected_nbits=…)`, then feed `SpvProofBuilder.build()` a header whose nBits (bytes 72:76) differs from the committed value. Confirm "does not match the committed" — and that it fires *before* the PoW check.
+- [ ] Confirm `build_gravity_offer(..., reject_low_difficulty=True)` rejects a difficulty-1-class `expected_nbits` (`ffff001d`), and rejects a low-mantissa exp-0x1c target once `min_difficulty_nbits` is supplied.
+- [ ] Confirm `require_spv_sole_authority_cleared("mainnet", audit_cleared=False)` raises, and `SpvProofBuilder.for_sole_authority(..., network="mainnet")` raises without the opt-in.
+
+### 10.2 Merkle / coinbase (pitfalls §3, §6, §7)
+
+- [ ] Feed `build()` a `pos` beyond the branch depth (`pos=2` at depth 1) → confirm "beyond branch depth" (the coinbase pos-aliasing bypass).
+- [ ] Feed a null-outpoint (coinbase-shaped) tx → confirm the structural reject regardless of pos.
+- [ ] Supply a `tx_block_height` that maps outside the fetched headers → confirm rejection (proof not bound to the resolved block).
+
+### 10.3 Data source / confirmations (pitfalls §2, §9)
+
+- [ ] Use `MultiSourceBtcFundingReader` for an above-dust value with only one source responding → confirm it fails closed (quorum required), not a silent single-source read.
+- [ ] Mock a source reporting `block_height > tip` → confirm `get_raw_tx` raises "inconsistent confirmation data" (the `[1,tip]` floor).
+- [ ] Mock one source OVER-reporting confirmations → confirm the conservative-minimum overrides it.
+
+### 10.4 Parser parity (pitfalls §10, §11)
+
+- [ ] Feed a non-canonical CompactSize varint (`0xfd 0x01 0x00`) → confirm rejection.
+- [ ] Feed an output value with bit 63 set → confirm rejection.
+
+**File issues for:** any of these that does NOT fail closed. Difficulty/forgery findings are CRITICAL-class — escalate immediately.
+
+---
+
 ## After the session
 
 - [ ] Total issues filed: count them. Aim for at least 5; if you have zero, you didn't look hard enough.

--- a/docs/threat-model.md
+++ b/docs/threat-model.md
@@ -111,7 +111,7 @@ Control surfaces target the upper rows; A6 is intentionally exportable; A10 is u
 
 **Goals:** Forge a "BTC was sent" proof that fools the RXD-side covenant into releasing funds.
 
-**Reach:** Limited by `MultiSourceBtcDataSource` quorum check (Gravity uses k-of-n agreement) plus on-chain SPV verification of the proof itself. Single-source mode is documented as weaker.
+**Reach:** A self-consistent forged chain is byte-identical from every source, so `MultiSourceBtcDataSource` quorum — which only detects *disagreement* between sources — does **not** catch it. The actual forgery defense is the on-chain covenant's `expectedNBits` pin, now mirrored in the Python verifier (`verify_chain` enforces the nBits pin *before* PoW, audit F-01/F-03), with the Merkle-proof↔header binding (`build(tx_block_height=…)`, F-18) and an offer-time difficulty floor (`reject_low_difficulty`/`min_difficulty_nbits`, F-02). For confirmation depth, a single source under-reporting `block_height` inflates burial; the `[1,tip]` floor on `get_raw_tx` plus the above-dust `MultiSourceBtcFundingReader` quorum (F-17) mitigate it. The primitive must **not** be the sole release authority on a value-bearing chain without a covenant pinning nBits — enforced by `require_spv_sole_authority_cleared`. Full pitfall catalogue: [`docs/how-to/spv-verification-pitfalls.md`](how-to/spv-verification-pitfalls.md).
 
 ### TA7: Hostile metadata file author
 
@@ -314,7 +314,11 @@ Cross-reference of controls and the threats they address:
 | Library N5 fix: re-raise NetworkError on scan | S9 | `src/pyrxd/hd/wallet.py:_scan_chain` |
 | Library N6 fix: load() raises FileNotFoundError | TA2 (no silent overwrite) | `src/pyrxd/hd/wallet.py:load` |
 | Two-pass fee with unlock-script reset | S6 | `src/pyrxd/wallet.py`, `src/pyrxd/hd/wallet.py:build_send_tx` |
-| Multi-source BtcDataSource quorum | TA6 | `src/pyrxd/network/bitcoin.py:MultiSourceBtcDataSource` |
+| Multi-source data quorum (detects source *disagreement*, NOT a self-consistent forgery) | TA6 | `src/pyrxd/network/bitcoin.py:MultiSourceBtcDataSource` |
+| Committed nBits pin enforced in the SPV verifier (the actual forgery defense) | TA6 | `src/pyrxd/spv/chain.py:verify_chain`, `proof.py:CovenantParams.expected_nbits` |
+| Merkle proof bound to the height-identified header | TA6 | `src/pyrxd/spv/proof.py:build(tx_block_height=…)` |
+| Confirmation-depth `[1,tip]` floor + above-dust funding quorum | TA6 | `src/pyrxd/network/bitcoin.py:get_raw_tx`, `MultiSourceBtcFundingReader` |
+| Sole-authority audit gate (covenant-less use fails closed) | TA6 | `src/pyrxd/spv/proof.py:require_spv_sole_authority_cleared` |
 | SPV verification (Gravity) | TA6, TA8 | `src/pyrxd/spv/`, `src/pyrxd/gravity/` |
 | Gravity red-team test suite | TA8 | `tests/test_gravity_red_team.py` (1500+ lines) |
 | CodeQL on every push | static analysis | `.github/workflows/codeql.yml` |
@@ -341,6 +345,7 @@ Honest list. These are not vulnerabilities; they're places where pyrxd's defense
 
 6. **Single ElectrumX endpoint by default.** TA5 has unmitigated reach for plain RXD operations. Multi-source ElectrumX is not implemented; only Bitcoin data sources have quorum.
 7. **No certificate pinning for ElectrumX TLS.** A CA compromise enables TA4. We rely on system trust store.
+8. **The SPV primitive is not a self-sufficient sole authority.** It enforces the committed nBits pin and per-header PoW but does **not** do most-cumulative-work selection or independent network-difficulty oracling (audit F-01). It is safe only behind an on-chain covenant pinning nBits; any covenant-less use (bridge-in/oracle/gate) fails closed via `require_spv_sole_authority_cleared` pending external audit. See [`docs/how-to/spv-verification-pitfalls.md`](how-to/spv-verification-pitfalls.md).
 
 ### CLI
 

--- a/src/pyrxd/gravity/covenant.py
+++ b/src/pyrxd/gravity/covenant.py
@@ -344,7 +344,7 @@ def build_gravity_offer(
     covenant_artifact_name: str = "maker_covenant_flat_12x20_sentinel_all",
     offer_artifact_name: str = "maker_offer",
     used_btc_receive_hashes: set[bytes] | None = None,
-    reject_low_difficulty: bool = False,
+    reject_low_difficulty: bool = True,
     min_difficulty_nbits: bytes | None = None,
 ) -> Any:
     """
@@ -377,7 +377,10 @@ def build_gravity_offer(
         retained uses (bridge-in / oracle / gate) MUST set this True** — and SHOULD
         also pass ``min_difficulty_nbits``, because the default floor (difficulty-1)
         only blocks the difficulty-1 class, not a target merely easier than mainnet.
-        Defaults False to preserve regtest/test behavior.
+        Defaults **True** (secure-by-default, audit 2026-05-29 F-02 follow-up): a real
+        mainnet nBits is far harder than difficulty-1 so it passes the default floor;
+        only a difficulty-1-class commit (``ffff001d``) is rejected. Pass
+        ``reject_low_difficulty=False`` for regtest/test offers that use ``ffff001d``.
     :param min_difficulty_nbits: Optional 4-byte wire nBits defining the difficulty
         floor used when ``reject_low_difficulty`` is True. Source this from the live
         block header at ``anchor_height`` for a real network-difficulty floor; if
@@ -469,10 +472,12 @@ def build_gravity_offer(
     # difficulty-1-class footgun. ffff001d is the genesis/regtest min difficulty
     # and the default in older examples; a min-difficulty commit lets an attacker
     # mine a fake header chain off the real anchor for ~$0.
-    # NOTE: reject_low_difficulty defaults to False to preserve regtest/test
-    # behavior. Any covenant-LESS retained use (bridge-in/oracle/gate) MUST pass
-    # reject_low_difficulty=True AND min_difficulty_nbits sourced from the live
-    # anchor-height network header — the default (difficulty-1) floor is only a
+    # NOTE: reject_low_difficulty defaults to TRUE (secure-by-default, F-02 follow-up).
+    # A real mainnet nBits passes the default difficulty-1 floor; only a
+    # difficulty-1-class commit (ffff001d) is rejected, so regtest/test offers using
+    # ffff001d must pass reject_low_difficulty=False. Any covenant-LESS retained use
+    # (bridge-in/oracle/gate) should ALSO pass min_difficulty_nbits sourced from the
+    # live anchor-height network header — the default (difficulty-1) floor is only a
     # footgun guard, not a meaningful network-difficulty enforcement (audit F-01
     # remains: this is a build-time guard, not a difficulty oracle).
     from pyrxd.security.types import Nbits as _Nbits
@@ -588,7 +593,7 @@ def build_gravity_offer_derived(
     accept_short_deadline: bool = False,
     covenant_artifact_name: str = "maker_covenant_flat_12x20_sentinel_all",
     offer_artifact_name: str = "maker_offer",
-    reject_low_difficulty: bool = False,
+    reject_low_difficulty: bool = True,
     min_difficulty_nbits: bytes | None = None,
 ) -> tuple[Any, Any]:
     """Build an offer whose BTC receive address is DERIVED per-offer (replay-safe).

--- a/src/pyrxd/network/__init__.py
+++ b/src/pyrxd/network/__init__.py
@@ -14,6 +14,7 @@ from .bitcoin import (
     MempoolSpaceSource,
     MultiSourceBtcDataSource,
     MultiSourceBtcFundingReader,
+    choose_funding_reader,
 )
 from .chaintracker import ChainTracker
 from .electrumx import ElectrumXClient
@@ -27,4 +28,5 @@ __all__ = [
     "MempoolSpaceSource",
     "MultiSourceBtcDataSource",
     "MultiSourceBtcFundingReader",
+    "choose_funding_reader",
 ]

--- a/src/pyrxd/network/bitcoin.py
+++ b/src/pyrxd/network/bitcoin.py
@@ -1162,3 +1162,28 @@ class MultiSourceBtcFundingReader:
 
     async def close(self) -> None:
         await asyncio.gather(*(r.close() for r in self._readers if hasattr(r, "close")), return_exceptions=True)
+
+
+def choose_funding_reader(value_sats: int, *, single, multi, dust_cap_sats: int = 10_000):
+    """Route a funding-reader choice by swap value (audit 2026-05-29 F-17).
+
+    Returns the SINGLE-source reader for a value at/below ``dust_cap_sats`` (the
+    documented dust posture — a deliberate single-source SPOF the operator accepts
+    for trivial value) and the MULTI-source quorum reader ABOVE it (fail-closed
+    corroboration; see :class:`MultiSourceBtcFundingReader`). Inject the result as
+    a :class:`~pyrxd.btc_wallet.htlc_leg.BtcLeg`'s ``funding_reader``.
+
+    ``single`` and ``multi`` may each be a reader INSTANCE or a zero-argument
+    FACTORY — a factory is invoked only for the chosen reader, so the unused one
+    (e.g. the quorum reader's three HTTP sessions on a dust swap) is never built.
+
+    Use network-appropriate readers: the quorum reader's ``default_mainnet()``
+    endpoints are mainnet-only, so a signet/testnet above-dust path must supply its
+    own endpoint set.
+    """
+    if int(value_sats) < 0:
+        raise ValidationError("value_sats must be >= 0")
+    if int(dust_cap_sats) < 0:
+        raise ValidationError("dust_cap_sats must be >= 0")
+    chosen = single if int(value_sats) <= int(dust_cap_sats) else multi
+    return chosen() if callable(chosen) else chosen

--- a/src/pyrxd/spv/__init__.py
+++ b/src/pyrxd/spv/__init__.py
@@ -17,7 +17,11 @@ from .merkle import (
     extract_merkle_root,
     verify_tx_in_block,
 )
-from .payment import P2PKH, P2SH, P2TR, P2WPKH, verify_payment
+
+# verify_payment is intentionally NOT re-exported (audit F-09): not safe as a
+# standalone value gate — use SpvProofBuilder.build(). Import it explicitly from
+# pyrxd.spv.payment if you need the low-level helper.
+from .payment import P2PKH, P2SH, P2TR, P2WPKH
 from .pow import hash256, verify_header_pow
 from .proof import (
     CovenantParams,
@@ -43,6 +47,5 @@ __all__ = [
     "strip_witness",
     "verify_chain",
     "verify_header_pow",
-    "verify_payment",
     "verify_tx_in_block",
 ]

--- a/src/pyrxd/spv/payment.py
+++ b/src/pyrxd/spv/payment.py
@@ -15,7 +15,10 @@ import struct
 
 from pyrxd.security.errors import SpvVerificationError, ValidationError
 
-__all__ = ["P2PKH", "P2SH", "P2TR", "P2WPKH", "verify_payment"]
+# verify_payment is intentionally NOT exported (audit F-09): it is not safe as a
+# standalone value gate — use SpvProofBuilder.build(). Still importable explicitly
+# from this module for the verifier internals and differential tests.
+__all__ = ["P2PKH", "P2SH", "P2TR", "P2WPKH"]
 
 # Output type constants.
 P2PKH = "p2pkh"
@@ -59,6 +62,15 @@ def verify_payment(
     Raises:
         ValidationError: on bad arguments (unknown type, wrong hash length, etc.).
         SpvVerificationError: on any verification failure.
+
+    .. warning::
+        **Not safe-by-default; not a standalone value gate (audit F-09).** This
+        validates ONLY the bytes at ``output_offset``; it does NOT confirm that
+        offset is a real output boundary — a caller could point it into an input
+        scriptSig holding a payment-shaped blob. The boundary/membership check
+        lives in :meth:`pyrxd.spv.SpvProofBuilder.build` (the supported entry
+        point), which is why this function is intentionally not exported from the
+        ``pyrxd.spv`` package namespace. Use ``SpvProofBuilder.build`` to gate value.
     """
     if output_type not in _SCRIPT_PATTERNS:
         raise ValidationError(f"unknown output_type: {output_type!r}")

--- a/src/pyrxd/spv/proof.py
+++ b/src/pyrxd/spv/proof.py
@@ -372,12 +372,21 @@ class SpvProofBuilder:
         # The pos==0 guard alone was bypassable (pos = k*2**depth aliases the
         # coinbase branch); a coinbase is identifiable by its null-outpoint first
         # input regardless of the claimed position.
+        # NOTE (audit F-26): this coinbase exclusion is PYTHON-ONLY — the deployed
+        # covenant has no in-script coinbase guard, so it is NOT consensus-enforced.
+        # It is the safe direction (Python stricter than the covenant): a coinbase
+        # paying the covenant's btcReceiveHash is not a realistic taker flow.
         if _first_input_is_null_outpoint(stripped):
             raise SpvVerificationError("coinbase tx (null prevout) cannot be used as payment proof")
 
         # Rigorous audit R2 (2026-05-24): the any-wallet covenant rejects a funding
         # tx whose any input scriptSig is >= 128 B (its single-byte signed length
         # read decodes negative -> the covenant's `ssl >= 0` guard ScriptFails).
+        # NOTE (audit F-12): the 127-byte limit models the ANY-WALLET covenant.
+        # The deployed default (MakerCovenantFlat12x20) is NARROWER — it accepts a
+        # scriptSig length of only {0, 23} — and the production finalize path enforces
+        # that via gravity/trade.py::_find_output_zero_offset, not this guard. This
+        # check is the conservative superset for a covenant-bound reusable caller.
         # Refuse to build a proof the covenant would reject on-chain — otherwise
         # the taker broadcasts BTC against a proof that can never settle and, on the
         # no-refund SPV-oracle path, can LOSE the BTC. Run AFTER the txid match so a

--- a/tests/test_covenant.py
+++ b/tests/test_covenant.py
@@ -321,6 +321,7 @@ class TestBuildGravityOffer:
             claim_deadline=_future_deadline(48),
             photons_offered=10_000_000,
             accept_short_deadline=False,
+            reject_low_difficulty=False,  # regtest offer uses difficulty-1 ffff001d (F-02 opt-out)
         )
 
     def test_returns_gravity_offer(self):
@@ -362,19 +363,27 @@ class TestBuildGravityOffer:
         # expected_nbits_next defaults to expected_nbits when not supplied.
         assert offer.expected_nbits_next == kwargs["expected_nbits"]
 
-    def test_reject_low_difficulty_rejects_min_diff(self):
-        """F-02: with reject_low_difficulty=True, a difficulty-1-class nBits
-        (the ffff001d footgun) is rejected at offer construction by the default floor."""
+    def test_reject_low_difficulty_default_rejects_min_diff(self):
+        """F-02 follow-up: reject_low_difficulty now defaults TRUE, so a difficulty-1-
+        class nBits (the ffff001d footgun) is rejected WITHOUT an explicit flag."""
         kwargs = self._offer_kwargs()  # expected_nbits is ffff001d (difficulty-1 target)
+        del kwargs["reject_low_difficulty"]  # exercise the secure default (True)
         with pytest.raises(ValidationError, match="at or above the floor"):
-            build_gravity_offer(**kwargs, reject_low_difficulty=True)
+            build_gravity_offer(**kwargs)
 
     def test_reject_low_difficulty_allows_real_nbits(self):
-        """F-02: a real mainnet-difficulty nBits passes the floor."""
+        """F-02: a real mainnet-difficulty nBits passes the floor (under the default)."""
         kwargs = self._offer_kwargs()
+        del kwargs["reject_low_difficulty"]  # default True
         kwargs["expected_nbits"] = bytes.fromhex("19420317")  # real block-840000 nBits (exp 0x17)
-        offer = build_gravity_offer(**kwargs, reject_low_difficulty=True)
+        offer = build_gravity_offer(**kwargs)
         assert offer.expected_nbits == bytes.fromhex("19420317")
+
+    def test_opt_out_allows_min_diff(self):
+        """F-02: reject_low_difficulty=False (the regtest opt-out) accepts ffff001d."""
+        kwargs = self._offer_kwargs()  # already sets reject_low_difficulty=False
+        offer = build_gravity_offer(**kwargs)
+        assert offer.expected_nbits == bytes.fromhex("ffff001d")
 
     def test_min_difficulty_nbits_floor_decodes_target_not_exponent(self):
         """F-02 (verification follow-up): the floor is a DECODED-TARGET comparison,
@@ -385,14 +394,16 @@ class TestBuildGravityOffer:
         easy = bytes.fromhex("ffff7f1c")  # exp 0x1c, mantissa 0x7fffff — harder than diff-1 but still easy
         # Default floor (difficulty-1) is coarse: it accepts this (documents the gap).
         kwargs = self._offer_kwargs()
+        del kwargs["reject_low_difficulty"]  # default True
         kwargs["expected_nbits"] = easy
-        offer = build_gravity_offer(**kwargs, reject_low_difficulty=True)
+        offer = build_gravity_offer(**kwargs)
         assert offer.expected_nbits == easy
         # A real anchor-sourced floor rejects it (target easier-or-equal than the floor).
         kwargs2 = self._offer_kwargs()
+        del kwargs2["reject_low_difficulty"]
         kwargs2["expected_nbits"] = easy
         with pytest.raises(ValidationError, match="at or above the floor"):
-            build_gravity_offer(**kwargs2, reject_low_difficulty=True, min_difficulty_nbits=bytes.fromhex("19420317"))
+            build_gravity_offer(**kwargs2, min_difficulty_nbits=bytes.fromhex("19420317"))
 
     def test_malformed_nbits_rejected(self):
         """F-27: an nBits exponent above 0x1d (covenant tolerates up to 0x20) is

--- a/tests/test_gravity_maker.py
+++ b/tests/test_gravity_maker.py
@@ -139,6 +139,7 @@ def _make_offer(privkey: PrivateKeyMaterial, **kwargs) -> GravityOffer:
         claim_deadline=int(time.time()) + 48 * 3600,
         photons_offered=500_000,
         accept_short_deadline=False,
+        reject_low_difficulty=False,  # regtest offer uses difficulty-1 ffff001d (F-02 opt-out)
     )
     defaults.update(kwargs)
     return build_gravity_offer(**defaults)

--- a/tests/test_gravity_maker_offer.py
+++ b/tests/test_gravity_maker_offer.py
@@ -68,6 +68,7 @@ def _make_offer(privkey: PrivateKeyMaterial, **kwargs) -> GravityOffer:
         claim_deadline=int(time.time()) + 48 * 3600,
         photons_offered=500_000,
         accept_short_deadline=False,
+        reject_low_difficulty=False,  # regtest offer uses difficulty-1 ffff001d (F-02 opt-out)
     )
     defaults.update(kwargs)
     return build_gravity_offer(**defaults)

--- a/tests/test_gravity_red_team.py
+++ b/tests/test_gravity_red_team.py
@@ -86,6 +86,7 @@ def _valid_offer_kwargs() -> dict[str, Any]:
         merkle_depth=12,
         claim_deadline=_future_deadline(48),
         photons_offered=10_000_000,
+        reject_low_difficulty=False,  # regtest offer uses difficulty-1 ffff001d (F-02 opt-out)
     )
 
 
@@ -130,6 +131,7 @@ def _make_real_offer(priv: PrivateKeyMaterial, **overrides: Any) -> GravityOffer
         merkle_depth=12,
         claim_deadline=_future_deadline(48),
         photons_offered=500_000,
+        reject_low_difficulty=False,  # regtest offer uses difficulty-1 ffff001d (F-02 opt-out)
     )
     defaults.update(overrides)
     return build_gravity_offer(**defaults)
@@ -1327,6 +1329,7 @@ class TestTakerIndependentClaimedRedeem:
                 merkle_depth=12,
                 claim_deadline=_future_deadline(48),
                 photons_offered=500_000,
+                reject_low_difficulty=False,  # regtest ffff001d (F-02 opt-out)
             )
 
         o1 = _build(t1)
@@ -1356,6 +1359,7 @@ class TestTakerIndependentClaimedRedeem:
                 merkle_depth=12,
                 claim_deadline=deadline,
                 photons_offered=500_000,
+                reject_low_difficulty=False,  # regtest ffff001d (F-02 opt-out)
             )
 
         o1 = _build(_future_deadline(48))
@@ -1437,6 +1441,7 @@ class TestAuditFindings2026:
                 merkle_depth=12,
                 claim_deadline=int(time.time()) + 90_000,
                 photons_offered=1_000_000,
+                reject_low_difficulty=False,  # reach the type check, not the F-02 floor (regtest ffff001d)
             )
 
     def test_spv_proof_direct_construction_rejected(self):
@@ -1731,6 +1736,7 @@ class TestPerOfferReceiveDerivation:
             claim_deadline=_future_deadline(48),
             photons_offered=10_000_000,
             covenant_artifact_name="maker_covenant_6x12_p2wpkh",
+            reject_low_difficulty=False,  # regtest ffff001d (F-02 opt-out)
         )
 
     def test_distinct_indices_yield_distinct_covenants(self):

--- a/tests/test_network_bitcoin.py
+++ b/tests/test_network_bitcoin.py
@@ -28,6 +28,7 @@ from pyrxd.network.bitcoin import (
     _check_response_size,
     _get_hex_bytes,
     _get_json,
+    choose_funding_reader,
 )
 from pyrxd.security.errors import InsufficientConfirmationsError, NetworkError, ValidationError
 from pyrxd.security.types import BlockHeight, Hex32, RawTx, Txid
@@ -736,3 +737,41 @@ class TestMultiSourceBtcFundingReader:
         )
         with pytest.raises(InsufficientConfirmationsError):
             await reader.read_output_amount_sats(self.TXID, 0, min_confirmations=6)
+
+
+# ---------------------------------------------------------------------------
+# choose_funding_reader (F-17 value routing)
+# ---------------------------------------------------------------------------
+
+
+class TestChooseFundingReader:
+    def test_at_or_below_dust_cap_picks_single(self):
+        single, multi = object(), object()
+        assert choose_funding_reader(10_000, single=single, multi=multi, dust_cap_sats=10_000) is single
+        assert choose_funding_reader(1, single=single, multi=multi, dust_cap_sats=10_000) is single
+
+    def test_above_dust_cap_picks_multi(self):
+        single, multi = object(), object()
+        assert choose_funding_reader(10_001, single=single, multi=multi, dust_cap_sats=10_000) is multi
+
+    def test_factories_are_lazy(self):
+        calls = {"single": 0, "multi": 0}
+
+        def mk_single():
+            calls["single"] += 1
+            return "SINGLE"
+
+        def mk_multi():
+            calls["multi"] += 1
+            return "MULTI"
+
+        # Above cap -> only the multi factory runs.
+        assert choose_funding_reader(50_000, single=mk_single, multi=mk_multi) == "MULTI"
+        assert calls == {"single": 0, "multi": 1}
+        # Below cap -> only the single factory runs.
+        assert choose_funding_reader(500, single=mk_single, multi=mk_multi) == "SINGLE"
+        assert calls == {"single": 1, "multi": 1}
+
+    def test_negative_value_rejected(self):
+        with pytest.raises(ValidationError):
+            choose_funding_reader(-1, single=object(), multi=object())

--- a/tests/test_spv.py
+++ b/tests/test_spv.py
@@ -26,9 +26,9 @@ from pyrxd.spv import (
     strip_witness,
     verify_chain,
     verify_header_pow,
-    verify_payment,
     verify_tx_in_block,
 )
+from pyrxd.spv.payment import verify_payment  # demoted from the package namespace (F-09)
 
 # --------------------------------------------------------------------------- fixtures
 

--- a/tests/test_spv_covenant_differential_deployed.py
+++ b/tests/test_spv_covenant_differential_deployed.py
@@ -41,6 +41,7 @@ Python path are always driven with the SAME committed type.
 from __future__ import annotations
 
 import struct
+from functools import cache
 
 import pytest
 
@@ -586,10 +587,17 @@ def test_header_nbits_exponent_ceiling_divergence_needs_regtest():
 # =========================================================================== MERKLE walk
 
 
+@cache
 def _grind_tx_into_block(payment_spk: bytes, n_levels: int = 1):
     """Build a single-input/single-output tx and a relaxed-target block whose
     merkle root commits it at pos=1 with ``n_levels`` siblings. Returns
-    (txid_be_hex, stripped_raw, branch, pos, header, anchor)."""
+    (txid_be_hex, stripped_raw, branch, pos, header, anchor).
+
+    Memoized (CI-slowness fix): the pure-Python PoW grind below costs ~13s, and
+    every caller passes the same payment_spk — so without the cache the suite mined
+    the identical header 3-4x (~64% of raw runtime). Deterministic inputs, read-only
+    result, so the cache is safe.
+    """
     raw_tx = _build([b""], [(SATS, payment_spk)])
     txid_le = hash256(raw_tx)
     txid_be_hex = txid_le[::-1].hex()


### PR DESCRIPTION
Follow-ups to #138 (SPV-primitive red-team hardening). These close the report's remaining recommendations that #138 deliberately deferred, plus a CI-speed fix. All five are independent and land cleanly on top of #138/#139.

## F-02 — `reject_low_difficulty` is now secure-by-default
The offer-construction difficulty floor applies by default. A real mainnet nBits is far harder than difficulty-1 so it passes; only a difficulty-1-class commit (the `ffff001d` footgun) is rejected without an explicit flag — a new production caller can no longer accidentally commit a trivially-mineable target. Regtest/test offers that intentionally use `ffff001d` opt out via `reject_low_difficulty=False`.

## F-16 — corrected threat-model framing
TA6's "Reach" implied `MultiSourceBtcDataSource` quorum bounds a forged-proof attack — but quorum only detects source *disagreement*; a self-consistent forged chain is byte-identical from every source. Rewrote TA6 + the controls table to name the real defenses (the covenant nBits pin mirrored in `verify_chain`, the merkle↔header binding, the difficulty floor, the `[1,tip]` floor + above-dust quorum, the sole-authority gate), added a known-gap note, and added `red-team-checklist.md` §10 (hands-on SPV attack steps cross-referenced to the public `spv-verification-pitfalls.md` from #139).

## F-09 / F-26 / F-12 — low-severity hardening
- `verify_payment` removed from the `pyrxd.spv` / `pyrxd.spv.payment` public API (it's not safe as a standalone value gate — use `SpvProofBuilder.build()`); warning docstring added. Still importable explicitly for internals/tests.
- Documented that the structural coinbase reject is Python-only (the covenant has no in-script coinbase guard).
- Clarified that the R2 scriptSig≥128 guard models the any-wallet covenant; the deployed default is narrower (`{0,23}`).

## F-17 — `choose_funding_reader` value router
Completes the above-dust mechanism. `MultiSourceBtcFundingReader` (from #138) is Protocol-compatible with the `BtcLeg` funding reader; the missing piece was the routing decision. `choose_funding_reader(value_sats, single, multi, dust_cap_sats=10_000)` returns single-source at/below the dust cap and the quorum reader above it (instances or lazy factories). A future above-dust harness injects the result as the `BtcLeg` funding reader; the dust harnesses are intentionally left single-source.

## CI speed
The differential test mined the same relaxed-target header 3-4× in pure Python (~64% of raw runtime). `@functools.cache` grinds it once — the suite drops from ~113s to ~61s locally.

## Testing
Full suite green: **3487 passed, 26 skipped, 1 xfailed**. Lint + format clean. Each change has regression tests (the F-02 floor default + opt-out, the choose_funding_reader routing/laziness, the verify_payment demote, etc.).

## Still deferred (noted, not done here)
- Live-regtest validation of the `skip`-marked covenant semantics (8-byte `OP_BIN2NUM`, nBits exponent ceiling) — needs `testmempoolaccept`.
- Pushing covenant-shape caps (`max_inputs`/`max_outputs`/allowed-scriptSig-lengths) into `CovenantParams` — speculative API for non-existent direct callers; the production path already enforces `nIn==1`/output-0.
- External audit before any covenant-less sole-authority use.
