### PR TITLE
fix(gravity): route BTC maker-stall recovery to mutual_refund

### DIFF
--- a/scripts/dust_swap_run.py
+++ b/scripts/dust_swap_run.py
@@ -324,8 +324,12 @@ async def run_dust_swap(args: argparse.Namespace) -> None:
             )
 
         print(
-            "\n  *** MONITORING WINDOW (BOTH_LOCKED): poll maybe_refund_asset_on_maker_stall well inside "
-            "maker_stall_safety_window_blocks. Do NOT walk away — the maker-stall steal is the real loss path. ***"
+            "\n  *** MONITORING WINDOW (BOTH_LOCKED): the maker-stall steal is the real loss path. Recovery in "
+            "THIS runbook is coord.mutual_refund() AFTER BOTH timeouts elapse (t_btc -> taker's BTC HTLC; "
+            "t_rxd/CSV -> maker's RXD covenant) — it refunds BOTH legs, so neither side takes one-sided loss. "
+            "Do NOT run maybe_refund_asset_on_maker_stall: its CSV refund pays the MAKER (the maker owns the "
+            "covenant), so as a TAKER it strands you — you gift the asset back and the maker still claims your "
+            "BTC with p (FSM finding #2). Do NOT walk away before both refunds confirm. ***"
         )
 
         # 3. Maker claims BTC, revealing p.

--- a/scripts/eth_swap_run.py
+++ b/scripts/eth_swap_run.py
@@ -505,8 +505,8 @@ async def run_sepolia_dust(args: argparse.Namespace) -> None:
             "is never revealed) is the real loss path. Recovery in THIS runbook is coord.mutual_refund() "
             "AFTER BOTH timeouts elapse (t_eth -> taker's ETH HTLC; t_rxd/CSV -> maker's RXD covenant); "
             "it refunds BOTH legs, so neither side takes one-sided loss. Do NOT use "
-            "maybe_refund_asset_on_maker_stall here — that is the BTC<->RXD runbook's proactive path where "
-            "the TAKER owns the RXD covenant; here the MAKER owns it (CLAIM->taker, CSV-refund->maker). "
+            "maybe_refund_asset_on_maker_stall here OR on the BTC<->RXD runbook — the MAKER owns the RXD "
+            "covenant in BOTH (CLAIM->taker, CSV-refund->maker), so as a TAKER it strands you (FSM finding #2). "
             "Do NOT walk away before both refunds confirm. ***"
         )
 

--- a/src/pyrxd/gravity/swap_coordinator.py
+++ b/src/pyrxd/gravity/swap_coordinator.py
@@ -1561,14 +1561,20 @@ class SwapCoordinator:
         (returns the unchanged record) when the trigger has not fired yet. Async
         because the asset refund broadcasts a Radiant covenant spend.
 
-        RUNBOOK SCOPE (red-team MEDIUM): this refunds ONLY the RXD covenant, whose CSV refund pays
-        the MAKER in BOTH directions (the maker owns the asset leg; p is not yet public) — it is NOT
-        a "taker reclaims the covenant" action (an earlier note wrongly said the taker owns it; the
-        covenant CLAIM pays the taker, the CSV REFUND pays the maker, same as eth_rxd_timelock.py).
-        It is sufficient stall recovery only when the OTHER party's value is independently
-        recoverable on its own leg. In the ETH<->RXD runbook the taker's value sits in the ETH HTLC,
-        which this method does NOT touch, so the correct ETH stall recovery is :meth:`mutual_refund`
-        (refunds BOTH legs after both timeouts) — NOT this method. Do not wire it into the ETH stall path.
+        RUNBOOK SCOPE (FSM finding #2, 2026-06-09 — VERIFIED on regtest): this refunds ONLY the RXD
+        covenant, whose CSV refund pays the MAKER in BOTH directions (the maker owns the asset leg; p
+        is not yet public) — it is NOT a "taker reclaims the covenant" action (an earlier note wrongly
+        said the taker owns it; the covenant CLAIM pays the taker, the CSV REFUND pays the maker, same
+        as eth_rxd_timelock.py).
+
+        This is a MAKER-side primitive (the maker recovering its own asset) and MUST NOT be wired into
+        a TAKER recovery path on EITHER counter-chain. A taker driven to run it strands itself: it
+        gifts the asset back to the maker AND destroys its only recourse (the claimable covenant) while
+        its own counter-leg stays locked, after which the maker — still holding p — claims the
+        counter-leg and takes both (proven by tests/test_xchain_swap_regtest_e2e.py::
+        TestMakerStallAssetOnlyRefundIsTakerLoss). The correct TAKER stall recovery on BOTH the BTC
+        and ETH runbooks is :meth:`mutual_refund` (refunds BOTH legs after both timeouts). The
+        watchtower (gravity.watch.decide) routes neither counter-chain's taker here.
         """
         if self.record.state is not SwapState.BOTH_LOCKED:
             raise ValidationError(

--- a/src/pyrxd/gravity/watch/README.md
+++ b/src/pyrxd/gravity/watch/README.md
@@ -38,7 +38,8 @@ RecordStore ─┐                                    ┌─ AlertChannel (authe
 | maker claimed + un-assessable (missing depth / `now<lock`) | `PAGE_SQUEEZED` | verify finality manually (fail-closed) |
 | `ASSET_VULNERABLE` | `PAGE_SQUEEZED` | winner-take-all decision |
 | `PARAMS_MISMATCH` | `PAGE_REFUND` | `taker_refund_btc` |
-| `MAKER_STALLS`, or `BOTH_LOCKED` + refund due | `PAGE_REFUND` | `maybe_refund_asset_on_maker_stall` |
+| `BOTH_LOCKED` + refund due | `PAGE_REFUND` | `mutual_refund` (broadcast once both timeouts elapse) |
+| `MAKER_STALLS` (unreachable post-fix) | `PAGE_SQUEEZED` | investigate — no clean step (FSM finding #2) |
 | `BOTH_LOCKED` (not yet due) / `NEGOTIATED` / `BTC_LOCKED` | `WATCH` | none |
 
 **Chain truth dominates a lagging record:** if the maker's claim is observed on-chain,

--- a/src/pyrxd/gravity/watch/decide.py
+++ b/src/pyrxd/gravity/watch/decide.py
@@ -307,20 +307,29 @@ def decide(
             autonomous_btc_refund=_btc_refund_matured(terms, obs),
             low_corroboration=corr,
         )
-    # 3c. Asset-leg proactive refund on maker stall (BOTH_LOCKED / MAKER_STALLS).
-    if state in (SwapState.BOTH_LOCKED, SwapState.MAKER_STALLS):
+    # 3c. Maker stall (FSM finding #2, 2026-06-09). Recovery is mutual_refund, NOT the asset-only
+    #     maybe_refund_asset_on_maker_stall — IDENTICALLY to the ETH branch (_decide_eth). The maker
+    #     locks the RXD covenant in this runbook too, so its CSV refund pays the MAKER; routing the
+    #     taker to it is a one-sided taker LOSS: it destroys the taker's only recourse (the claimable
+    #     covenant) while the taker's BTC stays locked until t_btc, and the maker (still privately
+    #     holding p) then claims the BTC via the maker-only claim leaf. mutual_refund unwinds BOTH legs
+    #     once both timeouts elapse (proven by the regtest PoC TestMakerStallAssetOnlyRefundIsTakerLoss).
+    if state is SwapState.MAKER_STALLS:
+        # Unreachable on the coordinator-driven path post-fix: the only entry to MAKER_STALLS is
+        # maybe_refund_asset_on_maker_stall, which is no longer a taker watchtower action and advances
+        # straight to the terminal in the same call. If observed anyway, NO clean coordinator step
+        # applies (mutual_refund is BOTH_LOCKED-only) → fail closed to a decision-required page rather
+        # than name a step the coordinator rejects (mirrors the ETH branch).
+        return Decision(
+            Intent.PAGE_SQUEEZED,
+            reason="unexpected MAKER_STALLS on a BTC swap — no clean coordinator refund from here; recover via mutual_refund once both timeouts elapse",
+            recommended_action="investigate (mutual_refund is only valid from BOTH_LOCKED)",
+            low_corroboration=corr,
+        )
+    if state is SwapState.BOTH_LOCKED:
         if obs.asset_locked_at_height is None:
             return Decision(Intent.WATCH, reason="asset lock height not yet observed", low_corroboration=corr)
         deadline = _refund_opens_at(policy, terms, obs.asset_locked_at_height)
-        if state is SwapState.MAKER_STALLS:
-            # The FSM already classified this as a stall — the refund is due.
-            return Decision(
-                Intent.PAGE_REFUND,
-                reason="maker stalling (MAKER_STALLS) — refund the asset proactively before t_rxd",
-                recommended_action="maybe_refund_asset_on_maker_stall",
-                deadline_rxd_height=deadline,
-                low_corroboration=corr,
-            )
         try:
             refund_due = should_taker_refund_proactively(
                 now_block_height=obs.now_rxd_height,
@@ -335,15 +344,15 @@ def decide(
             return Decision(
                 Intent.PAGE_REFUND,
                 reason=f"maker-stall predicate un-evaluable, fail-closed to refund page: {exc}",
-                recommended_action="maybe_refund_asset_on_maker_stall",
+                recommended_action="mutual_refund",
                 deadline_rxd_height=deadline,
                 low_corroboration=corr,
             )
         if refund_due:
             return Decision(
                 Intent.PAGE_REFUND,
-                reason="maker has not claimed and t_rxd maturity is approaching — refund the asset proactively",
-                recommended_action="maybe_refund_asset_on_maker_stall",
+                reason="maker has not claimed and t_rxd maturity approaching — prepare to mutual_refund (broadcast once both timeouts elapse)",
+                recommended_action="mutual_refund",
                 deadline_rxd_height=deadline,
                 low_corroboration=corr,
             )

--- a/tests/test_swap_coordinator.py
+++ b/tests/test_swap_coordinator.py
@@ -788,8 +788,10 @@ async def test_e2e_maker_stalls_taker_refunds_asset():
         now_block_height=1066, asset_locked_at_height=1000, maker_has_claimed_btc=False
     )
     assert rec.state is SwapState.ASSET_REFUNDED_TAKER_ACTS
-    assert rxd.refunded  # taker recovered the asset rather than wait
-    # Taker is whole on the asset side; never lost both.
+    assert rxd.refunded  # the covenant CSV refund was broadcast — it pays the MAKER, not the taker.
+    # NOTE: this exercises the helper's mechanics only. The CSV refund pays the maker (maker owns the
+    # covenant), so this is NOT a taker recovery — the watchtower routes a taker to mutual_refund
+    # instead (FSM finding #2, 2026-06-09). See test_xchain_swap_regtest_e2e for the taker-loss proof.
 
 
 async def test_maker_stall_noop_before_window():

--- a/tests/test_watch_alerts.py
+++ b/tests/test_watch_alerts.py
@@ -69,7 +69,7 @@ async def test_dedup_same_intent_not_resent():
 async def test_intent_change_repages():
     ch = FakeChannel()
     a = DedupAlerter(channel=ch)
-    await a.handle("s1", _d(Intent.PAGE_REFUND, action="maybe_refund_asset_on_maker_stall"))
+    await a.handle("s1", _d(Intent.PAGE_REFUND, action="mutual_refund"))
     await a.handle("s1", _d(Intent.PAGE_CLAIM))
     assert [p.intent for p in ch.sent] == [Intent.PAGE_REFUND, Intent.PAGE_CLAIM]
 

--- a/tests/test_watch_decide.py
+++ b/tests/test_watch_decide.py
@@ -142,6 +142,55 @@ def test_terminal_states_retire(state):
 
 
 # ---------------------------------------------------------------------------
+# Maker-stall recovery is SYMMETRIC across counter-chains (FSM finding #2, 2026-06-09 — FIXED)
+# ---------------------------------------------------------------------------
+# Both the BTC and ETH stall paths recommend the SAME safe recovery for the SAME situation
+# (BOTH_LOCKED, maker has not claimed, t_rxd maturity approaching): mutual_refund (unwinds BOTH
+# legs). Before the fix the BTC path named the asset-only maybe_refund_asset_on_maker_stall whose
+# CSV pays the MAKER — a one-sided taker loss (reproduced in test_xchain_swap_regtest_e2e.py::
+# TestMakerStallAssetOnlyRefundIsTakerLoss, which stays as the durable characterization of why that
+# helper is maker-only). These tests pin the symmetry so a regression re-surfaces here.
+
+
+def test_btc_and_eth_maker_stall_both_recommend_mutual_refund():
+    """The decision core is SYMMETRIC: identical maker-stall situation → mutual_refund on both."""
+    obs = Observations(maker_has_claimed_btc=False, now_rxd_height=170, asset_locked_at_height=LOCK)
+    btc = _decide(_record(SwapState.BOTH_LOCKED), obs)
+    eth = _decide_e(_eth(SwapState.BOTH_LOCKED), obs)
+    assert btc.intent is Intent.PAGE_REFUND and eth.intent is Intent.PAGE_REFUND
+    # Neither counter-chain routes the taker to the asset-only refund (pays the maker — the loss path).
+    assert btc.recommended_action == eth.recommended_action == "mutual_refund"
+
+
+def test_btc_maker_stalls_state_pages_squeezed_no_clean_step():
+    """MAKER_STALLS is unreachable on the coordinator path post-fix (its only producer,
+    maybe_refund_asset_on_maker_stall, is no longer a taker watchtower action). If a record is
+    observed there anyway, decide() fails closed to PAGE_SQUEEZED rather than naming a loss path —
+    mirroring the ETH branch."""
+    obs = Observations(maker_has_claimed_btc=False, now_rxd_height=150, asset_locked_at_height=LOCK)
+    d = _decide(_record(SwapState.MAKER_STALLS), obs)
+    assert d.intent is Intent.PAGE_SQUEEZED
+    assert d.recommended_action is not None and "mutual_refund" in d.recommended_action
+
+
+def test_asset_refunded_terminal_retires_while_btc_still_locked():
+    """Secondary strand (now unreachable on the taker path, but the invariant still holds): a record
+    at the terminal ASSET_REFUNDED_TAKER_ACTS makes the watchtower RETIRE — it stops tracking even
+    though a taker's BTC counter-leg would still be locked until t_btc. Removing the asset-only refund
+    from the taker path is what makes this terminal unreachable for a taker; this pins the underlying
+    terminal→RETIRE behavior so a future re-introduction of that path is caught."""
+    # BTC funding shallow + maker has NOT claimed: the BTC leg is unambiguously still locked.
+    obs = Observations(
+        maker_has_claimed_btc=False,
+        now_rxd_height=180,  # past t_rxd maturity (172) but t_btc (LOCK+144=244) is far off
+        asset_locked_at_height=LOCK,
+        btc_funding_confirmations=1,
+    )
+    d = _decide(_record(SwapState.ASSET_REFUNDED_TAKER_ACTS), obs)
+    assert d.intent is Intent.RETIRE  # no page to recover the still-locked BTC
+
+
+# ---------------------------------------------------------------------------
 # ETH counter-leg (v3) — finalized-checkpoint finality, mutual_refund on stall
 # ---------------------------------------------------------------------------
 # With _eth_policy(): rxd_burial = 2, counter_reserve_rxd = ceil(768/300) = 3, t_rxd = 72,
@@ -461,17 +510,19 @@ def test_both_locked_refund_not_due_watches():
 
 
 def test_both_locked_refund_due_pages_refund():
-    # now >= maturity - safety (166) → proactive refund due.
+    # now >= maturity - safety (166) → refund window near; the taker prepares mutual_refund (the
+    # safe both-legs unwind), NOT the asset-only refund that pays the maker (FSM finding #2).
     obs = Observations(maker_has_claimed_btc=False, now_rxd_height=167, asset_locked_at_height=LOCK)
     d = _decide(_record(SwapState.BOTH_LOCKED), obs)
     assert d.intent is Intent.PAGE_REFUND
-    assert d.recommended_action == "maybe_refund_asset_on_maker_stall"
+    assert d.recommended_action == "mutual_refund"
 
 
-def test_maker_stalls_pages_refund():
+def test_maker_stalls_pages_squeezed():
+    # Post-fix MAKER_STALLS is unreachable on the coordinator path; if seen, fail closed (no clean step).
     obs = Observations(maker_has_claimed_btc=False, now_rxd_height=150, asset_locked_at_height=LOCK)
     d = _decide(_record(SwapState.MAKER_STALLS), obs)
-    assert d.intent is Intent.PAGE_REFUND
+    assert d.intent is Intent.PAGE_SQUEEZED
 
 
 def test_both_locked_unknown_lock_height_watches():

--- a/tests/test_xchain_swap_regtest_e2e.py
+++ b/tests/test_xchain_swap_regtest_e2e.py
@@ -383,7 +383,7 @@ class _Seen:
 class _LockedSwap:
     """A swap driven to BOTH_LOCKED on both real chains, ready for any terminal path."""
 
-    def __init__(self, *, coord, cov, p_secret, broadcaster, t_btc, t_rxd, rxd_locked_at):
+    def __init__(self, *, coord, cov, p_secret, broadcaster, t_btc, t_rxd, rxd_locked_at, rxd_amount):
         self.coord = coord
         self.cov = cov
         self.p_secret = p_secret
@@ -391,6 +391,7 @@ class _LockedSwap:
         self.t_btc = t_btc
         self.t_rxd = t_rxd
         self.rxd_locked_at = rxd_locked_at
+        self.rxd_amount = rxd_amount
 
 
 async def _setup_locked_swap(nodes: _Nodes, *, t_rxd_blocks: int = 3) -> _LockedSwap:
@@ -503,6 +504,7 @@ async def _setup_locked_swap(nodes: _Nodes, *, t_rxd_blocks: int = 3) -> _Locked
         t_btc=t_btc,
         t_rxd=t_rxd,
         rxd_locked_at=rxd_locked_at,
+        rxd_amount=rxd_photons,
     )
 
 
@@ -591,9 +593,11 @@ class TestCrossChainSwap:
         assert btc_spent in (None, ""), "BTC HTLC should be refunded (spent)"
         assert rxd_spent in (None, ""), "RXD covenant should be refunded (spent)"
 
-    async def test_maker_stall_taker_refunds_asset_proactively(self, nodes):
-        """Maker locks the asset but stalls (never claims BTC). As t_rxd nears, the
-        taker proactively refunds the RXD asset rather than wait — never loses both."""
+    async def test_maker_stall_asset_only_refund_mechanics(self, nodes):
+        """Exercises the maybe_refund_asset_on_maker_stall MECHANICS (the helper still exists as a
+        maker-side primitive). NOTE: its CSV refund pays the MAKER, not the taker — see
+        TestMakerStallAssetOnlyRefundIsTakerLoss for why this is NOT a taker recovery. The watchtower
+        no longer routes a taker here (FSM finding #2); the safe taker recovery is mutual_refund."""
         s = await _setup_locked_swap(nodes)
         coord = s.coord
 
@@ -607,7 +611,73 @@ class TestCrossChainSwap:
         assert rec.state is SwapState.ASSET_REFUNDED_TAKER_ACTS
 
         rxd_spent = nodes.rxd("gettxout", coord.record.radiant_covenant_outpoint.split(":")[0], "0")
-        assert rxd_spent in (None, ""), "taker should have recovered the RXD asset (covenant spent)"
+        assert rxd_spent in (None, ""), "the covenant CSV refund was broadcast (covenant spent) — pays the MAKER"
+
+
+def _scan_value_for_spk(nodes: _Nodes, spk: bytes) -> int:
+    """Total confirmed UTXO value (sats) currently paying ``spk`` on the RXD chain."""
+    res = nodes.rxd("scantxoutset", "start", json.dumps([{"desc": f"raw({bytes(spk).hex()})"}]))
+    return round(sum(u["amount"] for u in res.get("unspents", [])) * 1e8)
+
+
+class TestMakerStallAssetOnlyRefundIsTakerLoss:
+    """ADVERSARIAL (FSM finding #2, 2026-06-09): on the BTC<->RXD runbook the asset-only
+    proactive refund (:meth:`maybe_refund_asset_on_maker_stall`) is NOT a taker defense — its
+    CSV refund pays the MAKER. If a taker is driven to run it on a maker stall (which the BTC
+    watchtower/runbook recommends: decide.py:311-349 + dust_swap_run.py:327), it DESTROYS the
+    taker's only recourse (the claimable covenant) while the taker's own BTC is still locked
+    until ``t_btc``. The maker, still privately holding ``p``, then claims the BTC (claim leaf is
+    maker-only, valid until ``t_btc``) and takes BOTH legs.
+
+    Contrast :meth:`TestCrossChainSwap.test_mutual_refund_when_maker_never_claims`, which unwinds
+    BOTH legs safely — the recovery the ETH path already mandates (decide.py:508-542)."""
+
+    async def test_asset_only_refund_gifts_asset_to_maker_then_maker_takes_btc(self, nodes):
+        # Small t_rxd (fast CSV), t_btc = t_rxd + 40 so the taker's BTC refund leaf is NOWHERE
+        # near open when the asset-only refund fires — the crux of the asymmetry.
+        s = await _setup_locked_swap(nodes, t_rxd_blocks=3)
+        coord = s.coord
+        loc = coord.record.btc_locator
+        cov_value = s.rxd_amount
+
+        # Sanity: before the refund, the asset sits in the covenant; neither party's holder
+        # script holds it yet.
+        assert _scan_value_for_spk(nodes, s.cov.maker_holder_script) == 0
+        assert _scan_value_for_spk(nodes, s.cov.taker_holder_script) == 0
+
+        # 1. Maker stalls (never claims BTC; p stays private). The taker is driven to the
+        #    asset-only proactive refund. Mature the RXD CSV so the refund is BIP68-spendable.
+        nodes.rxd_mine(s.t_rxd.value)
+        now = int(nodes.rxd("getblockcount"))
+        rec = await coord.maybe_refund_asset_on_maker_stall(
+            now_block_height=now, asset_locked_at_height=s.rxd_locked_at, maker_has_claimed_btc=False
+        )
+        assert rec.state is SwapState.ASSET_REFUNDED_TAKER_ACTS
+        nodes.rxd_mine(1)  # confirm the refund tx so scantxoutset sees the new output
+
+        # 2. THE BUG: the "taker's" proactive refund paid the MAKER, not the taker. The asset is
+        #    now back with the maker and the taker has NO covenant left to claim.
+        maker_got = _scan_value_for_spk(nodes, s.cov.maker_holder_script)
+        taker_got = _scan_value_for_spk(nodes, s.cov.taker_holder_script)
+        assert maker_got == cov_value, "the asset-only CSV refund pays the MAKER (maker_holder_script)"
+        assert taker_got == 0, "the taker recovered NOTHING from the covenant — its recourse is gone"
+
+        # 3. The taker's own BTC is STILL LOCKED: t_btc has not elapsed, so the refund leaf is not
+        #    open. The taker cannot recover the BTC yet.
+        funding_confs = int(nodes.btc("getrawtransaction", loc.funding_outpoint.txid, "true").get("confirmations", 0))
+        assert funding_confs < s.t_btc.value, "precondition: taker's BTC refund leaf must NOT be open yet"
+
+        # 4. The adversarial maker, still holding p, claims the BTC directly (bypassing the honest
+        #    coordinator — the FSM is terminal). The claim leaf is maker-only and valid until t_btc.
+        claim_txid = await coord.btc_leg.claim(loc, s.p_secret.unsafe_raw_bytes())
+        claim_decoded = nodes.btc("decoderawtransaction", s.broadcaster.last_raw[claim_txid].hex())
+
+        # 5. The maker now holds BOTH legs; the taker holds neither (one-sided taker loss).
+        btc_spent = nodes.btc("gettxout", loc.funding_outpoint.txid, str(loc.funding_outpoint.vout))
+        assert btc_spent in (None, ""), "maker claimed the taker's BTC HTLC (spent)"
+        assert claim_decoded["vout"], "the maker's BTC claim produced an output (to its own payout SPK)"
+        # The maker ends with the asset (RXD) AND the BTC; the taker is wiped out.
+        assert maker_got == cov_value and btc_spent in (None, "")
 
 
 # --------------------------------------------------------------------------- watchtower observation
@@ -782,8 +852,9 @@ class TestWatchtowerIntentSequence:
         assert len(channel.pages) == 1, "DedupAlerter must not re-page an unchanged situation"
 
     async def test_maker_stall_watch_then_page_refund(self, nodes):
-        """Maker locks the asset then stalls (never reveals p). As t_rxd nears, the tower pages a
-        proactive asset refund (WARN — recoverable, not a race), naming the coordinator step."""
+        """Maker locks the asset then stalls (never reveals p). As t_rxd nears, the tower pages the
+        safe both-legs recovery — mutual_refund (WARN — recoverable, not a race), NOT the asset-only
+        refund that pays the maker (FSM finding #2). The page names the coordinator step."""
         s = await _setup_locked_swap(nodes, t_rxd_blocks=30)
         coord = s.coord
         reconciler, channel = _watchtower(nodes, coord)
@@ -797,7 +868,7 @@ class TestWatchtowerIntentSequence:
         nodes.rxd_mine(27)
         r = await self._tick_one(reconciler)
         assert r.decision.intent is Intent.PAGE_REFUND
-        assert r.decision.recommended_action == "maybe_refund_asset_on_maker_stall"
+        assert r.decision.recommended_action == "mutual_refund"
         assert r.decision.deadline_rxd_height is not None
         assert r.alert_delivered is True
         assert len(channel.pages) == 1


### PR DESCRIPTION
## Summary

The HTLC swap watchtower's BTC↔RXD **maker-stall** recovery path recommended the asset-only `maybe_refund_asset_on_maker_stall`, whose RXD CSV refund pays the **maker** (the maker owns the covenant in this runbook). A taker driven to run it on a stall gives the asset back to the maker and loses its only recourse while its own BTC stays locked — a one-sided taker loss. The ETH↔RXD path already routes stalls to `mutual_refund` and forbids the asset-only helper; this brings BTC into line.

This is **security-sensitive** (pre-audit; external audit remains the hard gate before any real-value two-party use). Exploit detail is intentionally kept out of this description.

## Change (alert-layer routing only)

`decide()`'s BTC and ETH counter-leg branches are now structurally identical:
- BTC `BOTH_LOCKED` stall → recommend `mutual_refund` (broadcast once both timeouts elapse).
- BTC `MAKER_STALLS` → `PAGE_SQUEEZED` (state unreachable on the coordinator path; fail closed instead of naming a loss path).

No FSM states/events removed; no recovery mechanics or consensus code changed. `maybe_refund_asset_on_maker_stall` is retained as a **maker-only** primitive (docstring strengthened); the watchtower routes no taker to it on either chain. Runbook scripts + the watch README corrected.

## Verification

- Two-party adversarial **regtest reproduction** on two real nodes (`TestMakerStallAssetOnlyRefundIsTakerLoss`) — kept as the durable characterization of why the helper is maker-only.
- Pure `decide()` symmetry tests pin BTC ≡ ETH recovery routing.
- Full local CI gate green: 4066 passed / 70 skipped / 1 xfailed, coverage 87.9%, mypy + private-link check clean.

## Review provenance

Finding confirmed and fix shaped by a 4-reviewer divergent panel (security / architecture / simplicity / Python) before implementation; the minimal routing fix was chosen over removing FSM states.

🤖 Generated with [Claude Code](https://claude.com/claude-code)