### PR TITLE
feat: Tier-1 dev on-ramp sprint (S1-S6: SDK surface, regtest tooling, quickstart, examples, showcase, API ref)

### DIFF
--- a/docs/api/devnet.rst
+++ b/docs/api/devnet.rst
@@ -1,0 +1,6 @@
+pyrxd.devnet — Local regtest dev node
+=====================================
+
+.. automodule:: pyrxd.devnet
+   :members:
+   :show-inheritance:

--- a/docs/api/index.rst
+++ b/docs/api/index.rst
@@ -10,6 +10,7 @@ functions, and exceptions.
    pyrxd
    glyph
    gravity
+   swap
    hd
    network
    security
@@ -20,3 +21,4 @@ functions, and exceptions.
    curve
    fee_models
    btc_wallet
+   devnet

--- a/docs/api/swap.rst
+++ b/docs/api/swap.rst
@@ -1,0 +1,6 @@
+pyrxd.swap — Same-chain partial-transaction swaps
+=================================================
+
+.. automodule:: pyrxd.swap
+   :members:
+   :show-inheritance:

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -11,6 +11,7 @@ Install with ``pip install pyrxd``.
    :maxdepth: 1
    :caption: Documentation
 
+   showcase
    tutorials/index
    how-to/index
    concepts/index

--- a/docs/showcase.md
+++ b/docs/showcase.md
@@ -1,0 +1,110 @@
+# What you can build on Radiant
+
+`pyrxd` is a Python SDK for the [Radiant (RXD) blockchain](https://radiantcore.org/):
+transaction building, HD wallets, the Glyph token protocol (NFT / FT / dMint),
+same-chain swaps, and trustless **cross-chain atomic swaps**. This page is a
+tour of what is real and proven today, with on-chain transactions you can open
+in a block explorer and runnable examples you can read.
+
+A note on honesty up front: every link below points either to a real on-chain
+transaction or to code in this repository. Where a capability is proven only by
+a small proof run — not by an external security audit — this page says so
+explicitly. Read those caveats before moving real value.
+
+## Trustless cross-chain atomic swaps
+
+The headline. `pyrxd.gravity` implements **HTLC** (hash-time-locked contract)
+atomic swaps between Radiant and other chains. The mechanism, in one breath:
+both sides lock their asset to the same hash; revealing the secret preimage to
+claim one side mathematically reveals it to claim the other; if nobody claims,
+a **timelock** lets each party refund. There is no middleman and no custodian —
+the swap either completes for both parties or unwinds for both. That is what
+"atomic" means.
+
+### Proven swap directions
+
+Each row below is a real swap that was carried out end-to-end on real chains
+this week. Open any transaction in its explorer.
+
+| Direction | Networks | Proof (claim transactions) |
+|---|---|---|
+| **BTC ↔ RXD** | Bitcoin **mainnet** ↔ Radiant **mainnet** (real value, both sides) | BTC claim: [`0e2ba620…f6e3`](https://mempool.space/tx/0e2ba620073b5bd08ddfa6d418912eff7705eaab947afdbe56040a833e8ef6e3) · RXD claim: [`d9f8dee9…f67db`](https://radiantexplorer.com/tx/d9f8dee91ba7a1f874b4003e44898beddc4fac00ea670920990ed4589a8f67db) |
+| **ETH ↔ RXD** | Ethereum **Sepolia testnet** ↔ Radiant **mainnet** | ETH claim (Sepolia): [`0x30d06fe7…961e`](https://sepolia.etherscan.io/tx/0x30d06fe783054c98f25b4cb010e83e9b2d66ae22c069b4f9be802e24a0b2961e) · RXD claim: [`3704227c…26c8`](https://radiantexplorer.com/tx/3704227cadcc3b4cf9ee1cd6ceb62219a9a1cc9a5cce9b7cb52bc709c91e26c8) |
+| **Glyph NFT ↔ ETH** | NFT on Radiant **mainnet** ↔ Ethereum **Sepolia testnet** | NFT minted: [`04123935…d3ae`](https://radiantexplorer.com/tx/0412393546ea3bbaa96a5040a0cb4f086d2c1faa5c8e3375e658e60b3fdbd3ae) · NFT claimed: [`b717f9a5…1367`](https://radiantexplorer.com/tx/b717f9a5f8d085c92479331a0dddfa290dd43d42d37c398508db204dbd851367) · ETH HTLC ([`0x25Aa6302…0BFd`](https://sepolia.etherscan.io/address/0x25Aa6302FfFc35ED87827f1052f4ce8f44810BFd)) claim: [`0x0bad6831…fbc0`](https://sepolia.etherscan.io/tx/0x0bad68311ad4433edda16550def29f1c05e975cf66fbaf4b3ac8f117f2f6fbc0) |
+| **Glyph FT ↔ ETH** | FT on Radiant **mainnet** ↔ Ethereum **Sepolia testnet** | FT minted: [`e36c5503…ced23`](https://radiantexplorer.com/tx/e36c5503e4d4398ce1ed762e94d9f021c0f64901f008135f31d33e10d49ced23) · FT claimed: [`db97f0d1…9b51`](https://radiantexplorer.com/tx/db97f0d1bd6e8d7eb03e4d6e36e49ff378852552455fb3d942b5d493ff929b51) · ETH HTLC ([`0x5a2D2084…EAF0`](https://sepolia.etherscan.io/address/0x5a2D2084f19F85A676fa6872069760aA0e54EAF0)) claim: [`0x67a338bd…295ad`](https://sepolia.etherscan.io/tx/0x67a338bd4ba53eb2fa307626eb86ac14bbc6910e9b5a7e31317d8c2194f295ad) |
+
+**Network labels are exact.** BTC and RXD legs were on **mainnet** with real
+value. **Every ETH leg was on the Ethereum Sepolia testnet — not Ethereum
+mainnet.**
+
+> **Pre-audit caveat — read this.** These were small "dust" / proof runs whose
+> only purpose was to demonstrate the mechanism on real chains. **They are not a
+> security proof and this is not production-ready.** A single-operator proof run
+> shows the plumbing works; it does not exercise an adversarial untrusted
+> counterparty, and an external security audit is the hard gate before moving
+> real value with someone you don't trust. Treat the cross-chain swap code as
+> pre-audit.
+
+### Run it
+
+- [`examples/gravity_swap_demo.py`](../examples/gravity_swap_demo.py) — the full
+  Gravity swap flow (offer → claim → payment → finalize). Defaults to a safe
+  dry-run that builds every transaction but broadcasts nothing.
+- Concept walkthrough: [`docs/concepts/gravity.md`](concepts/gravity.md).
+
+## Native tokens
+
+Radiant carries tokens natively via the **Glyph** protocol. `pyrxd` builds all
+of them — and the NFT/FT mints above are themselves on-chain proof that the mint
+path works on mainnet.
+
+- **NFTs** — [`examples/glyph_mint_demo.py`](../examples/glyph_mint_demo.py):
+  a two-phase commit/reveal NFT mint on Radiant mainnet.
+  Tutorial: [`docs/tutorials/mint-a-glyph-nft.md`](tutorials/mint-a-glyph-nft.md).
+- **Fungible tokens** — [`examples/ft_deploy_premine.py`](../examples/ft_deploy_premine.py):
+  issue your own FT with a full premine; the reveal output's outpoint becomes
+  the permanent token ref.
+  Tutorial: [`docs/tutorials/mint-a-glyph-ft.md`](tutorials/mint-a-glyph-ft.md).
+- **dMint (permissionless mining-based issuance)** —
+  [`examples/dmint_v1_deploy_demo.py`](../examples/dmint_v1_deploy_demo.py):
+  deploy a V1 dMint token that emits N parallel contract UTXOs, each mineable
+  independently so claims race in parallel.
+  Concept: [`docs/concepts/dmint-v1-deploy.md`](concepts/dmint-v1-deploy.md).
+
+New to all this? The fastest way to mint a real token with zero risk is the
+local-regtest quickstart: [`docs/tutorials/quickstart.md`](tutorials/quickstart.md)
+(stand up a private chain in Docker, mint, tear it down).
+
+## Same-chain swaps
+
+For trading two assets that both live on Radiant — RXD ↔ token, or token ↔
+token — `pyrxd.swap` gives you a guard-railed **partial-transaction** API. It
+uses signature-level atomicity (`SIGHASH_SINGLE | ANYONECANPAY`): the maker
+signs one input committing to one output of what they want back, the taker adds
+their own inputs/outputs to complete the trade, and the whole thing settles in a
+**single** transaction — no escrow, no covenant, no second transaction. Because
+both legs are in one transaction, it confirms wholly or not at all.
+
+The core `create_offer` / `accept_offer` flow is **pure Python and needs no
+node** — you can build and verify an offer entirely offline and only touch the
+network to broadcast.
+
+- [`examples/partial_swap_demo.py`](../examples/partial_swap_demo.py) — the full
+  offer → transport → accept → verify flow, self-contained and runnable with no
+  node and no network.
+- Concept: [`docs/concepts/partial-tx-swaps.md`](concepts/partial-tx-swaps.md).
+
+This same-chain swap API is implemented and unit-tested (including adversarial
+cases); as with every value-moving primitive here, treat an external audit as
+the gate before real-value, untrusted-counterparty use.
+
+## Start building
+
+1. **5-minute quickstart** — [`docs/tutorials/quickstart.md`](tutorials/quickstart.md):
+   `pip install pyrxd`, bring up a local regtest chain in Docker, and mint your
+   first real on-chain Glyph token — no faucet, no mainnet RXD, nothing at risk.
+2. **Browse the runnable examples** — the [`examples/` index](../examples/README.md)
+   gives a guided path through end-to-end scripts for every flow above, each
+   labeled with its network and whether it defaults to a safe dry-run.
+3. **Read the concepts** — [`docs/concepts/index.md`](concepts/index.md) covers
+   Glyph structures, Gravity, dMint, and partial-tx swaps in depth.

--- a/docs/tutorials/index.md
+++ b/docs/tutorials/index.md
@@ -7,6 +7,7 @@ fungible token, run a Gravity swap.
 ```{toctree}
 :maxdepth: 1
 
+quickstart
 your-first-radiant-transaction
 inspect-a-radiant-transaction
 mint-a-glyph-nft
@@ -16,6 +17,12 @@ mint-from-a-dmint-contract
 
 ## Available now
 
+- **[5-minute quickstart: your first token on a local chain](quickstart.md)** —
+  the fastest path from `pip install` to a real on-chain Glyph NFT, minted on a
+  private regtest chain that runs entirely on your machine. One command
+  (`pyrxd regtest up`) stands up the node and hands you a pre-funded key; a
+  companion script mints the token; one command tears it all down. No faucet,
+  no mainnet RXD, nothing at risk. **Start here if you want to build.**
 - **[Your first Radiant transaction](your-first-radiant-transaction.md)** —
   fresh `pip install` to a built, signed RXD send. Walks through
   `pyrxd wallet new`, `pyrxd address`, `pyrxd balance --refresh`,

--- a/docs/tutorials/quickstart.md
+++ b/docs/tutorials/quickstart.md
@@ -1,0 +1,144 @@
+# 5-minute quickstart: your first token on a local chain
+
+The fastest path from `pip install pyrxd` to a real, on-chain Glyph token —
+minted on a private **regtest** chain that runs entirely on your machine. No
+testnet faucet, no mainnet RXD, no money at risk. When you're done you tear the
+whole chain down with one command.
+
+This is the recommended starting point for new contributors. It exercises the
+real SDK and the real node consensus rules — the only thing that isn't "real"
+is that the chain is yours alone and disposable.
+
+## What you'll need
+
+- **Docker** — the regtest node runs in a container.
+- **The `radiant-core` regtest image** present locally (the same image the test
+  suite uses, `radiant-core:v2.3.0-amd64`).
+- **pyrxd installed** — `pip install pyrxd`, or `poetry install` from a checkout.
+
+Everything below is regtest-only and reached over `docker exec`; the node binds
+to localhost and is never exposed.
+
+## Step 1 — stand up a local chain
+
+```console
+$ pyrxd regtest up
+regtest node up
+  container: pyrxd-devnet  (image radiant-core:v2.3.0-amd64)
+  height:    101
+  rpc:       user=pyrxd password=pyrxd wallet=devnet
+
+pre-funded dev key (import with PrivateKey(wif)):
+  address: mxeCaRUMTjAmRch131Tt5Hac4ZWvaQomJP
+  wif:     cVZMZLBJ8RMrZrEoeST9Be4bBxiFtcMA2UaPaZH1WdHd9UL5WVc1
+  funded:  100 RXD
+
+next:
+  pyrxd regtest mine 1            # advance the chain
+  pyrxd regtest fund <address> 50 # faucet 50 RXD to any address
+  pyrxd regtest down              # tear it all down
+```
+
+`up` starts the node, mines 101 blocks to mature a coinbase (so there's
+spendable RXD), creates a dev wallet, and hands you a **pre-funded key**. The
+printed WIF imports straight into the SDK — `PrivateKey(wif)` derives that exact
+regtest address.
+
+`up` is idempotent: run it again and it reports the running node rather than
+wiping it. Use `pyrxd regtest up --fresh` when you want a clean chain.
+
+## Step 2 — mint a Glyph NFT
+
+The repo ships a companion script that mints an NFT against the running node.
+It pulls a funded UTXO from the dev wallet, builds the two-phase commit/reveal
+with `GlyphBuilder`, broadcasts each transaction through the
+node, and mines a block to confirm each one:
+
+```console
+$ python examples/regtest_quickstart.py
+minting from mxeCaRUMTjAmRch131Tt5Hac4ZWvaQomJP  (UTXO 15bd14177471…:0, 5,000,000,000,000 photons)
+commit:  c10108ef496cac1f75fa9ccab4ce112bee0d6539f27c9f7edcc7a7c8a7572f33  (7,160,546 photons, confirmed)
+reveal:  94ac6d18113d48f5166f4629091015c872e954814963a92fec0f92b27178095a  (NFT output 3,454,046 photons, confirmed)
+
+NFT minted on regtest.
+  genesis ref: c10108ef496cac1f75fa9ccab4ce112bee0d6539f27c9f7edcc7a7c8a7572f33:0   <- this is the token's permanent identity
+  owner:       mxeCaRUMTjAmRch131Tt5Hac4ZWvaQomJP
+```
+
+Your txids will differ — they're real transactions on your chain. A Glyph token
+is minted in two transactions: a **commit** that locks a hash of the metadata,
+then a **reveal** that publishes the metadata and creates the token output. The
+token's permanent identity is its **genesis ref** — the commit `txid:vout`.
+
+The transaction-building in `regtest_quickstart.py` is the same logic as
+[`examples/glyph_mint_demo.py`](https://github.com/MudwoodLabs/pyrxd/tree/main/examples/glyph_mint_demo.py),
+which mints on mainnet via ElectrumX — only the transport is swapped to the
+local node.
+
+## Step 3 — look at what you minted
+
+The reveal output is a genuine NFT: its locking script carries
+`OP_PUSHINPUTREFSINGLETON` (the singleton ref that makes it one-of-one), and the
+reveal's input carries the `gly` envelope with your metadata. Decode it on the
+node:
+
+```console
+$ docker exec pyrxd-devnet radiant-cli -regtest -rpcuser=pyrxd -rpcpassword=pyrxd \
+    getrawtransaction <reveal-txid> 1
+```
+
+Look at `vout[0].scriptPubKey.asm` — it begins with `OP_PUSHINPUTREFSINGLETON`.
+
+You can also mine more blocks or fund any address from the faucet:
+
+```console
+$ pyrxd regtest mine 5
+mined 5 block(s) — height 108
+
+$ pyrxd regtest fund mvv7uazxVYtz7Y3WfLwKuYxYikNKfJEF8T 25
+funded mvv7uazxVYtz7Y3WfLwKuYxYikNKfJEF8T with 25 RXD
+  txid: b21d8dafbd6769b3ed58d62e1a163af93f94042879b420605de9c33bb8a53d51
+```
+
+## Step 4 — swap two assets (next)
+
+With a token in hand, the natural next step is to trade it. pyrxd has a
+same-chain swap API — a maker offers an asset and a taker funds the other side,
+with a single signature making the trade atomic (either both legs settle or
+neither does). It runs in one process, no node required:
+
+```console
+$ python examples/partial_swap_demo.py
+```
+
+See [Same-chain partial-transaction swaps](../concepts/partial-tx-swaps.md) for
+how the `SIGHASH_SINGLE | ANYONECANPAY` signature enforces the trade, and
+[Gravity](../concepts/gravity.md) for the cross-chain (HTLC) swap design.
+
+## Tear it down
+
+```console
+$ pyrxd regtest down
+regtest node down
+```
+
+That removes the container and wipes the chain — nothing is left running.
+
+## Command reference
+
+| Command | What it does |
+| --- | --- |
+| `pyrxd regtest up` | Start the node, mine 101, print a pre-funded key |
+| `pyrxd regtest up --fresh` | Same, but wipe any existing chain first |
+| `pyrxd regtest info` | Connection details + current height |
+| `pyrxd regtest mine <n>` | Mine `n` blocks (default 1) |
+| `pyrxd regtest fund <addr> <rxd>` | Faucet RXD to any address, confirmed in a block |
+| `pyrxd regtest down` | Stop and remove the node (wipes the chain) |
+
+## Where to go next
+
+- [Your first Radiant transaction](your-first-radiant-transaction.md) — the
+  wallet CLI and a signed RXD send.
+- [Mint a Glyph NFT](mint-a-glyph-nft.md) — the same mint flow, explained step
+  by step.
+- [Mint a Glyph FT](mint-a-glyph-ft.md) — fungible tokens.

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,139 @@
+# pyrxd examples — a guided path
+
+Runnable scripts that exercise the pyrxd SDK end to end. Each file has a
+module docstring with its full usage, environment variables, and safety
+notes — read the header of any script before running it.
+
+Every script can be run in place from the repo root, e.g.:
+
+```sh
+python examples/regtest_quickstart.py
+```
+
+## Safety labels
+
+These labels appear next to each example below. They are derived from the
+code (default `ELECTRUMX_URL`, `DRY_RUN` gating, `BTC_NETWORK`, etc.), not
+from assumption.
+
+- **no network** — pure in-process; builds/signs txs but never connects out.
+- **regtest** — runs against a local throwaway chain (`pyrxd regtest up`); zero real value.
+- **testnet** — broadcasts to public test networks (needs testnet coins); no mainnet value.
+- **mainnet — real value** — touches Radiant/Bitcoin mainnet. Most are
+  **safe-by-default** (`DRY_RUN=1` builds but does not broadcast); one is **not**.
+- **pre-audit** — the cross-chain Gravity swap covenant has not had an external
+  security audit. Do not use it with real funds.
+
+---
+
+## START HERE
+
+### `regtest_quickstart.py` — regtest, zero real value
+Mints a real Glyph NFT end-to-end on a **local regtest chain**. This is the
+companion to the 5-minute quickstart: it pulls a funded UTXO from the dev
+wallet, runs the two-phase commit/reveal via `GlyphBuilder`, broadcasts through
+the node RPC, and mines to confirm. No ElectrumX, no mainnet, no real value.
+
+Prerequisite: `pyrxd regtest up` (starts the local node + dev wallet).
+
+→ Read [`../docs/tutorials/quickstart.md`](../docs/tutorials/quickstart.md) alongside this script.
+
+---
+
+## Keys / HD wallets
+
+### `mnemonic_to_key.py` — no network
+Derives Radiant keys and addresses from a BIP39 mnemonic, showing both the
+high-level `HdWallet.from_mnemonic` path and the low-level
+`bip44_derive_xprv_from_mnemonic` primitive. Uses Radiant's SLIP-0044 coin
+type **512** (not Bitcoin's 0). Runs with a public test-vector mnemonic by
+default — override with `MNEMONIC=...`. Offline; derives keys only, moves
+nothing.
+
+---
+
+## Tokens (Glyph NFT / FT / dMint)
+
+All of these target **Radiant mainnet** and are **safe-by-default**: `DRY_RUN`
+defaults to `1`, so they build and print the raw transaction but do not
+broadcast unless you explicitly set `DRY_RUN=0`. They require a funded
+`*_WIF` key. The two that can spend real value on broadcast (dMint) add a
+second guard, `I_UNDERSTAND_THIS_IS_REAL=yes`.
+
+### `glyph_mint_demo.py` — mainnet — real value, `DRY_RUN=1` by default
+Mints a Glyph **NFT** via the commit/reveal two-phase flow over ElectrumX.
+Needs a funded `GLYPH_WIF` (~5M photons). Same tx-building logic as
+`regtest_quickstart.py`, but against mainnet instead of a local node.
+→ [`../docs/tutorials/mint-a-glyph-nft.md`](../docs/tutorials/mint-a-glyph-nft.md)
+
+### `ft_deploy_premine.py` — mainnet — real value, `DRY_RUN=1` by default
+Deploys a plain **fungible token (FT)** with a full premine — the "issue your
+own token" flow. Commit → reveal; the reveal outpoint becomes the permanent
+token ref. Needs a funded `GLYPH_WIF`.
+→ [`../docs/tutorials/mint-a-glyph-ft.md`](../docs/tutorials/mint-a-glyph-ft.md)
+
+### `ft_transfer_demo.py` — mainnet — real value, `DRY_RUN=1` by default
+Sends FT tokens **you already own** to another address, with the correct
+on-chain FT-UTXO filter (the step in-process unit tests hide). Needs
+`SENDER_WIF`, `TOKEN_CONTRACT` or `TOKEN_REF`, `RECIPIENT_ADDR`, and `AMOUNT`.
+
+### `dmint_v1_deploy_demo.py` — mainnet — real value, `DRY_RUN=1` + extra guard
+Deploys a **V1 dMint** (permissionless-mint) token: N parallel contract UTXOs
+that anyone can mine independently. Broadcasting requires **both** `DRY_RUN=0`
+**and** `I_UNDERSTAND_THIS_IS_REAL=yes` (a deliberate footgun guard). Needs a
+funded `GLYPH_WIF`.
+
+### `dmint_claim_demo.py` — mainnet — real value, `DRY_RUN=1` + extra guard
+Mines and claims a token from a **live V1 dMint contract** (e.g. RBG): spends
+the contract UTXO, runs a PoW search, and pays the miner an FT reward.
+Broadcasting requires `DRY_RUN=0` **and** `I_UNDERSTAND_THIS_IS_REAL=yes`.
+Needs `MINER_WIF`, `CONTRACT_TXID`, `CONTRACT_VOUT`. Note: the pure-Python PoW
+search can take tens of minutes to hours at live difficulty — set
+`EXTERNAL_MINER` to delegate.
+→ [`../docs/tutorials/mint-from-a-dmint-contract.md`](../docs/tutorials/mint-from-a-dmint-contract.md)
+
+---
+
+## Same-chain swaps
+
+### `partial_swap_demo.py` — no network
+End-to-end same-chain **partial-transaction swap** (`pyrxd.swap`): a maker's
+FT traded for plain RXD. Synthesises both parties' source UTXOs in memory, so
+it runs with **no node and no network** — it exercises the real swap API
+(signing, conservation, maker-signature re-verification) but never broadcasts.
+→ [`../docs/concepts/partial-tx-swaps.md`](../docs/concepts/partial-tx-swaps.md)
+
+---
+
+## Cross-chain / Gravity swaps (pre-audit)
+
+The Gravity BTC↔RXD swap covenant is **pre-audit** — it has not cleared an
+external security review. Treat all three scripts as reference material; do not
+use them with real mainnet value.
+
+### `gravity_swap_demo.py` — testnet, `DRY_RUN=1` by default — pre-audit
+The safe entry point for Gravity. Walks every step of a BTC↔RXD swap against
+**testnet** (Radiant + Bitcoin). `DRY_RUN=1` (default) builds and prints every
+tx but broadcasts nothing; `DRY_RUN=0` broadcasts to live testnets (no mainnet
+value).
+
+### `gravity_live_test.py` — RXD mainnet reads + BTC testnet, `DRY_RUN=1` by default — pre-audit
+Integration test driving the Gravity SDK against **live** networks: reads from
+RXD **mainnet** ElectrumX and BTC **testnet**, building txs from real covenant
+bytecode and running the SPV verifier on real BTC data. `DRY_RUN=0` broadcasts
+the maker-offer tx on **RXD mainnet** (real photons); the BTC side never
+broadcasts.
+
+### `gravity_full_trade.py` — RXD mainnet (+ BTC mainnet default) — NO dry-run — pre-audit
+The full offer → claim → finalize / forfeit / cancel state machine. **This
+script has no `DRY_RUN` mode** — it broadcasts real transactions. The BTC side
+defaults to **mainnet** (`BTC_NETWORK=bc`). As a guard, on mainnet it refuses to
+run unless you set `I_UNDERSTAND_THIS_IS_REAL=yes`, acknowledging irreversible
+value movement. Prefer `gravity_swap_demo.py` for a safe walkthrough.
+
+---
+
+## Documentation
+
+- Quickstart tutorial: [`../docs/tutorials/quickstart.md`](../docs/tutorials/quickstart.md)
+- Tutorials index: [`../docs/tutorials/index.md`](../docs/tutorials/index.md)

--- a/examples/gravity_full_trade.py
+++ b/examples/gravity_full_trade.py
@@ -34,6 +34,24 @@ Usage:
   GRAVITY_MODE=claim python3 examples/gravity_full_trade.py
   MAKER_RXD_WIF=<wif> GRAVITY_MODE=forfeit python3 examples/gravity_full_trade.py
   MAKER_RXD_WIF=<wif> GRAVITY_MODE=cancel python3 examples/gravity_full_trade.py
+
+Network & safety
+----------------
+This targets **RXD mainnet** ElectrumX (``radiant4people`` :50022) and, by
+default, **BTC mainnet** (``BTC_NETWORK=bc``, blockstream.info). The BTC side
+can be pointed at testnet via ``BTC_NETWORK=tb`` + a testnet ``BTC_API_URL``.
+
+.. warning::
+
+   **This script has NO dry-run mode — it broadcasts real transactions.**
+   ``GRAVITY_MODE=offer`` with a real ``MAKER_RXD_WIF`` builds and
+   **broadcasts a real MakerOffer transaction on RXD mainnet** (and the later
+   modes broadcast real claim/finalize/forfeit/cancel txs spending real
+   photons). The Gravity covenant is **pre-audit**. As a guard, on mainnet
+   (the default config) the script refuses to run unless you set
+   ``I_UNDERSTAND_THIS_IS_REAL=yes`` — an explicit acknowledgement that you
+   accept real, irreversible value movement. For a safe-by-default walkthrough
+   use ``gravity_swap_demo.py`` (testnet, ``DRY_RUN=1``) instead.
 """
 
 from __future__ import annotations
@@ -689,6 +707,18 @@ async def run() -> None:
     print("=" * 70)
     print(f"  Gravity Full Trade  —  mode: {GRAVITY_MODE}")
     print("=" * 70)
+    # Safety gate: this script broadcasts REAL transactions and has no dry-run.
+    # On mainnet (the default config) demand an explicit acknowledgement so a
+    # copy-pasted command can never move real value by accident.
+    on_mainnet = BTC_NETWORK == "bc" or "radiant4people" in RXD_ELECTRUMX_URL
+    if on_mainnet and os.environ.get("I_UNDERSTAND_THIS_IS_REAL") != "yes":
+        _fail(
+            "refusing to run on mainnet without acknowledgement.\n"
+            "         This script broadcasts REAL value and has no dry-run mode.\n"
+            "         To proceed on mainnet, set I_UNDERSTAND_THIS_IS_REAL=yes.\n"
+            "         For a safe walkthrough, use examples/gravity_swap_demo.py "
+            "(DRY_RUN=1 by default) instead."
+        )
     if GRAVITY_MODE == "offer":
         await mode_offer()
     elif GRAVITY_MODE == "claim":

--- a/examples/gravity_live_test.py
+++ b/examples/gravity_live_test.py
@@ -30,6 +30,18 @@ Key / address (RXD mainnet maker — do NOT expose WIF in logs):
   Address: optionally pin via EXPECTED_MAKER_ADDR (and EXPECTED_MAKER_PKH_HEX)
            to assert the WIF derives the address you expect; leave unset
            to skip the pin check.
+
+Network & safety
+----------------
+Reads from **RXD mainnet** ElectrumX (the only live RXD network) and **BTC
+testnet** APIs. Safe-by-default: ``DRY_RUN`` defaults to ``1`` and broadcasts
+nothing. ``DRY_RUN=0`` broadcasts the maker-offer tx on **RXD mainnet** (real
+photons); the BTC side never broadcasts.
+
+.. warning::
+
+   The Gravity cross-chain swap covenant is **pre-audit**. ``DRY_RUN=0`` moves
+   real mainnet value. Keep the default unless you accept that.
 """
 
 from __future__ import annotations

--- a/examples/gravity_swap_demo.py
+++ b/examples/gravity_swap_demo.py
@@ -35,6 +35,19 @@ Usage
     BTC_MEMPOOL_URL=https://mempool.space/testnet/api \\
     MAKER_RXD_WIF=<wif> TAKER_RXD_WIF=<wif> TAKER_BTC_WIF=<wif> \\
     python examples/gravity_swap_demo.py
+
+Network & safety
+----------------
+Targets Radiant + Bitcoin **testnet**. Safe-by-default: ``DRY_RUN`` defaults
+to ``1`` (builds and prints every tx, broadcasts nothing). ``DRY_RUN=0``
+broadcasts to live testnets — no mainnet value, but testnet coins still need
+funding.
+
+.. warning::
+
+   The Gravity cross-chain swap covenant is **pre-audit**. Do not adapt this
+   to mainnet / real value. See the project README and ``docs/`` for the
+   external-audit gate before any real-funds use.
 """
 
 from __future__ import annotations

--- a/examples/regtest_quickstart.py
+++ b/examples/regtest_quickstart.py
@@ -1,0 +1,195 @@
+#!/usr/bin/env python3
+"""Mint your first Glyph NFT on a local regtest chain — zero config.
+
+This is the companion script for the 5-minute quickstart
+(``docs/tutorials/quickstart.md``). It assumes a regtest node is already
+running::
+
+    pyrxd regtest up
+
+and then mints a Glyph NFT end-to-end against it: it pulls a funded UTXO from
+the dev wallet, builds the two-phase commit/reveal with the pyrxd SDK
+(:class:`pyrxd.glyph.GlyphBuilder`), broadcasts each tx through the node's RPC,
+and mines a block to confirm. No ElectrumX, no mainnet, no real value.
+
+    python examples/regtest_quickstart.py
+
+The transaction-building here is the same proven logic as
+``examples/glyph_mint_demo.py`` (which mints on mainnet via ElectrumX); only the
+transport is swapped — UTXO lookup, broadcast, and confirmation all go through
+``pyrxd regtest`` instead of a remote server.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+import time
+
+# Make pyrxd importable from the source tree when run in-place.
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
+
+from pyrxd.devnet import DevnetError, RegtestNode
+from pyrxd.fee_models import SatoshisPerKilobyte
+from pyrxd.glyph import GlyphBuilder, GlyphMetadata, GlyphProtocol
+from pyrxd.glyph.builder import CommitParams, RevealParams
+from pyrxd.keys import PrivateKey
+from pyrxd.script.script import Script
+from pyrxd.script.type import P2PKH, encode_pushdata, to_unlock_script_template
+from pyrxd.security.types import Hex20
+from pyrxd.transaction.transaction import Transaction, TransactionInput, TransactionOutput
+
+MIN_FEE_RATE = 10_000  # photons/byte — regtest relay floor matches mainnet
+REVEAL_BUDGET = 580 * MIN_FEE_RATE * 12 // 10 + 546
+COMMIT_VALUE = REVEAL_BUDGET + 200_000  # commit output must cover the reveal cost
+COMMIT_DUST = 276 * MIN_FEE_RATE
+
+
+# --------------------------------------------------------------------- tx builders
+# (identical to examples/glyph_mint_demo.py — pure SDK, no transport coupling)
+
+
+def _glyph_reveal_unlock(private_key: PrivateKey, scriptsig_suffix: bytes):
+    def sign(tx, input_index) -> Script:
+        tx_input = tx.inputs[input_index]
+        signature = private_key.sign(tx.preimage(input_index))
+        pubkey = private_key.public_key().serialize()
+        p2pkh_part = encode_pushdata(signature + tx_input.sighash.to_bytes(1, "little")) + encode_pushdata(pubkey)
+        return Script(p2pkh_part + scriptsig_suffix)
+
+    return to_unlock_script_template(sign, lambda: 107 + len(scriptsig_suffix))
+
+
+def _build_commit_tx(utxo: dict, key: PrivateKey, commit_script: bytes, commit_value: int, address: str) -> Transaction:
+    inp = TransactionInput(
+        source_txid=utxo["tx_hash"],
+        source_output_index=utxo["tx_pos"],
+        unlocking_script_template=P2PKH().unlock(key),
+    )
+    inp.satoshis = utxo["value"]
+    inp.locking_script = P2PKH().lock(address)
+    src_out = TransactionOutput(P2PKH().lock(address), utxo["value"])
+
+    class _SrcTx:
+        def __init__(self, out, _tx_pos: int = utxo["tx_pos"]) -> None:
+            self.outputs = {_tx_pos: out}
+
+    inp.source_transaction = _SrcTx(src_out)
+    if utxo["value"] < commit_value + COMMIT_DUST * 3:
+        raise ValueError(f"funding UTXO too small: {utxo['value']} < {commit_value + COMMIT_DUST * 3}")
+
+    tx = Transaction(
+        tx_inputs=[inp],
+        tx_outputs=[
+            TransactionOutput(Script(commit_script), commit_value),
+            TransactionOutput(P2PKH().lock(address), change=True),
+        ],
+    )
+    tx.fee(SatoshisPerKilobyte(MIN_FEE_RATE * 1000))
+    tx.sign()
+    return tx
+
+
+def _build_reveal_tx(
+    commit_txid: str, commit_value: int, commit_script: bytes, suffix: bytes, nft_script: bytes, key: PrivateKey
+) -> Transaction:
+    src = Transaction(tx_inputs=[], tx_outputs=[TransactionOutput(Script(commit_script), commit_value)])
+    src.txid = lambda: commit_txid  # type: ignore[method-assign]
+    reveal_input = TransactionInput(
+        source_transaction=src,
+        source_output_index=0,
+        unlocking_script_template=_glyph_reveal_unlock(key, suffix),
+    )
+    # Pass 1: measure the real signed size with a trial output value.
+    trial = Transaction(
+        tx_inputs=[reveal_input],
+        tx_outputs=[TransactionOutput(Script(nft_script), max(546, commit_value // 2))],
+    )
+    trial.sign()
+    fee = trial.byte_length() * (MIN_FEE_RATE + 500)
+    nft_value = commit_value - fee
+    if nft_value < 546:
+        raise ValueError(f"commit value {commit_value} too small for reveal fee {fee}")
+    # Pass 2: re-sign over the final output.
+    reveal_input.unlocking_script = None
+    tx = Transaction(tx_inputs=[reveal_input], tx_outputs=[TransactionOutput(Script(nft_script), nft_value)])
+    tx.sign()
+    return tx
+
+
+# --------------------------------------------------------------------- main flow
+
+
+def _funded_key(node: RegtestNode, need: int) -> tuple[PrivateKey, str, dict]:
+    """Pull a funded UTXO + its key from the dev wallet."""
+    unspent = node.cli("listunspent", "1", "9999999", wallet=True)
+    if not isinstance(unspent, list):
+        raise DevnetError("could not list regtest UTXOs")
+    for u in unspent:
+        value = round(u["amount"] * 1e8)
+        if value >= need:
+            wif = str(node.cli("dumpprivkey", u["address"], wallet=True))
+            return PrivateKey(wif), u["address"], {"tx_hash": u["txid"], "tx_pos": u["vout"], "value": value}
+    raise DevnetError(f"no UTXO with at least {need} photons — try `pyrxd regtest mine 10`")
+
+
+def main() -> None:
+    node = RegtestNode()
+    if not node.is_running():
+        print("regtest node is not running. Start it first:\n    pyrxd regtest up")
+        sys.exit(1)
+
+    key, address, utxo = _funded_key(node, COMMIT_VALUE + COMMIT_DUST * 3)
+    pkh = Hex20(key.public_key().hash160())
+    print(f"minting from {address}  (UTXO {utxo['tx_hash'][:12]}…:{utxo['tx_pos']}, {utxo['value']:,} photons)")
+
+    builder = GlyphBuilder()
+    metadata = GlyphMetadata(
+        protocol=[GlyphProtocol.NFT],
+        name="my-first-glyph",
+        description="Minted on regtest via the pyrxd quickstart",
+        token_type="quickstart",
+        attrs={"minted_at": str(int(time.time()))},
+    )
+    commit = builder.prepare_commit(CommitParams(metadata=metadata, owner_pkh=pkh, change_pkh=pkh, funding_satoshis=0))
+
+    # --- commit ---
+    commit_tx = _build_commit_tx(utxo, key, commit.commit_script, COMMIT_VALUE, address)
+    commit_txid = node.cli("sendrawtransaction", commit_tx.serialize().hex())
+    node.mine(1)
+    commit_value = commit_tx.outputs[0].satoshis
+    print(f"commit:  {commit_txid}  ({commit_value:,} photons, confirmed)")
+
+    # --- reveal ---
+    reveal = builder.prepare_reveal(
+        RevealParams(
+            commit_txid=str(commit_txid),
+            commit_vout=0,
+            commit_value=commit_value,
+            cbor_bytes=commit.cbor_bytes,
+            owner_pkh=pkh,
+            is_nft=True,
+        )
+    )
+    reveal_tx = _build_reveal_tx(
+        str(commit_txid), commit_value, commit.commit_script, reveal.scriptsig_suffix, reveal.locking_script, key
+    )
+    reveal_txid = node.cli("sendrawtransaction", reveal_tx.serialize().hex())
+    node.mine(1)
+
+    print(f"reveal:  {reveal_txid}  (NFT output {reveal_tx.outputs[0].satoshis:,} photons, confirmed)")
+    print()
+    print("NFT minted on regtest.")
+    print(f"  genesis ref: {commit_txid}:0   <- this is the token's permanent identity")
+    print(f"  owner:       {address}")
+    print()
+    print("inspect it on the node:")
+    print("  pyrxd regtest info")
+    print(
+        f"  docker exec {RegtestNode.CONTAINER} radiant-cli -regtest -rpcuser={RegtestNode.RPC_USER} "
+        f"-rpcpassword={RegtestNode.RPC_PASSWORD} getrawtransaction {reveal_txid} 1"
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -174,6 +174,10 @@ ignore = [
     "S603",   # subprocess call with non-shell args: dev scripts trust their own argv
     "S607",   # partial executable path: `git`, `python3` etc. resolved via PATH at dev time
 ]
+"src/pyrxd/devnet.py" = [
+    "S603",   # the module's whole purpose is shelling the docker CLI with fully-controlled list-form argv
+    "S607",   # `docker` resolved via PATH (guarded by shutil.which up front)
+]
 "docs/conf.py" = ["E", "F", "I"]
 
 [tool.ruff.lint.isort]

--- a/src/pyrxd/__init__.py
+++ b/src/pyrxd/__init__.py
@@ -10,13 +10,15 @@ Quickstart::
 
 Subpackages:
     pyrxd.glyph      — Glyph token protocol (NFT, FT, dMint, mutable, V2)
-    pyrxd.gravity    — BTC↔RXD atomic swaps (Gravity protocol)
+    pyrxd.swap       — Same-chain partial-transaction swaps (RXD/token)
+    pyrxd.gravity    — Cross-chain (BTC/ETH↔RXD) HTLC atomic swaps
     pyrxd.security   — Typed secrets, error hierarchy, secure RNG
     pyrxd.hd         — BIP-32/39/44 HD wallet
     pyrxd.network    — ElectrumX client, BTC data sources
     pyrxd.spv        — SPV chain/payment verification
     pyrxd.transaction — Transaction building and serialization
     pyrxd.script     — Script types and evaluation
+    pyrxd.devnet     — Local regtest dev node (see `pyrxd regtest`)
 
 Implementation note — lazy top-level re-exports:
 
@@ -89,6 +91,19 @@ _LAZY_EXPORTS: dict[str, tuple[str, str]] = {
     "mnemonic_from_entropy": ("pyrxd.hd.bip39", "mnemonic_from_entropy"),
     "script_hash_for_address": ("pyrxd.network.electrumx", "script_hash_for_address"),
     "seed_from_mnemonic": ("pyrxd.hd.bip39", "seed_from_mnemonic"),
+    # Same-chain swaps — pyrxd.swap (SIGHASH_SINGLE|ANYONECANPAY partial-tx offers)
+    "Asset": ("pyrxd.swap", "Asset"),
+    "FundingInput": ("pyrxd.swap", "FundingInput"),
+    "SwapOffer": ("pyrxd.swap", "SwapOffer"),
+    "SwapTerms": ("pyrxd.swap", "SwapTerms"),
+    "accept_offer": ("pyrxd.swap", "accept_offer"),
+    "create_offer": ("pyrxd.swap", "create_offer"),
+    # SPV verification
+    "SpvProof": ("pyrxd.spv", "SpvProof"),
+    "SpvProofBuilder": ("pyrxd.spv", "SpvProofBuilder"),
+    "verify_tx_in_block": ("pyrxd.spv", "verify_tx_in_block"),
+    # Local regtest dev node (see `pyrxd regtest` / the quickstart tutorial)
+    "RegtestNode": ("pyrxd.devnet", "RegtestNode"),
 }
 
 __all__ = sorted([*_LAZY_EXPORTS.keys(), "__version__"])

--- a/src/pyrxd/cli/main.py
+++ b/src/pyrxd/cli/main.py
@@ -163,12 +163,13 @@ def run() -> None:
 # and that breaks static analysis even though Python's import system
 # tolerates it at runtime.
 
-from . import glyph_cmds, query_cmds, setup_cmd, wallet_cmds  # noqa: E402
+from . import glyph_cmds, query_cmds, regtest_cmds, setup_cmd, wallet_cmds  # noqa: E402
 
 cli.add_command(glyph_cmds.glyph_group)
 cli.add_command(query_cmds.address_cmd)
 cli.add_command(query_cmds.balance_cmd)
 cli.add_command(query_cmds.utxos_cmd)
+cli.add_command(regtest_cmds.regtest_group)
 cli.add_command(setup_cmd.setup_cmd)
 cli.add_command(wallet_cmds.wallet_group)
 

--- a/src/pyrxd/cli/regtest_cmds.py
+++ b/src/pyrxd/cli/regtest_cmds.py
@@ -1,0 +1,140 @@
+"""``pyrxd regtest`` — one-command local Radiant regtest node for development.
+
+A thin CLI over :class:`pyrxd.devnet.RegtestNode`. The goal is for a fresh
+developer to get a funded, spendable regtest identity in a single command::
+
+    pyrxd regtest up
+
+which stands up an isolated regtest chain in docker, mines a mature coinbase,
+generates a pre-funded key, and prints the connection details. ``mine``,
+``fund``, ``info`` operate on the running node; ``down`` tears it down.
+
+These commands are intentionally self-contained (they do not touch the wallet
+or network config) — regtest is a throwaway sandbox reached via ``docker exec``.
+"""
+
+from __future__ import annotations
+
+import click
+
+from ..devnet import DevnetError, RegtestNode
+from .format import emit
+
+
+def _fail(exc: DevnetError) -> None:
+    raise click.ClickException(str(exc))
+
+
+@click.group(name="regtest")
+def regtest_group() -> None:
+    """Manage a local Radiant regtest node for development (docker)."""
+
+
+@regtest_group.command(name="up")
+@click.option("--fresh", is_flag=True, help="Tear down any existing node for a clean chain.")
+@click.option(
+    "--fund",
+    "fund_rxd",
+    type=float,
+    default=100.0,
+    metavar="RXD",
+    help="RXD to pre-fund the generated dev key with (default 100).",
+)
+@click.option("--json", "json_output", is_flag=True, help="Machine-readable output.")
+def regtest_up(fresh: bool, fund_rxd: float, json_output: bool) -> None:
+    """Start the regtest node and print a pre-funded dev key."""
+    node = RegtestNode()
+    try:
+        already = node.is_running() and not fresh
+        node.start(fresh=fresh)
+        info = node.info()
+        key = node.new_funded_key(fund_rxd)
+    except DevnetError as exc:
+        _fail(exc)
+    result = {**info, "dev_address": key.address, "dev_wif": key.wif, "dev_funded_rxd": key.funded_rxd}
+    if json_output:
+        click.echo(emit(result, mode="json"))
+        return
+    if already:
+        click.echo("regtest node already running (use --fresh for a clean chain)")
+    else:
+        click.echo("regtest node up")
+    click.echo(f"  container: {info['container']}  (image {info['image']})")
+    click.echo(f"  height:    {info['height']}")
+    click.echo(f"  rpc:       user={info['rpc_user']} password={info['rpc_password']} wallet={info['wallet']}")
+    click.echo("")
+    click.echo("pre-funded dev key (import with PrivateKey(wif)):")
+    click.echo(f"  address: {key.address}")
+    click.echo(f"  wif:     {key.wif}")
+    click.echo(f"  funded:  {key.funded_rxd:g} RXD")
+    click.echo("")
+    click.echo("next:")
+    click.echo("  pyrxd regtest mine 1            # advance the chain")
+    click.echo("  pyrxd regtest fund <address> 50 # faucet 50 RXD to any address")
+    click.echo("  pyrxd regtest down              # tear it all down")
+
+
+@regtest_group.command(name="down")
+def regtest_down() -> None:
+    """Stop and remove the regtest node (wipes the chain)."""
+    node = RegtestNode()
+    try:
+        node.stop()
+    except DevnetError as exc:
+        _fail(exc)
+    click.echo("regtest node down")
+
+
+@regtest_group.command(name="mine")
+@click.argument("count", type=int, default=1)
+@click.option(
+    "--to", "address", default=None, metavar="ADDRESS", help="Mine to this address (default: a fresh wallet address)."
+)
+@click.option("--json", "json_output", is_flag=True, help="Machine-readable output.")
+def regtest_mine(count: int, address: str | None, json_output: bool) -> None:
+    """Mine COUNT blocks (default 1)."""
+    node = RegtestNode()
+    try:
+        height = node.mine(count, address)
+    except DevnetError as exc:
+        _fail(exc)
+    if json_output:
+        click.echo(emit({"mined": count, "height": height}, mode="json"))
+    else:
+        click.echo(f"mined {count} block(s) — height {height}")
+
+
+@regtest_group.command(name="fund")
+@click.argument("address")
+@click.argument("amount", type=float, default=10.0)
+@click.option("--json", "json_output", is_flag=True, help="Machine-readable output.")
+def regtest_fund(address: str, amount: float, json_output: bool) -> None:
+    """Faucet AMOUNT RXD (default 10) to ADDRESS, confirmed in a block."""
+    node = RegtestNode()
+    try:
+        txid = node.fund(address, amount)
+    except DevnetError as exc:
+        _fail(exc)
+    if json_output:
+        click.echo(emit({"txid": txid, "address": address, "amount_rxd": amount}, mode="json"))
+    else:
+        click.echo(f"funded {address} with {amount:g} RXD")
+        click.echo(f"  txid: {txid}")
+
+
+@regtest_group.command(name="info")
+@click.option("--json", "json_output", is_flag=True, help="Machine-readable output.")
+def regtest_info(json_output: bool) -> None:
+    """Show the running node's connection + chain summary."""
+    node = RegtestNode()
+    try:
+        info = node.info()
+    except DevnetError as exc:
+        _fail(exc)
+    if json_output:
+        click.echo(emit(info, mode="json"))
+        return
+    click.echo(f"container: {info['container']}  (image {info['image']})")
+    click.echo(f"height:    {info['height']}")
+    click.echo(f"rpc:       user={info['rpc_user']} password={info['rpc_password']} wallet={info['wallet']}")
+    click.echo(f"exec:      {info['exec_prefix']} ...")

--- a/src/pyrxd/devnet.py
+++ b/src/pyrxd/devnet.py
@@ -1,0 +1,236 @@
+"""One-command local Radiant regtest node for development.
+
+Wraps a ``radiant-core`` regtest node running in docker so a developer can
+stand up an isolated chain, mine blocks, and fund an address without learning
+the node's RPC surface. This is the dev-facing promotion of the in-test
+``_RegtestNode`` helper (``tests/test_htlc_regtest_e2e.py``).
+
+Everything here targets **regtest only** — an ephemeral, throwaway chain bound
+to the local docker host. The RPC credentials are deliberately fixed (it is a
+localhost-only regtest sandbox reached via ``docker exec``, never exposed), so
+separate CLI invocations (`up`, `mine`, `fund`, `down`) reconnect to the same
+node with no state file to keep in sync.
+
+Prerequisites: ``docker`` on PATH and the ``radiant-core`` regtest image
+present locally (see :data:`RegtestNode.IMAGE`).
+"""
+
+from __future__ import annotations
+
+import json
+import shutil
+import subprocess  # nosec B404  # only ever runs a fixed `docker` argv (see call sites)
+import time
+from dataclasses import dataclass
+
+
+class DevnetError(RuntimeError):
+    """A devnet operation failed (docker missing, node not up, RPC error)."""
+
+
+@dataclass(frozen=True)
+class DevKey:
+    """A freshly generated, pre-funded regtest key handed to the developer."""
+
+    address: str
+    wif: str
+    funded_rxd: float
+
+
+class RegtestNode:
+    """A self-managed, isolated ``radiant-core`` regtest node (docker).
+
+    The node is identified by a fixed container name so that ``up`` /
+    ``mine`` / ``fund`` / ``down`` invoked as separate processes all operate on
+    the same chain. ``up`` is the only call that creates the container; the
+    others attach to the running one and raise :class:`DevnetError` if it is
+    absent.
+    """
+
+    IMAGE = "radiant-core:v2.3.0-amd64"
+    CONTAINER = "pyrxd-devnet"
+    RPC_USER = "pyrxd"
+    RPC_PASSWORD = "pyrxd"  # nosec B105  # localhost-only regtest sandbox cred (docker exec), not a secret
+    WALLET = "devnet"
+    _RPC_READY_TIMEOUT_S = 30
+
+    # ----------------------------------------------------------------- docker
+
+    @staticmethod
+    def _require_docker() -> None:
+        if shutil.which("docker") is None:
+            raise DevnetError("docker is not on PATH — install docker to use `pyrxd regtest`")
+
+    def cli(self, *args: str, wallet: bool = False) -> object:
+        """Run ``radiant-cli`` inside the container; parse JSON when possible."""
+        base = [
+            "docker",
+            "exec",
+            self.CONTAINER,
+            "radiant-cli",
+            "-regtest",
+            f"-rpcuser={self.RPC_USER}",
+            f"-rpcpassword={self.RPC_PASSWORD}",
+        ]
+        if wallet:
+            base.append(f"-rpcwallet={self.WALLET}")
+        try:
+            r = subprocess.run(base + list(args), capture_output=True, text=True, timeout=60)  # nosec B603 B607  # controlled docker argv
+        except FileNotFoundError as exc:  # docker vanished mid-run
+            raise DevnetError("docker is not on PATH — install docker to use `pyrxd regtest`") from exc
+        if r.returncode != 0:
+            raise DevnetError(f"radiant-cli {args[0] if args else ''} failed: {r.stderr.strip()}")
+        out = r.stdout.strip()
+        try:
+            return json.loads(out)
+        except json.JSONDecodeError:
+            return out
+
+    def is_running(self) -> bool:
+        """True if the devnet container exists and is running."""
+        self._require_docker()
+        r = subprocess.run(  # nosec B603 B607  # controlled docker argv
+            ["docker", "inspect", "-f", "{{.State.Running}}", self.CONTAINER],
+            capture_output=True,
+            text=True,
+        )
+        return r.returncode == 0 and r.stdout.strip() == "true"
+
+    # ----------------------------------------------------------------- lifecycle
+
+    def start(self, *, fresh: bool = False, initial_blocks: int = 101) -> None:
+        """Start the regtest node, create the dev wallet, and mature a coinbase.
+
+        Idempotent unless ``fresh`` is set: if the container is already running
+        it is left untouched (the chain state is preserved). ``fresh=True``
+        tears the existing container down first for a clean chain.
+        """
+        self._require_docker()
+        if fresh:
+            self.stop()
+        elif self.is_running():
+            return
+        else:
+            # A stopped/leftover container of the same name would block `run`.
+            subprocess.run(["docker", "rm", "-f", self.CONTAINER], capture_output=True)  # nosec B603 B607  # controlled docker argv
+
+        up = subprocess.run(  # nosec B603 B607  # controlled docker argv
+            [
+                "docker",
+                "run",
+                "-d",
+                "--name",
+                self.CONTAINER,
+                "--entrypoint",
+                "radiantd",
+                self.IMAGE,
+                "-regtest",
+                "-server",
+                "-txindex=1",
+                "-disablewallet=0",
+                "-fallbackfee=0.001",
+                f"-rpcuser={self.RPC_USER}",
+                f"-rpcpassword={self.RPC_PASSWORD}",
+                "-rpcbind=127.0.0.1",
+                "-rpcallowip=127.0.0.1",
+            ],
+            capture_output=True,
+            text=True,
+        )
+        if up.returncode != 0:
+            stderr = up.stderr.strip()
+            if "No such image" in stderr or "not found" in stderr:
+                raise DevnetError(
+                    f"regtest image {self.IMAGE!r} is not present locally — "
+                    "build or pull the radiant-core regtest image first"
+                )
+            raise DevnetError(f"failed to start regtest container: {stderr}")
+
+        self._await_rpc()
+        # Safety: never proceed unless this is genuinely a regtest chain.
+        chain = self.cli("getblockchaininfo")
+        if not isinstance(chain, dict) or chain.get("chain") != "regtest":
+            raise DevnetError("node did not come up as regtest — aborting")
+        self.cli("createwallet", self.WALLET)
+        if initial_blocks:
+            self.mine(initial_blocks)
+
+    def _await_rpc(self) -> None:
+        """Block until the node answers RPC (any chain). The regtest-only
+        guard is enforced by the caller once RPC is up."""
+        deadline = time.monotonic() + self._RPC_READY_TIMEOUT_S
+        while time.monotonic() < deadline:
+            try:
+                info = self.cli("getblockchaininfo")
+                if isinstance(info, dict) and "chain" in info:
+                    return
+            except DevnetError:
+                pass
+            time.sleep(0.5)
+        raise DevnetError(f"regtest RPC did not become ready within {self._RPC_READY_TIMEOUT_S}s")
+
+    def stop(self) -> None:
+        """Remove the devnet container (no-op if absent). Wipes the chain."""
+        self._require_docker()
+        subprocess.run(["docker", "rm", "-f", self.CONTAINER], capture_output=True)  # nosec B603 B607  # controlled docker argv
+
+    # ----------------------------------------------------------------- chain ops
+
+    def _ensure_running(self) -> None:
+        if not self.is_running():
+            raise DevnetError("regtest node is not running — start it with `pyrxd regtest up`")
+
+    def new_address(self) -> str:
+        """A fresh address from the dev wallet."""
+        self._ensure_running()
+        return str(self.cli("getnewaddress", wallet=True))
+
+    def mine(self, n: int = 1, address: str | None = None) -> int:
+        """Mine ``n`` blocks to ``address`` (a fresh wallet address by default).
+
+        Returns the new chain height.
+        """
+        self._ensure_running()
+        target = address or self.new_address()
+        self.cli("generatetoaddress", str(n), target)
+        return int(self.cli("getblockcount"))
+
+    def fund(self, address: str, amount_rxd: float, *, confirm: bool = True) -> str:
+        """Faucet: send ``amount_rxd`` RXD to ``address`` from the dev wallet.
+
+        Mines one block to confirm the payment unless ``confirm`` is False.
+        Returns the funding txid.
+        """
+        self._ensure_running()
+        txid = str(self.cli("sendtoaddress", address, f"{amount_rxd:.8f}", wallet=True))
+        if confirm:
+            self.mine(1)
+        return txid
+
+    def new_funded_key(self, amount_rxd: float = 100.0) -> DevKey:
+        """Generate a wallet key, fund it, and return its address + WIF.
+
+        The WIF is directly importable into pyrxd (``PrivateKey(wif)``), giving
+        a developer a spendable, pre-funded regtest identity in one step.
+        """
+        self._ensure_running()
+        address = self.new_address()
+        wif = str(self.cli("dumpprivkey", address, wallet=True))
+        self.fund(address, amount_rxd)
+        return DevKey(address=address, wif=wif, funded_rxd=amount_rxd)
+
+    def info(self) -> dict:
+        """Connection + chain summary for display."""
+        self._ensure_running()
+        chain = self.cli("getblockchaininfo")
+        height = chain.get("blocks") if isinstance(chain, dict) else None
+        return {
+            "container": self.CONTAINER,
+            "image": self.IMAGE,
+            "rpc_user": self.RPC_USER,
+            "rpc_password": self.RPC_PASSWORD,
+            "wallet": self.WALLET,
+            "height": height,
+            "exec_prefix": f"docker exec {self.CONTAINER} radiant-cli -regtest "
+            f"-rpcuser={self.RPC_USER} -rpcpassword={self.RPC_PASSWORD}",
+        }

--- a/tests/cli/test_regtest_cmds.py
+++ b/tests/cli/test_regtest_cmds.py
@@ -1,0 +1,219 @@
+"""Tests for ``pyrxd regtest`` (the dev regtest tooling CLI surface).
+
+These are fast unit tests: ``pyrxd.devnet.RegtestNode`` is stubbed so no
+docker is required. The live docker round-trip (up → mine → fund → claim) is
+exercised by the regtest e2e integration tests.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+from click.testing import CliRunner
+
+from pyrxd.cli.main import cli
+from pyrxd.devnet import DevKey, DevnetError
+
+
+def _extract_json(output: str) -> dict:
+    start, end = output.find("{"), output.rfind("}")
+    assert start != -1 and end != -1, f"no JSON in output:\n{output!r}"
+    return json.loads(output[start : end + 1])
+
+
+_INFO = {
+    "container": "pyrxd-devnet",
+    "image": "radiant-core:v2.3.0-amd64",
+    "rpc_user": "pyrxd",
+    "rpc_password": "pyrxd",
+    "wallet": "devnet",
+    "height": 101,
+    "exec_prefix": "docker exec pyrxd-devnet radiant-cli -regtest -rpcuser=pyrxd -rpcpassword=pyrxd",
+}
+
+
+class _FakeNode:
+    """A RegtestNode stand-in recording calls, no docker involved."""
+
+    def __init__(self, *, running: bool = False) -> None:
+        self._running = running
+        self.calls: list[tuple] = []
+
+    def is_running(self) -> bool:
+        return self._running
+
+    def start(self, *, fresh: bool = False) -> None:
+        self.calls.append(("start", fresh))
+        self._running = True
+
+    def stop(self) -> None:
+        self.calls.append(("stop",))
+        self._running = False
+
+    def info(self) -> dict:
+        return dict(_INFO)
+
+    def new_funded_key(self, amount_rxd: float = 100.0) -> DevKey:
+        self.calls.append(("new_funded_key", amount_rxd))
+        return DevKey(address="n1devaddress", wif="cVdevwif", funded_rxd=amount_rxd)
+
+    def mine(self, count: int = 1, address: str | None = None) -> int:
+        self.calls.append(("mine", count, address))
+        return 101 + count
+
+    def fund(self, address: str, amount_rxd: float) -> str:
+        self.calls.append(("fund", address, amount_rxd))
+        return "ab" * 32
+
+
+@pytest.fixture
+def runner() -> CliRunner:
+    return CliRunner()
+
+
+@pytest.fixture
+def patch_node(monkeypatch):
+    """Install a _FakeNode in place of RegtestNode for the regtest commands."""
+
+    def _install(node: _FakeNode) -> _FakeNode:
+        monkeypatch.setattr("pyrxd.cli.regtest_cmds.RegtestNode", lambda: node)
+        return node
+
+    return _install
+
+
+class TestUp:
+    def test_up_starts_and_prints_funded_key(self, runner, patch_node):
+        patch_node(_FakeNode(running=False))
+        result = runner.invoke(cli, ["regtest", "up", "--fund", "50"])
+        assert result.exit_code == 0, result.output
+        assert "regtest node up" in result.output
+        assert "n1devaddress" in result.output
+        assert "cVdevwif" in result.output
+        assert "50 RXD" in result.output
+
+    def test_up_json(self, runner, patch_node):
+        patch_node(_FakeNode(running=False))
+        result = runner.invoke(cli, ["regtest", "up", "--json"])
+        assert result.exit_code == 0, result.output
+        payload = _extract_json(result.output)
+        assert payload["dev_address"] == "n1devaddress"
+        assert payload["dev_wif"] == "cVdevwif"
+        assert payload["container"] == "pyrxd-devnet"
+
+    def test_up_idempotent_when_already_running(self, runner, patch_node):
+        node = patch_node(_FakeNode(running=True))
+        result = runner.invoke(cli, ["regtest", "up"])
+        assert result.exit_code == 0, result.output
+        assert "already running" in result.output
+        # start() called with fresh=False (a no-op inside the node)
+        assert ("start", False) in node.calls
+
+    def test_up_fresh_flag_passes_through(self, runner, patch_node):
+        node = patch_node(_FakeNode(running=True))
+        result = runner.invoke(cli, ["regtest", "up", "--fresh"])
+        assert result.exit_code == 0, result.output
+        assert ("start", True) in node.calls
+
+
+class TestMineFundDown:
+    def test_mine_default_one(self, runner, patch_node):
+        patch_node(_FakeNode(running=True))
+        result = runner.invoke(cli, ["regtest", "mine"])
+        assert result.exit_code == 0, result.output
+        assert "mined 1 block(s) — height 102" in result.output
+
+    def test_mine_count_json(self, runner, patch_node):
+        patch_node(_FakeNode(running=True))
+        result = runner.invoke(cli, ["regtest", "mine", "3", "--json"])
+        assert result.exit_code == 0, result.output
+        payload = _extract_json(result.output)
+        assert payload == {"mined": 3, "height": 104}
+
+    def test_fund(self, runner, patch_node):
+        node = patch_node(_FakeNode(running=True))
+        result = runner.invoke(cli, ["regtest", "fund", "n1target", "12.5"])
+        assert result.exit_code == 0, result.output
+        assert "funded n1target with 12.5 RXD" in result.output
+        assert ("fund", "n1target", 12.5) in node.calls
+
+    def test_fund_json(self, runner, patch_node):
+        patch_node(_FakeNode(running=True))
+        result = runner.invoke(cli, ["regtest", "fund", "n1target", "5", "--json"])
+        assert result.exit_code == 0, result.output
+        payload = _extract_json(result.output)
+        assert payload["address"] == "n1target"
+        assert payload["amount_rxd"] == 5
+
+    def test_info_human(self, runner, patch_node):
+        patch_node(_FakeNode(running=True))
+        result = runner.invoke(cli, ["regtest", "info"])
+        assert result.exit_code == 0, result.output
+        assert "container: pyrxd-devnet" in result.output
+        assert "height:    101" in result.output
+
+    def test_info_json(self, runner, patch_node):
+        patch_node(_FakeNode(running=True))
+        result = runner.invoke(cli, ["regtest", "info", "--json"])
+        assert result.exit_code == 0, result.output
+        assert _extract_json(result.output)["container"] == "pyrxd-devnet"
+
+    def test_down(self, runner, patch_node):
+        node = patch_node(_FakeNode(running=True))
+        result = runner.invoke(cli, ["regtest", "down"])
+        assert result.exit_code == 0, result.output
+        assert "regtest node down" in result.output
+        assert ("stop",) in node.calls
+
+
+class TestFailClosed:
+    def test_up_error_path(self, runner, monkeypatch):
+        class _Boom(_FakeNode):
+            def start(self, *, fresh: bool = False) -> None:
+                raise DevnetError("regtest image not present locally")
+
+        monkeypatch.setattr("pyrxd.cli.regtest_cmds.RegtestNode", lambda: _Boom())
+        result = runner.invoke(cli, ["regtest", "up"])
+        assert result.exit_code != 0
+        assert "not present locally" in result.output
+
+    def test_down_error_path(self, runner, monkeypatch):
+        class _Boom(_FakeNode):
+            def stop(self) -> None:
+                raise DevnetError("docker is not on PATH")
+
+        monkeypatch.setattr("pyrxd.cli.regtest_cmds.RegtestNode", lambda: _Boom())
+        result = runner.invoke(cli, ["regtest", "down"])
+        assert result.exit_code != 0
+        assert "docker is not on PATH" in result.output
+
+    def test_fund_error_path(self, runner, monkeypatch):
+        class _Boom(_FakeNode):
+            def fund(self, address: str, amount_rxd: float) -> str:
+                raise DevnetError("regtest node is not running")
+
+        monkeypatch.setattr("pyrxd.cli.regtest_cmds.RegtestNode", lambda: _Boom())
+        result = runner.invoke(cli, ["regtest", "fund", "n1t", "1"])
+        assert result.exit_code != 0
+        assert "not running" in result.output
+
+    def test_info_when_not_running_errors(self, runner, monkeypatch):
+        class _NotRunning(_FakeNode):
+            def info(self) -> dict:
+                raise DevnetError("regtest node is not running — start it with `pyrxd regtest up`")
+
+        monkeypatch.setattr("pyrxd.cli.regtest_cmds.RegtestNode", lambda: _NotRunning())
+        result = runner.invoke(cli, ["regtest", "info"])
+        assert result.exit_code != 0
+        assert "not running" in result.output
+
+    def test_mine_when_not_running_errors(self, runner, monkeypatch):
+        class _NotRunning(_FakeNode):
+            def mine(self, count: int = 1, address: str | None = None) -> int:
+                raise DevnetError("regtest node is not running — start it with `pyrxd regtest up`")
+
+        monkeypatch.setattr("pyrxd.cli.regtest_cmds.RegtestNode", lambda: _NotRunning())
+        result = runner.invoke(cli, ["regtest", "mine"])
+        assert result.exit_code != 0
+        assert "not running" in result.output

--- a/tests/test_devnet.py
+++ b/tests/test_devnet.py
@@ -1,0 +1,246 @@
+"""Unit tests for ``pyrxd.devnet.RegtestNode`` with docker fully mocked.
+
+No docker is required: ``subprocess.run`` and ``shutil.which`` are patched so
+the argv construction, JSON parsing, lifecycle logic, and fail-closed guards
+are all exercised in-process. The live docker round-trip is covered separately
+by the regtest integration path.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+
+import pytest
+
+from pyrxd.devnet import DevKey, DevnetError, RegtestNode
+
+
+class _FakeProc:
+    def __init__(self, returncode: int = 0, stdout: str = "", stderr: str = "") -> None:
+        self.returncode = returncode
+        self.stdout = stdout
+        self.stderr = stderr
+
+
+class _Docker:
+    """Configurable fake docker: routes by argv to canned RPC responses."""
+
+    def __init__(self, *, running: bool = True, chain: str = "regtest", height: int = 101) -> None:
+        self.running = running
+        self.chain = chain
+        self.height = height
+        self.run_fails_with = ""  # set to simulate `docker run` failure stderr
+        self.calls: list[list[str]] = []
+
+    def _rpc_method(self, argv: list[str]) -> str:
+        i = argv.index("radiant-cli")
+        for a in argv[i + 1 :]:
+            if not a.startswith("-"):
+                return a
+        return ""
+
+    def __call__(self, argv, capture_output=False, text=False, timeout=None):
+        self.calls.append(argv)
+        if argv[:2] == ["docker", "inspect"]:
+            return _FakeProc(0 if self.running else 1, "true" if self.running else "")
+        if argv[:2] == ["docker", "rm"]:
+            self.running = False
+            return _FakeProc(0)
+        if argv[:2] == ["docker", "run"]:
+            if self.run_fails_with:
+                return _FakeProc(1, stderr=self.run_fails_with)
+            self.running = True
+            return _FakeProc(0, stdout="containerid\n")
+        if argv[:2] == ["docker", "exec"]:
+            return _FakeProc(0, stdout=self._exec_stdout(argv))
+        raise AssertionError(f"unexpected argv: {argv}")
+
+    def _exec_stdout(self, argv: list[str]) -> str:
+        method = self._rpc_method(argv)
+        if method == "getblockchaininfo":
+            return json.dumps({"chain": self.chain, "blocks": self.height})
+        if method == "getblockcount":
+            return str(self.height)
+        if method == "getnewaddress":
+            return "n1FakeMineAddr"
+        if method == "createwallet":
+            return json.dumps({"name": "devnet"})
+        if method == "generatetoaddress":
+            return json.dumps(["00" * 32])
+        if method == "dumpprivkey":
+            return "cFakeWifValue"
+        if method == "sendtoaddress":
+            return "ab" * 32
+        return ""
+
+
+@pytest.fixture
+def patch_docker(monkeypatch):
+    def _install(docker: _Docker) -> _Docker:
+        monkeypatch.setattr("pyrxd.devnet.shutil.which", lambda _name: "/usr/bin/docker")
+        monkeypatch.setattr("pyrxd.devnet.subprocess.run", docker)
+        return docker
+
+    return _install
+
+
+class TestCli:
+    def test_parses_json(self, patch_docker):
+        patch_docker(_Docker())
+        out = RegtestNode().cli("getblockchaininfo")
+        assert out == {"chain": "regtest", "blocks": 101}
+
+    def test_returns_raw_string_when_not_json(self, patch_docker):
+        patch_docker(_Docker())
+        assert RegtestNode().cli("getnewaddress", wallet=True) == "n1FakeMineAddr"
+
+    def test_wallet_flag_added(self, patch_docker):
+        d = patch_docker(_Docker())
+        RegtestNode().cli("getnewaddress", wallet=True)
+        assert any("-rpcwallet=devnet" in a for a in d.calls[-1])
+
+    def test_nonzero_returncode_raises(self, patch_docker, monkeypatch):
+        monkeypatch.setattr("pyrxd.devnet.shutil.which", lambda _n: "/usr/bin/docker")
+        monkeypatch.setattr("pyrxd.devnet.subprocess.run", lambda *a, **k: _FakeProc(1, stderr="boom"))
+        with pytest.raises(DevnetError, match="boom"):
+            RegtestNode().cli("getblockchaininfo")
+
+    def test_docker_missing_raises(self, monkeypatch):
+        monkeypatch.setattr("pyrxd.devnet.shutil.which", lambda _n: None)
+        with pytest.raises(DevnetError, match="docker is not on PATH"):
+            RegtestNode().is_running()
+
+
+class TestLifecycle:
+    def test_is_running_true_false(self, patch_docker):
+        patch_docker(_Docker(running=True))
+        assert RegtestNode().is_running() is True
+        patch_docker(_Docker(running=False))
+        assert RegtestNode().is_running() is False
+
+    def test_start_idempotent_when_running(self, patch_docker):
+        d = patch_docker(_Docker(running=True))
+        RegtestNode().start()
+        # No `docker run` issued — we returned early.
+        assert not any(c[:2] == ["docker", "run"] for c in d.calls)
+
+    def test_start_fresh_then_run(self, patch_docker):
+        d = patch_docker(_Docker(running=True))
+        RegtestNode().start(fresh=True, initial_blocks=0)
+        assert any(c[:2] == ["docker", "rm"] for c in d.calls)
+        assert any(c[:2] == ["docker", "run"] for c in d.calls)
+
+    def test_start_from_stopped_runs_and_mines(self, patch_docker):
+        d = patch_docker(_Docker(running=False))
+        RegtestNode().start(initial_blocks=101)
+        assert any(c[:2] == ["docker", "run"] for c in d.calls)
+        assert any("generatetoaddress" in c for c in d.calls)
+
+    def test_start_image_missing(self, patch_docker):
+        d = _Docker(running=False)
+        d.run_fails_with = "Unable to find image 'x': No such image"
+        patch_docker(d)
+        with pytest.raises(DevnetError, match="not present locally"):
+            RegtestNode().start()
+
+    def test_start_other_run_failure(self, patch_docker):
+        d = _Docker(running=False)
+        d.run_fails_with = "some docker daemon error"
+        patch_docker(d)
+        with pytest.raises(DevnetError, match="failed to start"):
+            RegtestNode().start()
+
+    def test_start_refuses_non_regtest(self, patch_docker):
+        patch_docker(_Docker(running=False, chain="main"))
+        with pytest.raises(DevnetError, match="did not come up as regtest"):
+            RegtestNode().start(initial_blocks=0)
+
+    def test_stop_removes(self, patch_docker):
+        d = patch_docker(_Docker(running=True))
+        RegtestNode().stop()
+        assert any(c[:2] == ["docker", "rm"] for c in d.calls)
+
+
+class TestChainOps:
+    def test_mine_returns_height(self, patch_docker):
+        patch_docker(_Docker(running=True, height=105))
+        assert RegtestNode().mine(3) == 105
+
+    def test_mine_explicit_address(self, patch_docker):
+        d = patch_docker(_Docker(running=True))
+        RegtestNode().mine(1, address="n1Explicit")
+        gen = [c for c in d.calls if "generatetoaddress" in c][-1]
+        assert "n1Explicit" in gen
+
+    def test_mine_fails_closed_when_down(self, patch_docker):
+        patch_docker(_Docker(running=False))
+        with pytest.raises(DevnetError, match="not running"):
+            RegtestNode().mine()
+
+    def test_fund_sends_and_confirms(self, patch_docker):
+        d = patch_docker(_Docker(running=True))
+        txid = RegtestNode().fund("n1Target", 12.5)
+        assert txid == "ab" * 32
+        send = [c for c in d.calls if "sendtoaddress" in c][-1]
+        assert "n1Target" in send and "12.50000000" in send
+        # confirm=True mines a block
+        assert any("generatetoaddress" in c for c in d.calls)
+
+    def test_fund_no_confirm_skips_mine(self, patch_docker):
+        d = patch_docker(_Docker(running=True))
+        RegtestNode().fund("n1Target", 1.0, confirm=False)
+        assert not any("generatetoaddress" in c for c in d.calls)
+
+    def test_new_funded_key(self, patch_docker):
+        patch_docker(_Docker(running=True))
+        key = RegtestNode().new_funded_key(50.0)
+        assert isinstance(key, DevKey)
+        assert key.address == "n1FakeMineAddr"
+        assert key.wif == "cFakeWifValue"
+        assert key.funded_rxd == 50.0
+
+    def test_info(self, patch_docker):
+        patch_docker(_Docker(running=True, height=107))
+        info = RegtestNode().info()
+        assert info["height"] == 107
+        assert info["container"] == "pyrxd-devnet"
+        assert "docker exec" in info["exec_prefix"]
+
+    def test_info_fails_closed_when_down(self, patch_docker):
+        patch_docker(_Docker(running=False))
+        with pytest.raises(DevnetError, match="not running"):
+            RegtestNode().info()
+
+
+def test_await_rpc_times_out(monkeypatch):
+    """If RPC never reports regtest, start() raises rather than hanging."""
+    monkeypatch.setattr("pyrxd.devnet.shutil.which", lambda _n: "/usr/bin/docker")
+
+    def _never_ready(argv, **k):
+        if argv[:2] == ["docker", "run"]:
+            return _FakeProc(0)
+        if argv[:2] in (["docker", "rm"], ["docker", "inspect"]):
+            return _FakeProc(1)
+        return _FakeProc(1, stderr="not ready")  # every cli call fails
+
+    monkeypatch.setattr("pyrxd.devnet.subprocess.run", _never_ready)
+    # Collapse the wait loop so the test is instant.
+    monkeypatch.setattr(RegtestNode, "_RPC_READY_TIMEOUT_S", 0)
+    monkeypatch.setattr("pyrxd.devnet.time.sleep", lambda _s: None)
+    with pytest.raises(DevnetError, match="did not become ready"):
+        RegtestNode().start(initial_blocks=0)
+
+
+def test_cli_filenotfound_maps_to_devnet_error(monkeypatch):
+    monkeypatch.setattr("pyrxd.devnet.shutil.which", lambda _n: "/usr/bin/docker")
+
+    def _raise(*a, **k):
+        raise FileNotFoundError("docker")
+
+    monkeypatch.setattr("pyrxd.devnet.subprocess.run", _raise)
+    with pytest.raises(DevnetError, match="docker is not on PATH"):
+        RegtestNode().cli("getblockchaininfo")
+
+
+_ = subprocess  # keep the import meaningful for readers; patched via string paths


### PR DESCRIPTION
## Tier-1 dev on-ramp sprint (S1–S6)

Everything a developer hits in their first 30 minutes with pyrxd: import the
headline primitives, stand up a local chain, mint a token, and find a guided
path through the examples. Regtest/testnet only — no real value, no audit gate.

### S1 — curated SDK surface
`from pyrxd import …` now reaches the headline primitives directly (all lazy /
PEP 562, so `import pyrxd` stays cheap and the pyodide inspect path loads no
coincurve/aiohttp):
- `pyrxd.swap`: `create_offer`, `accept_offer`, `Asset`, `SwapOffer`, `SwapTerms`, `FundingInput`
- `pyrxd.spv`: `SpvProof`, `SpvProofBuilder`, `verify_tx_in_block`
- `pyrxd.devnet`: `RegtestNode`

The pre-audit cross-chain covenant builders stay in `pyrxd.gravity` (not hoisted).

### S2 — `pyrxd regtest` dev node
One command (`pyrxd regtest up`) → docker regtest + mine 101 + a pre-funded WIF
that round-trips into `PrivateKey()`. Plus `down`/`mine`/`fund`/`info`. Fixed
creds + container, `127.0.0.1`-only, hard `chain == "regtest"` guard.

### S3 — 5-minute quickstart
`examples/regtest_quickstart.py` mints a real NFT against the dev node (proven
on `radiant-core:v2.3.0` regtest — genuine `gly` envelope + singleton ref).
`docs/tutorials/quickstart.md` is the entry-point tutorial.

### S4 — examples audited + indexed
`examples/README.md` is a guided path with exact network/safety labels derived
from the code. Found a footgun: `gravity_full_trade.py` broadcast mainnet value
with no guard — added a mainnet safety gate (`I_UNDERSTAND_THIS_IS_REAL=yes`).

### S5 — showcase page
`docs/showcase.md` — proof-backed "What you can build on Radiant": the cross-chain
atomic swaps with real on-chain txids, native tokens, same-chain swaps. Honest
labels (BTC/RXD mainnet, every ETH leg Sepolia testnet) and a prominent pre-audit
caveat.

### S6 — API reference
Autodoc pages for `pyrxd.swap` and `pyrxd.devnet`, wired into the toctree.
Sphinx build clean.

### Tests / CI
- New modules ~98% covered by docker-mocked unit tests (no docker in CI).
- Full `task ci` green locally: 3969 passed, coverage 87.96%, mypy clean, sphinx clean.

> Note: this branch shares one pre-existing latent bug with `main` — `pyrxd
> --wallet $'\0'` leaked a `ValueError` (a fuzz test catches it stochastically).
> That's fixed separately in #188; merge #188 first (or expect the rare fuzz
> flake until it lands). It is unrelated to this sprint.
