### PR TITLE
feat(cli+glyph): setup --coin-type (#18) + classify rarer Glyph types in inspect (#135)

### DIFF
--- a/src/pyrxd/cli/config.py
+++ b/src/pyrxd/cli/config.py
@@ -9,6 +9,7 @@ Schema:
   electrumx = "wss://..."
   fee_rate = 10000                  # photons per byte
   wallet_path = "~/.pyrxd/wallet.dat"
+  coin_type = 512                   # SLIP-0044 coin type for `wallet new` derivation
 
   [networks.testnet]
   electrumx = "wss://..."
@@ -39,6 +40,9 @@ _DEFAULTS: dict[str, Any] = {
     "electrumx": "wss://electrumx.radiant4people.com:50022/",
     "fee_rate": 10_000,
     "wallet_path": str(DEFAULT_WALLET_PATH),
+    # SLIP-0044 coin type used when `wallet new` derives a fresh wallet.
+    # 512 = Radiant Standard (SLIP-0044). `setup --coin-type` writes this.
+    "coin_type": 512,
 }
 
 
@@ -50,6 +54,7 @@ class Config:
     electrumx: str = _DEFAULTS["electrumx"]
     fee_rate: int = 10_000
     wallet_path: Path = field(default_factory=lambda: DEFAULT_WALLET_PATH)
+    coin_type: int = 512
     networks: dict[str, dict[str, Any]] = field(default_factory=dict)
     source_path: Path | None = None  # which file (if any) was read
 
@@ -61,6 +66,7 @@ class Config:
                 electrumx=self.electrumx,
                 fee_rate=self.fee_rate,
                 wallet_path=self.wallet_path,
+                coin_type=self.coin_type,
                 networks=self.networks,
                 source_path=self.source_path,
             )
@@ -70,6 +76,7 @@ class Config:
             electrumx=overrides.get("electrumx", self.electrumx),
             fee_rate=int(overrides.get("fee_rate", self.fee_rate)),
             wallet_path=Path(overrides.get("wallet_path", self.wallet_path)).expanduser(),
+            coin_type=int(overrides.get("coin_type", self.coin_type)),
             networks=self.networks,
             source_path=self.source_path,
         )
@@ -95,6 +102,11 @@ def load(path: Path | None = None) -> Config:
     electrumx = os.environ.get("PYRXD_ELECTRUMX") or file_data.get("electrumx") or _DEFAULTS["electrumx"]
     fee_rate_raw = os.environ.get("PYRXD_FEE_RATE") or file_data.get("fee_rate") or _DEFAULTS["fee_rate"]
     wallet_path = os.environ.get("PYRXD_WALLET_PATH") or file_data.get("wallet_path") or _DEFAULTS["wallet_path"]
+    # ``or`` short-circuits on a falsy 0 — coin_type 0 (legacy Bitcoin-compatible)
+    # is a valid value, so fall through explicitly instead of treating 0 as unset.
+    coin_type_raw = os.environ.get("PYRXD_COIN_TYPE")
+    if coin_type_raw is None:
+        coin_type_raw = file_data.get("coin_type", _DEFAULTS["coin_type"])
 
     networks = file_data.get("networks", {})
     if not isinstance(networks, dict):
@@ -105,27 +117,60 @@ def load(path: Path | None = None) -> Config:
         electrumx=str(electrumx),
         fee_rate=int(fee_rate_raw),
         wallet_path=Path(str(wallet_path)).expanduser(),
+        coin_type=int(coin_type_raw),
         networks=networks,
         source_path=source_path,
     )
 
 
-def write_default(path: Path | None = None) -> Path:
+def write_default(path: Path | None = None, *, coin_type: int | None = None) -> Path:
     """Write the built-in defaults to *path*. Used by ``pyrxd setup``.
 
     Creates ``~/.pyrxd/`` with mode 0700 and writes the file with mode
     0600 (parent permissions matter because wallet.dat sits alongside).
-    Returns the resolved path.
+    *coin_type* overrides the SLIP-0044 coin type written for the
+    ``wallet new`` derivation path (default 512). Returns the resolved
+    path.
     """
     target = path or DEFAULT_CONFIG_PATH
     parent = target.parent
     parent.mkdir(parents=True, exist_ok=True, mode=0o700)
+    resolved_coin_type = _DEFAULTS["coin_type"] if coin_type is None else coin_type
     body = (
         f'network = "{_DEFAULTS["network"]}"\n'
         f'electrumx = "{_DEFAULTS["electrumx"]}"\n'
         f"fee_rate = {_DEFAULTS['fee_rate']}\n"
         f'wallet_path = "{_DEFAULTS["wallet_path"]}"\n'
+        f"coin_type = {resolved_coin_type}\n"
     )
     target.write_text(body)
+    target.chmod(0o600)
+    return target
+
+
+def set_coin_type(coin_type: int, path: Path | None = None) -> Path:
+    """Persist *coin_type* into the config at *path*, preserving other keys.
+
+    Used by ``pyrxd setup --coin-type``. If the file does not exist it is
+    created from the built-in defaults with the chosen coin type. If it
+    exists, only the ``coin_type`` key is updated (other lines are kept
+    verbatim so hand-edits survive). Returns the resolved path.
+    """
+    target = path or DEFAULT_CONFIG_PATH
+    if not target.exists():
+        return write_default(target, coin_type=coin_type)
+
+    lines = target.read_text().splitlines()
+    out: list[str] = []
+    replaced = False
+    for line in lines:
+        if line.lstrip().startswith("coin_type") and "=" in line.split("#", 1)[0]:
+            out.append(f"coin_type = {coin_type}")
+            replaced = True
+        else:
+            out.append(line)
+    if not replaced:
+        out.append(f"coin_type = {coin_type}")
+    target.write_text("\n".join(out) + "\n")
     target.chmod(0o600)
     return target

--- a/src/pyrxd/cli/query_cmds.py
+++ b/src/pyrxd/cli/query_cmds.py
@@ -50,7 +50,7 @@ def address_cmd(
                 fix="pass a non-negative integer to --index",
             )
         addr = wallet._derive_address(chain, index)
-        path = f"m/44'/512'/{wallet.account}'/{chain}/{index}"
+        path = f"m/44'/{wallet.coin_type}'/{wallet.account}'/{chain}/{index}"
     else:
         # `--next` — walks the wallet's known addresses.
         addr = wallet.next_receive_address() if not change else _next_internal_address(wallet)
@@ -90,7 +90,7 @@ def _next_internal_address(wallet: HdWallet) -> str:
 def _path_for_address(wallet: HdWallet, address: str) -> str:
     for rec in wallet.addresses.values():
         if rec.address == address:
-            return f"m/44'/512'/{wallet.account}'/{rec.change}/{rec.index}"
+            return f"m/44'/{wallet.coin_type}'/{wallet.account}'/{rec.change}/{rec.index}"
     return "?"
 
 

--- a/src/pyrxd/cli/setup_cmd.py
+++ b/src/pyrxd/cli/setup_cmd.py
@@ -56,33 +56,76 @@ async def _probe_electrumx(url: str) -> bool:
         return False
 
 
+# --coin-type choices, mapped to the wallet each value is for (Avian-UI
+# style). 512 is the SLIP-0044 default; 0 is for Photonic / Electron-Radiant
+# restores; 236 is the pre-#14 pyrxd path, surfaced for completeness but not
+# promoted (no modern wallet creates at it).
+_COIN_TYPE_CHOICES = ("0", "236", "512")
+_COIN_TYPE_HELP = (
+    "SLIP-0044 coin type for the wallet `wallet new` will derive: "
+    "512 = Radiant (Standard, SLIP-0044) [default]; "
+    "0 = Legacy Bitcoin-compatible (use for wallets created in Photonic or "
+    "Electron-Radiant); "
+    "236 = old pyrxd (pre-#14 BSV coin type; not promoted)."
+)
+
+
 @click.command(name="setup")
 @click.option(
     "--no-interactive",
     is_flag=True,
     help="Don't prompt for any input. Just write the default config and exit.",
 )
+@click.option(
+    "--coin-type",
+    type=click.Choice(_COIN_TYPE_CHOICES),
+    default=None,
+    help=_COIN_TYPE_HELP + " Omitted: keep the existing config value (default 512).",
+)
 @click.pass_obj
-def setup_cmd(ctx: CliContext, no_interactive: bool) -> None:
+def setup_cmd(ctx: CliContext, no_interactive: bool, coin_type: str | None) -> None:
     """Onboarding walkthrough — detects node, ElectrumX, wallet.
 
     Prints what it finds and how to fix any gaps. Writes
     ``~/.pyrxd/config.toml`` with built-in defaults if the file is
-    missing. Does NOT create a wallet — run ``pyrxd wallet new``
-    afterwards.
+    missing. ``--coin-type`` records the SLIP-0044 coin type so a
+    later ``pyrxd wallet new`` derives at ``m/44'/<coin_type>'/0'``.
+    Does NOT create a wallet — run ``pyrxd wallet new`` afterwards.
     """
+    # Persistence design: setup is non-destructive and does NOT create a
+    # wallet, so it cannot bind the coin type to a seed here. Instead it
+    # writes ``coin_type`` into ~/.pyrxd/config.toml; the next
+    # ``wallet new`` reads ctx.config.coin_type and passes it to
+    # HdWallet.from_mnemonic(coin_type=...), which records + persists it in
+    # the wallet file. This is real persistence (not just an echoed hint)
+    # and survives across processes.
+    #
+    # ``--coin-type`` is only persisted when explicitly passed (default is
+    # None, not 512). A bare ``setup`` re-run must NOT clobber a coin type a
+    # previous ``setup --coin-type 0`` recorded — it just reports the current
+    # value. The effective coin type shown/emitted is the chosen value, else
+    # the existing config value.
+    chosen_coin_type = int(coin_type) if coin_type is not None else None
+    coin_type_int = chosen_coin_type if chosen_coin_type is not None else ctx.config.coin_type
+
     # 1. Config file presence.
     config_path = _config.DEFAULT_CONFIG_PATH
     config_existed = config_path.exists()
     if not config_existed:
         if no_interactive:
-            written = _config.write_default()
+            written = _config.write_default(coin_type=coin_type_int)
             click.echo(f"wrote default config to {written}") if ctx.output_mode == "human" else None
         else:
             click.echo(f"\nNo config at {config_path}.")
             if click.confirm("Create one with built-in defaults?", default=True):
-                written = _config.write_default()
+                written = _config.write_default(coin_type=coin_type_int)
                 click.echo(f"  wrote {written}")
+    elif chosen_coin_type is not None:
+        # Config exists and the user explicitly chose a coin type — update only
+        # that key in place. This is the path that makes `setup --coin-type 0`
+        # on an existing install stick, without disturbing other keys. A bare
+        # `setup` (chosen is None) leaves the file untouched.
+        _config.set_coin_type(chosen_coin_type, config_path)
 
     # 2. Node probe.
     has_node = _probe_local_node()
@@ -103,6 +146,8 @@ def setup_cmd(ctx: CliContext, no_interactive: bool) -> None:
         "electrumx_reachable": has_electrumx,
         "wallet_path": str(wallet_path),
         "wallet_exists": has_wallet,
+        "coin_type": coin_type_int,
+        "derivation_path": f"m/44'/{coin_type_int}'/0'",
     }
 
     if ctx.output_mode == "json":
@@ -121,6 +166,7 @@ def setup_cmd(ctx: CliContext, no_interactive: bool) -> None:
     click.echo(f"  node:      {_NODE_PROBE_HOST}:{_NODE_PROBE_PORT} {'reachable' if has_node else 'NOT reachable'}")
     click.echo(f"  electrumx: {ctx.electrumx_url} {'reachable' if has_electrumx else 'NOT reachable'}")
     click.echo(f"  wallet:    {wallet_path} {'(exists)' if has_wallet else '(missing)'}")
+    click.echo(f"  coin type: {coin_type_int}  (new wallets derive at m/44'/{coin_type_int}'/0')")
 
     next_steps: list[str] = []
     if not has_electrumx and not has_node:

--- a/src/pyrxd/cli/wallet_cmds.py
+++ b/src/pyrxd/cli/wallet_cmds.py
@@ -101,6 +101,11 @@ def wallet_new(ctx: CliContext, mnemonic_words: str, passphrase: bool, no_clipbo
     entropy_n = 16 if word_count == 12 else 32
     mnemonic = mnemonic_from_entropy(secure_random_bytes(entropy_n))
 
+    # Derive at the coin type recorded in config (written by `setup
+    # --coin-type`). Defaults to 512 (SLIP-0044). Persisted into the
+    # wallet file by HdWallet so later `load` calls derive the same path.
+    coin_type = ctx.config.coin_type
+
     # In JSON mode: emit the mnemonic as JSON without the gate. The user
     # passed --yes deliberately, so we trust them. In any other mode,
     # show the box + Enter gate.
@@ -108,7 +113,7 @@ def wallet_new(ctx: CliContext, mnemonic_words: str, passphrase: bool, no_clipbo
         passphrase_str = ""  # nosec B105 — empty string is the BIP39 spec default, not a hardcoded secret
         if passphrase:
             passphrase_str = prompt_passphrase_input(optional=True)
-        wallet = HdWallet.from_mnemonic(mnemonic, passphrase=passphrase_str)
+        wallet = HdWallet.from_mnemonic(mnemonic, passphrase=passphrase_str, coin_type=coin_type)
         wallet.save(ctx.wallet_path)
         click.echo(
             emit(
@@ -116,6 +121,8 @@ def wallet_new(ctx: CliContext, mnemonic_words: str, passphrase: bool, no_clipbo
                     "mnemonic": mnemonic,
                     "wallet_path": str(ctx.wallet_path),
                     "address": wallet.next_receive_address(),
+                    "coin_type": wallet.coin_type,
+                    "path": f"m/44'/{wallet.coin_type}'/{wallet.account}'",
                 },
                 mode="json",
             )
@@ -134,7 +141,7 @@ def wallet_new(ctx: CliContext, mnemonic_words: str, passphrase: bool, no_clipbo
     passphrase_str = ""  # nosec B105 — empty string is the BIP39 spec default, not a hardcoded secret
     if passphrase:
         passphrase_str = prompt_passphrase_input(optional=True)
-    wallet = HdWallet.from_mnemonic(mnemonic, passphrase=passphrase_str)
+    wallet = HdWallet.from_mnemonic(mnemonic, passphrase=passphrase_str, coin_type=coin_type)
     wallet.save(ctx.wallet_path)
     next_addr = wallet.next_receive_address()
 
@@ -144,6 +151,7 @@ def wallet_new(ctx: CliContext, mnemonic_words: str, passphrase: bool, no_clipbo
 
     click.echo("")
     click.echo(f"Wallet saved to {ctx.wallet_path}")
+    click.echo(f"Derivation path: m/44'/{wallet.coin_type}'/{wallet.account}'")
     click.echo(f"First receive address: {next_addr}")
 
 
@@ -217,7 +225,7 @@ def wallet_load(ctx: CliContext, passphrase: bool) -> None:
 def wallet_export_xpub(ctx: CliContext, passphrase: bool) -> None:
     """Print the account-level xpub for watch-only / recipient use.
 
-    The xpub at ``m/44'/512'/<account>'`` lets external tools generate
+    The xpub at ``m/44'/<coin_type>'/<account>'`` lets external tools generate
     receive addresses for this wallet without ever seeing the seed.
     Safe to share with watch-only services or merchant integrations.
     No private key material is exported.
@@ -245,14 +253,14 @@ def wallet_export_xpub(ctx: CliContext, passphrase: bool) -> None:
     payload = {
         "xpub": str(xpub),
         "account": wallet.account,
-        "path": f"m/44'/512'/{wallet.account}'",
+        "path": f"m/44'/{wallet.coin_type}'/{wallet.account}'",
     }
     if ctx.output_mode == "json":
         click.echo(emit(payload, mode="json"))
     elif ctx.output_mode == "quiet":
         click.echo(emit(payload, mode="quiet", quiet_field="xpub"))
     else:
-        click.echo(f"\nxpub at m/44'/512'/{wallet.account}':")
+        click.echo(f"\nxpub at m/44'/{wallet.coin_type}'/{wallet.account}':")
         click.echo(f"  {xpub}")
         click.echo("\nThis xpub lets external tools generate receive addresses")
         click.echo("for this wallet WITHOUT seeing the seed. Safe to share with")

--- a/src/pyrxd/glyph/_inspect_core.py
+++ b/src/pyrxd/glyph/_inspect_core.py
@@ -39,6 +39,7 @@ from ..hash import hash256
 from ..security.errors import ValidationError
 from ..security.types import Txid
 from ..transaction.transaction import Transaction
+from .types import GlyphProtocol
 
 # --- Length / shape constants ----------------------------------------------
 #
@@ -321,6 +322,53 @@ def _inspect_script(script_hex: str) -> dict:
     }
 
 
+def _classify_metadata_protocol(metadata) -> str:
+    """Return the highest-specificity Glyph-protocol classification label.
+
+    Pure, self-contained mirror of
+    :func:`pyrxd.glyph.wave.classify_glyph_metadata`, duplicated here on
+    purpose: ``wave.py`` is **not** import-pure (its module-level
+    ``WaveResolverError`` definition pulls in ``pyrxd.network.rxindexer``,
+    which transitively drags ``aiohttp`` / ``websockets`` / ``coincurve``).
+    Importing it — even lazily — would defeat this module's Pyodide
+    no-heavy-deps contract (see the module docstring). The two functions
+    must stay in sync; the shared classification rules are exercised by the
+    test suite against both.
+
+    Operates on a parsed :class:`~pyrxd.glyph.types.GlyphMetadata` so the
+    WAVE case can require a resolvable ``attrs.name`` (legacy top-level-name
+    WAVE tokens exist on-chain but RXinDexer won't index them, so they
+    classify as their underlying ``mut``).
+
+    Ordering is highest-specificity-first; TIMELOCK is checked before
+    ENCRYPTED because TIMELOCK *requires* ENCRYPTED (see the protocol rules
+    in :mod:`~pyrxd.glyph.types`), so a timelocked token always carries both.
+    """
+    p = set(metadata.protocol)
+    has_wave_name = bool(metadata.attrs and metadata.attrs.get("name"))
+    if GlyphProtocol.WAVE in p and has_wave_name:
+        return "wave"
+    if GlyphProtocol.CONTAINER in p:
+        return "container"
+    if GlyphProtocol.AUTHORITY in p:
+        return "authority"
+    if GlyphProtocol.TIMELOCK in p:
+        return "timelock"
+    if GlyphProtocol.ENCRYPTED in p:
+        return "encrypted"
+    if GlyphProtocol.DMINT in p:
+        return "dmint"
+    if GlyphProtocol.MUT in p:
+        return "mut"
+    if GlyphProtocol.DAT in p:
+        return "dat"
+    if GlyphProtocol.FT in p:
+        return "ft"
+    if GlyphProtocol.NFT in p:
+        return "nft"
+    return "unknown"
+
+
 def _classify_raw_tx(txid_hex: str, raw: bytes, *, only_vout: int | None = None) -> dict:
     """Classify every output (and reveal CBOR) for a pre-fetched transaction.
 
@@ -436,6 +484,12 @@ def _classify_raw_tx(txid_hex: str, raw: bytes, *, only_vout: int | None = None)
         metadata_payload = {
             "input_index": input_idx,
             "protocol": [_sanitize_display_string(str(p)) for p in metadata.protocol],
+            # Human-friendly highest-specificity protocol label (e.g. "wave",
+            # "container", "timelock", "authority", "dat"). Computed from the
+            # real GlyphMetadata so the WAVE case can require a resolvable
+            # attrs.name. The label is drawn from a fixed internal vocabulary,
+            # not user-controllable CBOR text, so no sanitization is needed.
+            "classification": _classify_metadata_protocol(metadata),
             "name": _sanitize_display_string(metadata.name) if metadata.name else "",
             "ticker": _sanitize_display_string(metadata.ticker) if metadata.ticker else "",
             "description": _sanitize_display_string(metadata.description) if metadata.description else "",

--- a/src/pyrxd/glyph/wave.py
+++ b/src/pyrxd/glyph/wave.py
@@ -311,26 +311,40 @@ def classify_glyph_metadata(metadata: GlyphMetadata) -> str:
         ``[NFT, MUT, WAVE]`` without attrs.name → ``"mut"`` (legacy, won't resolve)
         ``[NFT, MUT, CONTAINER]`` → ``"container"``
         ``[NFT, MUT]`` → ``"mut"``
+        ``[NFT, AUTHORITY]`` → ``"authority"``
+        ``[NFT, ENCRYPTED, TIMELOCK]`` → ``"timelock"``
         ``[NFT, ENCRYPTED]`` → ``"encrypted"``
         ``[NFT]`` → ``"nft"``
         ``[FT, DMINT]`` → ``"dmint"``
         ``[FT]`` → ``"ft"``
+        ``[DAT]`` → ``"dat"``
 
     The string mirrors :attr:`GlyphOutput.glyph_type` values where applicable,
     with extensions for the metadata-only types that scripts alone can't
-    distinguish (WAVE/CONTAINER/ENCRYPTED share script templates with MUT/NFT).
+    distinguish (WAVE/CONTAINER/ENCRYPTED/TIMELOCK/AUTHORITY share script
+    templates with MUT/NFT, and DAT is data-only).
+
+    Ordering is highest-specificity-first: TIMELOCK is checked before
+    ENCRYPTED (TIMELOCK *requires* ENCRYPTED per the protocol rules in
+    :mod:`~pyrxd.glyph.types`, so a timelocked token always carries both).
     """
     p = set(metadata.protocol)
     if GlyphProtocol.WAVE in p and wave_attrs_from_metadata(metadata) is not None:
         return "wave"
     if GlyphProtocol.CONTAINER in p:
         return "container"
+    if GlyphProtocol.AUTHORITY in p:
+        return "authority"
+    if GlyphProtocol.TIMELOCK in p:
+        return "timelock"
     if GlyphProtocol.ENCRYPTED in p:
         return "encrypted"
     if GlyphProtocol.DMINT in p:
         return "dmint"
     if GlyphProtocol.MUT in p:
         return "mut"
+    if GlyphProtocol.DAT in p:
+        return "dat"
     if GlyphProtocol.FT in p:
         return "ft"
     if GlyphProtocol.NFT in p:

--- a/tests/cli/test_config.py
+++ b/tests/cli/test_config.py
@@ -76,6 +76,66 @@ def test_write_default_creates_dir_with_correct_perms(tmp_path: Path) -> None:
     assert cfg.network == "mainnet"
 
 
+def test_coin_type_defaults_to_512(tmp_path: Path) -> None:
+    cfg = _config.load(tmp_path / "absent.toml")
+    assert cfg.coin_type == 512
+
+
+def test_coin_type_from_file(tmp_path: Path) -> None:
+    cfg_file = tmp_path / "config.toml"
+    cfg_file.write_text('network = "mainnet"\ncoin_type = 0\n')
+    cfg = _config.load(cfg_file)
+    # coin_type 0 (legacy Bitcoin-compatible) must survive — it is falsy and a
+    # naive ``or`` chain would silently reset it to the 512 default.
+    assert cfg.coin_type == 0
+
+
+def test_coin_type_env_overrides_file(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    cfg_file = tmp_path / "config.toml"
+    cfg_file.write_text("coin_type = 512\n")
+    monkeypatch.setenv("PYRXD_COIN_TYPE", "236")
+    cfg = _config.load(cfg_file)
+    assert cfg.coin_type == 236
+
+
+def test_write_default_records_coin_type(tmp_path: Path) -> None:
+    target = tmp_path / "config.toml"
+    _config.write_default(target, coin_type=0)
+    cfg = _config.load(target)
+    assert cfg.coin_type == 0
+
+
+def test_set_coin_type_creates_when_missing(tmp_path: Path) -> None:
+    target = tmp_path / "config.toml"
+    _config.set_coin_type(0, target)
+    assert _config.load(target).coin_type == 0
+
+
+def test_set_coin_type_updates_in_place(tmp_path: Path) -> None:
+    target = tmp_path / "config.toml"
+    target.write_text('network = "testnet"\nfee_rate = 5000\ncoin_type = 512\n')
+    _config.set_coin_type(236, target)
+    cfg = _config.load(target)
+    # Only coin_type changed; the other keys are preserved verbatim.
+    assert cfg.coin_type == 236
+    assert cfg.network == "testnet"
+    assert cfg.fee_rate == 5000
+
+
+def test_set_coin_type_appends_when_key_absent(tmp_path: Path) -> None:
+    target = tmp_path / "config.toml"
+    target.write_text('network = "mainnet"\n')
+    _config.set_coin_type(0, target)
+    assert _config.load(target).coin_type == 0
+
+
+def test_for_network_preserves_coin_type(tmp_path: Path) -> None:
+    cfg_file = tmp_path / "config.toml"
+    cfg_file.write_text('network = "mainnet"\ncoin_type = 0\n[networks.testnet]\nfee_rate = 1\n')
+    cfg = _config.load(cfg_file)
+    assert cfg.for_network("testnet").coin_type == 0
+
+
 def test_tomllib_is_available_at_module_load() -> None:
     """The `config` module must successfully import a TOML reader regardless
     of Python version. On 3.11+ the stdlib ``tomllib`` resolves; on 3.10 the

--- a/tests/cli/test_query_cmds.py
+++ b/tests/cli/test_query_cmds.py
@@ -93,6 +93,89 @@ class TestAddressCmd:
         assert "m/44" not in line
 
 
+class TestAddressCoinType:
+    """Display strings must reflect the wallet's ACTUAL coin type, not a
+    hardcoded 512. A wallet created at coin_type 0 (Photonic / Electron-
+    Radiant legacy) must report m/44'/0'/... in its path output.
+    """
+
+    def _config_with_coin_type(self, tmp_path: Path, coin_type: int) -> Path:
+        cfg = tmp_path / "config.toml"
+        cfg.write_text(f'network = "mainnet"\ncoin_type = {coin_type}\n')
+        return cfg
+
+    def _create_wallet_with_config(self, runner: CliRunner, tmp_wallet_path: Path, cfg: Path) -> str:
+        result = runner.invoke(
+            cli,
+            ["--config", str(cfg), "--wallet", str(tmp_wallet_path), "--json", "--yes", "wallet", "new"],
+        )
+        assert result.exit_code == 0, result.output
+        return _extract_json(result.output)["mnemonic"]
+
+    def test_address_path_reflects_coin_type_zero(
+        self, runner: CliRunner, tmp_path: Path, tmp_wallet_path: Path
+    ) -> None:
+        cfg = self._config_with_coin_type(tmp_path, 0)
+        mnemonic = self._create_wallet_with_config(runner, tmp_wallet_path, cfg)
+        result = runner.invoke(
+            cli,
+            ["--config", str(cfg), "--wallet", str(tmp_wallet_path), "--json", "address", "--index", "0"],
+            input=f"{mnemonic}\n",
+        )
+        assert result.exit_code == 0, result.output
+        payload = _extract_json(result.output)
+        # The coin_type persisted in the wallet file is restored on load, so
+        # the path string must show 0 — not the legacy hardcoded 512.
+        assert payload["path"] == "m/44'/0'/0'/0/0"
+        assert "512" not in payload["path"]
+
+    def test_wallet_new_json_reports_coin_type_and_path(
+        self, runner: CliRunner, tmp_path: Path, tmp_wallet_path: Path
+    ) -> None:
+        cfg = self._config_with_coin_type(tmp_path, 0)
+        result = runner.invoke(
+            cli,
+            ["--config", str(cfg), "--wallet", str(tmp_wallet_path), "--json", "--yes", "wallet", "new"],
+        )
+        assert result.exit_code == 0, result.output
+        payload = _extract_json(result.output)
+        assert payload["coin_type"] == 0
+        assert payload["path"] == "m/44'/0'/0'"
+
+    def test_default_config_yields_512_path(self, runner: CliRunner, tmp_path: Path, tmp_wallet_path: Path) -> None:
+        cfg = self._config_with_coin_type(tmp_path, 512)
+        mnemonic = self._create_wallet_with_config(runner, tmp_wallet_path, cfg)
+        result = runner.invoke(
+            cli,
+            ["--config", str(cfg), "--wallet", str(tmp_wallet_path), "--json", "address", "--index", "3"],
+            input=f"{mnemonic}\n",
+        )
+        assert result.exit_code == 0, result.output
+        assert _extract_json(result.output)["path"] == "m/44'/512'/0'/0/3"
+
+
+class TestExportXpubCoinType:
+    """`wallet export-xpub` path output must track the wallet coin type."""
+
+    def test_xpub_path_reflects_coin_type_zero(self, runner: CliRunner, tmp_path: Path, tmp_wallet_path: Path) -> None:
+        cfg = tmp_path / "config.toml"
+        cfg.write_text('network = "mainnet"\ncoin_type = 0\n')
+        new = runner.invoke(
+            cli,
+            ["--config", str(cfg), "--wallet", str(tmp_wallet_path), "--json", "--yes", "wallet", "new"],
+        )
+        assert new.exit_code == 0, new.output
+        mnemonic = _extract_json(new.output)["mnemonic"]
+        result = runner.invoke(
+            cli,
+            ["--config", str(cfg), "--wallet", str(tmp_wallet_path), "--json", "wallet", "export-xpub"],
+            input=f"{mnemonic}\n",
+        )
+        assert result.exit_code == 0, result.output
+        payload = _extract_json(result.output)
+        assert payload["path"] == "m/44'/0'/0'"
+
+
 class TestUtxosCmd:
     """Cut 3 — read-only diagnostic. Covered with mocked ElectrumX."""
 

--- a/tests/cli/test_setup_cmd.py
+++ b/tests/cli/test_setup_cmd.py
@@ -98,3 +98,101 @@ class TestSetupHumanOutput:
         assert result.exit_code == 0, result.output
         assert "Next steps:" in result.output
         assert "wallet new" in result.output
+
+
+class TestSetupCoinType:
+    """`setup --coin-type` records the SLIP-0044 coin type for `wallet new`."""
+
+    def _run_setup(self, runner: CliRunner, tmp_path: Path, tmp_wallet_path: Path, *coin_args: str):
+        """Run `setup` with DEFAULT_CONFIG_PATH redirected into tmp_path."""
+        cfg_path = tmp_path / "config.toml"
+        n, e = _patches(node_ok=False, electrumx_ok=False)
+        with (
+            patch("pyrxd.cli.setup_cmd._config.DEFAULT_CONFIG_PATH", cfg_path),
+            n,
+            e,
+        ):
+            result = runner.invoke(
+                cli,
+                ["--wallet", str(tmp_wallet_path), "--json", "setup", "--no-interactive", *coin_args],
+            )
+        return result, cfg_path
+
+    def test_default_coin_type_is_512(self, runner: CliRunner, tmp_path: Path, tmp_wallet_path: Path) -> None:
+        result, _cfg_path = self._run_setup(runner, tmp_path, tmp_wallet_path)
+        assert result.exit_code == 0, result.output
+        payload = _extract_json(result.output)
+        assert payload["coin_type"] == 512
+        assert payload["derivation_path"] == "m/44'/512'/0'"
+
+    def test_coin_type_zero_in_payload_and_config(
+        self, runner: CliRunner, tmp_path: Path, tmp_wallet_path: Path
+    ) -> None:
+        result, cfg_path = self._run_setup(runner, tmp_path, tmp_wallet_path, "--coin-type", "0")
+        assert result.exit_code == 0, result.output
+        payload = _extract_json(result.output)
+        assert payload["coin_type"] == 0
+        assert payload["derivation_path"] == "m/44'/0'/0'"
+        # Persisted so a subsequent `wallet new` derives at m/44'/0'/0'.
+        from pyrxd.cli import config as _config
+
+        assert _config.load(cfg_path).coin_type == 0
+
+    def test_coin_type_512_in_config(self, runner: CliRunner, tmp_path: Path, tmp_wallet_path: Path) -> None:
+        result, cfg_path = self._run_setup(runner, tmp_path, tmp_wallet_path, "--coin-type", "512")
+        assert result.exit_code == 0, result.output
+        from pyrxd.cli import config as _config
+
+        assert _config.load(cfg_path).coin_type == 512
+
+    def test_invalid_coin_type_rejected(self, runner: CliRunner, tmp_path: Path, tmp_wallet_path: Path) -> None:
+        result, _cfg_path = self._run_setup(runner, tmp_path, tmp_wallet_path, "--coin-type", "999")
+        assert result.exit_code != 0
+
+    def test_existing_config_updated_in_place(self, runner: CliRunner, tmp_path: Path, tmp_wallet_path: Path) -> None:
+        cfg_path = tmp_path / "config.toml"
+        cfg_path.write_text('network = "testnet"\nfee_rate = 5000\n')
+        n, e = _patches(node_ok=False, electrumx_ok=False)
+        with patch("pyrxd.cli.setup_cmd._config.DEFAULT_CONFIG_PATH", cfg_path), n, e:
+            result = runner.invoke(
+                cli,
+                ["--wallet", str(tmp_wallet_path), "--json", "setup", "--coin-type", "0"],
+            )
+        assert result.exit_code == 0, result.output
+        from pyrxd.cli import config as _config
+
+        cfg = _config.load(cfg_path)
+        assert cfg.coin_type == 0
+        assert cfg.fee_rate == 5000  # untouched
+
+    def test_bare_rerun_does_not_clobber_existing_coin_type(
+        self, runner: CliRunner, tmp_path: Path, tmp_wallet_path: Path
+    ) -> None:
+        # A prior `setup --coin-type 0` recorded 0; a later bare `setup` (no
+        # --coin-type) must report it and leave it intact, not reset it to 512.
+        cfg_path = tmp_path / "config.toml"
+        cfg_path.write_text('network = "mainnet"\ncoin_type = 0\n')
+        n, e = _patches(node_ok=False, electrumx_ok=False)
+        with patch("pyrxd.cli.setup_cmd._config.DEFAULT_CONFIG_PATH", cfg_path), n, e:
+            result = runner.invoke(
+                cli,
+                ["--wallet", str(tmp_wallet_path), "--json", "setup", "--no-interactive"],
+            )
+        assert result.exit_code == 0, result.output
+        payload = _extract_json(result.output)
+        assert payload["coin_type"] == 0  # reported, not reset
+        from pyrxd.cli import config as _config
+
+        assert _config.load(cfg_path).coin_type == 0  # still 0 on disk
+
+    def test_human_summary_shows_coin_type(self, runner: CliRunner, tmp_path: Path, tmp_wallet_path: Path) -> None:
+        cfg_path = tmp_path / "config.toml"
+        n, e = _patches(node_ok=False, electrumx_ok=False)
+        with patch("pyrxd.cli.setup_cmd._config.DEFAULT_CONFIG_PATH", cfg_path), n, e:
+            result = runner.invoke(
+                cli,
+                ["--wallet", str(tmp_wallet_path), "setup", "--no-interactive", "--coin-type", "0"],
+            )
+        assert result.exit_code == 0, result.output
+        assert "coin type: 0" in result.output
+        assert "m/44'/0'/0'" in result.output

--- a/tests/test_glyph_wave.py
+++ b/tests/test_glyph_wave.py
@@ -210,6 +210,39 @@ class TestClassifyGlyphMetadata:
         md = GlyphMetadata(protocol=[GlyphProtocol.NFT, GlyphProtocol.ENCRYPTED], name="e")
         assert classify_glyph_metadata(md) == "encrypted"
 
+    def test_dat(self):
+        md = GlyphMetadata(protocol=[GlyphProtocol.DAT], name="d")
+        assert classify_glyph_metadata(md) == "dat"
+
+    def test_authority(self):
+        md = GlyphMetadata(protocol=[GlyphProtocol.NFT, GlyphProtocol.AUTHORITY], name="a")
+        assert classify_glyph_metadata(md) == "authority"
+
+    def test_timelock(self):
+        # TIMELOCK requires ENCRYPTED (which requires NFT) per the protocol
+        # rules in types.py — and must out-rank the bare "encrypted" label.
+        md = GlyphMetadata(
+            protocol=[GlyphProtocol.NFT, GlyphProtocol.ENCRYPTED, GlyphProtocol.TIMELOCK],
+            name="t",
+        )
+        assert classify_glyph_metadata(md) == "timelock"
+
+    def test_timelock_outranks_encrypted(self):
+        """A token carrying both ENCRYPTED and TIMELOCK is the more specific
+        'timelock', never the underlying 'encrypted'."""
+        md = GlyphMetadata(
+            protocol=[GlyphProtocol.NFT, GlyphProtocol.ENCRYPTED, GlyphProtocol.TIMELOCK],
+            name="t",
+        )
+        assert classify_glyph_metadata(md) == "timelock"
+
+    def test_authority_with_mut_outranks_mut(self):
+        md = GlyphMetadata(
+            protocol=[GlyphProtocol.NFT, GlyphProtocol.MUT, GlyphProtocol.AUTHORITY],
+            name="a",
+        )
+        assert classify_glyph_metadata(md) == "authority"
+
 
 # ─────────────────────────────────────────────── WaveResolver ──
 

--- a/tests/test_inspect_core_classification.py
+++ b/tests/test_inspect_core_classification.py
@@ -1,0 +1,181 @@
+"""Tests for the rarer-Glyph-protocol classification surfaced by the
+pure inspect core (``pyrxd.glyph._inspect_core``).
+
+Two layers:
+
+1. Unit tests of ``_classify_metadata_protocol`` directly — the fast,
+   high-value path. Covers every rarer protocol type from issue #135
+   (DAT, CONTAINER, ENCRYPTED, TIMELOCK, AUTHORITY, WAVE) plus the
+   highest-specificity ordering rules (TIMELOCK out-ranks ENCRYPTED;
+   AUTHORITY/CONTAINER out-rank MUT; legacy WAVE without ``attrs.name``
+   degrades to the underlying label).
+
+2. One end-to-end test that builds a real reveal transaction and asserts
+   ``_classify_raw_tx`` surfaces the ``classification`` key in its
+   ``metadata`` payload — proving the wiring, not just the helper.
+
+``_inspect_core`` must stay import-pure (no coincurve/websockets/aiohttp)
+so its classifier is a self-contained mirror of
+``pyrxd.glyph.wave.classify_glyph_metadata`` rather than an import of it;
+``tests/test_glyph_wave.py`` exercises the wave-side twin against the same
+rules so the two stay in sync.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from pyrxd.glyph._inspect_core import _classify_metadata_protocol, _classify_raw_tx
+from pyrxd.glyph.payload import build_reveal_scriptsig_suffix, encode_payload
+from pyrxd.glyph.types import GlyphMetadata, GlyphProtocol
+from pyrxd.glyph.wave import build_wave_metadata
+from pyrxd.hash import hash256
+from pyrxd.script.script import Script
+from pyrxd.transaction.transaction import Transaction
+from pyrxd.transaction.transaction_input import TransactionInput
+from pyrxd.transaction.transaction_output import TransactionOutput
+
+ADDR = "1JsKDV4xV8FXZjLDLcLvLY1aWCKBKt8XnQ"
+
+
+# ─────────────────────────────────── _classify_metadata_protocol (unit) ──
+
+
+class TestClassifyMetadataProtocol:
+    """Each rarer protocol type maps to its highest-specificity label.
+
+    Construction respects the protocol-combination rules in ``types.py``
+    (TIMELOCK requires ENCRYPTED; CONTAINER/ENCRYPTED/AUTHORITY require
+    NFT; WAVE requires NFT+MUT) so the GlyphMetadata validator accepts the
+    fixtures.
+    """
+
+    def test_dat(self):
+        md = GlyphMetadata(protocol=[GlyphProtocol.DAT], name="d")
+        assert _classify_metadata_protocol(md) == "dat"
+
+    def test_container(self):
+        md = GlyphMetadata(protocol=[GlyphProtocol.NFT, GlyphProtocol.CONTAINER], name="c")
+        assert _classify_metadata_protocol(md) == "container"
+
+    def test_encrypted(self):
+        md = GlyphMetadata(protocol=[GlyphProtocol.NFT, GlyphProtocol.ENCRYPTED], name="e")
+        assert _classify_metadata_protocol(md) == "encrypted"
+
+    def test_timelock(self):
+        md = GlyphMetadata(
+            protocol=[GlyphProtocol.NFT, GlyphProtocol.ENCRYPTED, GlyphProtocol.TIMELOCK],
+            name="t",
+        )
+        assert _classify_metadata_protocol(md) == "timelock"
+
+    def test_timelock_outranks_encrypted(self):
+        """TIMELOCK always carries ENCRYPTED — the more specific label wins."""
+        md = GlyphMetadata(
+            protocol=[GlyphProtocol.NFT, GlyphProtocol.ENCRYPTED, GlyphProtocol.TIMELOCK],
+            name="t",
+        )
+        assert _classify_metadata_protocol(md) != "encrypted"
+
+    def test_authority(self):
+        md = GlyphMetadata(protocol=[GlyphProtocol.NFT, GlyphProtocol.AUTHORITY], name="a")
+        assert _classify_metadata_protocol(md) == "authority"
+
+    def test_authority_outranks_mut(self):
+        md = GlyphMetadata(
+            protocol=[GlyphProtocol.NFT, GlyphProtocol.MUT, GlyphProtocol.AUTHORITY],
+            name="a",
+        )
+        assert _classify_metadata_protocol(md) == "authority"
+
+    def test_wave(self):
+        md = build_wave_metadata(qualified_name="alice.rxd", target=ADDR)
+        assert _classify_metadata_protocol(md) == "wave"
+
+    def test_legacy_wave_without_attrs_name_degrades_to_mut(self):
+        """WAVE lacking a resolvable attrs.name is a plain mutable NFT to
+        indexers — must not claim the 'wave' label."""
+        md = GlyphMetadata(
+            protocol=[GlyphProtocol.NFT, GlyphProtocol.MUT, GlyphProtocol.WAVE],
+            name="legacy.rxd",
+        )
+        assert _classify_metadata_protocol(md) == "mut"
+
+    # The common base types still classify correctly (regression guard for
+    # the ordering edits).
+    @pytest.mark.parametrize(
+        ("protocol", "expected"),
+        [
+            ([GlyphProtocol.NFT], "nft"),
+            ([GlyphProtocol.FT], "ft"),
+            ([GlyphProtocol.NFT, GlyphProtocol.MUT], "mut"),
+            ([GlyphProtocol.FT, GlyphProtocol.DMINT], "dmint"),
+        ],
+    )
+    def test_base_types_unchanged(self, protocol, expected):
+        md = GlyphMetadata(protocol=protocol, name="x", ticker="X")
+        assert _classify_metadata_protocol(md) == expected
+
+
+# ───────────────────────────── _classify_raw_tx classification wiring ──
+
+
+def _build_reveal_tx(metadata: GlyphMetadata) -> tuple[bytes, str]:
+    """Build a serialized tx whose vin[0] scriptSig embeds the reveal CBOR.
+
+    Returns (raw_bytes, real_txid). The scriptSig is just the ``gly`` + CBOR
+    suffix (sig/pubkey pushes are optional for the inspector's gly-marker
+    walker, which scans for the marker anywhere in the pushes).
+    """
+    cbor_bytes, _ = encode_payload(metadata)
+    scriptsig = build_reveal_scriptsig_suffix(cbor_bytes)
+    tx = Transaction(
+        tx_inputs=[
+            TransactionInput(
+                source_txid="a" * 64,
+                source_output_index=0,
+                unlocking_script=Script(scriptsig),
+            )
+        ],
+        tx_outputs=[TransactionOutput(Script(b"\x6a"), 0)],  # bare OP_RETURN
+    )
+    raw = bytes(tx.serialize())
+    real_txid = hash256(raw)[::-1].hex()
+    return raw, real_txid
+
+
+class TestClassifyRawTxSurfacesClassification:
+    def test_classification_key_present_for_container(self):
+        md = GlyphMetadata(protocol=[GlyphProtocol.NFT, GlyphProtocol.CONTAINER], name="c")
+        raw, txid = _build_reveal_tx(md)
+        result = _classify_raw_tx(txid, raw)
+        assert result["metadata"] is not None
+        assert result["metadata"]["classification"] == "container"
+
+    def test_classification_key_for_timelock(self):
+        md = GlyphMetadata(
+            protocol=[GlyphProtocol.NFT, GlyphProtocol.ENCRYPTED, GlyphProtocol.TIMELOCK],
+            name="t",
+        )
+        raw, txid = _build_reveal_tx(md)
+        result = _classify_raw_tx(txid, raw)
+        assert result["metadata"]["classification"] == "timelock"
+
+    def test_classification_key_for_wave(self):
+        md = build_wave_metadata(qualified_name="alice.rxd", target=ADDR)
+        raw, txid = _build_reveal_tx(md)
+        result = _classify_raw_tx(txid, raw)
+        assert result["metadata"]["classification"] == "wave"
+
+    @pytest.mark.parametrize(
+        ("metadata", "expected"),
+        [
+            (GlyphMetadata(protocol=[GlyphProtocol.DAT], name="d"), "dat"),
+            (GlyphMetadata(protocol=[GlyphProtocol.NFT, GlyphProtocol.ENCRYPTED], name="e"), "encrypted"),
+            (GlyphMetadata(protocol=[GlyphProtocol.NFT, GlyphProtocol.AUTHORITY], name="a"), "authority"),
+        ],
+    )
+    def test_classification_key_for_each_rarer_type(self, metadata, expected):
+        raw, txid = _build_reveal_tx(metadata)
+        result = _classify_raw_tx(txid, raw)
+        assert result["metadata"]["classification"] == expected


### PR DESCRIPTION
Finishes two long-open CLI/inspect issues.

## #18 — CLI surface for coin_type
- `pyrxd setup --coin-type {0,236,512}` records the SLIP-0044 coin type into `config.toml` so a later `wallet new` derives at `m/44'/<coin_type>'/0'`. Help text maps each value to the wallet it's for (512 = Radiant standard, 0 = Photonic/Electron-Radiant legacy, 236 = old pyrxd, not promoted).
- The flag persists **only when explicitly passed** — a bare `setup` re-run reports the current coin type without clobbering a previously recorded one (regression-tested).
- Fixes the user-facing path strings in `wallet export-xpub` and `query address` that hardcoded `m/44'/512'/...`; they now interpolate the wallet's actual `coin_type`, so a `coin_type=0` wallet no longer shows a misleading 512 path.
- The scan-paths recovery surface (acceptance criterion 3) already shipped earlier as `wallet recover --scan`.

## #135 — classify rarer Glyph protocol types in inspect core
- inspect's pure core now emits a human-friendly highest-specificity `classification` label for the metadata-only protocol types it previously surfaced only as raw values: DAT, CONTAINER, ENCRYPTED, TIMELOCK, AUTHORITY, WAVE (alongside the existing dmint/mut/ft/nft).
- Extends `wave.classify_glyph_metadata` with the missing branches (authority/timelock/dat), highest-specificity-first (TIMELOCK before ENCRYPTED, since TIMELOCK requires ENCRYPTED).
- `_inspect_core` keeps a self-contained mirror of the classifier rather than importing `wave.py` (which is not import-pure — it transitively pulls aiohttp/websockets/coincurve via rxindexer), preserving the module's Pyodide-safe contract. Both copies are kept in sync and test-covered.

## Verification
`task ci` green: 3940 passed, 66 skipped, coverage 88.00%.

Closes #18
Closes #135