### PR TITLE
fix(version): single-source __version__ from package metadata (0.6.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,20 @@ All notable changes to pyrxd are documented here. Format based on
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this project
 follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.6.1] — 2026-06-04
+
+Patch release. Fixes the package version reported by the CLI and the
+`pyrxd.__version__` attribute.
+
+### Fixed
+
+- `pyrxd --version` and `pyrxd.__version__` now report the actual installed
+  version. `__version__` was a hardcoded string in `pyrxd/__init__.py` that
+  was separate from `pyproject.toml`; it went stale and the 0.6.0 wheel
+  shipped reporting `0.5.1`. `__version__` is now derived from the installed
+  package metadata (`importlib.metadata.version`), so it tracks
+  `pyproject.toml` automatically and cannot drift again.
+
 ## [0.6.0] — 2026-06-04
 
 First release since 0.5.1 — 108 commits. The headline is **multi-path HD

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [project]
 name = "pyrxd"
-version = "0.6.0"
+version = "0.6.1"
 description = "Python SDK for the Radiant (RXD) blockchain — transactions, HD wallets, Glyph tokens (NFT/FT/dMint), Gravity cross-chain atomic swaps, SPV, and ElectrumX."
 authors = [
     {name = "Mudwood Labs", email = "opensource@mudwoodlabs.com"}

--- a/src/pyrxd/__init__.py
+++ b/src/pyrxd/__init__.py
@@ -36,9 +36,18 @@ see the same names with no behaviour change.
 
 from __future__ import annotations
 
+from importlib.metadata import PackageNotFoundError, version
 from typing import Any
 
-__version__ = "0.5.1"
+# Single source of truth for the version is pyproject.toml. Derive __version__
+# from the installed package metadata so the CLI's --version can never drift
+# from what was published — a hardcoded string here went stale and shipped a
+# 0.6.0 wheel that reported "0.5.1". The fallback covers a raw source checkout
+# with no installed dist metadata (and Pyodide, where pyrxd may load without it).
+try:
+    __version__ = version("pyrxd")
+except PackageNotFoundError:  # pragma: no cover - source checkout without install
+    __version__ = "0.0.0+unknown"
 
 # Map of public-name → (module, attr) pairs. Resolved lazily on first
 # attribute access. Order is alphabetical by name to make additions


### PR DESCRIPTION
## 0.6.1 — fix `--version` drift

`pyrxd` had **two version sources** — `pyproject.toml` and a hardcoded `__version__` in `src/pyrxd/__init__.py`. They drifted: the published **0.6.0 wheel reports `pyrxd --version` = `0.5.1`** (cosmetic; `recover` and all functionality are unaffected).

### Fix
- `__version__` now derives from `importlib.metadata.version("pyrxd")`, so it always tracks `pyproject.toml` and cannot drift again. Fallback to `0.0.0+unknown` for a raw source checkout / Pyodide with no installed metadata.
- Bump `0.6.0` → `0.6.1`; CHANGELOG entry added.

### Verified
- `import pyrxd` resolves `__version__` from metadata (no crash); `test_coverage_gaps` version assertions pass; ruff clean; private-link guard clean.

### After merge
Create release `v0.6.1` → `publish.yml` → PyPI.