### PR TITLE
feat(gravity): Glyph(NFT)↔ETH atomic swap harness + mainnet REST REF gate

### DIFF
--- a/docs/solutions/integration-issues/rxindexer-mainnet-rest-only-glyph-ref-gate-http-adapter.md
+++ b/docs/solutions/integration-issues/rxindexer-mainnet-rest-only-glyph-ref-gate-http-adapter.md
@@ -1,0 +1,176 @@
+---
+title: Mainnet RXinDexer is REST-only — the ElectrumX-ws REF gate had no endpoint
+problem_type: integration_issue
+component: pyrxd.gravity / glyph REF authenticity gate
+severity: high
+date_solved: 2026-06-04
+status: solved
+symptoms:
+  - The proven RxinDexerRefAdapter resolves a genesis ref via the ElectrumX-ws method glyph.get_token, which works on the glyph-enabled regtest electrumx but has NO endpoint on the mainnet RXinDexer deployment.
+  - The mainnet RXinDexer on host tr (/srv/rxindexer) listens ONLY on the REST api (127.0.0.1:8000); the glyph electrumx-ws ports (50010/50011/50012) are not listening.
+  - First REST attempts 404'd because I queried GET /tokens/{bare_txid} instead of the 72-hex wire ref.
+  - The radiant MCP (radiant_get_token) returned "unknown method glyph.get_token_info" against a public vanilla Radiant electrumx that does not serve glyph methods.
+  - pyrxd's ElectrumXClient is WebSocket-only and cannot connect to a raw-TCP/SSL electrumx port (e.g. :50012).
+root_cause: >
+  An indexer that exposes both an ElectrumX-ws interface and a FastAPI REST api can be deployed
+  with only one of them running. The proven REF gate spoke ElectrumX-ws (the regtest path); the
+  mainnet deployment runs the REST api only, so the gate had no live endpoint until a REST adapter
+  was written. Compounding it: the REST lookup keys on the 72-hex wire ref, not a bare txid, and the
+  URL key and the response identifier use different txid byte orders.
+tags: [rxindexer, electrumx, rest-api, glyph, nft, ref-gate, ref-authenticity, byte-order, gravity, htlc, mainnet, deployment, eth-rxd-swap]
+related_files:
+  - scripts/_glyph_ref_http.py
+  - scripts/eth_swap_run.py
+  - src/pyrxd/gravity/radiant_leg.py
+  - src/pyrxd/gravity/ref_authenticity.py
+  - src/pyrxd/glyph/types.py
+related_solutions:
+  - ../design-decisions/spv-oracle-swap-is-not-atomic-use-htlc.md
+  - ../design-decisions/spv-swap-deprecated-primitive-retained.md
+---
+
+# Mainnet RXinDexer is REST-only — the ElectrumX-ws REF gate had no endpoint
+
+Resolving a Glyph (NFT) by its **genesis ref** is the load-bearing R1 forgery defense in the
+ETH↔RXD HTLC swap: the covenant binds `reveal_txid:0`, and the swap coordinator's REF gate must
+confirm that ref is a genuine on-chain `gly` reveal (not a self-consistent fake singleton) before
+locking the asset. The proven gate spoke ElectrumX-ws. Taking the swap to **Radiant mainnet**
+surfaced that the production indexer doesn't serve that interface.
+
+## Symptom
+
+- `RxinDexerRefAdapter` (`src/pyrxd/gravity/radiant_leg.py`) resolves a ref via the ElectrumX-ws
+  method `glyph.get_token` over `wss://…`. This works against the regtest stack's glyph-enabled
+  electrumx but there is **no such endpoint on mainnet**.
+- The mainnet RXinDexer on host `tr` (`/srv/rxindexer`) runs **only** the indexer + REST api
+  (`rxindexer-api` on `127.0.0.1:8000`). The glyph electrumx-ws SERVICES (50010 tcp / 50011 wss /
+  50012 ssl) are **not listening**.
+- A public vanilla Radiant electrumx (`electrumx.radiant4people.com:50012`, raw SSL) does **not**
+  serve glyph methods (`radiant_get_token` → "unknown method glyph.get_token_info"), and pyrxd's
+  `ElectrumXClient` is WebSocket-only so it can't even connect to a raw-TCP/SSL electrumx port.
+
+Net effect: the REF gate that the whole swap's integrity depends on had no callable endpoint on the
+chain where real value moves.
+
+## Investigation (what didn't work, and why)
+
+1. **Point the existing adapter at a public electrumx.** Failed two ways: the public server doesn't
+   index glyphs (wrong method namespace), and pyrxd's `ElectrumXClient` needs a `wss://` port, not
+   the raw-SSL `:50012`.
+2. **Query the mainnet REST api with the bare txid** (`GET /tokens/{txid}`). Returned 404. The api
+   keys a token on its **72-hex wire ref**, not a bare txid.
+3. **Stand up / sync a glyph electrumx-ws on tr.** Rejected — a full electrumx sync is heavy and
+   unnecessary once the REST resolution path was understood.
+
+## Root cause
+
+Two independent facts had to line up:
+
+1. **Deployment shape.** RXinDexer ships both an ElectrumX-ws interface *and* a FastAPI REST api,
+   but a given deployment may run only one. Mainnet `tr` runs the REST api only. (Verified live:
+   `ss -tlnp` / the running services on `tr` show `:8000` bound to localhost; 50010/11/12 absent.)
+2. **Lookup key + byte order.** The REST per-token route keys on the **72-hex wire ref**
+   (`GlyphRef.to_bytes().hex()` = 36 bytes = txid + vout). And there is a **byte-order asymmetry**
+   between the URL key and the returned identifier (see below).
+
+## Solution
+
+A small HTTP adapter, `scripts/_glyph_ref_http.py::SshTrHttpRefAdapter`, that implements the same
+`RefAuthenticityIndexer` protocol (one async `resolve_ref`) and resolves the ref over the REST api
+via `ssh tr curl`. It is wired into `scripts/eth_swap_run.py` as the **default** mainnet NFT REF
+gate (used whenever `--rxd-indexer-ws` is omitted); the ElectrumX-ws adapter remains available for
+the regtest path.
+
+```python
+async def resolve_ref(self, genesis_ref: bytes) -> ResolvedRef | None:
+    ref = GlyphRef.from_bytes(bytes(genesis_ref))     # validates the 36-byte wire ref (raises -> fail-closed)
+    query_ref = ref.txid + struct.pack("<I", ref.vout).hex()   # URL key: DISPLAY-order txid + LE vout
+    token_id_expected = bytes(genesis_ref).hex()               # response id: INTERNAL-order txid + LE vout
+    body, code = await self._api_get(f"/tokens/{query_ref}")   # ssh <host> curl http://127.0.0.1:8000/...
+    if code == 404:
+        return None                                  # unknown ref -> R1 forgery / not a real glyph -> fail closed
+    if code != 200:
+        raise NetworkError(...)                      # transient/5xx -> raise -> gate fails closed (does NOT pass)
+    token = json.loads(body)
+    if str(token.get("token_id", "")).lower() != token_id_expected.lower():
+        return None                                  # id mismatch -> fail closed
+    confs = await self._chain_io.confirmations(ref.txid)   # REST response carries no confs; read from chain
+    return ResolvedRef(
+        genesis_outpoint=bytes(genesis_ref),
+        has_gly_marker=True,                         # a resolvable RXinDexer token IS a genuine gly reveal
+        payload_hash=b"",                            # REST api doesn't expose the envelope hash; gate uses it only if expected set
+        confirmations=confs,
+    )
+```
+
+**The byte-order subtlety (the part that costs an hour if you guess).** `GlyphRef` keeps the txid in
+**display** order in `.txid` and reverses it to **internal** order in `.to_bytes()`
+(`src/pyrxd/glyph/types.py:45` — `bytes.fromhex(self.txid)[::-1] + struct.pack("<I", self.vout)`):
+
+- **URL key** (`/tokens/{ref}`): `ref.txid` (display order) + 4-byte little-endian vout, hex.
+- **Response identifier** that you bind against: `bytes(genesis_ref).hex()` = **internal**-order
+  (reversed) txid + LE vout = `GlyphRef.to_bytes().hex()`.
+
+So the txid appears in *opposite* byte order in the request URL versus the value you compare in the
+response. This was confirmed empirically, not assumed.
+
+### Live verification (ground truth)
+
+| Ref queried | Result |
+| --- | --- |
+| `ff5c20f6…:0` (genuine mainnet glyph) | `ResolvedRef(has_gly_marker=True, confirmations=3378, genesis_outpoint == ref)` |
+| `3c0cf043…:0` (genuine mainnet glyph) | `ResolvedRef(confirmations=3914)` |
+| `de…de:0` (fabricated ref) | HTTP 404 → `None` (gate fails closed — R1 forgery rejected) |
+
+### Source-vs-deployment skew — a load-bearing caveat
+
+The **live endpoint is authoritative**, and there is measurable skew between the deployed mainnet api
+and the local RXinDexer source checkout (`/home/eric/apps/RXinDexer`):
+
+- The deployed `/tokens/{ref}` route returns a JSON object whose **`token_id`** field equals the
+  72-hex internal wire ref (this is what the live test bound against and what the adapter checks).
+- The local source checkout instead shows a `GET /glyphs/{ref}` handler whose response uses a
+  **`ref`** field formatted as display `txid_vout` (e.g. `abcd…_0`), with the `/tokens/{ref}/…`
+  routes being the holders/supply/history siblings. That does **not** match the live `/tokens/{ref}`
+  + `token_id` contract the adapter relies on — i.e. the checkout is a different version than what
+  runs on `tr`.
+
+This skew is *safe but brittle*: if the deployed api ever changes the field name or shape, the
+adapter's `token.get("token_id")` check returns `None` and the gate **fails closed** (blocks the
+swap; never passes a forgery). No fund-loss path, but a legitimate swap could be blocked until the
+adapter is reconciled with the then-current api. **Trust the live endpoint over the checkout; pin the
+adapter to the field the live api actually returns.**
+
+## Prevention
+
+- **When an indexer offers both ElectrumX-ws and REST, never assume both run.** Before wiring an
+  adapter, check the *actual* listening services on the target host (`ss -tlnp`, `docker ps`,
+  systemd units) — not the project README or a regtest compose file.
+- **Read the indexer source for the exact lookup-key format** rather than guessing from URL
+  conventions. Here the key is the 72-hex wire ref with a display-vs-internal txid byte-order
+  asymmetry; a bare txid 404s.
+- **Treat the live endpoint as the contract, the source checkout as a hint.** Version skew between a
+  local checkout and a deployed service is normal; verify the response shape against the live api and
+  pin the adapter to the field it actually returns.
+- **Keep the security property fail-closed across the transport swap.** Both the ElectrumX-ws and the
+  REST adapter must return `None` (or raise) on unknown ref / transient error so the REF gate refuses
+  rather than passes. The R1 fake-singleton defense is only as good as its weakest transport.
+- **Add a smoke check** that resolves a known-good mainnet ref and a fabricated ref before each
+  real-value run — proves the live api shape still matches the adapter and that forgeries still 404.
+
+## Status
+
+Solved and live-verified (2026-06-04). `SshTrHttpRefAdapter` is the default mainnet NFT REF gate in
+`scripts/eth_swap_run.py`; lint-clean; genuine mainnet glyphs resolve and a fabricated ref fails
+closed. The supervised mainnet Glyph↔ETH run is gated only on the operator's ETH-side inputs.
+
+## Related documentation
+
+- [GlyphRef wire format and byte order](../../concepts/glyph-structures-and-terminology.md) — the
+  display-vs-internal txid ordering this adapter has to get right.
+- [Gravity cross-chain swap overview](../../concepts/gravity.md) — where the REF gate sits in the
+  HTLC swap (Path B).
+- [SPV-oracle swap is not atomic — use HTLC](../design-decisions/spv-oracle-swap-is-not-atomic-use-htlc.md)
+  — why the swap is HTLC-based and the REF gate matters.
+- [SPV swap deprecated, primitive retained](../design-decisions/spv-swap-deprecated-primitive-retained.md)
+  — the retained one-way oracle/gate context.

--- a/scripts/_glyph_mainnet.py
+++ b/scripts/_glyph_mainnet.py
@@ -1,0 +1,307 @@
+"""Inline mainnet Glyph-NFT mint + singleton→covenant lock for the ETH↔RXD swap runner.
+
+This is the MAINNET adaptation of the proven regtest flow in
+``tests/test_xchain_eth_glyph_real_rxindexer_e2e.py`` (``_mint_glyph`` +
+``_spend_singleton_into_covenant``). Two differences, both because this moves REAL
+mainnet value:
+
+  * **No mining.** Regtest mines on demand; mainnet does not — every broadcast is
+    followed by a real-confirmation WAIT (poll ``getrawtransaction`` until
+    confirmations >= 1) before the next tx (which spends it) is built.
+  * **Confirm-before-broadcast.** Each of the (up to) three broadcasts — commit,
+    reveal, singleton-lock — pauses for an explicit operator y/N via ``confirm_fn``.
+
+Broadcasts + wallet reads go through the live ``SshTrRadiantClient`` (``radiant-cli``
+over ssh). The small tx-building helpers are replicated from the proven test (NOT
+imported — test code must not be a script dependency).
+
+Fees: mainnet relayfee is 0.10 RXD/kB; these txs are sub-kB, so ``fee_photons`` (default
+0.05 RXD) covers them with margin. The operator accepts the dust overpay.
+"""
+
+from __future__ import annotations
+
+import time
+from collections.abc import Callable
+from dataclasses import dataclass
+
+from pyrxd.glyph.builder import CommitParams, GlyphBuilder, RevealParams
+from pyrxd.glyph.types import GlyphMetadata, GlyphProtocol
+from pyrxd.keys import PrivateKey
+from pyrxd.script.script import Script
+from pyrxd.script.type import encode_pushdata, to_unlock_script_template
+from pyrxd.security.types import Hex20
+from pyrxd.transaction.transaction import Transaction
+from pyrxd.transaction.transaction_input import TransactionInput
+from pyrxd.transaction.transaction_output import TransactionOutput
+
+# Defaults (photons). commit funds the reveal fee + the singleton carrier; sized so
+# reveal_value and the lock carrier stay positive at the mainnet fee.
+DEFAULT_COMMIT_PHOTONS = 20_000_000  # 0.20 RXD
+DEFAULT_FEE_PHOTONS = 5_000_000  # 0.05 RXD per sub-kB tx (mainnet 0.10 RXD/kB, margin)
+
+
+@dataclass(frozen=True)
+class MintedNft:
+    """A genuinely-minted NFT singleton.
+
+    Radiant identifies a singleton by its IMMUTABLE genesis ref — the outpoint the reveal SPENT to
+    mint it (here ``commit_txid:0``), embedded in the singleton script via ``OP_PUSHINPUTREFSINGLETON``
+    (``d8<ref>``). That ref — NOT ``reveal_txid:0`` (the singleton's current *location*) — is what the
+    covenant binds and the indexer/REF gate resolves. ``reveal_txid`` is kept only as the spend source
+    for the lock tx (the UTXO the singleton currently sits on)."""
+
+    ref_str: str  # "<genesis_txid>:<genesis_vout>" — the true genesis ref (commit outpoint)
+    reveal_txid: str  # where the singleton currently sits (the lock tx spends reveal_txid:0)
+    genesis_txid: str  # display-order txid of the genesis ref the singleton carries (commit outpoint)
+    genesis_vout: int
+    owner_key: PrivateKey
+    locking_script: bytes
+    reveal_value: int
+
+
+def _genesis_ref_from_singleton(locking_script: bytes) -> tuple[str, int]:
+    """Parse the genesis ref the minted singleton actually carries (ground truth, not assumed).
+
+    A Radiant Glyph singleton begins ``OP_PUSHINPUTREFSINGLETON(0xd8) <36-byte ref> OP_DROP(0x75) …``
+    where ref = txid(32, internal/LE) ++ vout(4, LE). The token is identified by THIS ref (the outpoint
+    the reveal spent to mint it = the commit outpoint), not by where the singleton happens to sit now."""
+    if len(locking_script) < 37 or locking_script[0] != 0xD8:
+        raise RuntimeError(f"minted singleton does not start with d8<ref36>: {locking_script[:8].hex()}")
+    ref = locking_script[1:37]
+    return ref[:32][::-1].hex(), int.from_bytes(ref[32:36], "little")
+
+
+def _src(txid: str, vout: int, spk: bytes, val: int) -> Transaction:
+    outs = [TransactionOutput(Script(b"\x00"), 0) for _ in range(vout)]
+    outs.append(TransactionOutput(Script(spk), val))
+    t = Transaction(tx_inputs=[], tx_outputs=outs)
+    t.txid = lambda: txid  # type: ignore[method-assign]
+    return t
+
+
+def _p2pkh_unlock(key: PrivateKey):
+    pub = key.public_key().serialize()
+
+    def _u(tx, idx):
+        inp = tx.inputs[idx]
+        return Script(
+            encode_pushdata(key.sign(tx.preimage(idx)) + inp.sighash.to_bytes(1, "little")) + encode_pushdata(pub)
+        )
+
+    return to_unlock_script_template(_u, lambda: 110)
+
+
+def _glyph_unlock(key: PrivateKey, suffix: bytes):
+    pub = key.public_key().serialize()
+
+    def _u(tx, idx):
+        inp = tx.inputs[idx]
+        p2pkh = encode_pushdata(key.sign(tx.preimage(idx)) + inp.sighash.to_bytes(1, "little")) + encode_pushdata(pub)
+        return Script(p2pkh + suffix)
+
+    return to_unlock_script_template(_u, lambda: 200)
+
+
+def _p2pkh_spk(pkh: bytes) -> bytes:
+    return b"\x76\xa9\x14" + bytes(pkh) + b"\x88\xac"
+
+
+def _cli(rxd_client, *args: str):
+    """One radiant-cli call over ssh (parsed JSON / scalar)."""
+    return rxd_client._run_sync(*args)
+
+
+def _largest_wallet_utxo(rxd_client, min_photons: int) -> dict:
+    utxos = [u for u in _cli(rxd_client, "listunspent", "1", "9999999") if round(u["amount"] * 1e8) >= min_photons]
+    if not utxos:
+        raise RuntimeError(f"no mainnet wallet UTXO >= {min_photons} photons (~{min_photons / 1e8:.4f} RXD) to fund the mint")
+    return max(utxos, key=lambda x: x["amount"])
+
+
+def _wait_confirmed(rxd_client, txid: str, *, label: str, poll_s: float, log: Callable[[str], None]) -> None:
+    """Block until ``txid`` has >= 1 mainnet confirmation (no mining on mainnet)."""
+    log(f"    waiting for {label} ({txid}) to confirm on mainnet (poll {poll_s:.0f}s)…")
+    while True:
+        try:
+            v = _cli(rxd_client, "getrawtransaction", txid, "1")
+            confs = v.get("confirmations", 0) if isinstance(v, dict) else 0
+            if isinstance(confs, int) and confs >= 1:
+                log(f"    {label} confirmed ({confs} conf).")
+                return
+        except Exception:  # not yet in a block / mempool-only → keep polling
+            pass
+        time.sleep(poll_s)
+
+
+def load_minted_nft(rxd_client, *, reveal_txid: str, owner_wif: str) -> MintedNft:
+    """Reconstruct a :class:`MintedNft` for an ALREADY-minted NFT (skip the mint), e.g. to resume a
+    run that aborted after minting. Fetches the reveal tx on-chain for the singleton script + carrier
+    value, parses the true genesis ref from the singleton's ``d8`` opcode, and binds the owner key.
+
+    Safety: asserts the owner key's hash160 equals the p2pkh inside the singleton — i.e. this key can
+    actually spend the singleton into the covenant (a wrong key would fail to lock the asset)."""
+    v = _cli(rxd_client, "getrawtransaction", reveal_txid, "1")
+    if not isinstance(v, dict) or not v.get("vout"):
+        raise RuntimeError(f"reuse: reveal tx {reveal_txid} not found / has no outputs")
+    out0 = v["vout"][0]
+    locking_script = bytes.fromhex(out0["scriptPubKey"]["hex"])
+    reveal_value = round(float(out0["value"]) * 1e8)
+    g_txid, g_vout = _genesis_ref_from_singleton(locking_script)
+    key = PrivateKey(str(owner_wif))
+    # singleton spk = d8 <ref36> 75 76 a9 14 <pkh20> 88 ac  -> pkh at offset 41:61
+    spk_pkh = locking_script[41:61]
+    if spk_pkh != bytes(key.public_key().hash160()):
+        raise RuntimeError("reuse: owner WIF does not match the singleton's p2pkh — wrong key, cannot spend the NFT")
+    return MintedNft(
+        ref_str=f"{g_txid}:{g_vout}",
+        reveal_txid=reveal_txid,
+        genesis_txid=g_txid,
+        genesis_vout=g_vout,
+        owner_key=key,
+        locking_script=locking_script,
+        reveal_value=reveal_value,
+    )
+
+
+def wait_genesis_mature(
+    rxd_client, genesis_txid: str, *, need_confs: int, poll_s: float, log: Callable[[str], None] = print
+) -> None:
+    """Block until the NFT genesis tx reaches ``need_confs`` confirmations (the REF-gate depth).
+
+    The pre-lock gate fails closed on a shallow genesis — a reorg could void the NFT's provenance
+    AFTER the counter-leg is paid — so the harness must wait for genesis maturity before funding."""
+    log(f"    waiting for NFT genesis {genesis_txid} to reach {need_confs} confs (REF-gate reorg depth)…")
+    while True:
+        try:
+            v = _cli(rxd_client, "getrawtransaction", genesis_txid, "1")
+            c = v.get("confirmations", 0) if isinstance(v, dict) else 0
+            if isinstance(c, int) and c >= need_confs:
+                log(f"    genesis mature ({c} confs >= {need_confs}).")
+                return
+            log(f"    genesis at {c}/{need_confs} confs; waiting {poll_s:.0f}s…")
+        except Exception:
+            pass
+        time.sleep(poll_s)
+
+
+def mint_nft_inline(
+    rxd_client,
+    *,
+    name: str,
+    commit_photons: int = DEFAULT_COMMIT_PHOTONS,
+    fee_photons: int = DEFAULT_FEE_PHOTONS,
+    confirm_fn: Callable[[str], None],
+    poll_s: float = 30.0,
+    log: Callable[[str], None] = print,
+) -> MintedNft:
+    """Mint a throwaway NFT on Radiant mainnet (commit→reveal). Genesis ref = ``reveal_txid:0``.
+
+    Pauses for operator confirmation before EACH broadcast and waits for real confirmation
+    between the commit and the reveal (the reveal spends the commit output)."""
+    if commit_photons <= 2 * fee_photons:
+        raise RuntimeError("commit_photons must exceed 2*fee_photons (reveal + lock both pay a fee)")
+    builder = GlyphBuilder()
+    u = _largest_wallet_utxo(rxd_client, commit_photons + 2 * fee_photons)
+    key = PrivateKey(str(_cli(rxd_client, "dumpprivkey", u["address"])))
+    pkh = Hex20(key.public_key().hash160())
+    spk = bytes.fromhex(u["scriptPubKey"])
+    in_sats = round(u["amount"] * 1e8)
+
+    meta = GlyphMetadata(protocol=[GlyphProtocol.NFT], name=name, token_type="object")  # noqa: S106 (glyph token kind, not a secret)
+    commit = builder.prepare_commit(CommitParams(metadata=meta, owner_pkh=pkh, change_pkh=pkh, funding_satoshis=in_sats))
+
+    fin = TransactionInput(
+        source_transaction=_src(u["txid"], int(u["vout"]), spk, in_sats),
+        source_txid=u["txid"],
+        source_output_index=int(u["vout"]),
+        unlocking_script_template=_p2pkh_unlock(key),
+    )
+    fin.satoshis = in_sats
+    fin.locking_script = Script(spk)
+    commit_tx = Transaction(
+        tx_inputs=[fin],
+        tx_outputs=[
+            TransactionOutput(Script(commit.commit_script), commit_photons),
+            TransactionOutput(Script(_p2pkh_spk(pkh)), in_sats - commit_photons - fee_photons),
+        ],
+    )
+    commit_tx.sign()
+    confirm_fn(f"mint step 1/2: broadcast the NFT COMMIT tx on mainnet ({commit_photons / 1e8:.4f} RXD into the commit output)")
+    commit_txid = str(_cli(rxd_client, "sendrawtransaction", commit_tx.serialize().hex()))
+    log(f"    commit -> {commit_txid}")
+    _wait_confirmed(rxd_client, commit_txid, label="commit", poll_s=poll_s, log=log)
+
+    rev = builder.prepare_reveal(
+        RevealParams(
+            commit_txid=commit_txid,
+            commit_vout=0,
+            commit_value=commit_photons,
+            cbor_bytes=commit.cbor_bytes,
+            owner_pkh=pkh,
+            is_nft=True,
+        )
+    )
+    rin = TransactionInput(
+        source_transaction=_src(commit_txid, 0, commit.commit_script, commit_photons),
+        source_txid=commit_txid,
+        source_output_index=0,
+        unlocking_script_template=_glyph_unlock(key, rev.scriptsig_suffix),
+    )
+    rin.satoshis = commit_photons
+    rin.locking_script = Script(commit.commit_script)
+    reveal_value = commit_photons - fee_photons
+    reveal_tx = Transaction(tx_inputs=[rin], tx_outputs=[TransactionOutput(Script(rev.locking_script), reveal_value)])
+    reveal_tx.sign()
+    confirm_fn(f"mint step 2/2: broadcast the NFT REVEAL tx (creates the singleton at reveal_txid:0, carrier {reveal_value / 1e8:.4f} RXD)")
+    reveal_txid = str(_cli(rxd_client, "sendrawtransaction", reveal_tx.serialize().hex()))
+    # The genesis ref is the COMMIT outpoint the singleton carries (d8<ref>), NOT reveal_txid:0.
+    g_txid, g_vout = _genesis_ref_from_singleton(rev.locking_script)
+    log(f"    reveal -> {reveal_txid}  (singleton at reveal:0; genesis ref = {g_txid}:{g_vout} [the commit outpoint])")
+    _wait_confirmed(rxd_client, reveal_txid, label="reveal", poll_s=poll_s, log=log)
+    return MintedNft(
+        ref_str=f"{g_txid}:{g_vout}",
+        reveal_txid=reveal_txid,
+        genesis_txid=g_txid,
+        genesis_vout=g_vout,
+        owner_key=key,
+        locking_script=rev.locking_script,
+        reveal_value=reveal_value,
+    )
+
+
+def lock_singleton_into_covenant(
+    rxd_client,
+    *,
+    minted: MintedNft,
+    covenant_spk: bytes,
+    carrier_photons: int,
+    fee_photons: int = DEFAULT_FEE_PHOTONS,
+    confirm_fn: Callable[[str], None],
+    poll_s: float = 30.0,
+    log: Callable[[str], None] = print,
+) -> str:
+    """Spend the minted NFT singleton (``reveal_txid:0``) into the covenant SPK — the maker's
+    'lock the asset' step. Single input (NFT carries enough); change returns to the owner so
+    we don't overpay the fee into the void. Confirms before broadcast + waits for confirmation."""
+    if not (0 < carrier_photons <= minted.reveal_value - fee_photons):
+        raise RuntimeError("carrier_photons must be in (0, reveal_value - fee]")
+    rin = TransactionInput(
+        source_transaction=_src(minted.reveal_txid, 0, minted.locking_script, minted.reveal_value),
+        source_txid=minted.reveal_txid,
+        source_output_index=0,
+        unlocking_script_template=_p2pkh_unlock(minted.owner_key),
+    )
+    rin.satoshis = minted.reveal_value
+    rin.locking_script = Script(minted.locking_script)
+    outs = [TransactionOutput(Script(covenant_spk), carrier_photons)]
+    change = minted.reveal_value - carrier_photons - fee_photons
+    if change > 0:  # return the excess to the owner rather than burn it as fee
+        outs.append(TransactionOutput(Script(_p2pkh_spk(minted.owner_key.public_key().hash160())), change))
+    tx = Transaction(tx_inputs=[rin], tx_outputs=outs)
+    tx.sign()
+    confirm_fn(f"lock the NFT singleton into the covenant SPK on mainnet (carrier {carrier_photons / 1e8:.4f} RXD)")
+    txid = str(_cli(rxd_client, "sendrawtransaction", tx.serialize().hex()))
+    log(f"    asset lock -> {txid}")
+    _wait_confirmed(rxd_client, txid, label="asset-lock", poll_s=poll_s, log=log)
+    return txid

--- a/scripts/_glyph_ref_http.py
+++ b/scripts/_glyph_ref_http.py
@@ -1,0 +1,94 @@
+"""Mainnet Glyph genesis-ref authenticity adapter over the RXinDexer REST api (via ssh tr).
+
+The proven REF gate (``pyrxd.gravity.radiant_leg.RxinDexerRefAdapter``) resolves a genesis ref via
+the RXinDexer ElectrumX ws method ``glyph.get_token``. The mainnet RXinDexer deployment on ``tr``
+runs only the **REST api** (``:8000``, bound to tr-localhost — no electrumx glyph ws), so this adapter
+resolves the same fact over HTTP instead.
+
+Key fact (read from the RXinDexer source ``electrumx/server/rest_api.py`` + verified live 2026-06-04):
+``GET /tokens/{ref}`` keys a token on its **72-hex wire ref** == ``GlyphRef.to_bytes().hex()`` ==
+the api's returned ``token_id`` (e.g. ``ff5c20f6…:0`` → ``40e98ec5…00000000``). A resolvable token IS
+a genuine ``gly`` reveal; an unknown ref (the R1 fake-singleton forgery) → HTTP 404 → ``None`` → the
+gate fails closed. Implements the ``RefAuthenticityIndexer`` protocol (one async ``resolve_ref``).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import shlex
+import struct
+
+from pyrxd.glyph.types import GlyphRef
+from pyrxd.gravity.radiant_leg import RadiantChainIO
+from pyrxd.gravity.ref_authenticity import ResolvedRef
+from pyrxd.security.errors import NetworkError, ValidationError
+
+
+class SshTrHttpRefAdapter:
+    """Resolve a genesis ref via ``ssh <host> curl http://<api>/tokens/{72-hex-ref}``.
+
+    ``chain_io`` (a :class:`RadiantChainIO` over the same ssh-tr RXD client) supplies the genesis
+    tx's confirmations — the ``glyph.get_token`` REST response does not carry confs."""
+
+    def __init__(
+        self,
+        *,
+        chain_io: RadiantChainIO,
+        ssh_host: str = "tr",
+        api_base: str = "http://127.0.0.1:8000",
+        timeout_s: int = 15,
+    ) -> None:
+        if not isinstance(chain_io, RadiantChainIO):
+            raise ValidationError("SshTrHttpRefAdapter requires a RadiantChainIO")
+        self._chain_io = chain_io
+        self._ssh_host = ssh_host
+        self._base = api_base.rstrip("/")
+        self._timeout = int(timeout_s)
+
+    async def resolve_ref(self, genesis_ref: bytes) -> ResolvedRef | None:
+        ref = GlyphRef.from_bytes(bytes(genesis_ref))  # validates the 36-byte wire ref (raises -> fail-closed)
+        # The REST URL keys on the DISPLAY-order txid + little-endian vout (verified live: querying
+        # ff5c20f6…:0 resolves). The api then RETURNS the INTERNAL-order token_id (== the wire ref ==
+        # GlyphRef.to_bytes().hex()), which is what we bind against. (Asymmetric, but confirmed.)
+        query_ref = ref.txid + struct.pack("<I", ref.vout).hex()
+        token_id_expected = bytes(genesis_ref).hex()  # internal order == the response token_id
+        body, code = await self._api_get(f"/tokens/{query_ref}")
+        if code == 404:
+            return None  # unknown token -> R1 forgery / not a real glyph -> gate fails closed
+        if code != 200:
+            raise NetworkError(f"RXinDexer REST /tokens/{query_ref} -> HTTP {code}: {body[:160]!r}")
+        try:
+            token = json.loads(body)
+        except json.JSONDecodeError as exc:
+            raise NetworkError(f"RXinDexer REST returned non-JSON: {body[:160]!r}") from exc
+        if not isinstance(token, dict):
+            raise NetworkError(f"RXinDexer REST returned {type(token).__name__}, expected an object")
+        # Bind the resolution to the queried ref: the api's token_id MUST equal the wire ref (the
+        # token is genuinely minted at THIS genesis outpoint). A mismatch fails closed.
+        token_id = str(token.get("token_id", "")).lower()
+        if token_id != token_id_expected.lower():
+            return None
+        confs = await self._chain_io.confirmations(ref.txid)
+        return ResolvedRef(
+            genesis_outpoint=bytes(genesis_ref),
+            has_gly_marker=True,  # a resolvable RXinDexer token is a genuine gly reveal
+            payload_hash=b"",  # REST api does not expose the envelope payload hash; gate uses it only if expected set
+            confirmations=confs,
+        )
+
+    async def _api_get(self, path: str) -> tuple[str, int]:
+        """``ssh <host> curl <api><path>`` → (body, http_status). The api is tr-localhost-bound."""
+        remote = f"curl -s -m {self._timeout} -w '\\n%{{http_code}}' {shlex.quote(self._base + path)}"
+        argv = ["ssh", "-o", "BatchMode=yes", "-o", "ConnectTimeout=10", self._ssh_host, remote]
+        proc = await asyncio.create_subprocess_exec(
+            *argv, stdout=asyncio.subprocess.PIPE, stderr=asyncio.subprocess.PIPE
+        )
+        out, err = await asyncio.wait_for(proc.communicate(), timeout=self._timeout + 12)
+        text = out.decode(errors="replace")
+        nl = text.rfind("\n")
+        body, code_s = (text[:nl], text[nl + 1 :].strip()) if nl >= 0 else (text, "")
+        try:
+            return body, int(code_s)
+        except ValueError as exc:
+            raise NetworkError(f"RXinDexer REST query failed (ssh/curl): {err.decode(errors='replace')[:160] or text[:160]!r}") from exc

--- a/scripts/eth_swap_run.py
+++ b/scripts/eth_swap_run.py
@@ -47,18 +47,28 @@ from _dust_swap_shared import (
     confirm,
     rxd_blockcount,
 )
+from _glyph_mainnet import (  # scripts/ sibling (NFT path)
+    load_minted_nft,
+    lock_singleton_into_covenant,
+    mint_nft_inline,
+    wait_genesis_mature,
+)
+from _glyph_ref_http import SshTrHttpRefAdapter  # scripts/ sibling (mainnet REST REF gate)
 from radiant_mainnet_chainio import SshTrRadiantClient
 
 from pyrxd.btc_wallet import taproot as bt
 from pyrxd.eth_wallet.htlc_leg import EthHtlcContractLeg, load_artifact
 from pyrxd.eth_wallet.rpc import EthRpc
+from pyrxd.glyph.types import GlyphRef
 from pyrxd.gravity.eth_leg import EthLeg
 from pyrxd.gravity.eth_rxd_timelock import CrossClockMargin
-from pyrxd.gravity.htlc_covenant import build_htlc_covenant_rxd
-from pyrxd.gravity.radiant_leg import RadiantChainIO, RadiantCovenantLeg
+from pyrxd.gravity.htlc_covenant import build_htlc_covenant_nft, build_htlc_covenant_rxd
+from pyrxd.gravity.radiant_leg import RadiantChainIO, RadiantCovenantLeg, RxinDexerRefAdapter
 from pyrxd.gravity.swap_coordinator import CoordinatorConfig, MarginPolicy, SwapCoordinator
 from pyrxd.gravity.swap_state import NegotiatedTerms, SwapRecord, SwapState
 from pyrxd.keys import PrivateKey
+from pyrxd.network.electrumx import ElectrumXClient
+from pyrxd.network.rxindexer import RxinDexerClient
 from pyrxd.security.secrets import PrivateKeyMaterial, SecretBytes
 from pyrxd.security.types import Hex20
 
@@ -120,7 +130,9 @@ def _free_port() -> int:
     return port
 
 
-def _build_terms_and_covenant(args, *, eth_timeout: int):
+def _build_terms_and_covenant(args, *, eth_timeout: int, minted=None):
+    """Build the HTLC covenant + negotiated terms. ``minted`` (a MintedNft) is REQUIRED for the
+    NFT variant — the covenant binds the genesis ref ``reveal_txid:0`` of the freshly-minted NFT."""
     p_secret = SecretBytes(os.urandom(32))
     h = hashlib.sha256(p_secret.unsafe_raw_bytes()).digest()
     t_rxd = bt.Timelock(args.t_rxd_blocks, bt.TimeUnit.BLOCKS)
@@ -128,17 +140,37 @@ def _build_terms_and_covenant(args, *, eth_timeout: int):
     taker_rxd, maker_rxd = PrivateKey(os.urandom(32)), PrivateKey(os.urandom(32))
     taker_pkh = bytes(Hex20(taker_rxd.public_key().hash160()))
     maker_pkh = bytes(Hex20(maker_rxd.public_key().hash160()))
-    cov = build_htlc_covenant_rxd(
-        amount=args.rxd_photons, taker_pkh=taker_pkh, maker_pkh=maker_pkh, hashlock=h, refund_csv=t_rxd.value
-    )
+    if args.asset_variant == "nft":
+        if minted is None:
+            raise SystemExit("internal: the NFT path must mint the singleton before building the covenant")
+        # Bind the covenant to the TRUE genesis ref the singleton carries (the commit outpoint,
+        # parsed from its d8<ref>) — NOT reveal_txid:0 (the singleton's current location). Binding the
+        # wrong ref makes the covenant require a singleton that does not exist -> NFT permanently stranded.
+        cov = build_htlc_covenant_nft(
+            genesis_txid=minted.genesis_txid,
+            genesis_vout=minted.genesis_vout,
+            nft_carrier_value=args.nft_carrier_photons,
+            taker_pkh=taker_pkh,
+            maker_pkh=maker_pkh,
+            hashlock=h,
+            refund_csv=t_rxd.value,
+        )
+        asset_variant = "nft"
+        genesis_ref = GlyphRef(txid=minted.genesis_txid, vout=minted.genesis_vout).to_bytes()
+        radiant_amount = args.nft_carrier_photons
+    else:
+        cov = build_htlc_covenant_rxd(
+            amount=args.rxd_photons, taker_pkh=taker_pkh, maker_pkh=maker_pkh, hashlock=h, refund_csv=t_rxd.value
+        )
+        asset_variant, genesis_ref, radiant_amount = "rxd", b"", args.rxd_photons
     terms = NegotiatedTerms(
         hashlock=h,
-        btc_sats=args.rxd_photons,
-        radiant_amount=args.rxd_photons,
+        btc_sats=radiant_amount,
+        radiant_amount=radiant_amount,
         t_btc=t_btc,
         t_rxd=t_rxd,
-        asset_variant="rxd",
-        genesis_ref=b"",
+        asset_variant=asset_variant,
+        genesis_ref=genesis_ref,
         taker_dest_hash=cov.expected_taker_hash,
         maker_dest_hash=cov.expected_maker_hash,
         btc_claim_pubkey_xonly=b"\x00" * 32,
@@ -236,6 +268,14 @@ async def run_sepolia_dust(args: argparse.Namespace) -> None:
     for req in ("eth_rpc_url", "eth_key_hex", "eth_claim_to", "eth_refund_to"):
         if not getattr(args, req):
             raise SystemExit(f"stage=sepolia-dust requires --{req.replace('_', '-')}")
+    # Pre-flight: refuse BEFORE minting if the recovery file already exists (atomic_write_mode_600 is
+    # O_EXCL). A leftover file from a prior/aborted run would otherwise crash the keys-persist step
+    # AFTER the (real-value) mint — wasting the mint. Fail cheap, up front.
+    if Path(args.keys_out).expanduser().exists():
+        raise SystemExit(
+            f"recovery file already exists: {Path(args.keys_out).expanduser()} — move/delete it or pass a "
+            f"fresh --keys-out before a new run (refusing to mint over a stale recovery file)"
+        )
     # Pin the RXD network to the transport's true network (mainnet) — fail-closed like dust_swap_run.
     rxd_network = SshTrRadiantClient.NETWORK
     print(f"=== ETH↔RXD DUST swap — stage=sepolia-dust  (ETH=sepolia, RXD={rxd_network} mainnet) ===")
@@ -251,8 +291,30 @@ async def run_sepolia_dust(args: argparse.Namespace) -> None:
     }
     report = StepReport("sepolia-dust", provenance)
 
+    rxd_client = SshTrRadiantClient(rpcwallet=args.rxd_wallet)
+    minted = None
+    if args.asset_variant == "nft":
+        if args.nft_reuse_reveal_txid:
+            if not args.nft_owner_wif:
+                raise SystemExit("--nft-reuse-reveal-txid requires --nft-owner-wif (to spend the singleton)")
+            print(f"\n  --- NFT path: REUSING already-minted NFT at reveal {args.nft_reuse_reveal_txid} (no mint) ---")
+            minted = load_minted_nft(
+                rxd_client, reveal_txid=args.nft_reuse_reveal_txid, owner_wif=args.nft_owner_wif
+            )
+        else:
+            print("\n  --- NFT path: minting a fresh throwaway NFT on RXD MAINNET (commit→reveal, real-value) ---")
+            minted = mint_nft_inline(
+                rxd_client,
+                name=args.nft_name,
+                commit_photons=args.nft_commit_photons,
+                fee_photons=args.rxd_mint_fee_photons,
+                confirm_fn=lambda m: confirm(m, auto_yes=args.yes),
+                poll_s=args.confirm_poll_s,
+            )
+        print(f"  minted NFT genesis ref: {minted.ref_str}")
+    # eth_timeout starts AFTER the (slow, multi-block) mint, so the full window is available for the swap.
     eth_timeout = int(time.time()) + args.eth_timeout_s
-    terms, cov, p_secret, h, _rkeys = _build_terms_and_covenant(args, eth_timeout=eth_timeout)
+    terms, cov, p_secret, h, _rkeys = _build_terms_and_covenant(args, eth_timeout=eth_timeout, minted=minted)
 
     # Persist ALL run state (mode 600) BEFORE any broadcast — recovery/sweep. Holds the preimage p
     # + the ETH signing key + the RXD keys + the covenant SPK; single point of total compromise.
@@ -276,6 +338,10 @@ async def run_sepolia_dust(args: argparse.Namespace) -> None:
                 "maker_rxd_wif": _rkeys[1].wif(),
                 "rxd_covenant_spk": cov.funded_spk.hex(),
                 "t_rxd_blocks": terms.t_rxd.value,
+                "asset_variant": args.asset_variant,
+                "nft_genesis_ref": minted.ref_str if minted else None,
+                "nft_owner_wif": minted.owner_key.wif() if minted else None,
+                "nft_reveal_value": minted.reveal_value if minted else None,
                 "note": "ALL run state for recovery/sweep incl preimage p. mode 600 — delete after sweep.",
             },
             indent=2,
@@ -293,7 +359,6 @@ async def run_sepolia_dust(args: argparse.Namespace) -> None:
         eth_timeout=eth_timeout,
         network="sepolia",
     )
-    rxd_client = SshTrRadiantClient(rpcwallet=args.rxd_wallet)
     rxd_client.register_spk(cov.funded_spk)
     rxd_leg = RadiantCovenantLeg(
         network=rxd_network,
@@ -304,14 +369,36 @@ async def run_sepolia_dust(args: argparse.Namespace) -> None:
         min_confirmations=1,
         audit_cleared=True,
     )
+    # NFT: the REAL RXinDexer is the genesis-ref authenticity oracle (R1 fake-singleton defense).
+    # Plain RXD has no ref → no indexer needed. Default to the REST adapter over ssh-tr (the mainnet
+    # deployment runs only the HTTP api, no glyph electrumx ws); use the electrumx-ws adapter only
+    # when a --rxd-indexer-ws is explicitly given (e.g. a glyph-enabled electrumx).
+    indexer = None
+    if args.asset_variant == "nft":
+        chain_io = RadiantChainIO(rxd_client)
+        if args.rxd_indexer_ws:
+            ex = ElectrumXClient(urls=[args.rxd_indexer_ws], allow_insecure=args.rxd_indexer_insecure)
+            indexer = RxinDexerRefAdapter(RxinDexerClient(ex), chain_io)
+            print(f"  REF gate: electrumx-ws RxinDexerRefAdapter @ {args.rxd_indexer_ws}")
+        else:
+            indexer = SshTrHttpRefAdapter(chain_io=chain_io, ssh_host=args.rxd_ssh_host, api_base=args.rxd_api_base)
+            print(f"  REF gate: REST SshTrHttpRefAdapter via ssh {args.rxd_ssh_host} -> {args.rxd_api_base}")
+    cfg = CoordinatorConfig(margin_policy=policy, accept_nondurable_seen=True)
     coord = SwapCoordinator(
         record=SwapRecord(state=SwapState.NEGOTIATED, terms=terms),
         counter_leg=eth_leg,
         radiant_leg=rxd_leg,
-        indexer=None,
+        indexer=indexer,
         seen_store=InMemSeen(),
-        config=CoordinatorConfig(margin_policy=policy, accept_nondurable_seen=True),
+        config=cfg,
     )
+
+    # Before funding the counter-leg, wait for the NFT genesis to reach the REF-gate reorg depth
+    # (the pre-lock gate fails CLOSED on a shallow genesis). No-op for plain RXD (no genesis ref).
+    if minted is not None:
+        wait_genesis_mature(
+            rxd_client, minted.genesis_txid, need_confs=cfg.min_ref_confirmations, poll_s=args.confirm_poll_s
+        )
 
     try:
         # 1. Taker deploys + funds the ETH HTLC on Sepolia.
@@ -334,12 +421,25 @@ async def run_sepolia_dust(args: argparse.Namespace) -> None:
         confirm("maker_verify_counter_funding: verify the on-chain ETH HTLC pays the maker", auto_yes=args.yes)
         rec = await coord.maker_verify_counter_funding(rec.counterchain_locator.contract_address)
         report.step(name="maker_verify_counter_funding", chain="eth", state=rec.state.value)
-        print(f"  -> verified (claimant=maker, refundee=taker, H, timeout, funded)")
+        print("  -> verified (claimant=maker, refundee=taker, H, timeout, funded)")
 
-        # 2. Maker locks the RXD covenant on MAINNET (operator pays the SPK); taker re-validates.
-        print(f"\n  Fund the RXD covenant SPK on MAINNET as the maker (>= 1 conf):\n    {cov.funded_spk.hex()}")
+        # 2. Maker locks the ASSET on MAINNET, then the taker re-validates (incl. the genesis-ref
+        #    authenticity gate for an NFT). NFT: spend the minted singleton INTO the covenant SPK
+        #    (harness-driven, confirm-each). RXD: the operator funds the SPK out-of-band.
         rxd_locked_at = rxd_blockcount(rxd_client)
-        confirm("you have funded the RXD covenant SPK on mainnet and it has >= 1 conf", auto_yes=args.yes)
+        if args.asset_variant == "nft":
+            lock_singleton_into_covenant(
+                rxd_client,
+                minted=minted,
+                covenant_spk=cov.funded_spk,
+                carrier_photons=args.nft_carrier_photons,
+                fee_photons=args.rxd_mint_fee_photons,
+                confirm_fn=lambda m: confirm(m, auto_yes=args.yes),
+                poll_s=args.confirm_poll_s,
+            )
+        else:
+            print(f"\n  Fund the RXD covenant SPK on MAINNET as the maker (>= 1 conf):\n    {cov.funded_spk.hex()}")
+            confirm("you have funded the RXD covenant SPK on mainnet and it has >= 1 conf", auto_yes=args.yes)
         rec = await coord.post_asset_lock_revalidate(cov.funded_spk, now_unix_s=int(time.time()))
         report.step(
             name="post_asset_lock_revalidate",
@@ -436,6 +536,19 @@ def _args() -> argparse.Namespace:
     ap.add_argument("--rxd-fee-photons", type=int, default=5_000_000)
     ap.add_argument("--rxd-wallet", default="")
     ap.add_argument("--t-rxd-blocks", type=int, default=60)
+    # asset: plain RXD (default) or a freshly-minted NFT Glyph (Glyph↔ETH).
+    ap.add_argument("--asset-variant", choices=("rxd", "nft"), default="rxd")
+    ap.add_argument("--rxd-indexer-ws", default="", help="OPTIONAL glyph-enabled ElectrumX ws/wss URL for the NFT REF gate; if omitted, resolve via the REST api over ssh-tr")
+    ap.add_argument("--rxd-indexer-insecure", action="store_true", help="allow a non-TLS RXinDexer ws")
+    ap.add_argument("--rxd-ssh-host", default="tr", help="ssh host for the RXinDexer REST REF gate (default tr)")
+    ap.add_argument("--rxd-api-base", default="http://127.0.0.1:8000", help="RXinDexer REST api base on the ssh host")
+    ap.add_argument("--nft-reuse-reveal-txid", default="", help="reuse an already-minted NFT at this reveal txid (skip minting)")
+    ap.add_argument("--nft-owner-wif", default="", help="owner WIF for --nft-reuse-reveal-txid (spends the singleton into the covenant)")
+    ap.add_argument("--nft-name", default="ETH-RXD-REAL-NFT")
+    ap.add_argument("--nft-carrier-photons", type=int, default=1_000_000)  # carrier the covenant pins
+    ap.add_argument("--nft-commit-photons", type=int, default=20_000_000)  # mint commit funding
+    ap.add_argument("--rxd-mint-fee-photons", type=int, default=5_000_000)  # per mint/lock tx (mainnet 0.10 RXD/kB)
+    ap.add_argument("--confirm-poll-s", type=float, default=30.0, help="mainnet confirmation poll interval")
     # margin / cross-clock
     ap.add_argument("--margin-blocks", type=int, default=36)
     ap.add_argument("--btc-block-interval-s", type=float, default=600.0)

--- a/src/pyrxd/gravity/ref_authenticity.py
+++ b/src/pyrxd/gravity/ref_authenticity.py
@@ -136,7 +136,7 @@ async def verify_ref_authenticity(
 
     Raises:
         ValidationError: if the ref is not provably the advertised authentic
-            asset. The caller MUST NOT pay BTC when this raises.
+            asset. The caller MUST NOT pay the counter-leg (BTC or ETH) when this raises.
     """
     if asset_variant not in ("rxd", "ft", "nft"):
         raise ValidationError(f"unknown asset_variant {asset_variant!r}")
@@ -160,7 +160,7 @@ async def verify_ref_authenticity(
         resolved = await indexer.resolve_ref(ref)
     except Exception as exc:  # indexer unreachable/lagging/error => fail-closed.
         raise ValidationError(
-            f"indexer could not resolve REF ({exc}); fail-closed — do NOT pay BTC. "
+            f"indexer could not resolve REF ({exc}); fail-closed — do NOT pay the counter-leg. "
             "Consensus does NOT enforce mint provenance (rigorous audit R1)."
         ) from exc
 
@@ -170,7 +170,7 @@ async def verify_ref_authenticity(
     if resolved is None:
         raise ValidationError(
             "indexer returned no token for REF — it does not resolve to a minted asset. "
-            "The covenant's singleton may be a forged/self-crafted ref (rigorous audit R1). Do NOT pay BTC."
+            "The covenant's singleton may be a forged/self-crafted ref (rigorous audit R1). Do NOT pay the counter-leg."
         )
     if not isinstance(resolved, ResolvedRef):
         raise ValidationError(
@@ -183,14 +183,14 @@ async def verify_ref_authenticity(
     if not isinstance(resolved.genesis_outpoint, (bytes, bytearray)) or bytes(resolved.genesis_outpoint) != ref:
         raise ValidationError(
             "resolved token's genesis outpoint does not equal the advertised REF — wrong/forged asset. "
-            "(REF is the genesis outpoint, NOT the reveal txid.) Do NOT pay BTC."
+            "(REF is the genesis outpoint, NOT the reveal txid.) Do NOT pay the counter-leg."
         )
 
     # Binding (b): a real Glyph reveal carries a `gly` envelope marker.
     if resolved.has_gly_marker is not True:
         raise ValidationError(
             "resolved REF carries no `gly` envelope marker — it is a bare singleton, not a minted Glyph "
-            "(the exact R1 forgery). Do NOT pay BTC."
+            "(the exact R1 forgery). Do NOT pay the counter-leg."
         )
 
     # Binding (c): payload commitment, when the taker agreed to a specific one.
@@ -199,7 +199,7 @@ async def verify_ref_authenticity(
         or bytes(resolved.payload_hash) != bytes(expected_payload_hash)
     ):
         raise ValidationError(
-            "resolved REF payload hash does not match the advertised payload — wrong asset content. Do NOT pay BTC."
+            "resolved REF payload hash does not match the advertised payload — wrong asset content. Do NOT pay the counter-leg."
         )
 
     # Binding (e): the genesis must be deep enough that a reorg cannot void it.
@@ -207,5 +207,5 @@ async def verify_ref_authenticity(
     if not isinstance(confs, int) or isinstance(confs, bool) or confs < min_confirmations:
         raise ValidationError(
             f"genesis tx has {confs} confirmations < required {min_confirmations}; a shallow genesis can be "
-            "reorged out after payment, voiding provenance. Do NOT pay BTC."
+            "reorged out after payment, voiding provenance. Do NOT pay the counter-leg."
         )


### PR DESCRIPTION
## What

Adds **Glyph (NFT) ↔ ETH** support to the ETH↔RXD atomic-swap runner, plus the mainnet REST REF-gate adapter it needs. Proven end-to-end on real chains — a one-of-one Radiant Glyph on **mainnet** atomically swapped for ETH on **Sepolia** (dust value).

The RXD↔ETH HTLC harness itself landed in #155; this builds the NFT asset variant on top of it.

## Changes

- **`scripts/_glyph_ref_http.py`** (new) — `SshTrHttpRefAdapter`: resolves a Glyph genesis ref over the RXinDexer **REST api**. The mainnet indexer deployment runs no glyph ElectrumX-ws, so the proven ws adapter has no endpoint there. Handles the display-vs-internal txid byte order; **fails closed** on an unknown/forged ref (the R1 fake-singleton defense). Live-verified against real mainnet glyphs.
- **`scripts/_glyph_mainnet.py`** (new) — inline mainnet NFT mint (commit→reveal), singleton→covenant lock, a reuse path (`load_minted_nft`), and a genesis-maturity wait.
- **`scripts/eth_swap_run.py`** — `--asset-variant nft`; the REST adapter becomes the default mainnet REF gate when no `--rxd-indexer-ws` is given; waits for the genesis to reach REF-gate confirmation depth before funding the counter-leg; `--nft-reuse-*`; a pre-mint recovery-file pre-flight check.
- **`src/pyrxd/gravity/ref_authenticity.py`** — generalize the `Do NOT pay BTC` refusals to `the counter-leg` (this shared gate guards the BTC and ETH legs alike).
- **Docs** — `docs/solutions/integration-issues/rxindexer-mainnet-rest-only-glyph-ref-gate-http-adapter.md`.

## Bugs found + fixed during the first real run (each caught before value was at risk)

1. **The Glyph genesis ref is the COMMIT outpoint** carried in the singleton's `d8<ref>` — *not* `reveal_txid:0`. Binding the wrong ref would have stranded the NFT in an unspendable covenant. The ref is now parsed from the minted singleton (ground truth).
2. The recovery file used `O_EXCL` and **crashed after minting** on a stale file → added a pre-flight check so a leftover file aborts cheaply, pre-mint.
3. The REF gate requires N genesis confirmations; the harness now **waits for maturity** instead of crashing.

## Real-chain validation (dust)

Glyph(NFT) ↔ ETH, completed and verified on both chains:

| Leg | Chain | Txid / address |
| --- | --- | --- |
| NFT minted | Radiant mainnet | `0412393546ea3bbaa96a5040a0cb4f086d2c1faa5c8e3375e658e60b3fdbd3ae` |
| NFT claimed by taker | Radiant mainnet | `b717f9a5f8d085c92479331a0dddfa290dd43d42d37c398508db204dbd851367` |
| ETH HTLC | Sepolia | `0x25Aa6302FfFc35ED87827f1052f4ce8f44810BFd` |
| ETH claim (reveals preimage) | Sepolia | `0x0bad68311ad4433edda16550def29f1c05e975cf66fbaf4b3ac8f117f2f6fbc0` |

Outcome: maker +0.0001 ETH, taker received the NFT; the reorg gate held the NFT claim until the Sepolia claim finalized (~13 min).

## Tests

- 321 REF-gate / glyph tests green; `ruff` clean on all touched files.

## Caveats

- **Pre-external-audit.** A working real-chain demo is not a security proof — dust-only validation, not for real funds.
- The ETH leg runs on the **Sepolia testnet**; the Radiant side is mainnet.
- These are operator **run scripts**, not new library API.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
