### PR TITLE
feat(watchtower): make the runner signet/testnet-capable + signet dust-run runbook

### DIFF
--- a/docs/plans/2026-06-05-feat-watchtower-v2-refund-autonomy-plan.md
+++ b/docs/plans/2026-06-05-feat-watchtower-v2-refund-autonomy-plan.md
@@ -263,3 +263,49 @@ the audit at real amounts.
 - [ ] `decide()` pure & fail-closed; new branch never refunds when the asset is observed locked or maturity
       is unreadable; `decide()`/SwapRecord/coordinator/legs untouched; `executor=None` ⇒ v1 byte-identical.
 - [ ] Two-party regtest run auto-refunds on real consensus once `t_btc` matures; rejected if broadcast early.
+
+## Signet dust-run runbook (operator-driven)
+
+Signet is the mandatory step between regtest and mainnet-dust. Unlike regtest (self-managed docker,
+instant), signet needs **faucet coins** and **real block-time maturity** (~10-min blocks → `t_btc`
+maturity is tens of minutes to hours), so the operator drives it. The runner is now signet-capable
+(`_build_funding_reader` is network-aware; `--network`/`--mempool-base-url`/`--btc-broadcast-url`).
+
+**Network strings (important):** signet addresses use the **`tb`** HRP (shared with testnet), so build
+the HTLC and arm the tower with `--network tb`; the **endpoint** flags disambiguate signet from testnet.
+`tb` is in `AUDIT_CLEARED_NETWORKS`, so no `--audit-cleared` and no dust ceiling (it is a test network).
+
+1. **Get signet coins** — a signet faucet (e.g. `https://signetfaucet.com`, captcha-gated) to a P2WPKH
+   address you control. This is the one manual, external step.
+2. **Drive a swap to `BTC_LOCKED` on signet** — fund the HTLC address (the taker leg) and persist the
+   `SwapRecord` JSON (state `BTC_LOCKED`, `counter_chain="btc"`, a funded `btc_locator` with `network="tb"`).
+   For the maker-never-locks refund, leave the maker side unlocked (no covenant). Use a SMALL `t_btc`
+   (e.g. 2–6 blocks) so maturity is ~20 min–1 hr, and a dust `btc_sats`.
+3. **Pre-sign the refund** (online, with your key — never in the tower):
+   ```
+   python scripts/presign_refund.py --record <dir>/<swap_id>.json \
+       --refund-key-file <taker_refund_key.hex> \
+       --to-scriptpubkey <hex SPK of YOUR signet refund address> \
+       --fee-sats <fee> --out-dir <blobs-dir>
+   ```
+4. **Arm the tower for signet** (it stays ALERT-ONLY without `--refund-spk`):
+   ```
+   python scripts/watchtower_run.py \
+       --records-dir <dir> --refund-blobs-dir <blobs-dir> \
+       --network tb \
+       --mempool-base-url https://mempool.space/signet \   # signet Esplora: reads + claim detection
+       --btc-broadcast-url https://mempool.space/signet/api \  # signet broadcast endpoint
+       --quorum 1 --accept-single-source \                 # signet is single-source Esplora
+       --refund-spk <hex SPK of YOUR signet refund address> \  # MUST equal step 3's --to-scriptpubkey
+       --autonomous-refund-cap-sats <>= the funded btc_sats> \
+       --rxd-backend <your RXD source> \                   # ChainObserver reads rxd tip each tick
+       --measured --block-interval-s 600 --webhook-url <yours> --heartbeat-file <path>
+   ```
+   Wrong/mainnet `--mempool-base-url` on a signet run reads the wrong chain → funding never found →
+   the maturity gate stays WATCH (fail-closed, never a wrongful broadcast).
+5. **Wait for `t_btc` maturity**, then the tower auto-broadcasts the pre-signed refund. Verify the
+   funding outpoint is spent on `https://mempool.space/signet`. The operator page fires regardless
+   (the refund is also recoverable manually if the autonomous broadcast is declined for any bind).
+
+A signet run proves the operational plumbing on a real network; it is NOT a security proof, and the
+external audit remains the gate before any non-dust mainnet use.

--- a/scripts/watchtower_run.py
+++ b/scripts/watchtower_run.py
@@ -59,7 +59,7 @@ from pyrxd.gravity.watch import (
     mempool_space_outspend,
     run_loop,
 )
-from pyrxd.network.bitcoin import MempoolSpaceBroadcaster, MultiSourceBtcFundingReader
+from pyrxd.network.bitcoin import MempoolSpaceBroadcaster, MempoolSpaceFundingReader, MultiSourceBtcFundingReader
 from pyrxd.network.electrumx import ElectrumXClient
 
 logger = logging.getLogger("pyrxd.watchtower")
@@ -160,6 +160,20 @@ def _build_executor(args: argparse.Namespace, stack: contextlib.AsyncExitStack) 
             "autonomous refund DORMANT on %s (not audit-cleared) — ALERT-ONLY, broadcasts nothing", args.network
         )
     return executor
+
+
+def _build_funding_reader(network: str, esploras: list[str], quorum: int) -> MultiSourceBtcFundingReader:
+    """The BTC funding-depth + claim-depth reader, NETWORK-AWARE. Mainnet uses the three default 2-of-3
+    Esplora endpoints. Any other network (signet/testnet) builds from the configured --mempool-base-url /
+    --esplora-url, which MUST be that network's Esplora (e.g. ``https://mempool.space/signet``): the
+    funding-reader API base is that base + ``/api`` (the outspend path appends ``/api/tx/...`` to the bare
+    base). A single-source network clamps the quorum to the source count (signet is typically 1-of-1).
+    A wrong/mainnet base on a signet run reads the wrong chain → the funding is never found → the maturity
+    gate stays WATCH (fail-closed, never a wrongful broadcast)."""
+    if network == "bc":
+        return MultiSourceBtcFundingReader.default_mainnet(quorum=quorum)
+    readers = [MempoolSpaceFundingReader(base_url=u.rstrip("/") + "/api") for u in esploras]
+    return MultiSourceBtcFundingReader(readers, quorum=min(quorum, len(readers)), dust_cap_sats=10_000)
 
 
 async def _build_rxd_client(args: argparse.Namespace, stack: contextlib.AsyncExitStack):
@@ -327,7 +341,9 @@ async def _amain(argv=None) -> int:
     # Independent Esplora set for multi-source claim DETECTION (dedup, preserve order). Default a
     # free second source so corroboration is ON out of the box (red-team MEDIUM).
     esploras = [args.mempool_base_url, *(args.esplora_url or [])]
-    if len(esploras) == 1 and "blockstream.info" not in args.mempool_base_url:
+    # blockstream.info is a MAINNET endpoint — only auto-add it on mainnet (a signet/testnet run must
+    # point --mempool-base-url at that network's Esplora, e.g. https://mempool.space/signet).
+    if args.network == "bc" and len(esploras) == 1 and "blockstream.info" not in args.mempool_base_url:
         esploras.append("https://blockstream.info")
     _seen: set[str] = set()
     esploras = [u for u in esploras if not (u in _seen or _seen.add(u))]
@@ -341,7 +357,7 @@ async def _amain(argv=None) -> int:
             "one before relying on this tower."
         )
 
-    reader = MultiSourceBtcFundingReader.default_mainnet(quorum=args.quorum)
+    reader = _build_funding_reader(args.network, esploras, args.quorum)
     async with contextlib.AsyncExitStack() as stack:
         http_session = await stack.enter_async_context(aiohttp.ClientSession())
         rxd_client = await _build_rxd_client(args, stack)

--- a/tests/test_watch_v2_execute_invariants.py
+++ b/tests/test_watch_v2_execute_invariants.py
@@ -484,6 +484,20 @@ def test_records_store_ignores_refund_sidecars(tmp_path):
     assert active == []  # the refund sidecar is ignored, not a phantom/unreadable "record"
 
 
+def test_funding_reader_is_network_aware():
+    # The runner's BTC funding reader must follow --network: mainnet → 3 default 2-of-3 Esplora; signet →
+    # the configured signet Esplora (NOT mainnet), quorum clamped to the single source. A mainnet reader
+    # on a signet run would never find the funding (fail-closed WATCH), so this wiring is load-bearing.
+    from watchtower_run import _build_funding_reader
+
+    mainnet = _build_funding_reader("bc", ["https://mempool.space"], 2)
+    assert mainnet._quorum == 2 and len(mainnet._readers) == 3
+
+    signet = _build_funding_reader("signet", ["https://mempool.space/signet"], 2)
+    assert len(signet._readers) == 1 and signet._quorum == 1  # clamped to the single signet source
+    assert "signet/api" in signet._readers[0]._http._base_url  # signet Esplora API base, not mainnet
+
+
 def test_executor_module_is_keyless():
     src = Path(__file__).resolve().parent.parent / "src" / "pyrxd" / "gravity" / "watch" / "executor.py"
     text = src.read_text()


### PR DESCRIPTION
Follow-up to #171 (v2 autonomous BTC refund). Makes the watchtower runner able to **read/broadcast on signet/testnet**, and adds the operator runbook for the next step of the dust progression.

## The gap this closes
The runner hardcoded `MultiSourceBtcFundingReader.default_mainnet()`, so on signet the maturity gate read **mainnet** funding depth → never found the swap's funding → never fired (fail-closed, but unusable on signet).

## Change
- New `_build_funding_reader(network, esploras, quorum)` — network-aware: mainnet keeps the 3-endpoint 2-of-3 default; any other network builds from `--mempool-base-url`/`--esplora-url` (which must point at that network's Esplora, e.g. `https://mempool.space/signet`), with the quorum clamped to the source count (signet is 1-of-1). The funding-reader API base is the esplora base + `/api`.
- `blockstream.info` (a mainnet endpoint) is auto-added **only** on mainnet.
- A unit test pins the wiring (mainnet → 3 readers/quorum 2; signet → 1 reader/quorum 1, signet Esplora base).
- A turnkey **signet dust-run runbook** in the plan doc (network strings: `--network tb` + signet endpoints; faucet coins + ~block-maturity wait are the operator's part).

A wrong/mainnet base on a signet run reads the wrong chain → funding never found → maturity gate stays WATCH (**fail-closed, never a wrongful broadcast**). Signet stays operator-driven (faucet + real block time); this is the code that makes the tower *able* to act there. Still dust-only / external-audit-gated for non-dust mainnet.