### PR TITLE
fix(cli): clearer sweep error for a dust (sub-fee) balance

### DIFF
--- a/src/pyrxd/cli/wallet_cmds.py
+++ b/src/pyrxd/cli/wallet_cmds.py
@@ -561,11 +561,15 @@ def wallet_sweep(
             fix=f"check that {ctx.electrumx_url} is reachable, or use --electrumx URL",
         ) from exc
     except ValidationError as exc:
-        # build_send_max_tx raises ValidationError on insufficient-funds / dust.
+        # build_send_max_tx raises ValidationError when the balance is at or
+        # below the network fee (dust). Lead with the honest framing — these
+        # coins are simply too small to move; lowering --fee-rate only helps if
+        # the user raised it above the default in the first place.
         raise UserError(
             "could not build the sweep transaction",
             cause=str(exc),
-            fix="the funds may not exceed the network fee; try a lower --fee-rate or a different path",
+            fix="this balance is too small to move — it does not exceed the network fee (dust). "
+            "Lower --fee-rate only if you raised it above the default; otherwise these coins cannot be swept.",
         ) from exc
 
     if ctx.output_mode == "json":

--- a/tests/cli/test_wallet_sweep.py
+++ b/tests/cli/test_wallet_sweep.py
@@ -99,6 +99,17 @@ class TestWalletSweep:
         assert "no spendable funds" in result.output
         client.broadcast.assert_not_awaited()
 
+    def test_sub_fee_balance_refused_without_broadcast(self, runner: CliRunner) -> None:
+        # A balance at/below the network fee (dust) must be refused cleanly,
+        # before any broadcast. Mirrors the real mainnet 0.01-RXD case.
+        funded = _addr(512, 0, 0, 0)
+        client = _funded_client(funded, value=1_000)  # far below the per-tx fee
+        result = _invoke(runner, _ctx(client), ["sweep", "--coin-type", "512", "--to", DEST], confirm="y")
+        assert result.exit_code != 0
+        assert "could not build the sweep transaction" in result.output
+        assert "too small to move" in result.output  # honest dust framing
+        client.broadcast.assert_not_awaited()
+
     def test_invalid_destination_rejected(self, runner: CliRunner) -> None:
         client = _funded_client(None)
         result = _invoke(runner, _ctx(client), ["sweep", "--coin-type", "0", "--to", "not-an-address"])


### PR DESCRIPTION
Small UX fix surfaced by live mainnet testing of `wallet sweep`.

Sweeping a balance at/below the network fee (e.g. a 0.01 RXD balance vs a
~0.0192 RXD fee) correctly refuses — but the old guidance ("try a lower
--fee-rate or a different path") was misleading for genuine dust: lowering the
fee below the relay minimum won't help, and there's no other path holding those
coins.

The message now leads with the honest framing — the balance is too small to
move (it doesn't exceed the network fee) — and only suggests `--fee-rate` for
the case where the user actually raised it above the default.

Adds a regression test for the sub-fee refusal (refuses cleanly, no broadcast),
mirroring the real mainnet case. The refusal behaviour itself is unchanged —
this is wording + a test only.