### PR TITLE
docs: note that recover --scan takes a couple minutes (not frozen)

### DIFF
--- a/guides/recover-stuck-rxd.md
+++ b/guides/recover-stuck-rxd.md
@@ -125,6 +125,11 @@ Type or paste your seed phrase and press Enter.
 > looking at your screen can read them. It's working even though nothing shows.
 > (On Windows Command Prompt, right-click to paste.)
 
+> ⏳ **This is not instant.** The search checks a lot of addresses across several
+> possible paths, so give it **a couple of minutes**. If the screen sits there
+> with no output for a while, that's normal — it's working, not frozen. Don't
+> close it.
+
 The tool checks the likely addresses and tells you where your coins are. A
 successful result looks like this:
 


### PR DESCRIPTION
Small expectation-setting addition to the recovery guide (Step 2).

The multi-path scan makes many ElectrumX round-trips and isn't instant, so the
terminal can sit with no output for a bit. For a non-technical user that reads
as "frozen" and they may close it mid-scan. The guide now tells them it's normal,
to give it a couple of minutes, and not to close it.

Docs-only; no code change.