### PR TITLE
feat(gravity): FT (fungible-token) ↔ ETH atomic swap support

### DIFF
--- a/docs/solutions/integration-issues/rxindexer-mainnet-rest-only-glyph-ref-gate-http-adapter.md
+++ b/docs/solutions/integration-issues/rxindexer-mainnet-rest-only-glyph-ref-gate-http-adapter.md
@@ -125,7 +125,7 @@ response. This was confirmed empirically, not assumed.
 ### Source-vs-deployment skew — a load-bearing caveat
 
 The **live endpoint is authoritative**, and there is measurable skew between the deployed mainnet api
-and the local RXinDexer source checkout (`/home/eric/apps/RXinDexer`):
+and the local RXinDexer source checkout (`~/apps/RXinDexer`):
 
 - The deployed `/tokens/{ref}` route returns a JSON object whose **`token_id`** field equals the
   72-hex internal wire ref (this is what the live test bound against and what the adapter checks).

--- a/scripts/_glyph_mainnet.py
+++ b/scripts/_glyph_mainnet.py
@@ -305,3 +305,172 @@ def lock_singleton_into_covenant(
     log(f"    asset lock -> {txid}")
     _wait_confirmed(rxd_client, txid, label="asset-lock", poll_s=poll_s, log=log)
     return txid
+
+
+# --------------------------------------------------------------------------- FT (fungible token)
+
+
+@dataclass(frozen=True)
+class MintedFt:
+    """A genuinely-minted Glyph FT (full premine in one holder UTXO).
+
+    Like the NFT, the FT's identity is its IMMUTABLE genesis ref — the COMMIT outpoint carried in the
+    holder script's ``bd d0 <ref>`` (NOT the reveal txid). ``ft_amount`` photons = FT units (consensus:
+    1 photon = 1 unit). ``reveal_txid`` is where the premine holder currently sits (the lock spends it)."""
+
+    ref_str: str  # "<genesis_txid>:<genesis_vout>" — the true genesis ref (commit outpoint)
+    reveal_txid: str  # where the FT premine holder currently sits (the lock spends reveal_txid:0)
+    genesis_txid: str
+    genesis_vout: int
+    owner_key: PrivateKey
+    ft_script: bytes  # the 75-byte FT holder script (p2pkh + bd d0 <ref> + epilogue)
+    ft_amount: int  # premine photons == FT units
+
+
+def _genesis_ref_from_ft_script(ft_script: bytes) -> tuple[str, int]:
+    """Parse the genesis ref an FT holder script carries (ground truth, not assumed).
+
+    FT holder = ``76a914<pkh:20>88ac bd d0 <ref:36> <epilogue:12>`` (75 bytes). The ref (= the COMMIT
+    outpoint the FT was minted at, persists across transfers) sits at offset 27, after the 25-byte
+    p2pkh prologue + ``bd d0``."""
+    if len(ft_script) != 75 or ft_script[25] != 0xBD or ft_script[26] != 0xD0:
+        raise RuntimeError(f"not a 75-byte FT holder script (expect bd d0 at 25): {ft_script[:8].hex()}")
+    ref = ft_script[27:63]
+    return ref[:32][::-1].hex(), int.from_bytes(ref[32:36], "little")
+
+
+def mint_ft_inline(
+    rxd_client,
+    *,
+    name: str,
+    ticker: str = "",
+    premine_amount: int,
+    fee_photons: int = DEFAULT_FEE_PHOTONS,
+    confirm_fn: Callable[[str], None],
+    poll_s: float = 30.0,
+    log: Callable[[str], None] = print,
+) -> MintedFt:
+    """Mint a throwaway Glyph FT on Radiant mainnet (commit→reveal premine). Genesis ref = the COMMIT
+    outpoint the holder's ``bd d0 <ref>`` carries. The reveal output holds ``premine_amount`` photons
+    (= FT units). Pauses for operator confirmation before EACH broadcast + waits for confirmation."""
+    if premine_amount <= 0:
+        raise RuntimeError("premine_amount must be positive")
+    # commit funds the reveal: the reveal spends the commit -> ONE FT output (premine), leftover = fee.
+    commit_photons = premine_amount + fee_photons
+    builder = GlyphBuilder()
+    u = _largest_wallet_utxo(rxd_client, commit_photons + 2 * fee_photons)
+    key = PrivateKey(str(_cli(rxd_client, "dumpprivkey", u["address"])))
+    pkh = Hex20(key.public_key().hash160())
+    spk = bytes.fromhex(u["scriptPubKey"])
+    in_sats = round(u["amount"] * 1e8)
+
+    meta = GlyphMetadata(protocol=[GlyphProtocol.FT], name=name, ticker=ticker)
+    commit = builder.prepare_commit(CommitParams(metadata=meta, owner_pkh=pkh, change_pkh=pkh, funding_satoshis=in_sats))
+    fin = TransactionInput(
+        source_transaction=_src(u["txid"], int(u["vout"]), spk, in_sats),
+        source_txid=u["txid"],
+        source_output_index=int(u["vout"]),
+        unlocking_script_template=_p2pkh_unlock(key),
+    )
+    fin.satoshis = in_sats
+    fin.locking_script = Script(spk)
+    commit_tx = Transaction(
+        tx_inputs=[fin],
+        tx_outputs=[
+            TransactionOutput(Script(commit.commit_script), commit_photons),
+            TransactionOutput(Script(_p2pkh_spk(pkh)), in_sats - commit_photons - fee_photons),
+        ],
+    )
+    commit_tx.sign()
+    confirm_fn(f"FT mint step 1/2: broadcast the COMMIT tx on mainnet ({commit_photons / 1e8:.4f} RXD into the commit output)")
+    commit_txid = str(_cli(rxd_client, "sendrawtransaction", commit_tx.serialize().hex()))
+    log(f"    commit -> {commit_txid}")
+    _wait_confirmed(rxd_client, commit_txid, label="commit", poll_s=poll_s, log=log)
+
+    rev = builder.prepare_ft_deploy_reveal(
+        commit_txid=commit_txid,
+        commit_vout=0,
+        commit_value=commit_photons,
+        cbor_bytes=commit.cbor_bytes,
+        premine_pkh=pkh,
+        premine_amount=premine_amount,
+    )
+    rin = TransactionInput(
+        source_transaction=_src(commit_txid, 0, commit.commit_script, commit_photons),
+        source_txid=commit_txid,
+        source_output_index=0,
+        unlocking_script_template=_glyph_unlock(key, rev.scriptsig_suffix),
+    )
+    rin.satoshis = commit_photons
+    rin.locking_script = Script(commit.commit_script)
+    # ONE FT output (premine); the commit leftover (commit_photons - premine = fee_photons) is the fee.
+    reveal_tx = Transaction(
+        tx_inputs=[rin], tx_outputs=[TransactionOutput(Script(rev.locking_script), premine_amount)]
+    )
+    reveal_tx.sign()
+    g_txid, g_vout = _genesis_ref_from_ft_script(rev.locking_script)
+    confirm_fn(f"FT mint step 2/2: broadcast the REVEAL tx (premines {premine_amount} FT units at reveal:0)")
+    reveal_txid = str(_cli(rxd_client, "sendrawtransaction", reveal_tx.serialize().hex()))
+    log(f"    reveal -> {reveal_txid}  (FT premine at reveal:0; genesis ref = {g_txid}:{g_vout} [the commit outpoint])")
+    _wait_confirmed(rxd_client, reveal_txid, label="reveal", poll_s=poll_s, log=log)
+    return MintedFt(
+        ref_str=f"{g_txid}:{g_vout}",
+        reveal_txid=reveal_txid,
+        genesis_txid=g_txid,
+        genesis_vout=g_vout,
+        owner_key=key,
+        ft_script=rev.locking_script,
+        ft_amount=premine_amount,
+    )
+
+
+def lock_ft_into_covenant(
+    rxd_client,
+    *,
+    minted: MintedFt,
+    covenant_spk: bytes,
+    fee_photons: int = DEFAULT_FEE_PHOTONS,
+    confirm_fn: Callable[[str], None],
+    poll_s: float = 30.0,
+    log: Callable[[str], None] = print,
+) -> str:
+    """Lock the minted FT into the covenant SPK — the maker's 'lock the asset' step.
+
+    FT conservation: the FT photons (= amount) must flow WHOLE into the covenant output, which shares
+    the FT's ``codeScriptHash`` (same ``bd d0 <ref> epilogue``), so ``covenant out value == FT amount``.
+    The miner fee CANNOT be skimmed off the FT value — it comes from a SEPARATE plain-RXD wallet input,
+    with change back to the wallet. Confirms before broadcast + waits for confirmation."""
+    # FT input (the premine holder) — spent via the owner's p2pkh prologue; the epilogue enforces
+    # conservation against the covenant output at consensus time.
+    fin = TransactionInput(
+        source_transaction=_src(minted.reveal_txid, 0, minted.ft_script, minted.ft_amount),
+        source_txid=minted.reveal_txid,
+        source_output_index=0,
+        unlocking_script_template=_p2pkh_unlock(minted.owner_key),
+    )
+    fin.satoshis = minted.ft_amount
+    fin.locking_script = Script(minted.ft_script)
+    # Separate plain-RXD fee input from the wallet (its surplus over the fee returns as change).
+    fu = _largest_wallet_utxo(rxd_client, 2 * fee_photons)
+    fkey = PrivateKey(str(_cli(rxd_client, "dumpprivkey", fu["address"])))
+    fspk = bytes.fromhex(fu["scriptPubKey"])
+    fee_in_sats = round(fu["amount"] * 1e8)
+    feein = TransactionInput(
+        source_transaction=_src(fu["txid"], int(fu["vout"]), fspk, fee_in_sats),
+        source_txid=fu["txid"],
+        source_output_index=int(fu["vout"]),
+        unlocking_script_template=_p2pkh_unlock(fkey),
+    )
+    feein.satoshis = fee_in_sats
+    feein.locking_script = Script(fspk)
+    outs = [TransactionOutput(Script(covenant_spk), minted.ft_amount)]  # covenant carries the WHOLE FT amount
+    change = fee_in_sats - fee_photons
+    if change > 0:
+        outs.append(TransactionOutput(Script(_p2pkh_spk(fkey.public_key().hash160())), change))
+    tx = Transaction(tx_inputs=[fin, feein], tx_outputs=outs)
+    tx.sign()
+    confirm_fn(f"lock the FT ({minted.ft_amount} units) into the covenant SPK on mainnet (fee from a separate input)")
+    txid = str(_cli(rxd_client, "sendrawtransaction", tx.serialize().hex()))
+    log(f"    FT asset lock -> {txid}")
+    _wait_confirmed(rxd_client, txid, label="asset-lock", poll_s=poll_s, log=log)
+    return txid

--- a/scripts/_glyph_mainnet.py
+++ b/scripts/_glyph_mainnet.py
@@ -492,13 +492,24 @@ def lock_ft_into_covenant(
     )
     feein.satoshis = fee_in_sats
     feein.locking_script = Script(fspk)
-    outs = [TransactionOutput(Script(covenant_spk), minted.ft_amount)]  # covenant carries the WHOLE FT amount
-    change = fee_in_sats - fee_photons
-    if change > 0:
-        outs.append(TransactionOutput(Script(_p2pkh_spk(fkey.public_key().hash160())), change))
-    tx = Transaction(tx_inputs=[fin, feein], tx_outputs=outs)
-    tx.sign()
-    confirm_fn(f"lock the FT ({minted.ft_amount} units) into the covenant SPK on mainnet (fee from a separate input)")
+    # Two-pass fee: the 2-input lock with a ~224B covenant output is ~600B — well above the sub-kB
+    # mint txs — so a flat fee can fall UNDER the mainnet min-relay (0.10 RXD/kB = 10_000 photons/B).
+    # Measure the signed size and pay >= size * rate with margin (the FT value flows whole regardless;
+    # only the separate fee input + change absorb the fee).
+    def _build(fee: int) -> Transaction:
+        outs = [TransactionOutput(Script(covenant_spk), minted.ft_amount)]  # covenant carries the WHOLE FT amount
+        ch = fee_in_sats - fee
+        if ch > 0:
+            outs.append(TransactionOutput(Script(_p2pkh_spk(fkey.public_key().hash160())), ch))
+        fin.unlocking_script = None
+        feein.unlocking_script = None
+        t = Transaction(tx_inputs=[fin, feein], tx_outputs=outs)
+        t.sign()
+        return t
+
+    fee = max(fee_photons, _build(fee_photons).byte_length() * 15_000)  # 1.5x the 10_000 photons/B relay floor
+    tx = _build(fee)
+    confirm_fn(f"lock the FT ({minted.ft_amount} units) into the covenant SPK on mainnet (fee {fee / 1e8:.4f} RXD from a separate input)")
     txid = str(_cli(rxd_client, "sendrawtransaction", tx.serialize().hex()))
     log(f"    FT asset lock -> {txid}")
     _wait_confirmed(rxd_client, txid, label="asset-lock", poll_s=poll_s, log=log)

--- a/scripts/_glyph_mainnet.py
+++ b/scripts/_glyph_mainnet.py
@@ -424,6 +424,35 @@ def mint_ft_inline(
     )
 
 
+def load_minted_ft(rxd_client, *, reveal_txid: str, owner_wif: str) -> MintedFt:
+    """Reconstruct a :class:`MintedFt` for an ALREADY-minted FT (skip the mint), e.g. to resume a run
+    that aborted after minting. Fetches the reveal tx on-chain for the FT holder script + amount,
+    parses the genesis ref from the holder's ``bd d0 <ref>``, and binds the owner key.
+
+    Safety: asserts the owner key's hash160 equals the p2pkh inside the FT holder — i.e. this key can
+    actually spend the FT into the covenant."""
+    v = _cli(rxd_client, "getrawtransaction", reveal_txid, "1")
+    if not isinstance(v, dict) or not v.get("vout"):
+        raise RuntimeError(f"reuse: FT reveal tx {reveal_txid} not found / has no outputs")
+    out0 = v["vout"][0]
+    ft_script = bytes.fromhex(out0["scriptPubKey"]["hex"])
+    ft_amount = round(float(out0["value"]) * 1e8)
+    g_txid, g_vout = _genesis_ref_from_ft_script(ft_script)
+    key = PrivateKey(str(owner_wif))
+    # FT holder = 76 a9 14 <pkh:20> 88 ac ... -> pkh at offset 3:23
+    if ft_script[3:23] != bytes(key.public_key().hash160()):
+        raise RuntimeError("reuse: owner WIF does not match the FT holder's p2pkh — wrong key, cannot spend the FT")
+    return MintedFt(
+        ref_str=f"{g_txid}:{g_vout}",
+        reveal_txid=reveal_txid,
+        genesis_txid=g_txid,
+        genesis_vout=g_vout,
+        owner_key=key,
+        ft_script=ft_script,
+        ft_amount=ft_amount,
+    )
+
+
 def lock_ft_into_covenant(
     rxd_client,
     *,

--- a/scripts/eth_swap_run.py
+++ b/scripts/eth_swap_run.py
@@ -47,9 +47,11 @@ from _dust_swap_shared import (
     confirm,
     rxd_blockcount,
 )
-from _glyph_mainnet import (  # scripts/ sibling (NFT path)
+from _glyph_mainnet import (  # scripts/ sibling (NFT + FT paths)
     load_minted_nft,
+    lock_ft_into_covenant,
     lock_singleton_into_covenant,
+    mint_ft_inline,
     mint_nft_inline,
     wait_genesis_mature,
 )
@@ -62,7 +64,7 @@ from pyrxd.eth_wallet.rpc import EthRpc
 from pyrxd.glyph.types import GlyphRef
 from pyrxd.gravity.eth_leg import EthLeg
 from pyrxd.gravity.eth_rxd_timelock import CrossClockMargin
-from pyrxd.gravity.htlc_covenant import build_htlc_covenant_nft, build_htlc_covenant_rxd
+from pyrxd.gravity.htlc_covenant import build_htlc_covenant_ft, build_htlc_covenant_nft, build_htlc_covenant_rxd
 from pyrxd.gravity.radiant_leg import RadiantChainIO, RadiantCovenantLeg, RxinDexerRefAdapter
 from pyrxd.gravity.swap_coordinator import CoordinatorConfig, MarginPolicy, SwapCoordinator
 from pyrxd.gravity.swap_state import NegotiatedTerms, SwapRecord, SwapState
@@ -158,6 +160,23 @@ def _build_terms_and_covenant(args, *, eth_timeout: int, minted=None):
         asset_variant = "nft"
         genesis_ref = GlyphRef(txid=minted.genesis_txid, vout=minted.genesis_vout).to_bytes()
         radiant_amount = args.nft_carrier_photons
+    elif args.asset_variant == "ft":
+        if minted is None:
+            raise SystemExit("internal: the FT path must mint the FT before building the covenant")
+        # FT covenant: the FT VALUE flows whole into the covenant (conservation), so radiant_amount ==
+        # the minted FT amount — NOT an independent carrier. Genesis ref = the commit outpoint.
+        cov = build_htlc_covenant_ft(
+            genesis_txid=minted.genesis_txid,
+            genesis_vout=minted.genesis_vout,
+            amount=minted.ft_amount,
+            taker_pkh=taker_pkh,
+            maker_pkh=maker_pkh,
+            hashlock=h,
+            refund_csv=t_rxd.value,
+        )
+        asset_variant = "ft"
+        genesis_ref = GlyphRef(txid=minted.genesis_txid, vout=minted.genesis_vout).to_bytes()
+        radiant_amount = minted.ft_amount
     else:
         cov = build_htlc_covenant_rxd(
             amount=args.rxd_photons, taker_pkh=taker_pkh, maker_pkh=maker_pkh, hashlock=h, refund_csv=t_rxd.value
@@ -312,6 +331,18 @@ async def run_sepolia_dust(args: argparse.Namespace) -> None:
                 poll_s=args.confirm_poll_s,
             )
         print(f"  minted NFT genesis ref: {minted.ref_str}")
+    elif args.asset_variant == "ft":
+        print("\n  --- FT path: minting a fresh throwaway Glyph FT on RXD MAINNET (commit→reveal premine) ---")
+        minted = mint_ft_inline(
+            rxd_client,
+            name=args.ft_name,
+            ticker=args.ft_ticker,
+            premine_amount=args.ft_premine_photons,
+            fee_photons=args.rxd_mint_fee_photons,
+            confirm_fn=lambda m: confirm(m, auto_yes=args.yes),
+            poll_s=args.confirm_poll_s,
+        )
+        print(f"  minted FT genesis ref: {minted.ref_str}  ({minted.ft_amount} units)")
     # eth_timeout starts AFTER the (slow, multi-block) mint, so the full window is available for the swap.
     eth_timeout = int(time.time()) + args.eth_timeout_s
     terms, cov, p_secret, h, _rkeys = _build_terms_and_covenant(args, eth_timeout=eth_timeout, minted=minted)
@@ -339,9 +370,11 @@ async def run_sepolia_dust(args: argparse.Namespace) -> None:
                 "rxd_covenant_spk": cov.funded_spk.hex(),
                 "t_rxd_blocks": terms.t_rxd.value,
                 "asset_variant": args.asset_variant,
-                "nft_genesis_ref": minted.ref_str if minted else None,
-                "nft_owner_wif": minted.owner_key.wif() if minted else None,
-                "nft_reveal_value": minted.reveal_value if minted else None,
+                "asset_genesis_ref": minted.ref_str if minted else None,
+                "asset_owner_wif": minted.owner_key.wif() if minted else None,
+                # NFT carries reveal_value; FT carries ft_amount — persist whichever the mint produced.
+                "asset_reveal_value": getattr(minted, "reveal_value", None) if minted else None,
+                "asset_ft_amount": getattr(minted, "ft_amount", None) if minted else None,
                 "note": "ALL run state for recovery/sweep incl preimage p. mode 600 — delete after sweep.",
             },
             indent=2,
@@ -433,6 +466,15 @@ async def run_sepolia_dust(args: argparse.Namespace) -> None:
                 minted=minted,
                 covenant_spk=cov.funded_spk,
                 carrier_photons=args.nft_carrier_photons,
+                fee_photons=args.rxd_mint_fee_photons,
+                confirm_fn=lambda m: confirm(m, auto_yes=args.yes),
+                poll_s=args.confirm_poll_s,
+            )
+        elif args.asset_variant == "ft":
+            lock_ft_into_covenant(
+                rxd_client,
+                minted=minted,
+                covenant_spk=cov.funded_spk,
                 fee_photons=args.rxd_mint_fee_photons,
                 confirm_fn=lambda m: confirm(m, auto_yes=args.yes),
                 poll_s=args.confirm_poll_s,
@@ -537,7 +579,10 @@ def _args() -> argparse.Namespace:
     ap.add_argument("--rxd-wallet", default="")
     ap.add_argument("--t-rxd-blocks", type=int, default=60)
     # asset: plain RXD (default) or a freshly-minted NFT Glyph (Glyph↔ETH).
-    ap.add_argument("--asset-variant", choices=("rxd", "nft"), default="rxd")
+    ap.add_argument("--asset-variant", choices=("rxd", "nft", "ft"), default="rxd")
+    ap.add_argument("--ft-name", default="ETH-RXD-REAL-FT")
+    ap.add_argument("--ft-ticker", default="ERFT")
+    ap.add_argument("--ft-premine-photons", type=int, default=10_000_000)  # FT supply = covenant-locked amount (1 photon = 1 unit)
     ap.add_argument("--rxd-indexer-ws", default="", help="OPTIONAL glyph-enabled ElectrumX ws/wss URL for the NFT REF gate; if omitted, resolve via the REST api over ssh-tr")
     ap.add_argument("--rxd-indexer-insecure", action="store_true", help="allow a non-TLS RXinDexer ws")
     ap.add_argument("--rxd-ssh-host", default="tr", help="ssh host for the RXinDexer REST REF gate (default tr)")

--- a/scripts/eth_swap_run.py
+++ b/scripts/eth_swap_run.py
@@ -48,6 +48,7 @@ from _dust_swap_shared import (
     rxd_blockcount,
 )
 from _glyph_mainnet import (  # scripts/ sibling (NFT + FT paths)
+    load_minted_ft,
     load_minted_nft,
     lock_ft_into_covenant,
     lock_singleton_into_covenant,
@@ -332,16 +333,22 @@ async def run_sepolia_dust(args: argparse.Namespace) -> None:
             )
         print(f"  minted NFT genesis ref: {minted.ref_str}")
     elif args.asset_variant == "ft":
-        print("\n  --- FT path: minting a fresh throwaway Glyph FT on RXD MAINNET (commit→reveal premine) ---")
-        minted = mint_ft_inline(
-            rxd_client,
-            name=args.ft_name,
-            ticker=args.ft_ticker,
-            premine_amount=args.ft_premine_photons,
-            fee_photons=args.rxd_mint_fee_photons,
-            confirm_fn=lambda m: confirm(m, auto_yes=args.yes),
-            poll_s=args.confirm_poll_s,
-        )
+        if args.ft_reuse_reveal_txid:
+            if not args.ft_owner_wif:
+                raise SystemExit("--ft-reuse-reveal-txid requires --ft-owner-wif (to spend the FT)")
+            print(f"\n  --- FT path: REUSING already-minted FT at reveal {args.ft_reuse_reveal_txid} (no mint) ---")
+            minted = load_minted_ft(rxd_client, reveal_txid=args.ft_reuse_reveal_txid, owner_wif=args.ft_owner_wif)
+        else:
+            print("\n  --- FT path: minting a fresh throwaway Glyph FT on RXD MAINNET (commit→reveal premine) ---")
+            minted = mint_ft_inline(
+                rxd_client,
+                name=args.ft_name,
+                ticker=args.ft_ticker,
+                premine_amount=args.ft_premine_photons,
+                fee_photons=args.rxd_mint_fee_photons,
+                confirm_fn=lambda m: confirm(m, auto_yes=args.yes),
+                poll_s=args.confirm_poll_s,
+            )
         print(f"  minted FT genesis ref: {minted.ref_str}  ({minted.ft_amount} units)")
     # eth_timeout starts AFTER the (slow, multi-block) mint, so the full window is available for the swap.
     eth_timeout = int(time.time()) + args.eth_timeout_s
@@ -402,12 +409,12 @@ async def run_sepolia_dust(args: argparse.Namespace) -> None:
         min_confirmations=1,
         audit_cleared=True,
     )
-    # NFT: the REAL RXinDexer is the genesis-ref authenticity oracle (R1 fake-singleton defense).
-    # Plain RXD has no ref → no indexer needed. Default to the REST adapter over ssh-tr (the mainnet
-    # deployment runs only the HTTP api, no glyph electrumx ws); use the electrumx-ws adapter only
-    # when a --rxd-indexer-ws is explicitly given (e.g. a glyph-enabled electrumx).
+    # NFT/FT both carry a genesis ref → the REAL RXinDexer is the genesis-ref authenticity oracle
+    # (R1 fake-singleton defense). Plain RXD has no ref → no indexer needed. Default to the REST
+    # adapter over ssh-tr (the mainnet deployment runs only the HTTP api, no glyph electrumx ws);
+    # use the electrumx-ws adapter only when a --rxd-indexer-ws is explicitly given.
     indexer = None
-    if args.asset_variant == "nft":
+    if args.asset_variant in ("nft", "ft"):
         chain_io = RadiantChainIO(rxd_client)
         if args.rxd_indexer_ws:
             ex = ElectrumXClient(urls=[args.rxd_indexer_ws], allow_insecure=args.rxd_indexer_insecure)
@@ -583,6 +590,8 @@ def _args() -> argparse.Namespace:
     ap.add_argument("--ft-name", default="ETH-RXD-REAL-FT")
     ap.add_argument("--ft-ticker", default="ERFT")
     ap.add_argument("--ft-premine-photons", type=int, default=10_000_000)  # FT supply = covenant-locked amount (1 photon = 1 unit)
+    ap.add_argument("--ft-reuse-reveal-txid", default="", help="reuse an already-minted FT at this reveal txid (skip minting)")
+    ap.add_argument("--ft-owner-wif", default="", help="owner WIF for --ft-reuse-reveal-txid (spends the FT into the covenant)")
     ap.add_argument("--rxd-indexer-ws", default="", help="OPTIONAL glyph-enabled ElectrumX ws/wss URL for the NFT REF gate; if omitted, resolve via the REST api over ssh-tr")
     ap.add_argument("--rxd-indexer-insecure", action="store_true", help="allow a non-TLS RXinDexer ws")
     ap.add_argument("--rxd-ssh-host", default="tr", help="ssh host for the RXinDexer REST REF gate (default tr)")


### PR DESCRIPTION
## What

Adds the **FT (fungible-token) asset variant** to the ETH↔RXD atomic-swap harness, alongside the RXD + NFT variants that landed in #166. Proven end-to-end: a regtest mint→lock→claim round-trip, then a real dust **FT↔ETH swap on Radiant mainnet ↔ Sepolia**.

## Changes

- **`scripts/_glyph_mainnet.py`**: `mint_ft_inline` (commit→reveal premine; genesis ref = the COMMIT outpoint parsed from the holder's `bd d0 <ref>`), `lock_ft_into_covenant` (the FT value flows WHOLE into the covenant — it shares the FT's `codeScriptHash` via the appended `bd d0 <ref> epilogue` — so the miner fee comes from a SEPARATE plain-RXD input, with a size-based fee to clear mainnet min-relay), `load_minted_ft` (reuse/resume), and the `MintedFt` record.
- **`scripts/eth_swap_run.py`**: `--asset-variant ft`; the FT mint + lock branches; `build_htlc_covenant_ft` in `_build_terms_and_covenant` (radiant_amount == the minted FT amount); the REST REF adapter wired for `ft` (not just `nft`); `--ft-*` + `--ft-reuse-*` args; recovery-file fields generalized (`asset_*` + `ft_amount`).
- **docs**: `~/`-path lint fix in the rxindexer compound doc.

## Bugs found + fixed running the first mainnet FT swap (each caught fail-closed; no value lost)

1. The REST REF adapter was only wired for `nft`, so the FT path got `indexer=None` and the pre-lock gate refused funding (`indexer does not implement resolve_ref`). Wire it for both.
2. The FT lock paid a flat fee that fell under mainnet min-relay (the 2-input lock is ~600 B vs the sub-kB mint txs) → `min relay fee not met`. Now sized from the signed tx (re-proven on regtest).
3. Added FT reuse so an aborted run resumes from the already-mature FT instead of re-minting (mirrors the NFT reuse path from #166).

## Real-chain validation (dust)

Regtest-proven first (mint→lock→claim on `radiant-core:v2.3.0`), then the mainnet↔Sepolia dust swap — completed and verified on both chains:

| Leg | Chain | Txid / address |
| --- | --- | --- |
| FT minted (10M-unit supply) | Radiant mainnet | `e36c5503e4d4398ce1ed762e94d9f021c0f64901f008135f31d33e10d49ced23` |
| FT locked → covenant | Radiant mainnet | `f5af3a3f9da2aecb0c667c7d8f2172e9f14bdf7879f8f919bed633fefe9d963c` |
| FT claimed by taker | Radiant mainnet | `db97f0d1bd6e8d7eb03e4d6e36e49ff378852552455fb3d942b5d493ff929b51` |
| ETH HTLC | Sepolia | `0x5a2D2084f19F85A676fa6872069760aA0e54EAF0` |
| ETH claim (reveals preimage) | Sepolia | `0x67a338bd4ba53eb2fa307626eb86ac14bbc6910e9b5a7e31317d8c2194f295ad` |

Outcome: the FT settled to the taker, the ETH HTLC drained to the maker; the reorg gate held the FT claim until the Sepolia claim finalized.

## Tests

- Regtest FT mint→lock→claim round-trip proven; REF-gate / covenant unit tests green; `ruff` clean.

## Caveats

- **Pre-external-audit**; dust-only validation. The ETH leg runs on the **Sepolia testnet**; the Radiant side is mainnet. These are operator run scripts, not new library API.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
