### PR TITLE
feat(watchtower): production keyless RpcEthChainSource (alert-only v3 ETH)

### DIFF
--- a/scripts/watchtower_run.py
+++ b/scripts/watchtower_run.py
@@ -13,6 +13,8 @@ Backends:
               ``get_transaction_verbose(txid)`` via :func:`build_reconciler`.
 * BTC depth — ``MultiSourceBtcFundingReader`` (2-of-3 Esplora, conservative min depth).
 * BTC claim — mempool.space ``/outspend`` (detect the maker's claim of the HTLC outpoint).
+* ETH       — optional ``--eth-rpc-url`` (+ ``--eth-chain-id``): a keyless, read-only RPC to watch
+              RXD<->ETH swaps (detect the maker's ``Claimed`` event, finalized-checkpoint verdict).
 
 Example:
     python scripts/watchtower_run.py \
@@ -46,6 +48,7 @@ from pyrxd.gravity.watch import (
     LoggingAlertChannel,
     OutspendBtcClaimSource,
     Reconciler,
+    RpcEthChainSource,
     WebhookAlertChannel,
     combine_heartbeats,
     default_heartbeat,
@@ -68,8 +71,13 @@ def build_reconciler(
     policy: MarginPolicy,
     safety_window_blocks: int,
     alert_channel,
+    eth_source=None,
 ) -> Reconciler:
-    """Compose the real ports into a Reconciler (pure wiring — no network at call time)."""
+    """Compose the real ports into a Reconciler (pure wiring — no network at call time).
+
+    ``eth_source`` (an :class:`RpcEthChainSource`, optional) adds the ETH counter-leg watch path so a
+    records dir holding RXD↔ETH swaps is observed too. When ``None``, ETH-direction swaps fail closed
+    (the ChainObserver pages "no EthChainSource for an ETH swap" rather than silently skipping them)."""
     store = JsonDirRecordStore(records_dir)
     rxd_source = ElectrumRxdChainSource(rxd_client)
 
@@ -83,7 +91,8 @@ def build_reconciler(
 
     outspend_fns = [_make_outspend(u) for u in mempool_base_urls]
     btc_source = OutspendBtcClaimSource(outspend_fns=outspend_fns, funding_reader=btc_funding_reader)
-    observer = ChainObserver(btc=btc_source, rxd=rxd_source, rxd_corroborated=False)  # v1: RXD single-source
+    # v1/v3: RXD (and the single ETH RPC, if any) are single-source → every page is low-corroboration.
+    observer = ChainObserver(btc=btc_source, eth=eth_source, rxd=rxd_source, rxd_corroborated=False)
     alerter = DedupAlerter(channel=alert_channel)
     return Reconciler(
         store=store,
@@ -106,6 +115,28 @@ async def _build_rxd_client(args: argparse.Namespace, stack: contextlib.AsyncExi
     return await stack.enter_async_context(
         ElectrumXClient([args.rxd_electrumx_url], allow_insecure=args.allow_insecure)
     )
+
+
+async def _build_eth_source(args: argparse.Namespace, stack: contextlib.AsyncExitStack):
+    """Optional ETH counter-leg source (alert-only v3): a keyless, read-only ``RpcEthChainSource``
+    over ``EthRpc``. Returns ``None`` when ``--eth-rpc-url`` is unset (a BTC-only tower). Fails closed
+    on a wrong network (``assert_chain``) so the tower never watches the wrong chain, and registers
+    the RPC's ``close()`` on the exit stack. No key, no broadcast — read-only observation only."""
+    if not args.eth_rpc_url:
+        return None
+    if not args.eth_chain_id:
+        raise SystemExit("--eth-chain-id is required with --eth-rpc-url")
+    from pyrxd.eth_wallet.rpc import EthRpc
+
+    rpc = EthRpc(args.eth_rpc_url, expected_chain_id=args.eth_chain_id)
+    stack.push_async_callback(rpc.close)
+    await rpc.assert_chain()  # fail closed if the endpoint is not the negotiated chain
+    logger.info(
+        "ETH counter-leg watch ENABLED: rpc=%s chain_id=%d (read-only, no key, single-source → low-corroboration)",
+        args.eth_rpc_url,
+        args.eth_chain_id,
+    )
+    return RpcEthChainSource(rpc)
 
 
 def _policy_from_args(args: argparse.Namespace) -> MarginPolicy:
@@ -160,6 +191,18 @@ def _parse_args(argv=None) -> argparse.Namespace:
     p.add_argument("--webhook-secret", help="optional HMAC-SHA256 secret -> X-Watchtower-Signature header")
     # #2 dead-man's switch: write a liveness file each tick (watched by watchtower_deadman.py)
     p.add_argument("--heartbeat-file", help="write a liveness heartbeat here each tick")
+    # ETH counter-leg (alert-only v3): watch RXD↔ETH swaps too. Read-only, no key, never touches p.
+    p.add_argument(
+        "--eth-rpc-url",
+        help="Ethereum RPC URL to watch RXD<->ETH swaps (read-only; enables the ETH counter-leg source). "
+        "Single-source in v1 → ETH pages are low-corroboration. Requires --eth-chain-id.",
+    )
+    p.add_argument(
+        "--eth-chain-id",
+        type=int,
+        help="expected EIP-155 chain id for --eth-rpc-url (e.g. 1 mainnet, 11155111 Sepolia); "
+        "the tower fails closed if the endpoint reports a different chain",
+    )
     return p.parse_args(argv)
 
 
@@ -209,6 +252,7 @@ async def _amain(argv=None) -> int:
     async with contextlib.AsyncExitStack() as stack:
         http_session = await stack.enter_async_context(aiohttp.ClientSession())
         rxd_client = await _build_rxd_client(args, stack)
+        eth_source = await _build_eth_source(args, stack)
         reconciler = build_reconciler(
             records_dir=args.records_dir,
             rxd_client=rxd_client,
@@ -218,6 +262,7 @@ async def _amain(argv=None) -> int:
             policy=policy,
             safety_window_blocks=args.safety_window_blocks,
             alert_channel=_build_alert_channel(args, http_session),
+            eth_source=eth_source,
         )
         heartbeat = default_heartbeat(logger)
         if args.heartbeat_file:

--- a/src/pyrxd/eth_wallet/rpc.py
+++ b/src/pyrxd/eth_wallet/rpc.py
@@ -19,6 +19,7 @@ from pyrxd.security.errors import NetworkError, ValidationError
 __all__ = ["EthRpc"]
 
 _MAX_RESPONSE_BYTES = 10 * 1024 * 1024  # 10 MB cap, matching the BTC client
+_MAX_LOG_ENTRIES = 10_000  # bound an eth_getLogs return (a per-contract query yields a handful)
 
 
 def _require_web3() -> Any:
@@ -155,6 +156,21 @@ class EthRpc:
         except Exception as exc:
             raise NetworkError(f"eth_getTransactionByHash failed: {exc}") from exc
 
+    async def get_transaction_receipt(self, tx_hash: str) -> dict[str, Any] | None:
+        """A single NON-BLOCKING receipt fetch (`eth_getTransactionReceipt`). Returns ``None`` when
+        the tx is not currently mined — pending, or reorg-orphaned back to the mempool — instead of
+        blocking like :meth:`wait_receipt` (a poller must never sleep inside one read). A transport
+        failure is still a :class:`NetworkError` (fail-closed)."""
+        web3 = _require_web3()
+        try:
+            r = await self._w3.eth.get_transaction_receipt(tx_hash)
+        except Exception as exc:
+            not_found = getattr(web3.exceptions, "TransactionNotFound", None)
+            if not_found is not None and isinstance(exc, not_found):
+                return None
+            raise NetworkError(f"eth_getTransactionReceipt failed: {exc}") from exc
+        return dict(r)
+
     async def finalized_block_number(self) -> int:
         """Block number of the `finalized` consensus checkpoint (the reorg-safe tip).
 
@@ -185,6 +201,34 @@ class EthRpc:
             raise NetworkError(f"eth_getBlockByNumber({block_number}) failed: {exc}") from exc
         h = blk.get("hash")
         return bytes(h) if h is not None else b""
+
+    async def get_logs(
+        self,
+        *,
+        address: str,
+        topics: list[str | None | list[str]] | None = None,
+        from_block: int | str = "earliest",
+        to_block: int | str = "latest",
+    ) -> list[dict[str, Any]]:
+        """`eth_getLogs` for ONE contract address, optionally filtered by ``topics``. READ-ONLY.
+
+        Scoped to a single address (the per-swap-unique HTLC), so the result is that contract's own
+        event history — a handful of entries. Pass an int ``from_block`` (e.g. the deploy block) to
+        bound the scan; ``to_block="latest"`` catches a JUST-mined claim. Detection deliberately reads
+        to ``latest``, not ``finalized``: a watchtower must not MISS a fresh claim it has to race, and
+        reorg-safety is asserted SEPARATELY by the finalized-checkpoint verdict (a non-final log can
+        only ever cause a false PAGE, never a broadcast). Transport failure → :class:`NetworkError`;
+        the entry count is bounded (a pathological return must not OOM the tower)."""
+        filt: dict[str, Any] = {"address": address, "fromBlock": from_block, "toBlock": to_block}
+        if topics is not None:
+            filt["topics"] = topics
+        try:
+            raw = await self._w3.eth.get_logs(filt)
+        except Exception as exc:
+            raise NetworkError(f"eth_getLogs failed: {exc}") from exc
+        if len(raw) > _MAX_LOG_ENTRIES:
+            raise NetworkError(f"eth_getLogs returned {len(raw)} entries (> {_MAX_LOG_ENTRIES} cap); refusing")
+        return [dict(log) for log in raw]
 
     async def close(self) -> None:
         """Close the underlying provider session if it exposes one."""

--- a/src/pyrxd/gravity/watch/__init__.py
+++ b/src/pyrxd/gravity/watch/__init__.py
@@ -43,6 +43,7 @@ from pyrxd.gravity.watch.decide import (
     Observations,
     decide,
 )
+from pyrxd.gravity.watch.eth_adapters import RpcEthChainSource
 from pyrxd.gravity.watch.heartbeat import (
     DeadMansSwitch,
     DeadManVerdict,
@@ -92,6 +93,7 @@ __all__ = [
     "ReconcileResult",
     "Reconciler",
     "RecordStore",
+    "RpcEthChainSource",
     "RxdChainSource",
     "Severity",
     "WebhookAlertChannel",

--- a/src/pyrxd/gravity/watch/eth_adapters.py
+++ b/src/pyrxd/gravity/watch/eth_adapters.py
@@ -1,0 +1,140 @@
+"""Production ETH counter-leg transport for the watchtower — keyless, read-only (alert-only v3).
+
+:class:`RpcEthChainSource` satisfies the :class:`~pyrxd.gravity.watch.quorum.EthChainSource`
+port against a live Ethereum RPC, built on the **keyless** :class:`~pyrxd.eth_wallet.rpc.EthRpc`
+(which holds no signing key). It is the ETH analogue of ``OutspendBtcClaimSource`` and keeps the
+same alert-only invariant the rest of the tower does: it broadcasts nothing, holds no key, and
+**never reads the preimage ``p``** — the operator scrapes ``p`` from the maker's claim after a page.
+
+Two reads back the port:
+
+* ``claim_status`` — detects the maker's claim from the on-chain event log on the per-swap-unique
+  HTLC contract. Because each swap deploys a FRESH contract at a unique address, ANY log from that
+  address is swap activity (``p`` sits in a ``Claimed`` event's data — the tower never touches it).
+  Detection is SELECTOR-AGNOSTIC and FAILS TOWARD PAGING, mirroring the audited path
+  (``assert_claim_provenance`` scans every log from the contract, not one pinned selector): a
+  ``Claimed(bytes32)`` log is the canonical claim; a contract emitting ONLY ``Refunded()`` is not a
+  claim (the maker never revealed ``p``); any OTHER/unrecognised log on our per-swap contract is
+  treated as a claim so a differently-shaped event can never SILENTLY MISS one — over-paging on an
+  odd event is a false alarm (LOW for an alert-only tower), a missed claim is the forbidden failure.
+  The scan is bounded to the contract's lifetime (deploy block → chain head) and reads to ``latest``
+  so a just-mined claim is not missed; reorg-safety lives in the finality verdict, not detection.
+  KNOWN LIMITATION: a non-canonical contract that emits NO event at all on ``claim()`` cannot be
+  detected from logs (the canonical ``EthHtlc.sol`` DOES emit ``Claimed(bytes32)`` — deploy a
+  Claimed-emitting model). DETECTION is also single-source in v1, exactly like the verdict below —
+  a lagging/withholding sole RPC can DELAY a page (the per-tick re-scan recovers it); a multi-source
+  ETH detection+finality quorum is an audit-gated v2 requirement.
+
+* ``claim_finality_verdict`` — the post-Merge ``finalized``-checkpoint verdict. Its VERDICT LOGIC
+  (status → canonical-chain binding (fail-closed) → ``finalized`` checkpoint) is **identical** to the
+  audited ``EthHtlcContractLeg.claim_finality_verdict`` (``eth_wallet/htlc_leg.py``), reproduced here
+  ONLY so the alert-only tower needs no key (that leg's constructor mandates ``PrivateKeyMaterial``).
+  A differential parity test (``test_watch_eth_adapter.py::test_finality_verdict_parity_with_audited_leg``)
+  pins the two to agree on the verdict for any given receipt, so the LOGIC cannot silently drift. The
+  one deliberate difference is the receipt FETCH: the tower polls on its own interval, so it uses a
+  NON-BLOCKING ``get_transaction_receipt`` (a reorg-orphaned/not-yet-mined claim → ``NOT_YET_FINAL_LIVE``
+  → re-detect next tick) instead of the leg's blocking ``wait_receipt`` — a single read must never
+  sleep a whole reconcile tick. Single-source RPC in v1: a false read causes a false PAGE, never a
+  false broadcast (a multi-source ETH finality quorum is the audit-gated v2 requirement). A
+  multi-chain records dir watched by a single ``--eth-rpc-url`` fails CLOSED, not open: the deploy tx
+  is not found on the wrong chain → ``NetworkError`` → the reconciler pages a decision-required.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from pyrxd.eth_wallet.rpc import EthRpc
+from pyrxd.gravity.finality import CounterClaimFinality, CounterClaimState
+from pyrxd.gravity.watch.quorum import EthClaimStatus
+from pyrxd.security.errors import NetworkError
+
+__all__ = ["CLAIMED_TOPIC0", "REFUNDED_TOPIC0", "RpcEthChainSource"]
+
+# Pinned EthHtlc.sol event selectors (verified against web3 keccak by test_event_selectors_match_keccak):
+#   keccak256("Claimed(bytes32)")  — the canonical claim event; p is in the (non-indexed) log data.
+#   keccak256("Refunded()")        — the refund event; emitted when the maker did NOT reveal p.
+# Detection is selector-AGNOSTIC (see the module docstring) — these only refine which logs are a claim
+# vs a refund so a refund does not over-page, while an unrecognised event still fails toward paging.
+CLAIMED_TOPIC0 = "0xeddf608ef698454af2fb41c1df7b7e5154ff0d46969f895e0f39c7dfe7e6380a"
+REFUNDED_TOPIC0 = "0x8616bbbbad963e4e65b1366f1d75dfb63f9e9704bbbf91fb01bec70849906cf7"
+
+
+def _to_0x_hash(value: object) -> str:
+    """Normalise a web3 tx-hash to a 0x-prefixed hex string (what :class:`EthClaimStatus` requires).
+    web3 returns hashes as ``HexBytes`` (a ``bytes`` subclass) or, for raw-JSON RPCs, as a ``str``;
+    both are handled. Any other type raises here rather than being coerced into a non-0x string that
+    would only fail far downstream."""
+    if isinstance(value, str):
+        return value if value.startswith("0x") else "0x" + value
+    if isinstance(value, (bytes, bytearray)):  # web3 HexBytes is a bytes subclass
+        return "0x" + bytes(value).hex()
+    raise NetworkError(f"cannot normalise tx-hash of type {type(value).__name__!r} to a 0x-hex string")
+
+
+def _topic0(log: dict[str, Any]) -> str | None:
+    """The 0x-hex of a log's first topic (event selector), or ``None`` if it has no topics."""
+    topics = log.get("topics") or []
+    if not topics:
+        return None
+    return _to_0x_hash(topics[0]).lower()
+
+
+class RpcEthChainSource:
+    """``EthChainSource`` over a keyless :class:`EthRpc` (read-only, no key, never touches ``p``)."""
+
+    def __init__(self, rpc: EthRpc) -> None:
+        self._rpc = rpc
+
+    async def claim_status(self, contract_address: str, deploy_tx_hash: str) -> EthClaimStatus:
+        # Bound the log scan to the contract's lifetime. A pending/unmined deploy (no blockNumber)
+        # means the HTLC contract is not on-chain yet, so nothing can have claimed it → unclaimed.
+        # On the WRONG chain the deploy tx is not found → get_transaction raises → fail-closed page.
+        deploy = await self._rpc.get_transaction(deploy_tx_hash)
+        deploy_block = deploy.get("blockNumber")
+        if deploy_block is None:
+            return EthClaimStatus(claimed=False)
+        # Selector-AGNOSTIC scan of every log from this per-swap-unique contract (NO topic filter),
+        # bounded [deploy_block, latest]. A claim can only occur at/after the contract exists, so
+        # from_block can never exclude the claim; reading to latest catches a just-mined claim.
+        logs = await self._rpc.get_logs(address=contract_address, from_block=int(deploy_block), to_block="latest")
+        if not logs:
+            return EthClaimStatus(claimed=False)
+        claimed_logs = [lg for lg in logs if _topic0(lg) == CLAIMED_TOPIC0]
+        if claimed_logs:
+            chosen = claimed_logs[-1]  # canonical Claimed(bytes32) — the precise claim tx
+        elif all(_topic0(lg) == REFUNDED_TOPIC0 for lg in logs):
+            return EthClaimStatus(claimed=False)  # only Refunded() — the maker did NOT reveal p
+        else:
+            # An unrecognised event from OUR per-swap contract. Fail TOWARD paging: a differently
+            # shaped claim event must never be silently missed (over-paging is a false alarm only).
+            chosen = logs[-1]
+        tx_hash = chosen.get("transactionHash")
+        if tx_hash is None:
+            raise NetworkError("a log from the HTLC contract is missing transactionHash; cannot identify the claim")
+        return EthClaimStatus(claimed=True, claim_tx_hash=_to_0x_hash(tx_hash))
+
+    async def claim_finality_verdict(self, claim_tx_hash: str) -> CounterClaimFinality:
+        # VERDICT LOGIC identical to EthHtlcContractLeg.claim_finality_verdict (htlc_leg.py:438-460),
+        # pinned by test_finality_verdict_parity_with_audited_leg. The ONE deliberate difference: a
+        # NON-BLOCKING receipt read (the tower polls; it must never sleep a whole tick) — a not-yet-
+        # mined / reorg-orphaned claim → NOT_YET_FINAL_LIVE (re-detect next tick), not a 300s block.
+        receipt = await self._rpc.get_transaction_receipt(claim_tx_hash)
+        if receipt is None:
+            return CounterClaimFinality(state=CounterClaimState.NOT_YET_FINAL_LIVE)
+        if int(receipt.get("status", 0)) != 1:
+            return CounterClaimFinality(state=CounterClaimState.NOT_YET_FINAL_LIVE)
+        tx_block = int(receipt["blockNumber"])
+        # Bind the receipt to the canonical chain, FAIL-CLOSED: a lying receipt blockNumber is caught
+        # when its blockHash != the canonical hash at that height; a MISSING receipt blockHash or an
+        # EMPTY canonical hash means "cannot prove canonicality" → NOT_YET_FINAL_LIVE, never FINAL.
+        receipt_hash = receipt.get("blockHash")
+        if receipt_hash is None:
+            return CounterClaimFinality(state=CounterClaimState.NOT_YET_FINAL_LIVE)
+        canonical = await self._rpc.canonical_block_hash(tx_block)
+        if not canonical or bytes(receipt_hash) != canonical:
+            return CounterClaimFinality(state=CounterClaimState.NOT_YET_FINAL_LIVE)
+        finalized = await self._rpc.finalized_block_number()  # rejects finalized > head (fail-closed)
+        if tx_block <= finalized:
+            return CounterClaimFinality(state=CounterClaimState.FINAL)
+        return CounterClaimFinality(state=CounterClaimState.NOT_YET_FINAL_LIVE)

--- a/tests/test_watch_eth_adapter.py
+++ b/tests/test_watch_eth_adapter.py
@@ -1,0 +1,399 @@
+"""Tests for the production ETH counter-leg transport (``gravity.watch.eth_adapters``)
+and the read-only ``EthRpc.get_logs`` / ``get_transaction_receipt`` primitives it is built on.
+
+Coverage:
+* ``EthRpc.get_logs`` — filter shape, transport-failure → NetworkError, entry-count bound.
+* ``EthRpc.get_transaction_receipt`` — non-blocking fetch, not-found → None, error → NetworkError.
+* ``RpcEthChainSource.claim_status`` — SELECTOR-AGNOSTIC, fail-toward-paging detection: canonical
+  Claimed wins, Refunded-only is not a claim, an unrecognised event still pages (never a silent miss),
+  unclaimed/pending-deploy, tx-hash normalisation, the eth_getLogs filter args (no topic filter).
+* ``RpcEthChainSource.claim_finality_verdict`` — the verdict branches, the non-blocking not-found
+  branch, RPC-error propagation, AND a DIFFERENTIAL PARITY test asserting the VERDICT LOGIC agrees
+  with the audited ``EthHtlcContractLeg.claim_finality_verdict`` for any given receipt (the parity is
+  over the verdict LOGIC, not the receipt-fetch strategy — the tower polls non-blocking by design).
+* protocol conformance + an end-to-end ChainObserver→decide run through the REAL adapter.
+
+The tower is ALERT-ONLY: these reads hold no key, sign nothing, and never read the preimage ``p``.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from pyrxd.eth_wallet.htlc_leg import EthHtlcContractLeg
+from pyrxd.eth_wallet.rpc import _MAX_LOG_ENTRIES, EthRpc
+from pyrxd.gravity.finality import CounterClaimState
+from pyrxd.gravity.swap_state import SwapState
+from pyrxd.gravity.watch import ChainObserver, EthChainSource, Intent, RpcEthChainSource, decide
+from pyrxd.gravity.watch.eth_adapters import CLAIMED_TOPIC0, REFUNDED_TOPIC0, _to_0x_hash
+from pyrxd.security.errors import NetworkError
+from pyrxd.security.secrets import PrivateKeyMaterial
+from tests.test_watch_quorum import FakeRxd, _eth_policy, _eth_record
+
+_CONTRACT = "0x" + "ab" * 20
+_DEPLOY = "0x" + "cd" * 32
+_CLAIM_HASH = "0x" + "12" * 32
+_OTHER_HASH = "0x" + "99" * 32
+
+
+# ─────────────────────────────────────────────────────────── fakes ──
+
+
+class _FakeEthRpc:
+    """Minimal fake exposing the read-only methods ``RpcEthChainSource`` uses (plus ``wait_receipt``
+    so the audited leg can run against the SAME fake in the parity test).
+
+    ``claim_status`` drivers: ``deploy_block`` (None = unmined deploy) + ``logs``.
+    ``claim_finality_verdict`` drivers: ``receipt_found`` (False ⇒ get_transaction_receipt None),
+    ``receipt_error`` / ``finalized_error`` (raise), ``status`` / ``block`` / ``finalized`` /
+    ``block_hash`` (None ⇒ receipt omits blockHash) / ``canonical`` (None ⇒ node returns empty hash).
+    ``canonical_block_hash`` is HEIGHT-SENSITIVE: it returns the configured hash ONLY at ``block``,
+    a non-matching hash at any other height — so a wrong-height bind fails the parity test."""
+
+    def __init__(
+        self,
+        *,
+        deploy_block: int | None = 10,
+        logs: list | None = None,
+        receipt_found: bool = True,
+        receipt_error: Exception | None = None,
+        finalized_error: Exception | None = None,
+        status: int = 1,
+        block: int = 100,
+        finalized: int = 120,
+        block_hash: bytes | None = b"\x11" * 32,
+        canonical: bytes | None = b"\x11" * 32,
+    ) -> None:
+        self._deploy_block = deploy_block
+        self._logs = logs if logs is not None else []
+        self._receipt_found, self._receipt_error = receipt_found, receipt_error
+        self._finalized_error = finalized_error
+        self._status, self._block, self._finalized = status, block, finalized
+        self._bh, self._canonical = block_hash, canonical
+        self.get_logs_calls: list[dict] = []
+
+    async def get_transaction(self, tx_hash):
+        return {"blockNumber": self._deploy_block}
+
+    async def get_logs(self, *, address, topics=None, from_block="earliest", to_block="latest"):
+        self.get_logs_calls.append(
+            {"address": address, "topics": topics, "from_block": from_block, "to_block": to_block}
+        )
+        return list(self._logs)
+
+    def _receipt(self) -> dict:
+        r: dict = {"status": self._status, "blockNumber": self._block}
+        if self._bh is not None:
+            r["blockHash"] = self._bh
+        return r
+
+    async def get_transaction_receipt(self, tx_hash):  # non-blocking — the adapter uses this
+        if self._receipt_error is not None:
+            raise self._receipt_error
+        return self._receipt() if self._receipt_found else None
+
+    async def wait_receipt(self, tx_hash):  # blocking — the audited leg uses this (parity oracle)
+        return self._receipt()
+
+    async def canonical_block_hash(self, n):
+        if n != self._block:
+            return b"\x99" * 32  # wrong height → non-matching hash (catches a wrong-height bind)
+        return self._canonical if self._canonical is not None else b""
+
+    async def finalized_block_number(self):
+        if self._finalized_error is not None:
+            raise self._finalized_error
+        return self._finalized
+
+
+class _FakeEthNs:
+    def __init__(self, *, logs=None, exc=None, receipt=None, receipt_exc=None):
+        self._logs = logs if logs is not None else []
+        self._exc = exc
+        self._receipt = receipt
+        self._receipt_exc = receipt_exc
+        self.last_filter: dict | None = None
+
+    async def get_logs(self, filt):
+        self.last_filter = filt
+        if self._exc is not None:
+            raise self._exc
+        return self._logs
+
+    async def get_transaction_receipt(self, tx_hash):
+        if self._receipt_exc is not None:
+            raise self._receipt_exc
+        return self._receipt
+
+
+class _FakeW3:
+    def __init__(self, **kw):
+        self.eth = _FakeEthNs(**kw)
+
+
+def _rpc_with(**kw) -> EthRpc:
+    """A real EthRpc with its web3 swapped for a fake (no network); construction does not connect.
+
+    Constructing EthRpc requires web3 (the optional ``eth`` extra), which CI does not install — these
+    EthRpc-I/O tests therefore SKIP there (the same pattern as the keccak tests), exactly like the
+    rest of EthRpc's transport methods. The security-critical ADAPTER logic is web3-free (fakes) and
+    is covered in CI; here we exercise the thin get_logs / get_transaction_receipt wrappers locally."""
+    pytest.importorskip("web3")
+    r = EthRpc("http://localhost:8545", expected_chain_id=1)
+    r._w3 = _FakeW3(**kw)
+    return r
+
+
+def _leg(rpc) -> EthHtlcContractLeg:
+    # Mirrors test_finality_verdict.py::_leg — the audited keyed leg, used as the parity oracle.
+    return EthHtlcContractLeg(
+        rpc=rpc,
+        signing_key=PrivateKeyMaterial.generate(),
+        chain_id=11155111,
+        artifact={"abi": [], "bytecode": "0x00", "runtime_bytecode": "0x00"},
+    )
+
+
+def _log(topic0: str | None, tx_hash: object = _CLAIM_HASH) -> dict:
+    log: dict = {"transactionHash": tx_hash}
+    if topic0 is not None:
+        log["topics"] = [topic0]
+    return log
+
+
+# ───────────────────────────────────────────────────── pinned selectors ──
+
+
+def test_event_selectors_match_keccak():
+    web3 = pytest.importorskip("web3")
+    assert web3.Web3.to_hex(web3.Web3.keccak(text="Claimed(bytes32)")) == CLAIMED_TOPIC0
+    assert web3.Web3.to_hex(web3.Web3.keccak(text="Refunded()")) == REFUNDED_TOPIC0
+
+
+def test_to_0x_hash_normalises_forms_and_rejects_others():
+    assert _to_0x_hash("0xdeadbeef") == "0xdeadbeef"
+    assert _to_0x_hash("deadbeef") == "0xdeadbeef"
+    assert _to_0x_hash(b"\xab" * 32) == "0x" + "ab" * 32
+
+    class _HexBytes(bytes):  # web3 returns tx hashes as HexBytes — a bytes subclass
+        pass
+
+    assert _to_0x_hash(_HexBytes(b"\xcd" * 32)) == "0x" + "cd" * 32
+    # an unexpected type fails loudly here, not as a confusing downstream ValidationError
+    with pytest.raises(NetworkError):
+        _to_0x_hash(None)
+    with pytest.raises(NetworkError):
+        _to_0x_hash(12345)
+
+
+# ─────────────────────────────────────────────────── EthRpc.get_logs ──
+
+
+async def test_get_logs_returns_dicts_and_builds_filter():
+    rpc = _rpc_with(logs=[{"transactionHash": b"\x12" * 32, "x": 1}])
+    out = await rpc.get_logs(address=_CONTRACT, topics=[CLAIMED_TOPIC0], from_block=5, to_block="latest")
+    assert out == [{"transactionHash": b"\x12" * 32, "x": 1}]
+    assert rpc._w3.eth.last_filter == {
+        "address": _CONTRACT,
+        "fromBlock": 5,
+        "toBlock": "latest",
+        "topics": [CLAIMED_TOPIC0],
+    }
+
+
+async def test_get_logs_omits_topics_when_none():
+    rpc = _rpc_with(logs=[])
+    await rpc.get_logs(address=_CONTRACT, from_block=0)
+    assert "topics" not in rpc._w3.eth.last_filter
+
+
+async def test_get_logs_wraps_transport_error_as_network_error():
+    rpc = _rpc_with(exc=RuntimeError("boom"))
+    with pytest.raises(NetworkError):
+        await rpc.get_logs(address=_CONTRACT)
+
+
+async def test_get_logs_bounds_entry_count():
+    rpc = _rpc_with(logs=[{} for _ in range(_MAX_LOG_ENTRIES + 1)])
+    with pytest.raises(NetworkError):
+        await rpc.get_logs(address=_CONTRACT)
+
+
+# ───────────────────────────────────────── EthRpc.get_transaction_receipt ──
+
+
+async def test_get_transaction_receipt_returns_dict():
+    rpc = _rpc_with(receipt={"status": 1, "blockNumber": 100})
+    assert await rpc.get_transaction_receipt(_CLAIM_HASH) == {"status": 1, "blockNumber": 100}
+
+
+async def test_get_transaction_receipt_none_on_not_found():
+    web3 = pytest.importorskip("web3")
+    rpc = _rpc_with(receipt_exc=web3.exceptions.TransactionNotFound("nope"))
+    assert await rpc.get_transaction_receipt(_CLAIM_HASH) is None  # non-blocking; not a 300s wait
+
+
+async def test_get_transaction_receipt_wraps_other_error():
+    rpc = _rpc_with(receipt_exc=RuntimeError("boom"))
+    with pytest.raises(NetworkError):
+        await rpc.get_transaction_receipt(_CLAIM_HASH)
+
+
+# ───────────────────────────────────────── claim_status (detection) ──
+
+
+async def test_claim_status_detects_canonical_claimed_and_scans_selector_agnostic():
+    fake = _FakeEthRpc(deploy_block=10, logs=[_log(CLAIMED_TOPIC0, _CLAIM_HASH)])
+    status = await RpcEthChainSource(fake).claim_status(_CONTRACT, _DEPLOY)
+    assert status.claimed is True
+    assert status.claim_tx_hash == _CLAIM_HASH
+    # bounded to the contract lifetime, NO topic filter (selector-agnostic — mirrors the audited path)
+    assert fake.get_logs_calls == [{"address": _CONTRACT, "topics": None, "from_block": 10, "to_block": "latest"}]
+
+
+async def test_claim_status_prefers_claimed_log_over_refunded():
+    fake = _FakeEthRpc(deploy_block=10, logs=[_log(REFUNDED_TOPIC0, _OTHER_HASH), _log(CLAIMED_TOPIC0, _CLAIM_HASH)])
+    status = await RpcEthChainSource(fake).claim_status(_CONTRACT, _DEPLOY)
+    assert status.claimed is True
+    assert status.claim_tx_hash == _CLAIM_HASH  # the Claimed log, not just the newest
+
+
+async def test_claim_status_refunded_only_is_not_a_claim():
+    fake = _FakeEthRpc(deploy_block=10, logs=[_log(REFUNDED_TOPIC0, _OTHER_HASH)])
+    status = await RpcEthChainSource(fake).claim_status(_CONTRACT, _DEPLOY)
+    assert status.claimed is False  # maker refunded — never revealed p
+
+
+async def test_claim_status_unrecognised_event_fails_toward_paging():
+    # An event from OUR per-swap contract with a non-Claimed/non-Refunded selector must NOT be a
+    # silent miss — a differently-shaped claim event still pages (over-page is a false alarm only).
+    fake = _FakeEthRpc(deploy_block=10, logs=[_log("0x" + "77" * 32, _CLAIM_HASH)])
+    status = await RpcEthChainSource(fake).claim_status(_CONTRACT, _DEPLOY)
+    assert status.claimed is True
+    assert status.claim_tx_hash == _CLAIM_HASH
+
+
+async def test_claim_status_log_without_topics_fails_toward_paging():
+    fake = _FakeEthRpc(deploy_block=10, logs=[_log(None, _CLAIM_HASH)])
+    status = await RpcEthChainSource(fake).claim_status(_CONTRACT, _DEPLOY)
+    assert status.claimed is True
+
+
+async def test_claim_status_unclaimed_when_no_logs():
+    fake = _FakeEthRpc(deploy_block=10, logs=[])
+    status = await RpcEthChainSource(fake).claim_status(_CONTRACT, _DEPLOY)
+    assert status.claimed is False
+    assert status.claim_tx_hash is None
+
+
+async def test_claim_status_pending_deploy_is_unclaimed_and_skips_log_scan():
+    fake = _FakeEthRpc(deploy_block=None, logs=[_log(CLAIMED_TOPIC0, _CLAIM_HASH)])
+    status = await RpcEthChainSource(fake).claim_status(_CONTRACT, _DEPLOY)
+    assert status.claimed is False
+    assert fake.get_logs_calls == []  # no point scanning a contract that isn't mined yet
+
+
+async def test_claim_status_normalises_hexbytes_tx_hash():
+    fake = _FakeEthRpc(deploy_block=10, logs=[_log(CLAIMED_TOPIC0, b"\x34" * 32)])
+    status = await RpcEthChainSource(fake).claim_status(_CONTRACT, _DEPLOY)
+    assert status.claimed is True
+    assert status.claim_tx_hash == "0x" + "34" * 32  # bytes → 0x-hex, satisfies EthClaimStatus
+
+
+async def test_claim_status_missing_tx_hash_raises_typed_error():
+    fake = _FakeEthRpc(deploy_block=10, logs=[{"topics": [CLAIMED_TOPIC0]}])  # no transactionHash
+    with pytest.raises(NetworkError):
+        await RpcEthChainSource(fake).claim_status(_CONTRACT, _DEPLOY)
+
+
+# ──────────────────────────────────── claim_finality_verdict branches ──
+
+_FINAL = CounterClaimState.FINAL
+_LIVE = CounterClaimState.NOT_YET_FINAL_LIVE
+
+_VERDICT_MATRIX = [
+    ("reverted", {"status": 0}, _LIVE),
+    ("final_buried", {"status": 1, "block": 100, "finalized": 120}, _FINAL),
+    ("final_boundary", {"status": 1, "block": 120, "finalized": 120}, _FINAL),
+    ("not_yet_final", {"status": 1, "block": 200, "finalized": 120}, _LIVE),
+    ("missing_blockhash", {"status": 1, "block": 100, "finalized": 120, "block_hash": None}, _LIVE),
+    ("empty_canonical", {"status": 1, "block": 100, "finalized": 120, "canonical": None}, _LIVE),
+    ("canonical_mismatch", {"status": 1, "block": 100, "finalized": 120, "canonical": b"\x22" * 32}, _LIVE),
+]
+
+
+@pytest.mark.parametrize("name,kw,expected", _VERDICT_MATRIX, ids=[m[0] for m in _VERDICT_MATRIX])
+async def test_finality_verdict_branches(name, kw, expected):
+    verdict = await RpcEthChainSource(_FakeEthRpc(**kw)).claim_finality_verdict(_CLAIM_HASH)
+    assert verdict.state is expected
+    assert verdict.confirmations is None and verdict.required_depth is None  # ETH = depth-less checkpoint
+
+
+@pytest.mark.parametrize("name,kw,expected", _VERDICT_MATRIX, ids=[m[0] for m in _VERDICT_MATRIX])
+async def test_finality_verdict_parity_with_audited_leg(name, kw, expected):
+    # The keyless adapter's VERDICT LOGIC MUST agree with the audited keyed leg on every receipt —
+    # this is what makes reproducing the logic (instead of extracting it from eth_wallet) safe: a
+    # drift fails this test. The height-sensitive fake also forces the correct canonical-bind height.
+    adapter_state = (await RpcEthChainSource(_FakeEthRpc(**kw)).claim_finality_verdict(_CLAIM_HASH)).state
+    leg_state = (await _leg(_FakeEthRpc(**kw)).claim_finality_verdict(_CLAIM_HASH)).state
+    assert adapter_state is leg_state is expected
+
+
+async def test_finality_verdict_receipt_not_found_is_not_yet_final():
+    # A reorg-orphaned / not-yet-mined claim tx: the NON-BLOCKING read returns None (no 300s wait) and
+    # the verdict is NOT_YET_FINAL_LIVE → WATCH, re-detected next tick (fixes the tick-wedge finding).
+    verdict = await RpcEthChainSource(_FakeEthRpc(receipt_found=False)).claim_finality_verdict(_CLAIM_HASH)
+    assert verdict.state is CounterClaimState.NOT_YET_FINAL_LIVE
+
+
+async def test_finality_verdict_propagates_receipt_error_fail_closed():
+    src = RpcEthChainSource(_FakeEthRpc(receipt_error=NetworkError("rpc down")))
+    with pytest.raises(NetworkError):
+        await src.claim_finality_verdict(_CLAIM_HASH)
+
+
+async def test_finality_verdict_propagates_finalized_error_fail_closed():
+    # finalized_block_number raises (e.g. the finalized>head incoherence guard) → propagates, never FINAL.
+    src = RpcEthChainSource(_FakeEthRpc(status=1, block=100, finalized_error=NetworkError("incoherent")))
+    with pytest.raises(NetworkError):
+        await src.claim_finality_verdict(_CLAIM_HASH)
+
+
+# ───────────────────────────────── protocol conformance + integration ──
+
+
+def test_rpc_eth_chain_source_satisfies_protocol():
+    assert isinstance(RpcEthChainSource(_FakeEthRpc()), EthChainSource)
+
+
+async def test_real_adapter_through_chain_observer_final_pages_claim():
+    # Drive the REAL ChainObserver + RpcEthChainSource (over a fake EthRpc) end-to-end: a claimed +
+    # FINAL ETH counter-leg, observed at a safe RXD window, must PAGE_CLAIM (mirrors the FakeEth
+    # routing test, but through the production adapter wiring).
+    fake = _FakeEthRpc(deploy_block=10, logs=[_log(CLAIMED_TOPIC0, _CLAIM_HASH)], block=100, finalized=120)
+    rec = _eth_record(state=SwapState.SECRET_REVEALED)
+    obs = await ChainObserver(eth=RpcEthChainSource(fake), rxd=FakeRxd(tip=150, cov_confs=51)).observe("s", rec)
+    assert obs.eth_claim_detected is True
+    assert obs.eth_claim_finality is CounterClaimState.FINAL
+    d = decide(record=rec, observations=obs, policy=_eth_policy(), safety_window_blocks=6)
+    assert d.intent is Intent.PAGE_CLAIM
+    assert d.recommended_action == "taker_scrape_and_claim_asset"
+    assert d.low_corroboration is True  # single-source ETH RPC + RXD
+
+
+async def test_real_adapter_through_chain_observer_not_final_waits():
+    fake = _FakeEthRpc(deploy_block=10, logs=[_log(CLAIMED_TOPIC0, _CLAIM_HASH)], block=100, finalized=0)
+    rec = _eth_record(state=SwapState.SECRET_REVEALED)
+    obs = await ChainObserver(eth=RpcEthChainSource(fake), rxd=FakeRxd(tip=150, cov_confs=51)).observe("s", rec)
+    assert obs.eth_claim_detected is True
+    assert obs.eth_claim_finality is CounterClaimState.NOT_YET_FINAL_LIVE
+    d = decide(record=rec, observations=obs, policy=_eth_policy(), safety_window_blocks=6)
+    assert d.intent is Intent.WATCH
+
+
+async def test_real_adapter_unclaimed_through_chain_observer():
+    fake = _FakeEthRpc(deploy_block=10, logs=[])
+    rec = _eth_record(state=SwapState.BOTH_LOCKED)
+    obs = await ChainObserver(eth=RpcEthChainSource(fake), rxd=FakeRxd(tip=200, cov_confs=101)).observe("s", rec)
+    assert obs.eth_claim_detected is False
+    assert obs.eth_claim_finality is None


### PR DESCRIPTION
## Summary

Adds the production ETH counter-leg adapter so the **alert-only** watchtower can watch RXD↔ETH swaps against a live Ethereum RPC — until now only the abstract `EthChainSource` port + decision core existed (the e2e used an anvil shim). The tower stays alert-only: **read-only, holds no key, broadcasts nothing, never reads the preimage `p`** (the operator scrapes `p` after a page). It remains **outside the external-audit gate** (that gate is on the autonomous v2 broadcast path).

Built on the **keyless `EthRpc`** so the audited `eth_wallet` swap logic is untouched — the finalized-checkpoint verdict is *reproduced* and pinned to the audited `EthHtlcContractLeg.claim_finality_verdict` by a **differential parity test**, rather than extracted from the keyed leg.

## What's in it

- **`EthRpc.get_logs` + `get_transaction_receipt`** — read-only, `NetworkError`-wrapped, bounded. The receipt read is **non-blocking** (a poller must never sleep a whole reconcile tick).
- **`RpcEthChainSource`** — the `EthChainSource` adapter:
  - **Selector-agnostic claim detection that fails *toward* paging**: a `Claimed(bytes32)` log is the canonical claim; a `Refunded()`-only contract is correctly *not* a claim; any *unrecognised* event on the per-swap-unique contract still pages — so a differently-shaped (or absent canonical) claim event can never **silently miss** a claim. The `Claimed`/`Refunded` selectors are pinned and verified against keccak.
  - **Verdict logic identical to the audited leg** (status → canonical-chain bind, fail-closed → `finalized` checkpoint), pinned by `test_finality_verdict_parity_with_audited_leg`. A reorg-orphaned / not-yet-mined claim tx → `NOT_YET_FINAL_LIVE` (re-detect next tick), never a blocking wait that would wedge the tick.
- **Runner wiring** — optional `--eth-rpc-url` / `--eth-chain-id` (`assert_chain` fail-closed), injected into `ChainObserver`; BTC-only stays the default. An ETH-direction swap with no `--eth-rpc-url` fails closed (the observer pages), never silently skipped.

## Review

Built, then put through a divergent adversarial review (6 lenses, each finding independently verified against source). Two confirmed HIGH issues — a hardcoded-selector silent-miss and a 300s blocking receipt read that could wedge a reconcile tick and suppress other swaps' pages — were fixed here (selector-agnostic fail-toward-paging detection; non-blocking receipt read). Lower findings (height-sensitive parity fake, typed-error normalisation, honest docstrings) are also folded in.

## Testing

- New `tests/test_watch_eth_adapter.py`: `get_logs`/`get_transaction_receipt` primitives, selector-agnostic detection branches, the verdict matrix, the **differential parity test** vs the audited leg, the non-blocking not-found branch, fail-closed error propagation, protocol conformance, and an end-to-end `ChainObserver`→`decide` run through the real adapter.
- Full suite: 3830 passed / 0 failed / 78 skipped. Security-module coverage 100%. `RpcEthChainSource` 100% covered. ruff (lint+format), bandit, and mypy (`security/` gate) clean.

## Scope / follow-ups

Still alert-only. A **multi-source ETH finality + detection quorum** (`MultiSourceEthRpc`) remains the v2 requirement; single-source detection can *delay* (never permanently lose, given per-tick re-scan) a page, and is documented as such.