### PR TITLE
feat(swap): high-level partial-transaction swap API for same-chain trades (#123)

### DIFF
--- a/docs/concepts/index.md
+++ b/docs/concepts/index.md
@@ -7,6 +7,7 @@ and how Radiant differs from related blockchains.
 :maxdepth: 1
 
 gravity
+partial-tx-swaps
 glyph-structures-and-terminology
 radiant-fts-are-on-chain
 dmint-v1-deploy
@@ -19,6 +20,12 @@ external-miner-protocol
   Gravity protocol is, what a covenant is, and the difference between
   the mainnet-proven sentinel-artifact path and the experimental
   covenant variants. Read this before integrating `pyrxd.gravity`.
+- **[Same-chain partial-transaction swaps](partial-tx-swaps.md)** — the
+  `pyrxd.swap` offer/accept API for trading RXD and Glyph FTs in one
+  transaction via `SIGHASH_SINGLE | ANYONECANPAY`, how its safety rests
+  on the maker's signature (not the declared terms), and when to use it
+  instead of cross-chain Gravity. Read this before integrating
+  `pyrxd.swap`.
 - **[Understanding Glyph structures and terminology](glyph-structures-and-terminology.md)** —
   the difference between a `txid`, an `outpoint`, a `GlyphRef`, and a
   `contract_id`; what each `ft` / `nft` / `mut` / `commit-*` / `dmint`

--- a/docs/concepts/partial-tx-swaps.md
+++ b/docs/concepts/partial-tx-swaps.md
@@ -1,0 +1,123 @@
+# Same-chain partial-transaction swaps
+
+**Audience:** developers building same-chain RXD ↔ token (or token ↔
+token) trades with `pyrxd.swap` — e.g. a marketplace or an on-chain
+order flow.
+
+**Status:** the API is implemented and unit-tested (including adversarial
+cases). Like every value-moving primitive in pyrxd, treat an external
+audit as the gate before real-value, untrusted-counterparty use.
+
+## What this is
+
+A *partial-transaction swap* trades two assets atomically inside a
+**single** transaction using signature-level atomicity. The maker signs
+one input (the asset they give) committing to one output (the asset they
+want back) with `SIGHASH_SINGLE | ANYONECANPAY`. The taker then adds
+their own inputs and outputs to complete the trade and broadcasts.
+
+Because both legs settle in one transaction, the swap is atomic: it
+either confirms wholly or not at all. There is no escrow, no covenant,
+and no second transaction.
+
+```
+maker input[0]  ── gives asset X ──┐         ┌── output[0]  maker receives asset Y  (SINGLE-committed)
+                                   │   one    │
+taker input[1+] ── funds Y + fee ──┤   tx     ├── output[1]  taker receives asset X
+                                   │          ├── output[..] FT/RXD change to taker
+                                   └──────────┘
+```
+
+## When to use it (vs Gravity)
+
+| | `pyrxd.swap` (this) | [`pyrxd.gravity`](gravity.md) |
+|---|---|---|
+| Chains | **Same chain** (RXD ↔ RXD/token) | **Cross-chain** (RXD ↔ BTC/…) |
+| Atomicity | One transaction, signature-level | HTLC (hashlock + timelock) or SPV-oracle |
+| Counterparty | Maker + taker complete one tx | Two chains, two legs |
+
+Use `pyrxd.swap` for trading assets that live on Radiant. Use Gravity
+when the two assets live on different chains.
+
+## Why it is safe
+
+The maker's `SINGLE|ANYONECANPAY` signature is the enforcement — not the
+declared terms. That signature commits to:
+
+- the maker's **given** input: its outpoint, **value**, and locking
+  script (so the given amount/asset can't be misrepresented), and
+- **output[0]** only: the maker's **receive** asset and amount.
+
+`ANYONECANPAY` lets the taker add inputs; `SINGLE` lets the taker add
+outputs after index 0. Neither lets the taker alter what the maker gives
+or receives without invalidating the signature.
+
+`accept_offer` therefore, by construction:
+
+1. reads the maker's **real** given asset from the source transaction
+   (verified to hash to the input's outpoint) — never from the declared
+   terms;
+2. reconciles the real given/received assets against the stated
+   `SwapTerms` and rejects on any mismatch;
+3. **re-verifies the maker's signature** before and after completing the
+   transaction;
+4. derives the taker's received amount from the real given asset (there
+   is no caller knob to get it wrong);
+5. enforces token conservation per FT ref and returns RXD change to the
+   taker.
+
+This closes the classic footgun where a hand-rolled taker builds its
+received-amount output from caller-supplied parameters and never checks
+the maker's real prevout.
+
+## Glyph FT specifics
+
+Radiant FTs carry their amount as the output's photon value (1 photon =
+1 FT unit) and their identity as a genesis ref embedded in the
+[75-byte FT script](radiant-fts-are-on-chain.md). The swap API:
+
+- treats an FT output's photons as its token amount;
+- requires **ref continuity** — every FT ref in the outputs must be
+  funded by an input of the same ref (the Radiant consensus rule), with
+  surplus returned as FT change;
+- enforces amount conservation per ref in the SDK (there is no consensus
+  opcode that does this for plain transfers).
+
+## Limitations (v1)
+
+- **Whole-UTXO give.** The maker spends their entire given UTXO; `SINGLE`
+  protects only output[0], so a maker-side change output would be
+  unprotected. Pre-split the UTXO to sell a partial amount.
+- **RXD and FT only.** NFTs (singletons) are out of scope.
+- **Explicit fee.** `accept_offer(fee=…)` takes an absolute photon fee;
+  the taker funds it.
+
+## Minimal example
+
+See [`examples/partial_swap_demo.py`](https://github.com/MudwoodLabs/pyrxd/blob/main/examples/partial_swap_demo.py)
+for a runnable end-to-end demo (offer → transport → accept → verify),
+covering an FT-for-RXD trade with conservation and change.
+
+```python
+from pyrxd.swap import Asset, FundingInput, SwapOffer, accept_offer, create_offer
+
+# Maker: give an FT UTXO, want 800 RXD photons.
+offer = create_offer(
+    give_source_tx=maker_ft_source_tx,
+    give_vout=0,
+    maker_key=maker_key,
+    receive=Asset("rxd", 800),
+    maker_receive_pkh=maker_pkh,
+)
+payload = offer.to_dict()  # JSON-able; send over any transport
+
+# Taker: verify + complete + sign.
+tx = accept_offer(
+    SwapOffer.from_dict(payload),
+    funding=[FundingInput(taker_rxd_source_tx, 0, taker_key)],
+    taker_receive_pkh=taker_pkh,
+    taker_change_pkh=taker_pkh,
+    fee=300,
+)
+raw = tx.serialize().hex()  # broadcast
+```

--- a/examples/partial_swap_demo.py
+++ b/examples/partial_swap_demo.py
@@ -1,0 +1,119 @@
+#!/usr/bin/env python3
+"""Same-chain partial-transaction swap (``pyrxd.swap``) — end-to-end demo.
+
+Shows the full offer → transport → accept → verify flow for a Glyph FT
+traded against plain RXD, all in one process:
+
+    Maker:  gives 1000 FT units, wants 800 RXD photons.
+    Taker:  funds the 800 + fee, receives the 1000 FT.
+
+This demo is self-contained: it synthesises the maker's and taker's
+source UTXOs in memory so it runs with no node and no network — it
+exercises the *real* swap API (signing, conservation, and the maker
+signature re-verification), it just doesn't broadcast.
+
+To run a real swap, replace the synthetic source transactions with ones
+fetched from the chain via :mod:`pyrxd.swap.resolve`
+(``fetch_transaction`` / ``fetch_funding_input``) and broadcast the
+resulting hex. The maker's source transaction travels inside the offer,
+so the taker needs the network only to gather their own funding.
+
+Usage::
+
+    python examples/partial_swap_demo.py
+
+See also: docs/concepts/partial-tx-swaps.md
+"""
+
+from __future__ import annotations
+
+from pyrxd.glyph.script import build_ft_locking_script, extract_ref_from_ft_script, is_ft_script
+from pyrxd.glyph.types import GlyphRef
+from pyrxd.keys import PrivateKey
+from pyrxd.script.script import Script
+from pyrxd.script.type import P2PKH
+from pyrxd.security.types import Hex20, Txid
+from pyrxd.swap import Asset, FundingInput, SwapOffer, accept_offer, create_offer
+from pyrxd.transaction.transaction import Transaction
+from pyrxd.transaction.transaction_output import TransactionOutput
+
+
+def _p2pkh_source(pkh: bytes, value: int) -> Transaction:
+    tx = Transaction()
+    tx.add_output(TransactionOutput(P2PKH().lock(pkh), value))
+    return tx
+
+
+def _ft_source(pkh: bytes, ref: GlyphRef, value: int) -> Transaction:
+    tx = Transaction()
+    tx.add_output(TransactionOutput(Script(build_ft_locking_script(Hex20(pkh), ref)), value))
+    return tx
+
+
+def _describe(out: TransactionOutput) -> str:
+    script = out.locking_script.serialize()
+    if is_ft_script(script.hex()):
+        ref = extract_ref_from_ft_script(script)
+        return f"{out.satoshis:>6} FT  (ref {ref.txid[:8]}…:{ref.vout})"
+    return f"{out.satoshis:>6} RXD"
+
+
+def main() -> None:
+    maker = PrivateKey()
+    taker = PrivateKey()
+    maker_pkh = maker.public_key().hash160()
+    taker_pkh = taker.public_key().hash160()
+    token_ref = GlyphRef(txid=Txid("cd" * 32), vout=0)
+
+    # --- Maker side --------------------------------------------------------
+    # The maker holds an FT UTXO of 1000 units and wants 800 RXD for it.
+    maker_ft_utxo = _ft_source(maker_pkh, token_ref, 1000)
+    offer = create_offer(
+        give_source_tx=maker_ft_utxo,
+        give_vout=0,
+        maker_key=maker,
+        receive=Asset(kind="rxd", amount=800),
+        maker_receive_pkh=maker_pkh,
+    )
+    print("Maker created an offer:")
+    print(f"  gives:    {offer.terms.give.amount} FT (ref {token_ref.txid[:8]}…)")
+    print(f"  receives: {offer.terms.receive.amount} RXD")
+
+    # The offer is JSON-able — send it over any transport.
+    payload = offer.to_dict()
+    print(f"\nOffer serialized to a {len(str(payload))}-char transport payload.\n")
+
+    # --- Taker side --------------------------------------------------------
+    # The taker funds the maker's 800 RXD (+ fee) from a 2000-RXD UTXO and
+    # receives the FT. accept_offer reads the maker's real given asset from
+    # the offer, reconciles the terms, and re-verifies the maker signature.
+    taker_rxd_utxo = _p2pkh_source(taker_pkh, 2000)
+    fee = 300
+    tx = accept_offer(
+        SwapOffer.from_dict(payload),
+        funding=[FundingInput(source_tx=taker_rxd_utxo, vout=0, key=taker)],
+        taker_receive_pkh=taker_pkh,
+        taker_change_pkh=taker_pkh,
+        fee=fee,
+    )
+
+    print("Taker accepted; final swap transaction:")
+    print(
+        f"  inputs:  {len(tx.inputs)} (maker FT + taker RXD), all signed: "
+        f"{all(i.unlocking_script is not None for i in tx.inputs)}"
+    )
+    print("  outputs:")
+    print(f"    [0] maker receives: {_describe(tx.outputs[0])}")
+    print(f"    [1] taker receives: {_describe(tx.outputs[1])}")
+    for i, out in enumerate(tx.outputs[2:], start=2):
+        print(f"    [{i}] taker change:   {_describe(out)}")
+
+    total_in = maker_ft_utxo.outputs[0].satoshis + taker_rxd_utxo.outputs[0].satoshis
+    total_out = sum(o.satoshis for o in tx.outputs)
+    print(f"\n  fee (in - out): {total_in - total_out} photons")
+    print(f"\nBroadcast-ready raw tx ({len(tx.serialize())} bytes):")
+    print(f"  {tx.serialize().hex()[:80]}…")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/pyrxd/swap/__init__.py
+++ b/src/pyrxd/swap/__init__.py
@@ -1,0 +1,56 @@
+"""Same-chain partial-transaction swaps for RXD and Glyph FTs.
+
+A high-level, guard-railed offer/accept API over ``SIGHASH_SINGLE |
+ANYONECANPAY`` signature-level atomicity — the "maker signs one input
+committing to one output, taker completes and broadcasts" pattern.
+
+Quick start::
+
+    from pyrxd.swap import create_offer, accept_offer, Asset, FundingInput
+
+    # Maker: give 1000 RXD-photons, want 50 units of FT `ref`.
+    offer = create_offer(
+        give_source_tx=maker_utxo_source_tx,
+        give_vout=0,
+        maker_key=maker_key,
+        receive=Asset(kind="ft", amount=50, ref=ft_ref),
+        maker_receive_pkh=maker_pkh,
+    )
+    payload = offer.to_dict()          # send over any transport
+
+    # Taker: verify + complete + sign.
+    tx = accept_offer(
+        SwapOffer.from_dict(payload),
+        funding=[FundingInput(source_tx=taker_ft_source, vout=0, key=taker_key)],
+        taker_receive_pkh=taker_pkh,
+        taker_change_pkh=taker_pkh,
+        fee=500,
+    )
+    raw = tx.serialize().hex()         # broadcast
+
+This is distinct from :mod:`pyrxd.gravity`, which does *cross-chain*
+atomic swaps gated by SPV proofs. Use this for same-chain RXD/token
+trades; use Gravity when the two assets live on different chains.
+
+The core (``create_offer`` / ``accept_offer``) is pure — no network. Use
+the :mod:`pyrxd.swap.resolve` helpers to fetch the transactions an offer
+references.
+"""
+
+from __future__ import annotations
+
+from .partial import FundingInput, accept_offer, create_offer
+from .resolve import fetch_funding_input, fetch_transaction
+from .types import Asset, AssetKind, SwapOffer, SwapTerms
+
+__all__ = [
+    "Asset",
+    "AssetKind",
+    "FundingInput",
+    "SwapOffer",
+    "SwapTerms",
+    "accept_offer",
+    "create_offer",
+    "fetch_funding_input",
+    "fetch_transaction",
+]

--- a/src/pyrxd/swap/partial.py
+++ b/src/pyrxd/swap/partial.py
@@ -1,0 +1,347 @@
+"""Same-chain partial-transaction swaps (``SIGHASH_SINGLE | ANYONECANPAY``).
+
+The classic offer/accept pattern, made safe-by-construction:
+
+* :func:`create_offer` — the maker signs ONE input (the asset they give)
+  committing to ONE output (the asset they want back), using
+  ``SIGHASH_SINGLE | ANYONECANPAY``. That signature cryptographically
+  binds the given input's outpoint/value/script **and** the receive
+  output — nothing else.
+* :func:`accept_offer` — the taker reads the maker's *real* given asset
+  from the source transaction (verified to hash to the input's outpoint),
+  reconciles it against the declared terms, **re-verifies the maker's
+  signature**, then adds their own funding + receive + change outputs,
+  enforces token conservation, signs their inputs, and returns a fully
+  signed transaction ready to broadcast.
+
+Why this is atomic: both assets move in a single transaction, so it
+either confirms wholly or not at all. Why it is safe: because the maker
+only signs ``SINGLE|ANYONECANPAY``, the taker can add inputs/outputs
+freely, but cannot alter what the maker gives or receives without
+invalidating the maker's signature — which :func:`accept_offer` checks
+before returning.
+
+Scope (v1): plain RXD and Glyph FT assets, on the same chain. The maker
+spends their entire given UTXO (SINGLE protects only output[0], so a
+maker-side change output would be unprotected — pre-split the UTXO to
+sell a partial amount). NFTs are out of scope.
+
+This module is pure (no network). To fetch the source/funding
+transactions an offer references, see :mod:`pyrxd.swap.resolve`.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from ..constants import SIGHASH
+from ..glyph.script import build_ft_locking_script, extract_ref_from_ft_script, is_ft_script
+from ..glyph.types import GlyphRef
+from ..keys import PrivateKey, PublicKey
+from ..script.script import Script
+from ..script.type import P2PKH
+from ..security.errors import ValidationError
+from ..security.types import Hex20
+from ..transaction.transaction import Transaction
+from ..transaction.transaction_input import TransactionInput
+from ..transaction.transaction_output import TransactionOutput
+from .types import Asset, SwapOffer, SwapTerms
+
+# Photons below this are not worth a standalone change output; fold into fee.
+# (Token/FT change is always emitted regardless — it carries token value.)
+_DUST_PHOTONS = 546
+
+# A maker offer input is signed with this so the taker can complete the tx.
+_OFFER_SIGHASH = SIGHASH.SINGLE_ANYONECANPAY_FORKID
+
+
+# ─────────────────────────────── asset helpers ───────────────────────────────
+
+
+def _is_p2pkh(script: bytes) -> bool:
+    return len(script) == 25 and script[:3] == b"\x76\xa9\x14" and script[23:] == b"\x88\xac"
+
+
+def _owner_pkh_of(script: bytes) -> bytes:
+    """Owner PKH of a spendable output (plain P2PKH or an FT lock — both embed it at [3:23])."""
+    if _is_p2pkh(script) or is_ft_script(script.hex()):
+        return script[3:23]
+    raise ValidationError("output is not a spendable P2PKH or FT script")
+
+
+def _asset_of(satoshis: int, script: bytes) -> Asset:
+    """Classify an output's spendable asset. Rejects anything but RXD / FT."""
+    if is_ft_script(script.hex()):
+        return Asset(kind="ft", amount=satoshis, ref=extract_ref_from_ft_script(script))
+    if _is_p2pkh(script):
+        return Asset(kind="rxd", amount=satoshis, ref=None)
+    raise ValidationError("unsupported asset: output is neither plain RXD (P2PKH) nor a Glyph FT")
+
+
+def _build_asset_output(asset: Asset, pkh: bytes) -> TransactionOutput:
+    """Build the output that pays *asset* to the holder of *pkh*."""
+    if asset.kind == "ft":
+        if asset.ref is None:  # guaranteed by Asset.__post_init__; guard keeps types + bandit happy
+            raise ValidationError("FT asset is missing its ref")
+        return TransactionOutput(Script(build_ft_locking_script(Hex20(pkh), asset.ref)), asset.amount)
+    return TransactionOutput(P2PKH().lock(pkh), asset.amount)
+
+
+# ───────────────────────── maker-signature re-verification ───────────────────
+
+
+def _parse_p2pkh_scriptsig(unlocking: bytes) -> tuple[bytes, bytes]:
+    """Parse a ``<sig+sighash> <pubkey>`` P2PKH scriptSig into its two pushes.
+
+    Both pushes are short (sig ~71-72 B, pubkey 33 B), so each is a single
+    OP_PUSHBYTES (length-prefixed) opcode. Anything else is malformed.
+    """
+    pos = 0
+    pushes: list[bytes] = []
+    for _ in range(2):
+        if pos >= len(unlocking):
+            raise ValidationError("malformed P2PKH scriptSig: too few pushes")
+        n = unlocking[pos]
+        if not 1 <= n <= 75:  # minimal direct push only
+            raise ValidationError("malformed P2PKH scriptSig: unexpected opcode")
+        pos += 1
+        if pos + n > len(unlocking):
+            raise ValidationError("malformed P2PKH scriptSig: truncated push")
+        pushes.append(unlocking[pos : pos + n])
+        pos += n
+    if pos != len(unlocking):
+        raise ValidationError("malformed P2PKH scriptSig: trailing bytes")
+    return pushes[0], pushes[1]
+
+
+def _verify_owner_signature(tx: Transaction, index: int) -> None:
+    """Re-verify that input *index* carries a valid owner signature for the current tx.
+
+    Confirms (a) the pubkey in the scriptSig hashes to the prevout's owner
+    PKH and (b) the signature validates against the input's preimage as
+    computed over the *current* transaction. For a ``SINGLE|ANYONECANPAY``
+    maker input this stays valid no matter what the taker appends — so a
+    failure here means the given/received terms were tampered with.
+    """
+    inp = tx.inputs[index]
+    if inp.unlocking_script is None or inp.locking_script is None or inp.satoshis is None:
+        raise ValidationError(f"input {index} is not ready for signature verification")
+    sig_with_flag, pubkey = _parse_p2pkh_scriptsig(inp.unlocking_script.serialize())
+    if len(sig_with_flag) < 2:
+        raise ValidationError("malformed signature push")
+    der, flag = sig_with_flag[:-1], sig_with_flag[-1]  # signature + its trailing sighash-type byte
+    # The sighash type is NOT carried in the tx wire format (it lives only in
+    # the signature byte), so a parsed input always reports the default flag.
+    # Restore the actual flag from the signature before computing the preimage,
+    # or the digest would not match what the signer committed to.
+    inp.sighash = SIGHASH(flag) if flag in iter(SIGHASH) else flag
+    pub = PublicKey(pubkey)
+    if pub.hash160() != _owner_pkh_of(inp.locking_script.serialize()):
+        raise ValidationError(f"input {index} pubkey does not match the prevout owner")
+    if not pub.verify(der, tx.preimage(index)):
+        raise ValidationError(f"input {index} signature does not validate against the transaction")
+
+
+# ─────────────────────────────── public API ──────────────────────────────────
+
+
+def create_offer(
+    *,
+    give_source_tx: Transaction,
+    give_vout: int,
+    maker_key: PrivateKey,
+    receive: Asset,
+    maker_receive_pkh: bytes | Hex20,
+) -> SwapOffer:
+    """Build a maker's signed partial-swap offer.
+
+    The maker offers to spend ``give_source_tx.outputs[give_vout]`` (the
+    *given* asset, owned by ``maker_key``) in exchange for ``receive``
+    paid to ``maker_receive_pkh`` in output[0]. The given input is signed
+    ``SINGLE|ANYONECANPAY`` so any taker can complete the swap.
+
+    The whole given UTXO is spent (its full value flows to the taker);
+    pre-split the UTXO beforehand to sell a partial amount.
+    """
+    if not 0 <= give_vout < len(give_source_tx.outputs):
+        raise ValidationError(f"give_vout {give_vout} out of range for the source transaction")
+    give_out = give_source_tx.outputs[give_vout]
+    give_script = give_out.locking_script.serialize()
+
+    # The maker must actually own the given UTXO.
+    if _owner_pkh_of(give_script) != maker_key.public_key().hash160():
+        raise ValidationError("maker_key does not own the given UTXO")
+
+    give = _asset_of(give_out.satoshis, give_script)
+    maker_pkh = bytes(maker_receive_pkh)
+
+    tx = Transaction()
+    tx.add_input(
+        TransactionInput(
+            source_transaction=give_source_tx,
+            source_output_index=give_vout,
+            unlocking_script_template=P2PKH().unlock(maker_key),
+            sighash=_OFFER_SIGHASH,
+        )
+    )
+    tx.add_output(_build_asset_output(receive, maker_pkh))
+    tx.sign(bypass=True)  # signs only the maker input (output[0] committed via SINGLE)
+
+    return SwapOffer(
+        partial_tx_hex=tx.serialize().hex(),
+        give_source_tx_hex=give_source_tx.serialize().hex(),
+        give_vout=give_vout,
+        terms=SwapTerms(give=give, receive=receive),
+    )
+
+
+@dataclass
+class FundingInput:
+    """A taker-owned UTXO used to fund the maker's receive + fee (and/or to pay an FT the maker wants).
+
+    ``source_tx`` is the taker's own previous transaction, so its
+    value/script are trusted (the taker controls it). ``key`` signs it.
+    """
+
+    source_tx: Transaction
+    vout: int
+    key: PrivateKey
+
+
+def accept_offer(
+    offer: SwapOffer,
+    *,
+    funding: list[FundingInput],
+    taker_receive_pkh: bytes | Hex20,
+    taker_change_pkh: bytes | Hex20,
+    fee: int,
+) -> Transaction:
+    """Complete and sign a maker's offer, returning a broadcast-ready transaction.
+
+    Safety, by construction:
+
+    * The maker's given asset is read from ``offer.give_source_tx_hex``
+      (verified to hash to the maker input's outpoint) — never from the
+      declared terms — and reconciled against ``offer.terms.give``.
+    * The maker's receive output (output[0]) is read from the partial tx
+      and reconciled against ``offer.terms.receive``.
+    * The maker's signature is re-verified both before and after the taker
+      completes the transaction, so tampered terms are rejected.
+    * Token conservation is enforced per FT ref; RXD change goes to the
+      taker. The taker receives the maker's given asset in output[1].
+
+    ``fee`` is the absolute fee in photons; the taker funds it.
+    """
+    if not funding:
+        raise ValidationError("at least one funding input is required")
+    taker_recv_pkh = bytes(taker_receive_pkh)
+    taker_chg_pkh = bytes(taker_change_pkh)
+
+    partial = Transaction.from_hex(bytes.fromhex(offer.partial_tx_hex))
+    give_source = Transaction.from_hex(bytes.fromhex(offer.give_source_tx_hex))
+    if partial is None or give_source is None:
+        raise ValidationError("offer contains an unparseable transaction")
+    if not partial.inputs or not partial.outputs:
+        raise ValidationError("offer partial transaction is missing the maker input/output")
+
+    maker_in = partial.inputs[0]
+    # The source tx the taker was handed must be the real funder of the maker input.
+    if give_source.txid() != maker_in.source_txid:
+        raise ValidationError("give_source_tx does not match the maker input's outpoint")
+    give_vout = maker_in.source_output_index
+    if not 0 <= give_vout < len(give_source.outputs):
+        raise ValidationError("maker input references a non-existent source output")
+    give_out = give_source.outputs[give_vout]
+    # from_hex does not populate prevout value/script — set them so the
+    # preimage (and thus signature verification) is computed correctly.
+    maker_in.satoshis = give_out.satoshis
+    maker_in.locking_script = give_out.locking_script
+
+    # Reconcile the REAL given/received assets against the declared terms.
+    real_give = _asset_of(give_out.satoshis, give_out.locking_script.serialize())
+    if real_give != offer.terms.give:
+        raise ValidationError(f"offer give terms do not match the chain: declared {offer.terms.give}, real {real_give}")
+    real_receive = _asset_of(partial.outputs[0].satoshis, partial.outputs[0].locking_script.serialize())
+    if real_receive != offer.terms.receive:
+        raise ValidationError(
+            f"offer receive terms do not match the partial tx: declared {offer.terms.receive}, real {real_receive}"
+        )
+
+    # The maker signature must be valid on the offer as received.
+    _verify_owner_signature(partial, 0)
+
+    # Snapshot the maker's committed output so we can prove we never touched it.
+    maker_output_0 = partial.outputs[0].serialize()
+
+    # output[1]: the taker receives exactly the maker's given asset.
+    partial.add_output(_build_asset_output(real_give, taker_recv_pkh))
+
+    # Add the taker's funding inputs (signed ALL_FORKID — the taker finalizes).
+    for f in funding:
+        if not 0 <= f.vout < len(f.source_tx.outputs):
+            raise ValidationError("funding input references a non-existent source output")
+        partial.add_input(
+            TransactionInput(
+                source_transaction=f.source_tx,
+                source_output_index=f.vout,
+                unlocking_script_template=P2PKH().unlock(f.key),
+                sighash=SIGHASH.ALL_FORKID,
+            )
+        )
+
+    _balance_and_add_change(partial, taker_chg_pkh, fee)
+
+    partial.sign(bypass=True)  # signs only the taker inputs; maker input is preserved
+
+    # Post-combine invariants: maker output untouched, signature still valid.
+    if partial.outputs[0].serialize() != maker_output_0:
+        raise ValidationError("internal error: maker receive output changed during accept")
+    _verify_owner_signature(partial, 0)
+    return partial
+
+
+def _balance_and_add_change(tx: Transaction, taker_change_pkh: bytes, fee: int) -> None:
+    """Enforce per-FT-ref conservation and append FT/RXD change outputs.
+
+    Each FT ref must conserve (sum of input photons of that ref == sum of
+    output photons); any surplus becomes an FT change output to the taker.
+    The remaining (non-FT) photon surplus, less ``fee``, becomes an RXD
+    change output. Raises if the taker under-funded any leg.
+    """
+    if fee < 0:
+        raise ValidationError("fee must be non-negative")
+
+    ft_in: dict[GlyphRef, int] = {}
+    total_in = 0
+    for inp in tx.inputs:
+        if inp.satoshis is None or inp.locking_script is None:
+            raise ValidationError("an input is missing its prevout value/script")
+        total_in += inp.satoshis
+        asset = _asset_of(inp.satoshis, inp.locking_script.serialize())
+        if asset.kind == "ft":
+            ft_in[asset.ref] = ft_in.get(asset.ref, 0) + asset.amount  # type: ignore[index]
+
+    ft_out: dict[GlyphRef, int] = {}
+    total_out = 0
+    for out in tx.outputs:
+        total_out += out.satoshis
+        asset = _asset_of(out.satoshis, out.locking_script.serialize())
+        if asset.kind == "ft":
+            ft_out[asset.ref] = ft_out.get(asset.ref, 0) + asset.amount  # type: ignore[index]
+
+    # FT change: per ref, emit the surplus back to the taker; a deficit is
+    # under-funding (and the chain would reject the unbacked output ref).
+    for ref in set(ft_in) | set(ft_out):
+        surplus = ft_in.get(ref, 0) - ft_out.get(ref, 0)
+        if surplus < 0:
+            raise ValidationError(f"funding lacks {-surplus} units of FT {ref.txid}:{ref.vout}")
+        if surplus > 0:
+            tx.add_output(_build_asset_output(Asset(kind="ft", amount=surplus, ref=ref), taker_change_pkh))
+            total_out += surplus
+
+    rxd_change = total_in - total_out - fee
+    if rxd_change < 0:
+        raise ValidationError(f"funding is {-rxd_change} photons short of covering the swap plus fee")
+    if rxd_change >= _DUST_PHOTONS:
+        tx.add_output(TransactionOutput(P2PKH().lock(taker_change_pkh), rxd_change))
+    # else: sub-dust remainder is left to the fee rather than emitting dust.

--- a/src/pyrxd/swap/resolve.py
+++ b/src/pyrxd/swap/resolve.py
@@ -1,0 +1,55 @@
+"""Async helpers to fetch the transactions a swap references.
+
+Kept separate from the pure :mod:`pyrxd.swap.partial` core so that
+``import pyrxd.swap`` pulls in no network dependencies — the
+``ElectrumXClient`` import is deferred into the functions that use it.
+
+A maker uses :func:`fetch_transaction` to load the source tx of the UTXO
+they want to give; a taker uses :func:`fetch_funding_input` to load each
+of their own funding UTXOs. The maker's source tx travels inside the
+:class:`~pyrxd.swap.types.SwapOffer`, so a taker never needs the network
+to *verify* an offer — only to gather their own funding.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from ..keys import PrivateKey
+from ..security.errors import ValidationError
+from ..security.types import Txid
+from ..transaction.transaction import Transaction
+from .partial import FundingInput
+
+if TYPE_CHECKING:
+    from ..network.electrumx import ElectrumXClient
+
+
+async def fetch_transaction(client: ElectrumXClient, txid: str | Txid) -> Transaction:
+    """Fetch and parse a transaction, verifying it actually hashes to *txid*.
+
+    The server-honesty check (computed txid == requested txid) means a
+    hostile or buggy server cannot substitute a different transaction.
+    """
+    wanted = Txid(str(txid))
+    raw = await client.get_transaction(wanted)
+    tx = Transaction.from_hex(bytes(raw))
+    if tx is None:
+        raise ValidationError(f"could not parse the transaction returned for {wanted}")
+    if tx.txid() != str(wanted):
+        raise ValidationError(f"server returned a transaction whose hash != requested txid ({wanted})")
+    return tx
+
+
+async def fetch_funding_input(
+    client: ElectrumXClient,
+    *,
+    txid: str | Txid,
+    vout: int,
+    key: PrivateKey,
+) -> FundingInput:
+    """Resolve one of the taker's UTXOs into a :class:`FundingInput` for ``accept_offer``."""
+    source_tx = await fetch_transaction(client, txid)
+    if not 0 <= vout < len(source_tx.outputs):
+        raise ValidationError(f"vout {vout} out of range for transaction {txid}")
+    return FundingInput(source_tx=source_tx, vout=vout, key=key)

--- a/src/pyrxd/swap/types.py
+++ b/src/pyrxd/swap/types.py
@@ -1,0 +1,111 @@
+"""Value types for the same-chain partial-transaction swap API.
+
+A swap moves two assets atomically inside one transaction using
+``SIGHASH_SINGLE | ANYONECANPAY`` signature-level atomicity (see
+:mod:`pyrxd.swap.partial`). These dataclasses describe *what* is being
+traded; they carry no key material and are safe to serialize and send
+over any transport (the offer envelope is JSON-able via ``to_dict``).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Literal
+
+from ..glyph.types import GlyphRef
+from ..security.errors import ValidationError
+from ..security.types import Txid
+
+AssetKind = Literal["rxd", "ft"]
+
+
+@dataclass(frozen=True)
+class Asset:
+    """One side of a trade: plain RXD, or a Glyph fungible token.
+
+    ``amount`` is in photons. For an FT this is also the token-unit count
+    (Radiant convention: 1 photon = 1 FT unit). ``ref`` is the FT's
+    genesis/commit outpoint (the permanent token identity) and is required
+    for — and only for — ``kind == "ft"``.
+    """
+
+    kind: AssetKind
+    amount: int
+    ref: GlyphRef | None = None
+
+    def __post_init__(self) -> None:
+        if self.amount <= 0:
+            raise ValidationError(f"asset amount must be positive, got {self.amount}")
+        if self.kind == "ft" and self.ref is None:
+            raise ValidationError("an FT asset requires a genesis ref")
+        if self.kind == "rxd" and self.ref is not None:
+            raise ValidationError("a plain RXD asset must not carry a ref")
+
+    def to_dict(self) -> dict:
+        return {
+            "kind": self.kind,
+            "amount": self.amount,
+            "ref": None if self.ref is None else {"txid": str(self.ref.txid), "vout": self.ref.vout},
+        }
+
+    @classmethod
+    def from_dict(cls, d: dict) -> Asset:
+        ref_d = d.get("ref")
+        ref = None if ref_d is None else GlyphRef(txid=Txid(str(ref_d["txid"])), vout=int(ref_d["vout"]))
+        return cls(kind=d["kind"], amount=int(d["amount"]), ref=ref)
+
+
+@dataclass(frozen=True)
+class SwapTerms:
+    """The trade as the maker states it: maker gives ``give``, receives ``receive``.
+
+    From the taker's seat this reads in reverse — the taker receives
+    ``give`` and pays ``receive``. The terms are a human-readable
+    cross-check; the maker's signature on the partial tx is what actually
+    enforces them (see :func:`pyrxd.swap.partial.accept_offer`).
+    """
+
+    give: Asset
+    receive: Asset
+
+    def to_dict(self) -> dict:
+        return {"give": self.give.to_dict(), "receive": self.receive.to_dict()}
+
+    @classmethod
+    def from_dict(cls, d: dict) -> SwapTerms:
+        return cls(give=Asset.from_dict(d["give"]), receive=Asset.from_dict(d["receive"]))
+
+
+@dataclass(frozen=True)
+class SwapOffer:
+    """A maker's signed partial transaction plus everything a taker needs to verify it.
+
+    Transport-agnostic. ``partial_tx_hex`` holds the maker's input
+    (signed ``SINGLE|ANYONECANPAY``) and output[0] (what the maker wants
+    to receive). ``give_source_tx_hex`` is the *full* previous transaction
+    that funds the maker's input, so the taker can read the maker's real
+    given-asset value/script from the chain rather than trusting the
+    declared ``terms`` — and confirm it hashes to the input's outpoint.
+    """
+
+    partial_tx_hex: str
+    give_source_tx_hex: str
+    give_vout: int
+    terms: SwapTerms
+
+    def to_dict(self) -> dict:
+        return {
+            "partial_tx_hex": self.partial_tx_hex,
+            "give_source_tx_hex": self.give_source_tx_hex,
+            "give_vout": self.give_vout,
+            "terms": self.terms.to_dict(),
+        }
+
+    @classmethod
+    def from_dict(cls, d: dict) -> SwapOffer:
+        return cls(
+            partial_tx_hex=str(d["partial_tx_hex"]),
+            give_source_tx_hex=str(d["give_source_tx_hex"]),
+            give_vout=int(d["give_vout"]),
+            terms=SwapTerms.from_dict(d["terms"]),
+        )

--- a/tests/test_swap_partial.py
+++ b/tests/test_swap_partial.py
@@ -1,0 +1,396 @@
+"""Tests for the same-chain partial-transaction swap API (issue #123).
+
+Covers the four asset directions (RXD/FT × give/receive), token
+conservation + change, and — most importantly — the adversarial cases the
+issue calls out: a taker must never be trickable by caller-supplied
+amounts or a tampered offer. The maker's SINGLE|ANYONECANPAY signature is
+the enforcement; these tests prove it.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from pyrxd.glyph.script import (
+    build_ft_locking_script,
+    extract_owner_pkh_from_ft_script,
+    extract_ref_from_ft_script,
+    is_ft_script,
+)
+from pyrxd.glyph.types import GlyphRef
+from pyrxd.keys import PrivateKey
+from pyrxd.script.script import Script
+from pyrxd.script.type import P2PKH
+from pyrxd.security.errors import ValidationError
+from pyrxd.security.types import Hex20, Txid
+from pyrxd.swap import Asset, FundingInput, SwapOffer, accept_offer, create_offer
+from pyrxd.swap.partial import _is_p2pkh
+from pyrxd.transaction.transaction import Transaction
+from pyrxd.transaction.transaction_output import TransactionOutput
+
+_REF_G = GlyphRef(txid=Txid("aa" * 32), vout=0)
+_REF_R = GlyphRef(txid=Txid("bb" * 32), vout=1)
+
+
+def _key() -> tuple[PrivateKey, bytes]:
+    k = PrivateKey()
+    return k, k.public_key().hash160()
+
+
+def _rxd_src(pkh: bytes, value: int) -> Transaction:
+    tx = Transaction()
+    tx.add_output(TransactionOutput(P2PKH().lock(pkh), value))
+    return tx
+
+
+def _ft_src(pkh: bytes, ref: GlyphRef, value: int) -> Transaction:
+    tx = Transaction()
+    tx.add_output(TransactionOutput(Script(build_ft_locking_script(Hex20(pkh), ref)), value))
+    return tx
+
+
+def _roundtrip(offer):
+    """Send the offer through dict serialization, as a real transport would."""
+    return SwapOffer.from_dict(offer.to_dict())
+
+
+def _classify(out: TransactionOutput) -> tuple[str, int, GlyphRef | None]:
+    s = out.locking_script.serialize()
+    if is_ft_script(s.hex()):
+        return ("ft", out.satoshis, extract_ref_from_ft_script(s))
+    assert _is_p2pkh(s)
+    return ("rxd", out.satoshis, None)
+
+
+def _assert_balanced(tx: Transaction, maker_give: int, funding_total: int, fee: int) -> None:
+    total_in = maker_give + funding_total
+    total_out = sum(o.satoshis for o in tx.outputs)
+    assert total_in - total_out == fee
+    assert all(i.unlocking_script is not None for i in tx.inputs)  # broadcast-ready
+
+
+# ─────────────────────────────── happy paths ─────────────────────────────────
+
+
+def test_rxd_for_rxd() -> None:
+    mk, mk_pkh = _key()
+    tk, tk_pkh = _key()
+    offer = create_offer(
+        give_source_tx=_rxd_src(mk_pkh, 1000),
+        give_vout=0,
+        maker_key=mk,
+        receive=Asset("rxd", 600),
+        maker_receive_pkh=mk_pkh,
+    )
+    tx = accept_offer(
+        _roundtrip(offer),
+        funding=[FundingInput(_rxd_src(tk_pkh, 2000), 0, tk)],
+        taker_receive_pkh=tk_pkh,
+        taker_change_pkh=tk_pkh,
+        fee=200,
+    )
+    # out0 maker receives 600 rxd; out1 taker receives the 1000 rxd given.
+    assert _classify(tx.outputs[0]) == ("rxd", 600, None)
+    assert _classify(tx.outputs[1]) == ("rxd", 1000, None)
+    _assert_balanced(tx, 1000, 2000, 200)
+
+
+def test_ft_for_rxd() -> None:
+    mk, mk_pkh = _key()
+    tk, tk_pkh = _key()
+    offer = create_offer(
+        give_source_tx=_ft_src(mk_pkh, _REF_G, 1000),
+        give_vout=0,
+        maker_key=mk,
+        receive=Asset("rxd", 800),
+        maker_receive_pkh=mk_pkh,
+    )
+    tx = accept_offer(
+        _roundtrip(offer),
+        funding=[FundingInput(_rxd_src(tk_pkh, 2000), 0, tk)],
+        taker_receive_pkh=tk_pkh,
+        taker_change_pkh=tk_pkh,
+        fee=300,
+    )
+    assert _classify(tx.outputs[0]) == ("rxd", 800, None)  # maker receive
+    assert _classify(tx.outputs[1]) == ("ft", 1000, _REF_G)  # taker receives the FT
+    # taker receives the FT under their own pkh
+    assert extract_owner_pkh_from_ft_script(tx.outputs[1].locking_script.serialize()) == Hex20(tk_pkh)
+    _assert_balanced(tx, 1000, 2000, 300)
+
+
+def test_rxd_for_ft() -> None:
+    mk, mk_pkh = _key()
+    tk, tk_pkh = _key()
+    offer = create_offer(
+        give_source_tx=_rxd_src(mk_pkh, 1000),
+        give_vout=0,
+        maker_key=mk,
+        receive=Asset("ft", 50, _REF_R),
+        maker_receive_pkh=mk_pkh,
+    )
+    tx = accept_offer(
+        _roundtrip(offer),
+        funding=[
+            FundingInput(_ft_src(tk_pkh, _REF_R, 60), 0, tk),  # taker pays FT (60, wants 50 to maker)
+            FundingInput(_rxd_src(tk_pkh, 5000), 0, tk),  # rxd for fee + change
+        ],
+        taker_receive_pkh=tk_pkh,
+        taker_change_pkh=tk_pkh,
+        fee=300,
+    )
+    assert _classify(tx.outputs[0]) == ("ft", 50, _REF_R)  # maker receives 50 FT
+    assert _classify(tx.outputs[1]) == ("rxd", 1000, None)  # taker receives the rxd given
+    # FT change of 10 (60 - 50) returns to taker; rxd change = 6060-50-1000-10-300 = 4700
+    kinds = [_classify(o) for o in tx.outputs]
+    assert ("ft", 10, _REF_R) in kinds
+    assert ("rxd", 4700, None) in kinds
+    _assert_balanced(tx, 1000, 5060, 300)
+
+
+def test_ft_for_ft() -> None:
+    mk, mk_pkh = _key()
+    tk, tk_pkh = _key()
+    offer = create_offer(
+        give_source_tx=_ft_src(mk_pkh, _REF_G, 100),
+        give_vout=0,
+        maker_key=mk,
+        receive=Asset("ft", 30, _REF_R),
+        maker_receive_pkh=mk_pkh,
+    )
+    tx = accept_offer(
+        _roundtrip(offer),
+        funding=[
+            FundingInput(_ft_src(tk_pkh, _REF_R, 40), 0, tk),
+            FundingInput(_rxd_src(tk_pkh, 5000), 0, tk),
+        ],
+        taker_receive_pkh=tk_pkh,
+        taker_change_pkh=tk_pkh,
+        fee=300,
+    )
+    kinds = [_classify(o) for o in tx.outputs]
+    assert _classify(tx.outputs[0]) == ("ft", 30, _REF_R)  # maker receives R_r
+    assert _classify(tx.outputs[1]) == ("ft", 100, _REF_G)  # taker receives R_g
+    assert ("ft", 10, _REF_R) in kinds  # FT change of R_r to taker
+    assert ("rxd", 4700, None) in kinds  # rxd change
+    _assert_balanced(tx, 100, 5040, 300)
+
+
+def test_exact_funding_no_rxd_change() -> None:
+    mk, mk_pkh = _key()
+    tk, tk_pkh = _key()
+    offer = create_offer(
+        give_source_tx=_ft_src(mk_pkh, _REF_G, 1000),
+        give_vout=0,
+        maker_key=mk,
+        receive=Asset("rxd", 800),
+        maker_receive_pkh=mk_pkh,
+    )
+    # funding == receive + fee exactly → no rxd change output.
+    tx = accept_offer(
+        _roundtrip(offer),
+        funding=[FundingInput(_rxd_src(tk_pkh, 900), 0, tk)],
+        taker_receive_pkh=tk_pkh,
+        taker_change_pkh=tk_pkh,
+        fee=100,
+    )
+    assert len(tx.outputs) == 2  # maker receive + taker FT only
+    _assert_balanced(tx, 1000, 900, 100)
+
+
+def test_sub_dust_change_folded_into_fee() -> None:
+    mk, mk_pkh = _key()
+    tk, tk_pkh = _key()
+    offer = create_offer(
+        give_source_tx=_ft_src(mk_pkh, _REF_G, 1000),
+        give_vout=0,
+        maker_key=mk,
+        receive=Asset("rxd", 800),
+        maker_receive_pkh=mk_pkh,
+    )
+    # 900 funding, fee 90 → would-be change 10 (< dust) is folded into the fee.
+    tx = accept_offer(
+        _roundtrip(offer),
+        funding=[FundingInput(_rxd_src(tk_pkh, 900), 0, tk)],
+        taker_receive_pkh=tk_pkh,
+        taker_change_pkh=tk_pkh,
+        fee=90,
+    )
+    assert len(tx.outputs) == 2  # no dust change output
+    total_out = sum(o.satoshis for o in tx.outputs)
+    assert (1000 + 900) - total_out == 100  # effective fee = stated 90 + 10 folded
+
+
+def test_offer_dict_roundtrip() -> None:
+    mk, mk_pkh = _key()
+    offer = create_offer(
+        give_source_tx=_ft_src(mk_pkh, _REF_G, 1000),
+        give_vout=0,
+        maker_key=mk,
+        receive=Asset("rxd", 800),
+        maker_receive_pkh=mk_pkh,
+    )
+    again = SwapOffer.from_dict(offer.to_dict())
+    assert again == offer
+    assert again.terms.give == Asset("ft", 1000, _REF_G)
+    assert again.terms.receive == Asset("rxd", 800)
+
+
+# ─────────────────────────────── adversarial ─────────────────────────────────
+
+
+def test_create_offer_rejects_non_owned_utxo() -> None:
+    mk, _ = _key()
+    _, other_pkh = _key()
+    with pytest.raises(ValidationError, match="does not own"):
+        create_offer(
+            give_source_tx=_rxd_src(other_pkh, 1000),  # owned by someone else
+            give_vout=0,
+            maker_key=mk,
+            receive=Asset("rxd", 600),
+            maker_receive_pkh=other_pkh,
+        )
+
+
+def test_tampered_declared_give_terms_rejected() -> None:
+    """A lying offer that overstates what the maker gives is rejected — the
+    taker re-derives the real given asset from the chain, not the terms."""
+    mk, mk_pkh = _key()
+    tk, tk_pkh = _key()
+    offer = create_offer(
+        give_source_tx=_ft_src(mk_pkh, _REF_G, 100),  # really only 100 FT
+        give_vout=0,
+        maker_key=mk,
+        receive=Asset("rxd", 800),
+        maker_receive_pkh=mk_pkh,
+    )
+    d = offer.to_dict()
+    d["terms"]["give"]["amount"] = 100000  # claim a much bigger give
+    with pytest.raises(ValidationError, match="give terms do not match"):
+        accept_offer(
+            SwapOffer.from_dict(d),
+            funding=[FundingInput(_rxd_src(tk_pkh, 2000), 0, tk)],
+            taker_receive_pkh=tk_pkh,
+            taker_change_pkh=tk_pkh,
+            fee=300,
+        )
+
+
+def test_tampered_receive_output_breaks_maker_signature() -> None:
+    """Editing the maker's receive output (to extract more from the taker)
+    invalidates the maker's SINGLE signature → rejected."""
+    mk, mk_pkh = _key()
+    tk, tk_pkh = _key()
+    offer = create_offer(
+        give_source_tx=_ft_src(mk_pkh, _REF_G, 1000),
+        give_vout=0,
+        maker_key=mk,
+        receive=Asset("rxd", 800),
+        maker_receive_pkh=mk_pkh,
+    )
+    partial = Transaction.from_hex(bytes.fromhex(offer.partial_tx_hex))
+    partial.outputs[0].satoshis = 5000  # maker now appears to demand 5000
+    tampered = SwapOffer(
+        partial_tx_hex=partial.serialize().hex(),
+        give_source_tx_hex=offer.give_source_tx_hex,
+        give_vout=offer.give_vout,
+        terms=offer.terms,
+    )
+    with pytest.raises(ValidationError, match="signature does not validate|receive terms do not match"):
+        accept_offer(
+            tampered,
+            funding=[FundingInput(_rxd_src(tk_pkh, 9000), 0, tk)],
+            taker_receive_pkh=tk_pkh,
+            taker_change_pkh=tk_pkh,
+            fee=300,
+        )
+
+
+def test_substituted_give_source_tx_rejected() -> None:
+    """Swapping in a different source tx (claiming a bigger given asset) is
+    caught by the outpoint-hash check."""
+    mk, mk_pkh = _key()
+    tk, tk_pkh = _key()
+    offer = create_offer(
+        give_source_tx=_ft_src(mk_pkh, _REF_G, 100),
+        give_vout=0,
+        maker_key=mk,
+        receive=Asset("rxd", 800),
+        maker_receive_pkh=mk_pkh,
+    )
+    d = offer.to_dict()
+    d["give_source_tx_hex"] = _ft_src(mk_pkh, _REF_G, 100000).serialize().hex()  # different tx
+    with pytest.raises(ValidationError, match="does not match the maker input"):
+        accept_offer(
+            SwapOffer.from_dict(d),
+            funding=[FundingInput(_rxd_src(tk_pkh, 2000), 0, tk)],
+            taker_receive_pkh=tk_pkh,
+            taker_change_pkh=tk_pkh,
+            fee=300,
+        )
+
+
+def test_underfunded_rejected() -> None:
+    mk, mk_pkh = _key()
+    tk, tk_pkh = _key()
+    offer = create_offer(
+        give_source_tx=_ft_src(mk_pkh, _REF_G, 1000),
+        give_vout=0,
+        maker_key=mk,
+        receive=Asset("rxd", 800),
+        maker_receive_pkh=mk_pkh,
+    )
+    with pytest.raises(ValidationError, match="short of covering"):
+        accept_offer(
+            _roundtrip(offer),
+            funding=[FundingInput(_rxd_src(tk_pkh, 500), 0, tk)],  # < 800 + fee
+            taker_receive_pkh=tk_pkh,
+            taker_change_pkh=tk_pkh,
+            fee=300,
+        )
+
+
+def test_insufficient_ft_funding_rejected() -> None:
+    mk, mk_pkh = _key()
+    tk, tk_pkh = _key()
+    offer = create_offer(
+        give_source_tx=_rxd_src(mk_pkh, 1000),
+        give_vout=0,
+        maker_key=mk,
+        receive=Asset("ft", 50, _REF_R),  # maker wants 50 FT
+        maker_receive_pkh=mk_pkh,
+    )
+    with pytest.raises(ValidationError, match="lacks .* units of FT"):
+        accept_offer(
+            _roundtrip(offer),
+            funding=[
+                FundingInput(_ft_src(tk_pkh, _REF_R, 30), 0, tk),  # only 30, need 50
+                FundingInput(_rxd_src(tk_pkh, 500), 0, tk),
+            ],
+            taker_receive_pkh=tk_pkh,
+            taker_change_pkh=tk_pkh,
+            fee=100,
+        )
+
+
+def test_taker_receive_amount_is_derived_not_assumed() -> None:
+    """The taker's received amount always equals the maker's real given
+    amount — there is no caller knob to get it wrong (the wild failure
+    mode from the issue)."""
+    mk, mk_pkh = _key()
+    tk, tk_pkh = _key()
+    offer = create_offer(
+        give_source_tx=_ft_src(mk_pkh, _REF_G, 777),
+        give_vout=0,
+        maker_key=mk,
+        receive=Asset("rxd", 800),
+        maker_receive_pkh=mk_pkh,
+    )
+    tx = accept_offer(
+        _roundtrip(offer),
+        funding=[FundingInput(_rxd_src(tk_pkh, 2000), 0, tk)],
+        taker_receive_pkh=tk_pkh,
+        taker_change_pkh=tk_pkh,
+        fee=300,
+    )
+    assert _classify(tx.outputs[1]) == ("ft", 777, _REF_G)  # exactly what the maker gave

--- a/tests/test_swap_resolve.py
+++ b/tests/test_swap_resolve.py
@@ -1,0 +1,63 @@
+"""Tests for the async swap resolver helpers (pyrxd.swap.resolve)."""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from pyrxd.keys import PrivateKey
+from pyrxd.script.type import P2PKH
+from pyrxd.security.errors import ValidationError
+from pyrxd.swap.resolve import fetch_funding_input, fetch_transaction
+from pyrxd.transaction.transaction import Transaction
+from pyrxd.transaction.transaction_output import TransactionOutput
+
+
+def _utxo_tx(value: int = 1000) -> Transaction:
+    tx = Transaction()
+    tx.add_output(TransactionOutput(P2PKH().lock(PrivateKey().public_key().hash160()), value))
+    return tx
+
+
+class _FakeClient:
+    """Minimal stand-in for ElectrumXClient.get_transaction."""
+
+    def __init__(self, raw_by_txid: dict[str, bytes]):
+        self._raw = raw_by_txid
+
+    async def get_transaction(self, txid):
+        return self._raw[str(txid)]
+
+
+def test_fetch_transaction_returns_parsed_tx() -> None:
+    tx = _utxo_tx()
+    client = _FakeClient({tx.txid(): tx.serialize()})
+    got = asyncio.run(fetch_transaction(client, tx.txid()))
+    assert got.txid() == tx.txid()
+
+
+def test_fetch_transaction_rejects_hash_mismatch() -> None:
+    real = _utxo_tx(1000)
+    other = _utxo_tx(2000)
+    # Server returns `other` bytes when `real`'s txid is requested.
+    client = _FakeClient({real.txid(): other.serialize()})
+    with pytest.raises(ValidationError, match="hash"):
+        asyncio.run(fetch_transaction(client, real.txid()))
+
+
+def test_fetch_funding_input_builds_funding() -> None:
+    key = PrivateKey()
+    tx = Transaction()
+    tx.add_output(TransactionOutput(P2PKH().lock(key.public_key().hash160()), 1234))
+    client = _FakeClient({tx.txid(): tx.serialize()})
+    fi = asyncio.run(fetch_funding_input(client, txid=tx.txid(), vout=0, key=key))
+    assert fi.vout == 0
+    assert fi.source_tx.outputs[0].satoshis == 1234
+
+
+def test_fetch_funding_input_rejects_bad_vout() -> None:
+    tx = _utxo_tx()
+    client = _FakeClient({tx.txid(): tx.serialize()})
+    with pytest.raises(ValidationError, match="out of range"):
+        asyncio.run(fetch_funding_input(client, txid=tx.txid(), vout=5, key=PrivateKey()))


### PR DESCRIPTION
Adds `pyrxd.swap` — a guard-railed offer/accept API over `SIGHASH_SINGLE | ANYONECANPAY` for same-chain RXD and Glyph FT trades. Integrators previously had to hand-assemble this from five low-level modules with no safety rails.

## API
- **`create_offer(...)`** — the maker signs ONE input (the asset they give) committing to ONE output (the asset they want), `SIGHASH_SINGLE|ANYONECANPAY`. That signature binds the given input's outpoint/value/script and the receive output — nothing else.
- **`accept_offer(...)`** — the taker completes + signs + returns a broadcast-ready tx. Safe by construction:
  - reads the maker's **real** given asset from the source tx (verified to hash to the input's outpoint), not the declared terms;
  - reconciles both legs against `SwapTerms` and rejects on mismatch;
  - **re-verifies the maker's signature** before and after completing the tx;
  - derives the taker's received amount from the real given asset (no caller knob to get it wrong — closes the wild failure mode in the issue);
  - enforces FT ref conservation (FT change) and returns RXD change.
- **`pyrxd.swap.resolve`** — thin async ElectrumX helpers (`fetch_transaction` with a server-honesty hash check, `fetch_funding_input`). The core is pure: `import pyrxd.swap` pulls in no network deps.

## Scope
All four directions (RXD/FT × give/receive). The maker spends the whole given UTXO (SINGLE protects only output[0] — pre-split to sell partial). NFTs out of scope. Explicit photon fee, funded by the taker.

## Why safe
The maker's signature is the enforcement, not the declared terms. `ANYONECANPAY` lets the taker add inputs; `SINGLE` lets them add outputs after index 0; neither lets them alter what the maker gives or receives without invalidating the signature.

## Tests + docs
Happy paths (all 4 directions), conservation/change, sub-dust folding, dict round-trip, the async resolver, and adversarial cases: tampered declared terms, tampered receive output (breaks the maker sig), substituted source tx, under-funding, insufficient FT funding. Plus `docs/concepts/partial-tx-swaps.md` and a runnable `examples/partial_swap_demo.py`.

Distinct from `pyrxd.gravity` (cross-chain); the doc explains when to use which.

## Verification
`task ci` green: 3971 passed, coverage 87.94%.

Closes #123