### PR TITLE
docs: add Electron-Wallet move option to the recovery guide

### DIFF
--- a/guides/recover-stuck-rxd.md
+++ b/guides/recover-stuck-rxd.md
@@ -150,8 +150,13 @@ it in the next step. (If yours says `512`, use `512`.)
 
 ## Step 3 — Move your coins to safety
 
-First, you need a **destination** — a receive address from a wallet you control
-and trust. The easiest options:
+Now that Step 2 told you the **coin type** and **path**, you can move the coins.
+There are two ways — pick whichever you're more comfortable with. **Both are
+fine; Option B may feel safer because the actual sending happens in a long-
+established graphical wallet.**
+
+First, either way, you need a **destination** — a receive address from a wallet
+you control and trust:
 
 - Create a fresh wallet in a current Radiant wallet app and copy its **receive
   address**, or
@@ -160,8 +165,10 @@ and trust. The easiest options:
 A Radiant address starts with `1` and looks like
 `1FzegoRZEXAPKztjVSkiX9VfK7s2ecwMGM`.
 
-Then run this, replacing the coin type with what Step 2 told you, and the
-address with your destination:
+### Option A — move them with this tool (command line)
+
+Run this, replacing the coin type with what Step 2 told you and the address with
+your destination:
 
 ```
 pyrxd wallet sweep --coin-type 0 --to YOUR_DESTINATION_ADDRESS
@@ -196,6 +203,35 @@ transaction ID into a block explorer to watch it confirm.
 > A small **network fee** is taken out (paid to miners, not to anyone else) —
 > that's normal for any blockchain transaction. If your balance is *very* small
 > (smaller than the fee), the tool will refuse rather than waste it.
+
+### Option B — move them with Electron-Wallet (graphical wallet)
+
+If you'd rather use a normal wallet window than the command line, the
+**Electron-Wallet** lets you enter a custom derivation path. Once you tell it the
+path Step 2 found, it shows your coins and you send them like any normal
+transaction.
+
+> 🔒 **Get the right build, and check it.** Use the **maintained** wallet at
+> <https://github.com/Radiant-Core/Electron-Wallet> — **not** the old archived
+> "RadiantBlockchain/electron-radiant". Fake copies of Electrum-style wallets are
+> a common way people get their seed stolen, so download only from that official
+> releases page, and **verify the SHA256 checksum** they publish with the
+> download before you run it. If you can't verify it, use Option A instead.
+
+1. Install the official Electron-Wallet (verified as above) and start a **restore
+   from seed**.
+2. When it asks for the **derivation path**, match it to Step 2:
+   - Step 2 said **coin type 512** → choose the **"Radiant Standard"** preset
+     (`m/44'/512'/0'`).
+   - Step 2 said **coin type 0** → choose the **"Legacy"** preset (`m/44'/0'/0'`).
+   - If Step 2's path had a non-zero account (e.g. `m/44'/0'/1'/0/0`), type the
+     path **up to the third apostrophe** yourself — for that example,
+     `m/44'/0'/1'`.
+3. Finish the restore. Electron will scan and show your balance.
+4. Send it to your destination address like a normal transaction.
+
+> Your seed only ever goes into the wallet app on your own computer — never into
+> a website or to a person. Same rule as everywhere in this guide.
 
 ---
 


### PR DESCRIPTION
Follow-up to the recovery guide (#161, #162).

Step 3 (moving recovered coins) now offers two routes:
- **Option A:** the pyrxd `wallet sweep` command (as before).
- **Option B:** restore the seed in the maintained **Radiant-Core/Electron-Wallet**,
  enter the exact derivation path the scan found, and send via the GUI.

Why add Option B: for the value-bearing step it's a sound — arguably more
conservative — choice, because the signing happens in a long-established,
maintained, checksummed, partially-audited Electrum-family wallet rather than
pyrxd's newer (not independently audited) sweep. `recover --scan` (read-only)
is equally low-risk either way; this gives a GUI option for the risky part.

The guide makes build verification **non-optional**: use the maintained
Radiant-Core build (NOT the archived RadiantBlockchain/electron-radiant), and
verify the published SHA256 checksum before running it — fake Electrum-style
wallets are a recurring seed-theft vector. If it can't be verified, use Option A.

Also corrects an earlier inaccuracy: Electron does a full gap-limit scan (it's
Electrum-based), so it checks many addresses — it just only scans the one
derivation path it's pointed at, which is why pyrxd's automatic multi-path scan
finds what manual wallet imports miss.

Docs-only; no code change.