### PR TITLE
feat(cli): wallet sweep — move funds from any derived path

### DIFF
--- a/guides/recover-stuck-rxd.md
+++ b/guides/recover-stuck-rxd.md
@@ -1,0 +1,212 @@
+# Recovering RXD that's stuck in a wallet
+
+**Your coins are almost certainly safe.** If a block explorer shows a balance on
+your address but your wallet shows **zero** after you restore your seed phrase,
+the money is not lost — your wallet is just looking at the wrong address. This
+guide walks you through finding it and moving it somewhere safe, step by step,
+in plain language.
+
+---
+
+## ⚠️ Read this first — stay safe
+
+Recovering stuck coins makes you a target for scammers. Before anything else:
+
+- **Never type or paste your seed phrase (your 12 or 24 words) into a website,
+  a "recovery service," a chat, or hand it to a person.** No legitimate tool or
+  helper ever needs your seed. Anyone who asks for it is trying to steal from you.
+- **Only run the official software** described below, **on your own computer.**
+- Your seed phrase **is** your money. Treat it like cash.
+
+If you keep that one rule, the rest of this is safe and straightforward.
+
+---
+
+## Why this happens (in plain English)
+
+Your seed phrase doesn't unlock *one* address — it can generate a whole tree of
+them. Think of one key that fits many doors. Different wallets (and even
+different versions of the *same* wallet) sometimes pick a **different door** to
+show you.
+
+So your coins are sitting safely behind one door, but your wallet is standing in
+front of a different, empty one. We just need to find the right door, then move
+the coins to a wallet you control.
+
+---
+
+## What you'll need
+
+- **A computer** — Windows, Mac, or Linux. (Sorry, this part can't be done on a
+  phone. If you only have a phone, borrow or use a computer — and **never** put
+  your seed into a phone app you're not sure about.)
+- **Your seed phrase** (the 12 or 24 words).
+- About 15 minutes.
+
+---
+
+## Step 1 — Install the recovery tool (`pyrxd`)
+
+`pyrxd` is a free, open-source Radiant toolkit. Install it once.
+
+### On Windows
+
+1. **Install Python.** Go to <https://www.python.org/downloads/> and click the
+   big "Download Python" button. Run the installer.
+   - **Important:** on the first screen, tick the box that says
+     **"Add Python to PATH"** before clicking Install. (If you miss it, just
+     run the installer again.)
+2. **Open a terminal.** Press the Windows key, type `cmd`, and open
+   **Command Prompt**.
+3. **Install pyrxd.** Type this and press Enter:
+   ```
+   pip install pyrxd
+   ```
+   Wait for it to finish (a page of text will scroll by — that's normal).
+
+### On Mac or Linux
+
+Open the **Terminal** app and run:
+```
+pip3 install pyrxd
+```
+(Most Macs and Linux machines already have Python. If `pip3` isn't found,
+install Python from <https://www.python.org/downloads/> first.)
+
+> **Check it worked:** type `pyrxd --help` and press Enter. If you see a list of
+> commands, you're ready. If it says "command not found," close and reopen the
+> terminal, or re-run the Python installer with "Add Python to PATH" ticked.
+
+The official package lives at <https://pypi.org/project/pyrxd/> and the source
+code is public at <https://github.com/MudwoodLabs/pyrxd>. Don't install anything
+that *claims* to be pyrxd from anywhere else.
+
+---
+
+## Step 2 — Find your coins
+
+In the terminal, run:
+
+```
+pyrxd wallet recover --scan
+```
+
+It will ask:
+
+```
+Mnemonic (input hidden):
+```
+
+Type or paste your seed phrase and press Enter.
+
+> **You won't see the words appear as you type — that's on purpose**, so nobody
+> looking at your screen can read them. It's working even though nothing shows.
+> (On Windows Command Prompt, right-click to paste.)
+
+The tool checks the likely addresses and tells you where your coins are. A
+successful result looks like this:
+
+```
+Found funds. Recover with the wallet that derives the matching path:
+
+  0.10000000 RXD  m/44'/0'/0'/0/0
+      coin type 0 — legacy
+      1CB9FyqzQiyjUw9gXyYmjHNUxjG8gQScYh
+
+Total confirmed   0.10000000 RXD
+```
+
+The important part is the **coin type** (here, `0`) — note it down. You'll use
+it in the next step. (If yours says `512`, use `512`.)
+
+> **If it says "No on-chain history found":** double-check your seed words and
+> their order, and confirm on a block explorer that the balance is really on an
+> address. If the explorer shows it but the scan doesn't, the coins may be on an
+> unusual path — see "Still stuck?" at the bottom.
+
+---
+
+## Step 3 — Move your coins to safety
+
+First, you need a **destination** — a receive address from a wallet you control
+and trust. The easiest options:
+
+- Create a fresh wallet in a current Radiant wallet app and copy its **receive
+  address**, or
+- Use your **deposit address** from an exchange you use.
+
+A Radiant address starts with `1` and looks like
+`1FzegoRZEXAPKztjVSkiX9VfK7s2ecwMGM`.
+
+Then run this, replacing the coin type with what Step 2 told you, and the
+address with your destination:
+
+```
+pyrxd wallet sweep --coin-type 0 --to YOUR_DESTINATION_ADDRESS
+```
+
+Enter your seed at the hidden prompt again. The tool shows you exactly what it's
+about to do and asks you to confirm:
+
+```
+  Sweep:
+    from path:   m/44'/0'/0'
+    inputs:      1 UTXO(s)
+    total found: 0.10000000 RXD
+    network fee: 0.01920000 RXD
+    you receive: 0.08080000 RXD
+    to address:  1FzegoRZEXAPKztjVSkiX9VfK7s2ecwMGM
+
+Broadcast this sweep? [y/N]:
+```
+
+**Check the "to address" line carefully** — that's where your coins are going.
+If it's correct, type `y` and press Enter. You'll get a transaction ID:
+
+```
+Swept 0.08080000 RXD to 1FzegoRZEXAPKztjVSkiX9VfK7s2ecwMGM
+Transaction: f4a6af5f1b2055cb3d7e0af4ae5447c263972d2eb4c053fd7cb89a8c81754254
+```
+
+That's it — your coins are on their way to your new wallet. You can paste the
+transaction ID into a block explorer to watch it confirm.
+
+> A small **network fee** is taken out (paid to miners, not to anyone else) —
+> that's normal for any blockchain transaction. If your balance is *very* small
+> (smaller than the fee), the tool will refuse rather than waste it.
+
+---
+
+## Good to know
+
+- This tool is **read-only until you confirm.** Step 2 only *looks*; nothing
+  moves until you type `y` in Step 3.
+- Your seed never leaves your computer. The tool only sends ordinary public
+  addresses to the network to check balances — never your words.
+- If your coins turn out to be on the *common* path, the current
+  [Photonic Wallet](https://github.com/Radiant-Core/Photonic-Wallet)'s "Recover"
+  screen can also restore them without a computer (tick "Use legacy derivation
+  path" if it shows empty). The tool above is the thorough fallback that also
+  handles the less-common paths a phone wallet can't reach.
+
+---
+
+## Still stuck?
+
+If Step 2 finds nothing even though the explorer shows your balance:
+
+1. Re-check every seed word and the order — one wrong word changes everything.
+2. Widen the search:
+   ```
+   pyrxd wallet recover --scan --coin-types 0,512 --accounts 0,1,2,3
+   ```
+3. Confirm the funded address on an explorer and check whether it matches any
+   address the scan derived. If it matches none, your old wallet may have used
+   an unusual setup — ask for help in a **trusted** Radiant community channel,
+   and remember: **never share your seed phrase, even with someone helping you.**
+
+---
+
+*This guide and the `pyrxd` tool are open source. Verify the tool at
+<https://github.com/MudwoodLabs/pyrxd> and <https://pypi.org/project/pyrxd/>
+before installing.*

--- a/src/pyrxd/cli/wallet_cmds.py
+++ b/src/pyrxd/cli/wallet_cmds.py
@@ -16,6 +16,7 @@ from typing import cast
 
 import click
 
+from ..constants import Network
 from ..hd.bip39 import mnemonic_from_entropy
 from ..hd.discovery import DEFAULT_ACCOUNTS, DEFAULT_COIN_TYPES, coin_type_label, discover
 from ..hd.wallet import HdWallet
@@ -472,15 +473,22 @@ def wallet_sweep(
     """
     if coin_type < 0 or account < 0:
         raise UserError("--coin-type and --account must be non-negative")
+    if fee_rate <= 0:
+        # Validate before the mnemonic prompt so a bad invocation fails
+        # without the user first typing their seed.
+        raise UserError("--fee-rate must be a positive integer (photons per kB)")
     # Block --json without --yes early (a broadcast must not auto-confirm).
     ok, why = ctx.is_destructive_mode_safe()
     if not ok:
         raise UserError(why or "destructive op without --yes in --json mode")
-    if not validate_address(to_address):
+    # Pin the destination to the ACTIVE network. Without this, a testnet-prefixed
+    # address (m.../n...) passes validation on mainnet, and the sweep pays a
+    # script no mainnet key can spend — an unrecoverable loss from a paste error.
+    if not validate_address(to_address, network=Network(ctx.network)):
         raise UserError(
             "invalid --to address",
-            cause="not a valid Radiant P2PKH address",
-            fix="pass an address you control (starts with 1)",
+            cause=f"not a valid {ctx.network} Radiant P2PKH address",
+            fix=f"pass a {ctx.network} address you control" + (" (starts with 1)" if ctx.network == "mainnet" else ""),
         )
 
     mnemonic = prompt_mnemonic_input()

--- a/src/pyrxd/cli/wallet_cmds.py
+++ b/src/pyrxd/cli/wallet_cmds.py
@@ -12,6 +12,7 @@ Cut 3 (deferred):
 from __future__ import annotations
 
 import asyncio
+from typing import cast
 
 import click
 
@@ -20,10 +21,13 @@ from ..hd.discovery import DEFAULT_ACCOUNTS, DEFAULT_COIN_TYPES, coin_type_label
 from ..hd.wallet import HdWallet
 from ..security.errors import NetworkError, ValidationError
 from ..security.rng import secure_random_bytes
+from ..utils import validate_address
+from ..wallet import DEFAULT_FEE_RATE
 from .context import CliContext
 from .errors import NetworkBoundaryError, UserError, WalletDecryptError
 from .format import emit, format_photons
 from .prompts import (
+    confirm_action,
     prompt_mnemonic_input,
     prompt_passphrase_input,
     show_mnemonic,
@@ -420,6 +424,151 @@ def wallet_recover(ctx: CliContext, scan: bool, coin_types: str, accounts: str, 
     click.echo(emit(payload, mode="human", human_lines=lines))
 
 
+@wallet_group.command(name="sweep")
+@click.option(
+    "--coin-type",
+    type=int,
+    required=True,
+    help="SLIP-0044 coin type the funds are on (e.g. 0 or 512). Use `wallet recover --scan` to find it.",
+)
+@click.option(
+    "--account",
+    type=int,
+    default=0,
+    show_default=True,
+    help="BIP44 account index the funds are on.",
+)
+@click.option(
+    "--to",
+    "to_address",
+    required=True,
+    help="Destination address to send everything to (an address you control).",
+)
+@click.option(
+    "--fee-rate",
+    type=int,
+    default=DEFAULT_FEE_RATE,
+    show_default=True,
+    help="Fee rate in photons per kB.",
+)
+@click.option(
+    "--passphrase/--no-passphrase",
+    default=False,
+    help="Prompt for the BIP39 passphrase if the seed was created with one.",
+)
+@click.pass_obj
+def wallet_sweep(
+    ctx: CliContext, coin_type: int, account: int, to_address: str, fee_rate: int, passphrase: bool
+) -> None:
+    """Move ALL funds from a derived path to an address you control.
+
+    Sweeps every spendable UTXO under ``m/44'/<coin-type>'/<account>'`` to --to,
+    minus the network fee. Use this to rescue funds that `wallet recover --scan`
+    found at a derivation path no GUI wallet can reach (a non-zero account, or a
+    higher address index).
+
+    This signs and broadcasts a real transaction. You are shown the amount,
+    fee, and destination, and asked to confirm before anything is broadcast.
+    """
+    if coin_type < 0 or account < 0:
+        raise UserError("--coin-type and --account must be non-negative")
+    # Block --json without --yes early (a broadcast must not auto-confirm).
+    ok, why = ctx.is_destructive_mode_safe()
+    if not ok:
+        raise UserError(why or "destructive op without --yes in --json mode")
+    if not validate_address(to_address):
+        raise UserError(
+            "invalid --to address",
+            cause="not a valid Radiant P2PKH address",
+            fix="pass an address you control (starts with 1)",
+        )
+
+    mnemonic = prompt_mnemonic_input()
+    if not mnemonic:
+        raise UserError(
+            "mnemonic is required",
+            cause="no input received",
+            fix="enter the BIP39 mnemonic for the wallet holding the funds",
+        )
+    passphrase_str = ""  # nosec B105 — empty string is the BIP39 spec default, not a hardcoded secret
+    if passphrase:
+        passphrase_str = prompt_passphrase_input(optional=False)
+
+    try:
+        wallet = HdWallet.from_mnemonic(mnemonic, passphrase=passphrase_str, account=account, coin_type=coin_type)
+    except (ValidationError, ValueError) as exc:
+        raise WalletDecryptError() from exc
+
+    path = f"m/44'/{coin_type}'/{account}'"
+
+    async def _sweep() -> dict[str, object]:
+        client = ctx.make_client()
+        async with client:
+            await wallet.refresh(client)
+            triples = await wallet.collect_spendable(client)
+            if not triples:
+                raise UserError(
+                    f"no spendable funds at {path}",
+                    cause="the scan found no UTXOs on this coin type / account",
+                    fix="double-check --coin-type and --account (run `wallet recover --scan` first)",
+                )
+            tx = wallet.build_send_max_tx(triples, to_address, fee_rate=fee_rate)
+            total_in = sum(t[0].value for t in triples)
+            out_value = tx.outputs[0].satoshis
+            fee = total_in - out_value
+
+            summary = [
+                "\n  Sweep:",
+                f"    from path:   {path} ({coin_type_label(coin_type)})",
+                f"    inputs:      {len(triples)} UTXO(s)",
+                f"    total found: {format_photons(total_in)}",
+                f"    network fee: {format_photons(fee)}",
+                f"    you receive: {format_photons(out_value)}",
+                f"    to address:  {to_address}",
+                "",
+            ]
+            if not confirm_action(summary, ctx=ctx, prompt_text="Broadcast this sweep?"):
+                raise UserError(
+                    "aborted by user",
+                    cause="confirmation declined",
+                    fix="re-run when you are ready to broadcast",
+                )
+
+            txid = await client.broadcast(tx.serialize())
+            return {
+                "txid": str(txid),
+                "from_path": path,
+                "to": to_address,
+                "swept_photons": out_value,
+                "fee_photons": fee,
+                "inputs": len(triples),
+            }
+
+    try:
+        result = asyncio.run(_sweep())
+    except NetworkError as exc:
+        raise NetworkBoundaryError(
+            "could not reach ElectrumX",
+            cause=str(exc),
+            fix=f"check that {ctx.electrumx_url} is reachable, or use --electrumx URL",
+        ) from exc
+    except ValidationError as exc:
+        # build_send_max_tx raises ValidationError on insufficient-funds / dust.
+        raise UserError(
+            "could not build the sweep transaction",
+            cause=str(exc),
+            fix="the funds may not exceed the network fee; try a lower --fee-rate or a different path",
+        ) from exc
+
+    if ctx.output_mode == "json":
+        click.echo(emit(result, mode="json"))
+    elif ctx.output_mode == "quiet":
+        click.echo(emit(result, mode="quiet", quiet_field="txid"))
+    else:
+        click.echo(f"\nSwept {format_photons(cast(int, result['swept_photons']))} to {to_address}")
+        click.echo(f"Transaction: {result['txid']}")
+
+
 # Confirmation helper used by Cut 1 destructive ops outside this module.
 # Re-exported for tests + future cuts.
 __all__ = [
@@ -429,4 +578,5 @@ __all__ = [
     "wallet_load",
     "wallet_new",
     "wallet_recover",
+    "wallet_sweep",
 ]

--- a/tests/cli/test_wallet_sweep.py
+++ b/tests/cli/test_wallet_sweep.py
@@ -147,6 +147,30 @@ class TestWalletSweep:
         assert "mnemonic is required" in result.output
         client.broadcast.assert_not_awaited()
 
+    def test_testnet_address_rejected_on_mainnet(self, runner: CliRunner) -> None:
+        # MEDIUM-1 fix: a testnet-prefixed --to must be rejected on a mainnet
+        # config, or the sweep would pay a script no mainnet key can spend.
+        testnet_dest = "mipcBbFg9gMiCh81Kj8tqqdgoZub1ZJRfn"  # valid testnet P2PKH
+        client = _funded_client(_addr(0, 0, 0, 0))
+        result = _invoke(runner, _ctx(client), ["sweep", "--coin-type", "0", "--to", testnet_dest])
+        assert result.exit_code != 0
+        assert "invalid --to" in result.output
+        client.broadcast.assert_not_awaited()
+
+    def test_zero_fee_rate_rejected_before_seed_prompt(self, runner: CliRunner) -> None:
+        # LOW-2 fix: bad --fee-rate fails before the mnemonic is requested.
+        client = _funded_client(_addr(0, 0, 0, 0))
+        result = runner.invoke(
+            wallet_group,
+            ["sweep", "--coin-type", "0", "--to", DEST, "--fee-rate", "0"],
+            obj=_ctx(client),
+            input="",  # no mnemonic provided — must fail before needing it
+        )
+        assert result.exit_code != 0
+        assert "--fee-rate" in result.output
+        assert "Mnemonic" not in result.output  # never reached the seed prompt
+        client.broadcast.assert_not_awaited()
+
     def test_negative_coin_type_rejected(self, runner: CliRunner) -> None:
         client = _funded_client(None)
         result = _invoke(runner, _ctx(client), ["sweep", "--coin-type", "-1", "--to", DEST])

--- a/tests/cli/test_wallet_sweep.py
+++ b/tests/cli/test_wallet_sweep.py
@@ -1,0 +1,163 @@
+"""Tests for `pyrxd wallet sweep` — move funds from a derived path (value-bearing)."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from click.testing import CliRunner
+
+from pyrxd.cli.config import Config
+from pyrxd.cli.context import CliContext
+from pyrxd.cli.wallet_cmds import wallet_group
+from pyrxd.hd.wallet import HdWallet
+from pyrxd.network.electrumx import UtxoRecord
+
+MNEMONIC = "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about"
+# A valid, unrelated P2PKH destination (the canonical abandon-seed coin-0 address).
+DEST = "1LqBGSKuX5yYUonjxT5qGfpUsXKYYWeabA"
+
+
+@pytest.fixture
+def runner() -> CliRunner:
+    return CliRunner()
+
+
+def _addr(coin_type: int, account: int, change: int, index: int) -> str:
+    w = HdWallet.from_mnemonic(MNEMONIC, account=account, coin_type=coin_type)
+    return w._derive_address(change, index)
+
+
+def _funded_client(funded_addr: str | None, *, value: int = 100_000_000) -> MagicMock:
+    """Mock ElectrumX: *funded_addr* has history + one UTXO; everything else empty."""
+    from pyrxd.network.electrumx import script_hash_for_address
+
+    async def _get_history(script_hash):
+        if funded_addr and script_hash_for_address(funded_addr) == script_hash:
+            return [{"tx_hash": "ab" * 32, "height": 800000}]
+        return []
+
+    async def _get_utxos(script_hash):
+        if funded_addr and script_hash_for_address(funded_addr) == script_hash:
+            return [UtxoRecord(tx_hash="ab" * 32, tx_pos=0, value=value, height=800000)]
+        return []
+
+    client = MagicMock()
+    client.get_history = _get_history
+    client.get_utxos = _get_utxos
+    client.get_balance = AsyncMock(return_value=(0, 0))
+    client.broadcast = AsyncMock(return_value="cd" * 32)
+    client.__aenter__ = AsyncMock(return_value=client)
+    client.__aexit__ = AsyncMock(return_value=None)
+    return client
+
+
+def _ctx(client: MagicMock, *, output_mode: str = "human", yes: bool = False) -> CliContext:
+    return CliContext(
+        config=Config(
+            network="mainnet", electrumx="wss://test/", fee_rate=10_000, wallet_path=Path("/tmp/_pyrxd_sweep")
+        ),
+        network="mainnet",
+        electrumx_url="wss://test/",
+        fee_rate=10_000,
+        wallet_path=Path("/tmp/_pyrxd_sweep"),
+        output_mode=output_mode,
+        yes=yes,
+        client_factory=lambda: client,
+    )
+
+
+def _invoke(runner: CliRunner, ctx: CliContext, args: list[str], *, confirm: str = "y"):
+    # Mnemonic at the hidden prompt, then the y/N broadcast confirmation.
+    return runner.invoke(wallet_group, args, obj=ctx, input=f"{MNEMONIC}\n{confirm}\n")
+
+
+class TestWalletSweep:
+    def test_sweeps_funded_path_and_broadcasts(self, runner: CliRunner) -> None:
+        funded = _addr(0, 0, 0, 0)
+        client = _funded_client(funded)
+        result = _invoke(runner, _ctx(client), ["sweep", "--coin-type", "0", "--to", DEST], confirm="y")
+        assert result.exit_code == 0, result.output
+        assert "Swept" in result.output
+        assert "cdcd" in result.output  # txid prefix
+        client.broadcast.assert_awaited_once()
+
+    def test_confirmation_decline_does_not_broadcast(self, runner: CliRunner) -> None:
+        funded = _addr(0, 0, 0, 0)
+        client = _funded_client(funded)
+        result = _invoke(runner, _ctx(client), ["sweep", "--coin-type", "0", "--to", DEST], confirm="n")
+        assert result.exit_code != 0
+        assert "abort" in result.output.lower()
+        client.broadcast.assert_not_awaited()
+
+    def test_no_funds_errors_without_broadcast(self, runner: CliRunner) -> None:
+        client = _funded_client(None)  # nothing funded anywhere
+        result = _invoke(runner, _ctx(client), ["sweep", "--coin-type", "0", "--to", DEST])
+        assert result.exit_code != 0
+        assert "no spendable funds" in result.output
+        client.broadcast.assert_not_awaited()
+
+    def test_invalid_destination_rejected(self, runner: CliRunner) -> None:
+        client = _funded_client(None)
+        result = _invoke(runner, _ctx(client), ["sweep", "--coin-type", "0", "--to", "not-an-address"])
+        assert result.exit_code != 0
+        assert "invalid --to" in result.output
+        client.broadcast.assert_not_awaited()
+
+    def test_json_requires_yes(self, runner: CliRunner) -> None:
+        client = _funded_client(_addr(0, 0, 0, 0))
+        result = _invoke(runner, _ctx(client, output_mode="json"), ["sweep", "--coin-type", "0", "--to", DEST])
+        assert result.exit_code != 0
+        assert "--yes" in result.output
+        client.broadcast.assert_not_awaited()
+
+    def test_json_with_yes_emits_txid(self, runner: CliRunner) -> None:
+        funded = _addr(512, 0, 0, 0)
+        client = _funded_client(funded)
+        ctx = _ctx(client, output_mode="json", yes=True)
+        # --yes skips the confirm prompt; only the mnemonic is read from stdin.
+        result = runner.invoke(
+            wallet_group, ["sweep", "--coin-type", "512", "--to", DEST], obj=ctx, input=f"{MNEMONIC}\n"
+        )
+        assert result.exit_code == 0, result.output
+        start, end = result.output.find("{"), result.output.rfind("}")
+        payload = json.loads(result.output[start : end + 1])
+        assert payload["txid"] == "cd" * 32
+        assert payload["from_path"] == "m/44'/512'/0'"
+        assert payload["to"] == DEST
+        client.broadcast.assert_awaited_once()
+
+    def test_invalid_mnemonic_rejected_without_broadcast(self, runner: CliRunner) -> None:
+        client = _funded_client(_addr(0, 0, 0, 0))
+        result = runner.invoke(
+            wallet_group,
+            ["sweep", "--coin-type", "0", "--to", DEST],
+            obj=_ctx(client),
+            input="not a real bip39 mnemonic phrase here\ny\n",
+        )
+        assert result.exit_code != 0
+        client.broadcast.assert_not_awaited()
+
+    def test_empty_mnemonic_rejected(self, runner: CliRunner) -> None:
+        client = _funded_client(_addr(0, 0, 0, 0))
+        result = runner.invoke(wallet_group, ["sweep", "--coin-type", "0", "--to", DEST], obj=_ctx(client), input="\n")
+        assert result.exit_code != 0
+        assert "mnemonic is required" in result.output
+        client.broadcast.assert_not_awaited()
+
+    def test_negative_coin_type_rejected(self, runner: CliRunner) -> None:
+        client = _funded_client(None)
+        result = _invoke(runner, _ctx(client), ["sweep", "--coin-type", "-1", "--to", DEST])
+        assert result.exit_code != 0
+        client.broadcast.assert_not_awaited()
+
+    def test_summary_shows_amount_fee_and_destination(self, runner: CliRunner) -> None:
+        funded = _addr(0, 0, 0, 0)
+        client = _funded_client(funded)
+        result = _invoke(runner, _ctx(client), ["sweep", "--coin-type", "0", "--to", DEST], confirm="y")
+        assert "from path:   m/44'/0'/0'" in result.output
+        assert "to address:" in result.output
+        assert DEST in result.output
+        assert "you receive" in result.output


### PR DESCRIPTION
## What

Completes the wallet-recovery story shipped in 0.6.0. `wallet recover --scan`
*finds* funds at a BIP44 derivation path, but moving funds from a path no GUI
wallet can reach (a non-zero account, or an address index beyond a fixed-leaf
wallet's range) previously required writing Python. This adds the missing
command:

```
pyrxd wallet sweep --coin-type N --account A --to <address>
```

Derives that account, gap-scans for UTXOs, builds a max-value sweep to `--to`
(minus fee) via the existing `HdWallet.build_send_max_tx`, shows amount + fee +
destination, and broadcasts **only after y/N confirmation**.

## Value-bearing safeguards

This is the first wallet CLI command that signs and broadcasts a real
transaction, so it was built and reviewed accordingly:

- **Confirm-before-broadcast.** The single broadcast path is unreachable
  without an interactive y/N confirm (or an explicit `--yes`); `--json` without
  `--yes` is refused. Declining aborts before broadcast.
- **Destination pinned to the active network.** `--to` is validated against the
  running network, so a testnet-prefixed address cannot be swept to on mainnet
  (which would be unrecoverable).
- **Fail-safe.** Wrong coin-type/account → no UTXOs → error, no broadcast.
  Insufficient-for-fee / dust → error, no broadcast. The summary shows the exact
  fee and received amount before you confirm.
- **Seed handling.** Mnemonic via hidden prompt only (never argv/env); only the
  signed transaction crosses the wire, never key material; invalid/empty
  mnemonics are rejected without echoing input.

## Review & testing

- A focused security review of the value-bearing surface (wrong-destination,
  confirm-gate bypass, key/seed handling, silent-loss, reuse correctness, edge
  cases) returned no Critical/High. It surfaced one medium (destination network
  not pinned) and one low (fee-rate validated late), **both fixed in this PR**
  with tests.
- 12 unit tests covering broadcast, decline-aborts, no-funds, bad/foreign-network
  address, json-needs-yes, json+yes, invalid/empty mnemonic, fee-rate, summary.
- Proven end-to-end on mainnet: a real sweep moved funds from a derived path to
  a destination wallet through the live confirm-before-broadcast path.
- `task ci` green: 3773 passed, 87.7% coverage, mypy clean.