### PR TITLE
ci(security): least-privilege combine-prs token + CodeQL security-extended

### DIFF
--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -1,10 +1,9 @@
 # CodeQL scan configuration for pyrxd.
 #
-# codeql.yml runs the 'security-and-quality' suite, which adds code-quality
-# queries on top of the security ones. Those quality queries generate a lot of
-# low-value noise on throwaway spike scripts and demo code that is not part of
-# the shipped library/CLI. Exclude those non-shipped paths so the Security tab
-# reflects code that actually runs in production, tests, and operational scripts.
+# codeql.yml runs the 'security-extended' suite (security only — the code-quality
+# queries are intentionally NOT used; ruff/mypy/bandit own quality/style and run
+# pre-merge). These path excludes keep the Security tab focused on code that
+# actually runs in production, tests, and operational scripts.
 #
 # Still scanned: src/, tests/, scripts/ (the latter includes real-value run
 # harnesses worth auditing).

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -36,9 +36,14 @@ jobs:
         uses: github/codeql-action/init@87557b9c84dde89fdd9b10e88954ac2f4248e463  # v4.36.1
         with:
           languages: python
-          # security-and-quality includes the security-extended ruleset plus
-          # additional code-quality queries. Worth the extra 30s on a small lib.
-          queries: security-and-quality
+          # security-extended (NOT security-and-quality): the full security ruleset
+          # WITHOUT the code-quality queries. ruff (B/SIM/F families), mypy and bandit
+          # already own the quality/style space and run in `task ci` + the pre-push hook,
+          # so the quality queries are redundant — they only re-surface, POST-merge, the
+          # residue ruff can't model (idiomatic `...` Protocol stubs, pytest.raises,
+          # deliberately `# noqa`'d code) as recurring false-positive noise. Keep security
+          # coverage here; catch quality issues pre-merge where they belong.
+          queries: security-extended
           # Excludes non-shipped spike/demo dirs from scanning (see config).
           config-file: ./.github/codeql/codeql-config.yml
 

--- a/.github/workflows/combine-prs.yml
+++ b/.github/workflows/combine-prs.yml
@@ -36,9 +36,11 @@ on:
         type: boolean
         default: true
 
+# Minimal default token (GHAS Token-Permissions): read-only at the top level; the single
+# `combine` job escalates to the write scopes it actually needs (create the combined branch +
+# open the combined PR).
 permissions:
-  contents: write
-  pull-requests: write
+  contents: read
 
 concurrency:
   group: combine-prs
@@ -47,6 +49,9 @@ concurrency:
 jobs:
   combine:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
     steps:
       - name: Checkout
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3


### PR DESCRIPTION
Two related CI-security changes surfaced while triaging GitHub Advanced Security alerts after the #155 merge.

### 1. Token-Permissions (resolves code-scanning HIGH #306)
`combine-prs.yml` granted `contents: write` + `pull-requests: write` at the top level, so the whole workflow ran with a write-scoped `GITHUB_TOKEN`. Now the default is `contents: read`, with the two write scopes escalated only on the single `combine` job. No behavior change.

### 2. CodeQL `security-extended` (drop redundant quality-query noise)
Switched `codeql.yml` from `security-and-quality` to `security-extended`. The quality queries are redundant with ruff (B/SIM/F), mypy, and bandit, which run in `task ci` + the pre-push hook and catch quality issues pre-merge. CodeQL only re-surfaced them post-merge as recurring false-positive noise on idioms it can't model (`...` Protocol stubs, `pytest.raises`, deliberately `# noqa`'d code). A full triage of the post-#155 batch was 0/56 useful. Full security ruleset stays; quality stays owned by the linters.

### The other 56 alerts
All triaged and dismissed with documented reasons (false-positive idioms + intentional patterns: required `security-events: write` for SARIF upload, intentional fuzz-harness `except: pass`, named opcode/offset constants, a pytest-fixture import, etc.). None were real vulnerabilities in the #155 code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)