### PR TITLE
feat(agent): CLI signing agent (A′ — sign-on-behalf) for #8

### DIFF
--- a/docs/brainstorms/2026-06-08-pyrxd-cli-signer-seam-design.md
+++ b/docs/brainstorms/2026-06-08-pyrxd-cli-signer-seam-design.md
@@ -1,0 +1,278 @@
+# Design: key-custody for the pyrxd CLI (#8 agent, Ledger) — REVISED post-review
+
+**Status:** draft / brainstorm, **revised after a divergent review panel**
+(architecture-strategist · code-simplicity-reviewer · kieran-python ·
+security-sentinel, each writing independently). Working space — references
+private/sibling projects (rxdpy-signer, the Ledger app). Sanitize before
+any public release.
+
+**What changed in this revision (panel findings folded in):**
+- **The central question moved.** The first draft assumed a `Signer` seam
+  was needed. The panel showed that depends entirely on *what #8 is* —
+  see §0. The minimal #8 needs **no seam**.
+- **Factual correction.** The first draft claimed gravity/swap sign via
+  `P2PKH().unlock(key)`. **False for gravity:** it hand-rolls the Radiant
+  BIP143 preimage and signs via `coincurve` directly
+  (`gravity/transactions.py:125-182`); the HTLC fee input uses a bare WIF
+  (`gravity/htlc_spend.py:118-140`). Only the HD-wallet P2PKH path and
+  `pyrxd.swap` go through the template. So a template-level seam does NOT
+  unify "all signing," and leaves the real-money gravity/HTLC paths
+  outside custody.
+- **If a seam is built, the contract is tightened** (typed return,
+  full-path KeyId, structured re-derivable request, prevout
+  verification, set-then-sign sighash) — §3.
+- **Security: not safe to build the out-of-process backend as first
+  drafted** — §4. The default in-process signer is *not* a custody
+  improvement; say so honestly.
+
+---
+
+## 0. The crux: what is #8, actually? (decide this first)
+
+Issue #8 is filed as a **mnemonic re-entry UX** problem
+(`docs/cli-security-backlog.md`): retyping the mnemonic on every command
+is annoying and increases exposure. There are **three** distinct products
+hiding under that, with very different security:
+
+### Path A — seed-vending agent. NOT RECOMMENDED (convenience only).
+`pyrxd agent unlock` holds the seed in a daemon; `_load_wallet` fetches
+the seed/xprv back from it and signs in the CLI as today. One branch, no
+seam.
+- **Security: same as today or worse.** The socket becomes a
+  *seed-vending machine* — anything that opens it gets the **whole
+  seed**, not one signature, and there's **no confirmation possible**
+  because the agent doesn't sign, it vends. Same-uid processes (a
+  malicious pip dep, a plugin) pass `SO_PEERCRED` trivially → silent
+  full-wallet drain. Plus the seed now sits resident in a long-lived
+  process (bigger memory-scrape window) *and* still re-enters the CLI.
+- Only narrow win: cuts mnemonic-*entry* exposure (shoulder-surf,
+  clipboard, scrollback) to once per session.
+- This is the `ssh-agent` anti-pattern (real agents never hand the key
+  back). **Do not build this.**
+
+### Path A′ — sign-on-behalf agent. RECOMMENDED near-term. NO generalized seam.
+`pyrxd agent unlock` holds the wallet in the daemon (`SecretBytes`,
+auto-lock). The daemon **signs on behalf** — the CLI sends an *unsigned*
+tx + input coordinates; the agent re-derives the keys, verifies, signs,
+and returns the **signed tx**. The key **never leaves the daemon**.
+- **Security: a real improvement.** Reaching the socket no longer equals
+  stealing the key — a same-uid attacker can at most *request* a
+  signature, which the **interactive per-spend confirmation** gates.
+- **Cost: moderate, not large.** The agent just wraps `HdWallet` and
+  moves the `tx.sign()` step inside the daemon. The CLI becomes
+  *watch-only* (builds txs from addresses/xpub, no keys) and defers
+  signing. This is more than Path A's "one branch" (the CLI/agent split
+  is real) but **far less than Path B** — it needs **none** of the
+  generalized `Signer`/`KeyId`/`unlock_with_signer` machinery (§2–§3).
+- **Mandatory hardening (because it signs):** the §4 requirements apply —
+  prevout authenticity (C1), no blind-signing + confirmation (H1/H2),
+  socket auth, memory hygiene, TOCTOU. These are inherent to *any*
+  key-protecting agent, seam or not.
+
+### Path B — pluggable `Signer` seam. LATER, Ledger-driven.
+A′ generalized so the signing backend is swappable (agent, **Ledger**,
+HSM). Adds the `Signer` Protocol + `KeyId` + template rewrite (§2–§3).
+- **Cost: large.** Justified by **Ledger** (key in hardware), which is a
+  separate, unscheduled goal — *not* by #8.
+
+**Recommendation (panel-informed):** build **A′ now** — it's the version
+that actually improves custody for #8, without the speculative seam.
+Build the **Path B seam only when Ledger is scheduled**, and co-design it
+against two real backends (the A′ agent + Ledger) rather than guessing.
+Extracting a seam from two real implementations beats inventing it for
+zero.
+
+§4 below is the hardening A′ must adopt now. §2–§3 specify the Path B seam
+**for when it's time**, so it isn't re-litigated.
+
+---
+
+## 1. Current signing paths (corrected)
+
+There is no single interface every command signs through. There are
+**three distinct shapes**, and a template-level seam only covers the
+first two-and-a-bit:
+
+1. **HD-wallet P2PKH** — `P2PKH().unlock(privkey)` →
+   `privkey.sign(tx.preimage(i))` (`script/type.py:77-90`,
+   `hd/wallet.py:763-789`). The raw `PrivateKey` lives in-process.
+2. **`pyrxd.swap`** — also `P2PKH().unlock(key)` (the merged #123 work).
+3. **gravity + HTLC** — **does NOT use the template.** Hand-rolls the
+   preimage and signs via `coincurve`
+   (`gravity/transactions.py:125-182`, `_sign_radiant_p2sh_input`);
+   covenant/HTLC spends carry custom scriptSigs; the fee input signs a
+   bare WIF (`gravity/htlc_spend.py:118-140`). **This is where real value
+   moves** (the proven mainnet swaps).
+
+Implication: the custody seam must be anchored at the **digest /
+signing-request** level shared by (1)(2)(3), not the P2PKH-`Script`
+level — otherwise it covers the easy half and leaves gravity/HTLC's keys
+in-process while claiming "pluggable custody."
+
+## 2. Where to cut the seam (altitude — the architect-vs-security reconciliation)
+
+The two reviewers pushed opposite ways and **both are right**, which
+pins the answer:
+
+- **Architecture:** don't pass the live pyrxd `Transaction` object across
+  a socket/device boundary — backends would have to link pyrxd's preimage
+  code; a Ledger can't parse a Python object anyway. Push the cut *down*
+  toward a digest.
+- **Security:** don't pass a **bare digest** — that's blind signing; the
+  backend can't verify prevout value/script (fee-theft, C1) or show the
+  user what they sign (H1/H3). Push the cut *up* toward structured intent.
+
+**Reconciliation — a structured, serializable, self-verifying signing
+request** (neither a live object nor a bare digest):
+
+```python
+@dataclass(frozen=True)
+class SigningRequest:
+    raw_tx: bytes                 # canonical serialized tx (parseable by a device)
+    input_index: int
+    key_id: KeyId                 # full BIP32 path (§3)
+    sighash: SIGHASH
+    prevouts: list[PrevOut]       # value+script per input — but see C1:
+                                  # the backend RE-VERIFIES these, never trusts them
+```
+
+The backend (agent/Ledger) re-derives the preimage *from the bytes it
+will display*, independently confirms the prevouts (re-fetch by outpoint,
+or require full source txs and check `txid`), and signs **that exact**
+preimage in one atomic step (no display-then-resign TOCTOU, Security M2).
+The in-process template path can keep computing `tx.preimage(i)` locally
+and calling a thin `sign_digest` — the wire artifact only matters at the
+process/device boundary.
+
+## 3. The `Signer` contract (tightened per kieran + architecture)
+
+```python
+@dataclass(frozen=True, slots=True)
+class KeyId:                       # full path — NOT a bare (change, index) tuple
+    change: int
+    index: int
+    account: int = 0
+    coin_type: int = 512
+    def bip32_path(self) -> str: ...
+
+@dataclass(frozen=True)
+class InputSignature:              # typed — carries the sighash it committed to
+    der: bytes                    # strict DER, low-s (matches PrivateKey.sign)
+    pubkey: PublicKey             # returned WITH the sig (one call, can't desync)
+    sighash: SIGHASH
+
+@runtime_checkable
+class Signer(Protocol):
+    def sign(self, request: SigningRequest) -> InputSignature: ...
+```
+
+Tightening (all from the panel):
+- **Typed return** `InputSignature(der, pubkey, sighash)` — not bare
+  `bytes`. The template asserts `sig.sighash == expected` and assembles
+  the scriptSig in one place. Pubkey returned *with* the sig so a backend
+  can't sign with key A and report pubkey B (architect MINOR 7/8).
+- **Full-path `KeyId` dataclass**, frozen+slots (hashable → cacheable).
+  A bare `(change, index)` can't address gravity/imported keys and forces
+  every backend to re-guess `m/44'/coin'/account'` (architect M3, kieran
+  M2, security L2). Define it correctly *before* it enters the Protocol.
+- **Set-then-sign sighash.** `from_hex` does NOT recover sighash (it's
+  not a serialized field — `transaction_input.py:58-87` defaults it to
+  `ALL_FORKID`). Pass sighash explicitly, *set* it on the input before
+  preimage (like `RPuzzle.unlock`, `type.py:259`), and assert the backend
+  signed under it. This is the exact footgun the #123 swap work already
+  hit (kieran M3).
+- **Wallet owns the signer.** Give `HdWallet` a `self._signer`
+  (default `LocalSigner(self._xprv)`); don't thread `(signer, key_id)`
+  through every method signature — match how `RefAuthenticityIndexer` /
+  `FeeUtxoSource` are constructor-injected (architect M5).
+- **Standardize on `PrivateKeyMaterial`,** not `keys.PrivateKey`, inside
+  `LocalSigner` (zeroize per call, like `eth_wallet/htlc_leg.py:271-279`).
+  Keep `P2PKH().unlock(PrivateKey)` as a thin deprecated shim; do **not**
+  let `keys.PrivateKey` into the Protocol surface (architect M6).
+- **No "expose the privkey for back-compat" escape hatch** (security M1).
+- **Typed error taxonomy:** `SignerError(ValidationError)` /
+  `SignerUnavailableError(NetworkError)` so the `_load_wallet` fallback
+  ladder branches on type, not exception-string matching (kieran m6).
+- **Ctor `isinstance` check** at each injection site (`runtime_checkable`
+  only checks method names) — fail closed, name the missing method
+  (kieran m1).
+
+## 4. Security requirements for any sign-on-behalf agent (A′ AND Path B)
+
+These apply the moment a daemon/device signs on your behalf — i.e. to
+**A′ now**, and to Path B's agent/Ledger backends later
+(security-sentinel — MUST adopt). They do NOT apply to Path A's
+seed-vending model, which is why Path A is rejected: it has no signing
+step to gate, so a same-uid attacker just takes the seed. The in-process
+path (today, and Path B's `LocalSigner`) inherits the caller==wallet
+trust model and is *not* itself a custody improvement (state plainly — M3):
+
+- **C1 (critical) — prevout authenticity.** The preimage commits to each
+  input's `satoshis` + `locking_script`, which today come from
+  caller-supplied data (`transaction_input.py:32-34`,
+  `hd/wallet.py:781-789`). A lying caller (claims a 100-RXD UTXO is 1 RXD)
+  gets a valid tx that burns 99 RXD to fee. The backend MUST
+  independently obtain/verify prevout value+script (re-fetch by outpoint
+  or verify full source-tx `txid`), never trust the request's claim.
+- **H1/H3 — no blind signing.** The backend MUST receive a structured tx
+  it can fully parse and attribute (which outputs are change to its own
+  derived keys vs external), and MUST refuse if it can't. No signing of
+  bare 32-byte digests. A Ledger backend is a **gating spike**: confirm
+  the device app parses Radiant's BIP143 incl. the ref-aware
+  `hashOutputHashes` field (`transaction_preimage.py:66-92`) *before*
+  `LedgerSigner` is more than a stub; until then it IS blind-signing.
+- **H2 — same-uid is inside the trust boundary.** `SO_PEERCRED`
+  uid==owner + `0700` socket dir are necessary but **not sufficient**: a
+  same-uid process (compromised dep, malicious plugin) passes them. The
+  real control for non-trivial amounts is **interactive per-spend
+  confirmation** (show attributed outputs/total/fee, require a keypress).
+- **Memory hygiene under failure (L1):** `mlock` the seed pages, disable
+  core dumps, `PR_SET_DUMPABLE 0`, `SIGTERM`/`SIGINT` handlers that
+  zeroize; document that `SIGKILL`/crash cannot be scrubbed.
+- **sighash is security-relevant (L3):** treat anything other than the
+  expected `ALL|FORKID` on a normal spend as requiring confirmation.
+
+### Agent threat-model doc (issue #8 criterion #4) MUST contain
+1. Socket auth: `0700` dir **and** `SO_PEERCRED` uid==owner; explicit
+   admission same-uid processes can originate requests.
+2. The real control: interactive per-spend confirmation with amount
+   thresholds.
+3. Prevout authenticity (C1).
+4. Display==sign atomicity / TOCTOU single-buffer rule (M2).
+5. Memory hygiene + the honest `SIGKILL` limit (L1).
+6. Explicit non-goals: does not defend a user who blind-confirms; signs
+   only structured re-derivable txs, never arbitrary digests.
+
+## 5. Net effect on the open work (revised)
+
+- **#8 (now):** build **Path A′** — sign-on-behalf agent (key never
+  leaves the daemon), CLI goes watch-only and defers signing, with the §4
+  hardening (prevout check, confirmation, socket auth, memory hygiene).
+  No generalized seam. This is the version that actually improves custody.
+  (Path A, seed-vending, is rejected — §0.)
+- **Ledger / pluggable custody (later):** build **Path B** — the §3 seam +
+  §4 hardening, co-designed against the A′ agent **and** Ledger together.
+  This is where the seam earns its keep.
+- **rxdpy-signer:** out of scope and intentionally unmentioned in the
+  seam — it's a different SDK and a different altitude (intent/HTTP). The
+  first draft's "two-altitude" framing was concept bloat (simplicity);
+  reuse its *patterns* (sealed-at-rest, hash-chained audit, policy-in-PR)
+  for the agent's at-rest story, nothing more.
+
+## 6. Recommended sequencing
+
+1. **Path A′ #8** as its own PR: daemon holds the wallet + signs on
+   behalf; CLI watch-only build → defer sign → receive signed tx; socket
+   (`0700` + `0600` + `SO_PEERCRED`), auto-lock, the §4 hardening
+   (prevout verification, per-spend confirmation, mlock/no-coredump/
+   `PR_SET_DUMPABLE`), and the issue-#8 threat-model doc. Ships the UX
+   *and* a real custody gain.
+2. **Decide Ledger.** If/when scheduled → Path B: land the §3 `Signer`
+   seam as a zero-behavior-change refactor (LocalSigner default,
+   byte-identical, two-pass-fee regression test), then add `AgentSigner`
+   (sign-on-behalf, §4 hardening) and `LedgerSigner` (after the parsing
+   spike) as additive backends.
+3. Only then retrofit gravity/HTLC signing onto the seam (the hand-rolled
+   `_sign_radiant_p2sh_input` calls `sign` on a digest it already
+   computes — low-friction once the seam exists).
+```

--- a/docs/plans/2026-06-08-feat-cli-signing-agent-a-prime-plan.md
+++ b/docs/plans/2026-06-08-feat-cli-signing-agent-a-prime-plan.md
@@ -1,0 +1,273 @@
+---
+title: "CLI signing agent (A′ — sign-on-behalf) for issue #8"
+type: feat
+date: 2026-06-08
+status: plan
+design: docs/brainstorms/2026-06-08-pyrxd-cli-signer-seam-design.md
+review: divergent panel (architecture-strategist + code-simplicity-reviewer + kieran-python + security-sentinel), 2026-06-08
+issue: "#8 — CLI: mnemonic re-entry per command — design an agent-process unlock pattern"
+---
+
+# ✨ feat: CLI signing agent (A′)
+
+> **Scope decision (after a divergent review panel).** This is **Path A′**
+> from the design doc: a **sign-on-behalf** agent. The daemon holds the
+> wallet and signs; the key **never leaves it**. This is deliberately NOT
+> Path A (a "seed-vending" agent — rejected: its socket hands back the
+> whole seed, so any same-uid process drains the wallet with no
+> confirmation) and NOT Path B (a generalized pluggable `Signer` seam —
+> deferred until Ledger is actually scheduled). A′ is the smallest design
+> that *actually improves custody* for #8.
+>
+> **Provenance.** Every file:line below was read during the design pass +
+> the divergent panel (spike-based, not doc-derived). Effort is relative
+> complexity (S/M/L), never fabricated hours. Nothing here is built yet.
+
+---
+
+## Overview
+
+Today every wallet-touching pyrxd command prompts for the mnemonic,
+decrypts the wallet **in the CLI process**, and signs there
+(`cli/prompts.py:123-155` `_load_wallet` → `HdWallet.load` →
+`collect_spendable`/`_build_utxo_input` → `P2PKH().unlock(privkey)` at
+`script/type.py:77`). Issue #8 asks for an `ssh-agent`-style unlock so the
+user types the mnemonic once per session.
+
+**A′ = a local daemon that holds the unlocked wallet and signs on the
+CLI's behalf.** The CLI becomes *watch-only*: it builds the unsigned
+transaction from public material (addresses + account xpub), hands it to
+the agent over a Unix socket, and gets back a **signed** transaction. The
+seed/keys live only in the daemon — reaching the socket lets an attacker
+*request* a signature (gated by per-spend confirmation), never *take* the
+key.
+
+This is strictly better custody than today (key no longer re-derived in
+every short-lived CLI invocation) **and** the requested UX — but only if
+the signing-side hardening (§ Load-bearing) ships with it. Without that
+hardening it degrades to Path A's posture, so the hardening is not
+optional.
+
+## Problem Statement
+
+- **UX:** mnemonic re-entry on every command (`docs/cli-security-backlog.md`).
+- **Custody (the real prize):** the seed is decrypted into the CLI process
+  on every command. A sign-on-behalf agent removes the key from the CLI
+  entirely — *if* it doesn't just hand the key back.
+- **Trap:** the obvious implementation (agent vends the seed) is the
+  `ssh-agent` anti-pattern and improves nothing. The work is in making the
+  agent **sign**, safely.
+
+## Architecture (A′)
+
+```
+  pyrxd <cmd>                              pyrxd-agent (daemon)
+  ───────────                              ────────────────────
+  build unsigned tx (watch-only:           holds HdWallet in SecretBytes
+   addresses + xpub, no keys)              (auto-lock timer)
+        │  SigningRequest                          │
+        │  {raw_tx, inputs:[{path,outpoint}], ─────▶ verify prevouts (C1)
+        │   sighash}                                attribute outputs (H1)
+        │                                           confirm w/ user (H2)
+        │  SignedTx  ◀───────────────────────────── re-derive keys, sign
+   broadcast                                        return signed tx
+```
+
+- **CLI side (watch-only):** build the tx exactly as today's
+  `build_send_tx`/swap/glyph builders do, but parameterized so the signing
+  step is deferred. The CLI needs only addresses + the account xpub (the
+  agent vends the xpub on unlock; xpub is a privacy artifact, not a
+  signing secret).
+- **Agent side (signer):** holds the decrypted `HdWallet`; on a
+  `SigningRequest` it re-derives the per-input keys (`_privkey_for`,
+  `hd/wallet.py:739`), runs the § Load-bearing checks, signs, returns the
+  signed tx.
+- **Transport:** Unix domain socket at `~/.pyrxd/agent.sock` (`0700` dir,
+  `0600` socket), `SO_PEERCRED` uid==owner.
+- **Fallback:** if the socket is absent/locked, commands fall back to
+  today's mnemonic prompt (typed `SignerUnavailableError`).
+
+### Module layout (small — A′ is NOT the generalized seam)
+
+```
+src/pyrxd/agent/
+  __init__.py
+  protocol.py     # SigningRequest / SignedResult frames + (de)serialization
+  daemon.py       # socket server, SO_PEERCRED, lifecycle, auto-lock
+  signer.py       # holds HdWallet; verify → confirm → sign  (the brain)
+  client.py       # CLI-side: is-agent-live? send request, get signed tx
+  confirm.py      # interactive per-spend confirmation UI
+src/pyrxd/cli/agent_cmds.py   # `pyrxd agent unlock|lock|status`
+# edits: cli/prompts.py (_load_wallet routes to client when live);
+#        hd/wallet.py (watch-only tx-build path that defers signing)
+```
+
+No `Signer` Protocol, no `KeyId` dataclass, no `unlock_with_signer`, no
+template rewrite — those are Path B.
+
+## What A′ deliberately does NOT do (and why that's safe)
+
+- **No generalized `Signer` seam / Ledger backend.** Deferred to Path B,
+  co-designed against two real backends when Ledger is scheduled. Building
+  it now is speculative generality (simplicity review).
+- **No gravity/HTLC agent signing.** Those hand-roll signing
+  (`gravity/transactions.py:125-182`) and move real value behind the
+  audit gate; routing them through the agent is out of scope for #8.
+- **No remote/networked agent.** Local Unix socket only. (Windows: TCP
+  loopback + token is a documented future variant, not v1.)
+- **No seed vending.** The agent never returns key material — the core
+  invariant, conformance-tested.
+
+## Load-bearing safety properties (MUST ship with A′, not after)
+
+These are the §4 hardening from the design doc; they are what separate A′
+(secure) from A (not). Cutting any of them reduces A′ to A.
+
+1. **Prevout authenticity (C1).** The preimage commits to each input's
+   `satoshis`+`locking_script` (`transaction_preimage.py:133-135`), which
+   today come from caller data (`transaction_input.py:32-34`,
+   `hd/wallet.py:781-789`). The agent MUST independently establish them
+   (require full source txs in the request and verify
+   `hash256(src)[::-1]==outpoint.txid`, then read value/script from the
+   real output) — never trust the request's claimed amounts. Defeats the
+   fake-low-value → burn-to-fee theft.
+2. **No blind signing + per-spend confirmation (H1/H2).** The agent parses
+   the tx, attributes each output as change-to-own-derived-key vs
+   external, and for non-trivial spends shows destinations/total/fee and
+   requires a keypress. This is THE control, because same-uid processes
+   pass `SO_PEERCRED` and can originate requests.
+3. **Never return key material.** The socket exposes sign + xpub +
+   address, never the seed/privkey. Conformance test asserts responses
+   contain no 32-byte scalar matching the key.
+4. **Display==sign atomicity (TOCTOU).** The agent computes the preimage,
+   displays from *that* preimage, and signs *that* preimage — no
+   display-then-resign of caller-resent bytes.
+5. **Sighash is security-relevant.** Anything other than the expected
+   `ALL|FORKID` on a normal spend requires confirmation. (Also avoids the
+   `from_hex`-drops-sighash footgun, `transaction_input.py:58-87`: the
+   agent sets sighash explicitly before signing, like `RPuzzle.unlock`.)
+6. **Memory hygiene.** Seed in `SecretBytes` (`security/secrets.py:73`);
+   `mlock` the pages, disable core dumps, `PR_SET_DUMPABLE 0`,
+   `SIGTERM`/`SIGINT` handlers that `zeroize`. Honest limit: `SIGKILL`/
+   crash cannot be scrubbed (document it).
+7. **Socket auth:** `0700` dir **and** `0600` socket **and** `SO_PEERCRED`
+   uid==owner (all three, not any one).
+
+## Implementation Phases (complexity = ESTIMATED relative size)
+
+### Phase 0 — Spike (S)
+Prove two things against real code before building: (a) the CLI can build a
+valid send tx from addresses+xpub with signing deferred (watch-only), and
+(b) the agent, re-deriving keys from the held seed, produces **byte-
+identical** signatures to today's in-CLI path. Gate the rest on this.
+
+### Phase 1 — Watch-only tx-build path (M)
+Refactor `hd/wallet.py` so tx construction (`build_send_tx:822`,
+`_build_utxo_input:763`, `collect_spendable:791`) can run from public
+material and emit `(unsigned_tx, [input coords: path + outpoint + source
+tx])` without deriving private keys. Existing in-process signing stays the
+default; this just adds the "stop before signing" seam internally.
+
+### Phase 2 — Agent signer core, in-process (M–L)
+`agent/signer.py` + `protocol.py`: holds `HdWallet`; consumes a
+`SigningRequest`, re-derives keys, signs, returns the signed tx. Auto-lock
+timer + `zeroize`. Fully unit-testable with no socket.
+
+### Phase 3 — Signing-side hardening (M) — load-bearing §1-5
+Prevout verification (C1), output attribution + confirmation (H1/H2),
+never-return-key invariant, TOCTOU single-buffer, sighash policy. This is
+the security heart; treat its tests as the acceptance gate.
+
+### Phase 4 — Unix socket transport + auth + memory hygiene (M)
+`agent/daemon.py` + `client.py`: framed request/response, `0700`/`0600`,
+`SO_PEERCRED`, stale-socket cleanup, single-instance lock, `mlock`/
+`PR_SET_DUMPABLE`/no-coredump/signal-zeroize (§6-7).
+
+### Phase 5 — CLI surface + fallback (S–M)
+`pyrxd agent unlock|lock|status`; `_load_wallet`/command signing routes to
+the agent when live, falls back to the mnemonic prompt on
+`SignerUnavailableError`. No behavior change when the agent is off.
+
+### Phase 6 — Threat-model doc + test sweep (M)
+The issue-#8 threat-model doc (contents below) + tests: socket perms,
+auto-lock zeroize, prevout-lie rejection, confirmation gate (accept/
+reject), fallback-when-down, concurrent clients, wrong-uid peer refusal.
+
+## Deferred to Path B (Ledger / pluggable seam)
+The generalized `Signer` Protocol + `KeyId` + `unlock_with_signer` +
+template rewrite, plus a `LedgerSigner` (after a spike confirming the
+device app parses Radiant BIP143 incl. ref-aware `hashOutputHashes`,
+`transaction_preimage.py:66-92`). Co-design against the A′ agent + Ledger
+together. See the design doc §2-§3.
+
+## Alternatives Considered
+- **Path A (seed-vending agent):** rejected — `ssh-agent` anti-pattern;
+  socket hands back the whole seed, no confirmation, same-or-worse than
+  today.
+- **Status quo (prompt per command):** smallest resident-key footprint,
+  but the UX cost #8 is about; loses to A′ on convenience and on
+  long-session ergonomics.
+- **rxdpy-signer (the sibling service):** different SDK (`rxdpy`), different
+  altitude (intent/HTTP, multi-caller, web-tier). Out of scope; reuse its
+  *patterns* (sealed-at-rest, hash-chained audit) for the agent's at-rest
+  story only.
+
+## Acceptance Criteria
+Maps issue #8's criteria + the panel's mandatory additions:
+- [ ] `pyrxd agent unlock` / `lock` / `status` subcommands.
+- [ ] Wallet-touching commands use the agent when live; **fall back to the
+      mnemonic prompt** when it isn't.
+- [ ] The agent **signs on behalf** and **never returns key material**
+      (conformance-tested).
+- [ ] Prevout authenticity enforced (a request lying about an input's
+      value is rejected) — test.
+- [ ] Non-trivial spends require interactive confirmation showing
+      attributed outputs/total/fee — test (accept + reject paths).
+- [ ] Auto-lock zeroizes the seed after timeout — test.
+- [ ] Socket: `0700` dir + `0600` socket + `SO_PEERCRED`; wrong-uid peer
+      refused — test.
+- [ ] Documented threat model + auth analysis (criterion #4).
+- [ ] Byte-identical signatures vs the in-CLI path for the same tx (Phase
+      0 invariant) — permanent regression test.
+
+## Risks & Mitigations
+- **Watch-only refactor churns the hot wallet path (Phase 1).** → keep
+  in-CLI signing the default; gate on the Phase-0 byte-identical test.
+- **Confirmation UX fatigue → users blind-confirm.** → amount thresholds
+  (small spends below a cap skip the prompt within an unlock window);
+  document that blind-confirm is out of the trust boundary.
+- **Cross-platform (no AF_UNIX on Windows).** → v1 is POSIX; document the
+  TCP-loopback+token variant as future, don't build it.
+- **Crash leaves seed in memory.** → mlock/no-coredump/PR_SET_DUMPABLE;
+  honestly document the SIGKILL limit.
+
+## Dependencies
+- Existing: `SecretBytes`/`PrivateKeyMaterial` (`security/secrets.py`),
+  `HdWallet` (`hd/wallet.py`), the encrypted wallet loader.
+- New stdlib only: `socket` (AF_UNIX, SO_PEERCRED), `ctypes`/`mlock`,
+  `signal`, `prctl` via `ctypes` for `PR_SET_DUMPABLE`.
+
+## Testing Strategy
+Unit-test the signer brain (Phase 2-3) with no socket; integration-test the
+daemon over a real socket in a tmp dir; property/adversarial tests for the
+prevout-lie and confirmation paths; a permanent byte-identical regression
+test vs in-CLI signing.
+
+## Documentation Plan
+- Threat-model doc (issue #8 criterion #4) MUST contain: socket auth +
+  the same-uid admission; per-spend confirmation as the real control;
+  prevout authenticity; TOCTOU single-buffer rule; memory hygiene + the
+  SIGKILL limit; explicit non-goals (no blind-confirm defense, no digest
+  signing, no seed vending).
+- A how-to: "unlock once with the pyrxd agent."
+
+## References (internal, file:line — verified during design)
+- `src/pyrxd/cli/prompts.py:123-155` — `_load_wallet` (integration point)
+- `src/pyrxd/hd/wallet.py:739,763,791,822` — key derivation + tx build
+- `src/pyrxd/script/type.py:77` — `P2PKH.unlock` (today's in-CLI signing)
+- `src/pyrxd/security/secrets.py:73` — `SecretBytes` (zeroize/unpicklable)
+- `src/pyrxd/transaction/transaction_preimage.py:66-92,133-135` — preimage commits to prevout value/script + ref-aware field
+- `src/pyrxd/transaction/transaction_input.py:32-34,58-87` — prevout from caller data; `from_hex` drops sighash
+- `src/pyrxd/eth_wallet/htlc_leg.py:271-279` — `PrivateKeyMaterial` zeroize-after-use pattern to mirror
+- `docs/cli-security-backlog.md` — the #8 spec
+- `docs/brainstorms/2026-06-08-pyrxd-cli-signer-seam-design.md` — the design + panel findings

--- a/docs/threat-model.md
+++ b/docs/threat-model.md
@@ -60,6 +60,7 @@ Ranked roughly by value to an attacker:
 | A8 | A signed transaction in flight | bytes | Transient; sent over wss to ElectrumX |
 | A9 | UTXO ownership info | tuples (txid, vout, value, owner) | In-memory after `collect_spendable()`; on disk in `addresses` dict of wallet.dat |
 | A10 | Network metadata (which addresses, balances, history) | observable on-chain | Public, but linkability matters for privacy |
+| A11 | Unlocked wallet held by the signing agent | in-memory `HdWallet` (seed in `SecretBytes`) | The `pyrxd agent` daemon process, for the unlock window only; reachable via a `0600` Unix socket |
 
 Control surfaces target the upper rows; A6 is intentionally exportable; A10 is unavoidable on a public chain.
 
@@ -282,6 +283,20 @@ Each scenario lists actor → action → asset → control(s) → residual risk.
 - **Control:** Tests use disposable mnemonics. CI logs are private.
 - **Residual risk:** Low (synthetic mnemonics never hold real funds). Tracked as [issue #9](https://github.com/MudwoodLabs/pyrxd/issues/9).
 
+### S18: Same-uid process abuses the signing agent to spend (TA1) — issue #8
+
+- **Action:** With the agent unlocked (A11), a malicious same-uid process connects to the socket and submits its own `SigningRequest` to drain the wallet. It passes `SO_PEERCRED` (same uid) and the `0600`/`0700` filesystem checks — those gate *other users*, not a co-resident attacker.
+- **Asset:** A11 (the unlocked wallet) → A8 (a signed, fund-moving tx).
+- **Control (THE control):** **per-spend confirmation.** The agent parses the tx, independently verifies each prevout (C1 — see S19), attributes every output (change re-derived and verified, the rest shown as external payees), and requires a human keypress **on the daemon's own controlling terminal** (`/dev/tty`) before signing — a channel the requesting process cannot drive. A detached daemon with no tty **fails closed** (declines). Small spends below an explicit, opt-in `--auto-confirm-under` threshold skip the prompt; that threshold is documented as outside the trust boundary. The agent **never returns key material** (conformance-tested), so reaching the socket lets an attacker *request* a signature, never *take* the key.
+- **Residual risk:** A user who blind-confirms, or who sets a high `--auto-confirm-under`, is unprotected — by their own choice. The confirmation is the boundary; automation of it is out of scope. Idle auto-lock and `agent lock` bound the unlock window.
+
+### S19: Agent tricked into a fee-theft / fund-redirect signature (TA1)
+
+- **Action:** A request lies about an input's prevout value (to burn the surplus to fees) or asks for a non-`ALL|FORKID` sighash (to recombine the signature into a different, fund-redirecting tx), while showing the user a benign-looking spend.
+- **Asset:** A4/A11 → A8.
+- **Control:** **Prevout authenticity (C1)** — the agent requires the full source tx for each input, verifies it hashes to the input's outpoint, and reads value/script from the *real* prevout (never the request's claim); the displayed summary is derived from the verified tx (display == sign). The agent re-derives the signing key and refuses to sign an input it does not own. **Sighash policy** — v1 signs only `ALL|FORKID`; any other type is refused (it would commit to fewer outputs than the confirmation showed). Partially-owned txs are refused (every input must be attributable).
+- **Residual risk:** v1 is P2PKH-only and fully-owned-only by design; multi-party / mixed-owner signing is out of scope.
+
 ## Controls in place
 
 Cross-reference of controls and the threats they address:
@@ -321,6 +336,13 @@ Cross-reference of controls and the threats they address:
 | Sole-authority audit gate (covenant-less use fails closed) | TA6 | `src/pyrxd/spv/proof.py:require_spv_sole_authority_cleared` |
 | SPV verification (Gravity) | TA6, TA8 | `src/pyrxd/spv/`, `src/pyrxd/gravity/` |
 | Gravity red-team test suite | TA8 | `tests/test_gravity_red_team.py` (1500+ lines) |
+| Agent per-spend confirmation on `/dev/tty` (fails closed w/o tty) | S18 | `src/pyrxd/agent/confirm.py`, `signer.py` |
+| Agent prevout authenticity (source-tx verified, value/script from real prevout) | S19 | `src/pyrxd/agent/signer.py:_verify_and_prepare_input` |
+| Agent `ALL\|FORKID`-only sighash + fully-owned-only | S19 | `src/pyrxd/agent/signer.py` |
+| Agent never returns key material (conformance-tested) | S18 | `src/pyrxd/agent/signer.py`, `tests/test_agent_signer.py` |
+| Agent socket: `0700` dir + `0600` socket + `SO_PEERCRED` uid==owner | TA1 (other-uid) | `src/pyrxd/agent/daemon.py:_bind/_read_peer_uid` |
+| Agent idle auto-lock + on-demand `lock` (seed zeroized) | A11 window | `src/pyrxd/agent/daemon.py:lock`, `_should_autolock` |
+| Agent process hygiene (mlock, PR_SET_DUMPABLE 0, no core dumps; best-effort) | A11 residency | `src/pyrxd/agent/hygiene.py` |
 | CodeQL on every push | static analysis | `.github/workflows/codeql.yml` |
 | Bandit on every push | security smells | `.github/workflows/ci.yml` |
 | ruff lint + format | code hygiene | `.github/workflows/lint.yml` |
@@ -351,7 +373,7 @@ Honest list. These are not vulnerabilities; they're places where pyrxd's defense
 
 8. **Broadcast summary doesn't show resolved `owner_pkh` from metadata files.** S7 residual risk. **Should be addressed before v0.3.0 release.**
 9. **No clipboard hygiene warning.** S3 residual risk. [Issue #11.](https://github.com/MudwoodLabs/pyrxd/issues/11)
-10. **Mnemonic re-entry per command** with no agent process. S2/S3 residual risk amplified by repetition. [Issue #8.](https://github.com/MudwoodLabs/pyrxd/issues/8)
+10. **Mnemonic re-entry per command** is mitigated by the optional `pyrxd agent` (issue #8, Path A′): a sign-on-behalf daemon holds the wallet for an unlock window so the mnemonic is typed once, and the key is removed from the short-lived CLI process entirely (the daemon signs). Residual: while unlocked, a same-uid process can *request* signatures — gated by per-spend confirmation (S18), never by taking the key. The agent is **opt-in**; with it off, the per-command prompt (and its S2/S3 residual risk) remains the default. The agent has not had a third-party audit (gap #1 applies).
 
 ### Protocol
 

--- a/src/pyrxd/agent/__init__.py
+++ b/src/pyrxd/agent/__init__.py
@@ -1,0 +1,38 @@
+"""pyrxd.agent — local sign-on-behalf signing agent (issue #8, Path A').
+
+A daemon holds the unlocked wallet and signs transactions the CLI builds
+*watch-only*; the key never leaves the agent. Reaching the agent lets a
+caller *request* a signature (gated by per-spend confirmation), never
+*take* the key.
+
+This package is the in-process signing brain (:mod:`~pyrxd.agent.signer`)
+plus its wire types (:mod:`~pyrxd.agent.protocol`). The Unix-socket
+daemon and the CLI client are layered on top (later phases). It is NOT
+the generalized ``Signer`` seam (that is the deferred Path B); the agent
+simply wraps :class:`~pyrxd.hd.wallet.HdWallet`.
+
+Security model: see docs/plans/2026-06-08-feat-cli-signing-agent-a-prime-plan.md
+§ "Load-bearing safety properties". The signer independently verifies
+each input's prevout (never trusts caller-claimed values), attributes
+outputs (change re-derived and verified, the rest shown as external),
+and requires confirmation before signing.
+"""
+
+from __future__ import annotations
+
+from .errors import SignerDeclined, SignerError, SignerUnavailableError
+from .protocol import ChangeClaim, ExternalOutput, InputToSign, SignedResult, SigningRequest, SpendSummary
+from .signer import AgentSigner
+
+__all__ = [
+    "AgentSigner",
+    "ChangeClaim",
+    "ExternalOutput",
+    "InputToSign",
+    "SignedResult",
+    "SignerDeclined",
+    "SignerError",
+    "SignerUnavailableError",
+    "SigningRequest",
+    "SpendSummary",
+]

--- a/src/pyrxd/agent/__init__.py
+++ b/src/pyrxd/agent/__init__.py
@@ -20,12 +20,17 @@ and requires confirmation before signing.
 
 from __future__ import annotations
 
+from .client import AgentClient
+from .confirm import TtyConfirmer, format_spend_summary
+from .daemon import AgentDaemon
 from .errors import SignerDeclined, SignerError, SignerUnavailableError
 from .protocol import ChangeClaim, ExternalOutput, InputToSign, SignedResult, SigningRequest, SpendSummary
 from .signer import AgentSigner
 from .watch_only import UnsignedSend, WatchOnlyTxBuilder, WatchOnlyUtxo
 
 __all__ = [
+    "AgentClient",
+    "AgentDaemon",
     "AgentSigner",
     "ChangeClaim",
     "ExternalOutput",
@@ -36,7 +41,9 @@ __all__ = [
     "SignerUnavailableError",
     "SigningRequest",
     "SpendSummary",
+    "TtyConfirmer",
     "UnsignedSend",
     "WatchOnlyTxBuilder",
     "WatchOnlyUtxo",
+    "format_spend_summary",
 ]

--- a/src/pyrxd/agent/__init__.py
+++ b/src/pyrxd/agent/__init__.py
@@ -23,6 +23,7 @@ from __future__ import annotations
 from .client import AgentClient
 from .confirm import TtyConfirmer, format_spend_summary
 from .daemon import AgentDaemon
+from .discover import WatchOnlyScan, collect_watch_only_utxos
 from .errors import SignerDeclined, SignerError, SignerUnavailableError
 from .protocol import ChangeClaim, ExternalOutput, InputToSign, SignedResult, SigningRequest, SpendSummary
 from .signer import AgentSigner
@@ -43,7 +44,9 @@ __all__ = [
     "SpendSummary",
     "TtyConfirmer",
     "UnsignedSend",
+    "WatchOnlyScan",
     "WatchOnlyTxBuilder",
     "WatchOnlyUtxo",
+    "collect_watch_only_utxos",
     "format_spend_summary",
 ]

--- a/src/pyrxd/agent/__init__.py
+++ b/src/pyrxd/agent/__init__.py
@@ -23,6 +23,7 @@ from __future__ import annotations
 from .errors import SignerDeclined, SignerError, SignerUnavailableError
 from .protocol import ChangeClaim, ExternalOutput, InputToSign, SignedResult, SigningRequest, SpendSummary
 from .signer import AgentSigner
+from .watch_only import UnsignedSend, WatchOnlyTxBuilder, WatchOnlyUtxo
 
 __all__ = [
     "AgentSigner",
@@ -35,4 +36,7 @@ __all__ = [
     "SignerUnavailableError",
     "SigningRequest",
     "SpendSummary",
+    "UnsignedSend",
+    "WatchOnlyTxBuilder",
+    "WatchOnlyUtxo",
 ]

--- a/src/pyrxd/agent/client.py
+++ b/src/pyrxd/agent/client.py
@@ -1,0 +1,81 @@
+"""CLI-side client for the signing agent.
+
+Thin, stateless wrapper over the Unix socket: each call opens a connection, does
+one request/response round-trip, and closes. If the socket is absent or refuses
+the connection the agent is simply not running — the caller gets a typed
+:class:`SignerUnavailableError` and falls back to the in-process mnemonic prompt.
+Daemon-side refusals (declined confirmation, validation failures) surface as the
+same typed errors the in-process signer raises, so callers handle one vocabulary.
+"""
+
+from __future__ import annotations
+
+import socket
+from pathlib import Path
+
+from .errors import SignerDeclined, SignerError, SignerUnavailableError
+from .protocol import SignedResult, SigningRequest
+from .transport import recv_frame, send_frame
+
+
+class AgentClient:
+    """Talks to a running :class:`~pyrxd.agent.daemon.AgentDaemon`."""
+
+    def __init__(self, socket_path: str | Path, *, connect_timeout_s: float = 2.0) -> None:
+        self._socket_path = Path(socket_path)
+        self._timeout = connect_timeout_s
+
+    def is_live(self) -> bool:
+        """True iff an agent answers a status query on the socket (never raises)."""
+        try:
+            resp = self._roundtrip({"op": "status"})
+        except (SignerUnavailableError, SignerError):
+            return False
+        return bool(resp.get("ok"))
+
+    def account_xpub(self) -> str:
+        """The account xpub the agent vends (for watch-only tx building)."""
+        return self._unwrap(self._roundtrip({"op": "xpub"}))["xpub"]
+
+    def sign(self, request: SigningRequest) -> SignedResult:
+        """Send a signing request; return the signed tx or raise the typed error."""
+        resp = self._roundtrip({"op": "sign", "request": request.to_dict()})
+        return SignedResult.from_dict(self._unwrap(resp))
+
+    def lock(self) -> None:
+        """Ask the agent to lock (zeroize + shut down). No-op if already down."""
+        try:
+            self._roundtrip({"op": "lock"})
+        except SignerUnavailableError:
+            pass
+
+    # ---- internals -------------------------------------------------------
+
+    def _connect(self) -> socket.socket:
+        sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+        sock.settimeout(self._timeout)
+        try:
+            sock.connect(str(self._socket_path))
+        except OSError as exc:
+            sock.close()
+            raise SignerUnavailableError(f"signing agent not reachable at {self._socket_path}: {exc}") from exc
+        return sock
+
+    def _roundtrip(self, request: dict) -> dict:
+        sock = self._connect()
+        try:
+            send_frame(sock, request)
+            return recv_frame(sock)
+        finally:
+            sock.close()
+
+    @staticmethod
+    def _unwrap(resp: dict) -> dict:
+        """Return the ``result`` payload, or raise the typed error the daemon sent."""
+        if resp.get("ok"):
+            return resp["result"]
+        kind = resp.get("kind")
+        message = str(resp.get("error", "agent error"))
+        if kind == "declined":
+            raise SignerDeclined(message)
+        raise SignerError(message)

--- a/src/pyrxd/agent/confirm.py
+++ b/src/pyrxd/agent/confirm.py
@@ -1,0 +1,73 @@
+"""Per-spend confirmation UI for the signing agent (load-bearing control H2).
+
+The confirmation is THE control that separates A′ from a seed-vending agent: a
+same-uid process passes ``SO_PEERCRED`` and can *originate* a signing request,
+so the only thing standing between it and a signature is a human approving the
+*attributed* spend. Therefore the prompt must reach the user through a channel
+the requesting process cannot drive — the daemon's own controlling terminal
+(``/dev/tty``), never the requester's stdin.
+
+:func:`format_spend_summary` is pure (and unit-tested); :class:`TtyConfirmer`
+does the I/O. If there is no controlling tty (a detached daemon with nowhere to
+ask), confirmation FAILS CLOSED — the spend is declined, never auto-approved.
+"""
+
+from __future__ import annotations
+
+from .protocol import SpendSummary
+
+#: Spends whose total to EXTERNAL payees is at/below this skip the prompt within
+#: an unlock window (the plan's UX-fatigue mitigation). 0 = always confirm.
+DEFAULT_AUTO_CONFIRM_UNDER = 0
+
+
+def format_spend_summary(summary: SpendSummary) -> str:
+    """Render the verified spend for human review (pure; no I/O).
+
+    Shows every external payee + amount, the change total, the input total, and
+    the fee — all derived from the *verified* tx (prevouts checked, change
+    re-derived), so what the user sees is what gets signed.
+    """
+    lines = ["", "  ── pyrxd agent: approve this spend? ──"]
+    if summary.external_outputs:
+        for e in summary.external_outputs:
+            lines.append(f"    send  {e.amount:>16,} photons  →  {e.dest}")
+    else:
+        lines.append("    (no external payees — self-spend / consolidation)")
+    lines.append(f"    change      {summary.change_total:>16,} photons")
+    lines.append(f"    inputs      {summary.input_total:>16,} photons")
+    lines.append(f"    fee         {summary.fee:>16,} photons")
+    flags = ", ".join(f"0x{f:02x}" for f in summary.sighash_flags)
+    lines.append(f"    sighash     {flags or '(none)'}")
+    return "\n".join(lines)
+
+
+class TtyConfirmer:
+    """Confirms spends on the daemon's controlling terminal (``/dev/tty``).
+
+    ``auto_confirm_under`` lets small spends (total external ≤ threshold) skip
+    the prompt — documented as outside the trust boundary. With no tty available
+    the call fails closed (returns ``False``).
+    """
+
+    def __init__(self, *, auto_confirm_under: int = DEFAULT_AUTO_CONFIRM_UNDER) -> None:
+        self._threshold = auto_confirm_under
+
+    def __call__(self, summary: SpendSummary) -> bool:
+        if summary.total_external <= self._threshold:
+            return True
+        try:
+            tty = open("/dev/tty", "r+")  # noqa: SIM115 — need explicit lifetime around the prompt
+        except OSError:
+            # No controlling terminal (detached daemon) → cannot ask → fail closed.
+            return False
+        try:
+            tty.write(format_spend_summary(summary))
+            tty.write("\n  approve? [y/N]: ")
+            tty.flush()
+            answer = tty.readline().strip().lower()
+        except OSError:
+            return False
+        finally:
+            tty.close()
+        return answer in ("y", "yes")

--- a/src/pyrxd/agent/daemon.py
+++ b/src/pyrxd/agent/daemon.py
@@ -116,7 +116,7 @@ class AgentDaemon:
         wallet, self._wallet, self._signer = self._wallet, None, None
         try:
             wallet._seed.zeroize()
-        except Exception:
+        except Exception:  # nosec B110 — best-effort scrub; locking must succeed even if zeroize raises
             pass
         self._close_socket()
 

--- a/src/pyrxd/agent/daemon.py
+++ b/src/pyrxd/agent/daemon.py
@@ -1,0 +1,225 @@
+"""The signing-agent daemon: a local Unix-socket server holding the unlocked
+wallet and signing on the CLI's behalf (load-bearing §6-7).
+
+Security posture (all THREE required, not any one):
+* ``0700`` on the socket's directory **and** ``0600`` on the socket itself, so
+  only the owner can reach it at the filesystem layer.
+* ``SO_PEERCRED`` — the connecting process's uid must equal the daemon owner's;
+  a different uid is refused before any request is read.
+
+The seed lives in the held :class:`HdWallet` for the unlock window only. An idle
+timeout auto-locks (zeroizes the seed and shuts down); ``lock`` does it on
+demand. Confirmation is delegated to an injected :data:`ConfirmFn` that must
+prompt on the daemon's OWN terminal (see :mod:`pyrxd.agent.confirm`) — never the
+requester, who is the very same-uid process the confirmation defends against.
+
+The accept loop is single-threaded and serial: one connection, one request, one
+response. That is plenty for a single-user CLI agent and keeps the seed-touching
+path free of concurrency. The listening socket carries a short timeout so the
+loop wakes to evaluate the idle auto-lock even with no traffic.
+"""
+
+from __future__ import annotations
+
+import os
+import socket
+import struct
+import time
+from collections.abc import Callable
+from pathlib import Path
+
+from ..hd.bip32 import Xpub
+from .errors import SignerDeclined, SignerError
+from .hygiene import harden_process
+from .protocol import SigningRequest
+from .signer import AgentSigner, ConfirmFn
+from .transport import recv_frame, send_frame
+
+#: ``struct ucred`` from SO_PEERCRED: pid, uid, gid (three 32-bit ints).
+_UCRED = struct.Struct("3i")
+
+#: Default idle window before auto-lock (15 minutes).
+DEFAULT_IDLE_TIMEOUT_S = 900.0
+
+
+class AgentDaemon:
+    """Holds an unlocked wallet and signs requests arriving on a Unix socket."""
+
+    def __init__(
+        self,
+        wallet,
+        *,
+        socket_path: str | Path,
+        confirm: ConfirmFn,
+        idle_timeout_s: float = DEFAULT_IDLE_TIMEOUT_S,
+        poll_interval_s: float = 0.5,
+        clock: Callable[[], float] = time.monotonic,
+        harden: bool = True,
+    ) -> None:
+        self._wallet = wallet
+        self._signer: AgentSigner | None = AgentSigner(wallet)
+        # The account xpub is public — cache it so it survives lock() and the CLI
+        # can keep building watch-only after the seed is gone.
+        self._account_xpub = str(Xpub.from_xprv(wallet._xprv))
+        self._socket_path = Path(socket_path)
+        self._confirm = confirm
+        self._idle_timeout_s = idle_timeout_s
+        self._poll = poll_interval_s
+        self._clock = clock
+        self._harden = harden
+        self._owner_uid = os.getuid()
+        self._last_activity = clock()
+        self._locked = False
+        self._sock: socket.socket | None = None
+        self._hardening: dict | None = None
+
+    # ---- pure, unit-testable policy --------------------------------------
+
+    def _peer_authorized(self, uid: int) -> bool:
+        """A peer is authorized iff its uid is the daemon owner's."""
+        return uid == self._owner_uid
+
+    def _should_autolock(self, now: float) -> bool:
+        return not self._locked and (now - self._last_activity) >= self._idle_timeout_s
+
+    @property
+    def locked(self) -> bool:
+        return self._locked
+
+    # ---- lifecycle -------------------------------------------------------
+
+    def serve_forever(self) -> None:
+        """Bind, harden, then serve until locked (idle, on-demand, or signal)."""
+        self._bind()
+        if self._harden:
+            self._hardening = harden_process().as_dict()
+        try:
+            while not self._locked:
+                try:
+                    conn, _ = self._sock.accept()
+                except TimeoutError:
+                    if self._should_autolock(self._clock()):
+                        self.lock()
+                    continue
+                except OSError:
+                    break  # socket closed under us (lock() / shutdown)
+                with conn:
+                    self._serve_conn(conn)
+        finally:
+            self._close_socket()
+
+    def lock(self) -> None:
+        """Zeroize the seed, drop the wallet, and stop serving. Idempotent."""
+        if self._locked:
+            return
+        self._locked = True
+        wallet, self._wallet, self._signer = self._wallet, None, None
+        try:
+            wallet._seed.zeroize()
+        except Exception:
+            pass
+        self._close_socket()
+
+    # ---- socket plumbing -------------------------------------------------
+
+    def _bind(self) -> None:
+        directory = self._socket_path.parent
+        directory.mkdir(mode=0o700, parents=True, exist_ok=True)
+        os.chmod(directory, 0o700)  # enforce even if it pre-existed looser
+        if self._socket_path.exists():
+            if self._probe_live():
+                raise SignerError(f"an agent is already running at {self._socket_path}")
+            self._socket_path.unlink()  # stale socket from a dead daemon
+
+        sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+        # umask so the socket is created 0600 (no group/other), then chmod to be sure.
+        old_umask = os.umask(0o177)
+        try:
+            sock.bind(str(self._socket_path))
+        finally:
+            os.umask(old_umask)
+        os.chmod(self._socket_path, 0o600)
+        sock.listen(8)
+        sock.settimeout(self._poll)
+        self._sock = sock
+
+    def _probe_live(self) -> bool:
+        """True iff something is accepting on the existing socket (single-instance)."""
+        probe = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+        probe.settimeout(0.5)
+        try:
+            probe.connect(str(self._socket_path))
+            return True
+        except OSError:
+            return False
+        finally:
+            probe.close()
+
+    def _close_socket(self) -> None:
+        if self._sock is not None:
+            try:
+                self._sock.close()
+            finally:
+                self._sock = None
+        try:
+            self._socket_path.unlink()
+        except OSError:
+            pass
+
+    # ---- request handling ------------------------------------------------
+
+    def _serve_conn(self, conn: socket.socket) -> None:
+        uid = self._read_peer_uid(conn)
+        if uid is None or not self._peer_authorized(uid):
+            self._safe_send(conn, {"ok": False, "kind": "error", "error": "peer not authorized"})
+            return
+        try:
+            req = recv_frame(conn)
+        except SignerError as exc:
+            self._safe_send(conn, {"ok": False, "kind": "error", "error": str(exc)})
+            return
+        self._safe_send(conn, self._dispatch(req))
+
+    def _read_peer_uid(self, conn: socket.socket) -> int | None:
+        try:
+            raw = conn.getsockopt(socket.SOL_SOCKET, socket.SO_PEERCRED, _UCRED.size)
+            _pid, uid, _gid = _UCRED.unpack(raw)
+            return uid
+        except OSError:
+            return None
+
+    def _dispatch(self, req: dict) -> dict:
+        if self._locked or self._signer is None:
+            return {"ok": False, "kind": "locked", "error": "agent is locked"}
+        self._last_activity = self._clock()
+        op = req.get("op")
+        if op == "status":
+            return {"ok": True, "result": {"unlocked": True, "xpub": self._account_xpub, "hardening": self._hardening}}
+        if op == "xpub":
+            return {"ok": True, "result": {"xpub": self._account_xpub}}
+        if op == "lock":
+            self.lock()
+            return {"ok": True, "result": {"locked": True}}
+        if op == "sign":
+            return self._handle_sign(req)
+        return {"ok": False, "kind": "error", "error": f"unknown op {op!r}"}
+
+    def _handle_sign(self, req: dict) -> dict:
+        try:
+            request = SigningRequest.from_dict(req["request"])
+        except (KeyError, TypeError, ValueError) as exc:
+            return {"ok": False, "kind": "error", "error": f"bad signing request: {exc}"}
+        try:
+            result = self._signer.sign(request, confirm=self._confirm)
+        except SignerDeclined as exc:
+            return {"ok": False, "kind": "declined", "error": str(exc)}
+        except SignerError as exc:
+            return {"ok": False, "kind": "error", "error": str(exc)}
+        return {"ok": True, "result": result.to_dict()}
+
+    @staticmethod
+    def _safe_send(conn: socket.socket, obj: dict) -> None:
+        try:
+            send_frame(conn, obj)
+        except (OSError, SignerError):
+            pass  # peer hung up; nothing more to do

--- a/src/pyrxd/agent/discover.py
+++ b/src/pyrxd/agent/discover.py
@@ -1,0 +1,77 @@
+"""Watch-only UTXO discovery from an account xpub (CLI-side, no private key).
+
+The agent vends the account ``xpub`` on unlock; this turns it into a spendable
+UTXO set the way ``HdWallet.refresh``/``collect_spendable`` do — but key-free.
+For each spendable output it also fetches the FULL source tx, because the agent
+verifies every prevout against it (C1) before signing. Network I/O only; the
+returned coords + source txs are exactly what :class:`WatchOnlyTxBuilder` needs.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from ..hd.bip32 import Xpub
+from ..network.electrumx import ElectrumXClient, script_hash_for_address
+from ..security.errors import ValidationError
+from ..security.types import Txid
+from .watch_only import WatchOnlyUtxo
+
+#: BIP44 chains: 0 = external/receive, 1 = internal/change.
+_EXTERNAL_CHAIN = 0
+_INTERNAL_CHAIN = 1
+_DEFAULT_GAP_LIMIT = 20
+
+
+@dataclass(frozen=True)
+class WatchOnlyScan:
+    """Result of a watch-only scan: spendable UTXOs + the next unused change index."""
+
+    utxos: list[WatchOnlyUtxo]
+    next_change_index: int
+
+
+async def collect_watch_only_utxos(
+    account_xpub: Xpub, client: ElectrumXClient, *, gap_limit: int = _DEFAULT_GAP_LIMIT
+) -> WatchOnlyScan:
+    """Gap-limit scan both BIP44 chains from the public xpub and collect spendable UTXOs.
+
+    ``get_history`` marks a derived address used; ``get_utxos`` enumerates its
+    spendable outputs; ``get_transaction`` fetches each output's source tx (for the
+    agent's C1 prevout check). Also reports the next unused internal index, so the
+    caller can place change on a fresh change address. No private key is touched.
+    """
+    if not isinstance(account_xpub, Xpub):
+        raise ValidationError("account_xpub must be an Xpub (watch-only discovery: no private key)")
+    if not isinstance(gap_limit, int) or isinstance(gap_limit, bool) or gap_limit <= 0:
+        raise ValidationError("gap_limit must be a positive int")
+
+    utxos: list[WatchOnlyUtxo] = []
+    next_change_index = 0
+    for change in (_EXTERNAL_CHAIN, _INTERNAL_CHAIN):
+        chain_xpub = account_xpub.ckd(change)
+        consecutive_unused = 0
+        index = 0
+        while consecutive_unused < gap_limit:
+            address = chain_xpub.ckd(index).address()
+            script_hash = script_hash_for_address(address)
+            if await client.get_history(script_hash):
+                consecutive_unused = 0
+                if change == _INTERNAL_CHAIN:
+                    next_change_index = index + 1
+                for utxo in await client.get_utxos(script_hash):
+                    raw = await client.get_transaction(Txid(utxo.tx_hash))
+                    utxos.append(
+                        WatchOnlyUtxo(
+                            txid=utxo.tx_hash,
+                            vout=utxo.tx_pos,
+                            value=utxo.value,
+                            change=change,
+                            index=index,
+                            source_tx_hex=bytes(raw).hex(),
+                        )
+                    )
+            else:
+                consecutive_unused += 1
+            index += 1
+    return WatchOnlyScan(utxos=utxos, next_change_index=next_change_index)

--- a/src/pyrxd/agent/errors.py
+++ b/src/pyrxd/agent/errors.py
@@ -1,0 +1,26 @@
+"""Typed errors for the signing agent.
+
+A typed taxonomy so the CLI fallback ladder branches on exception *type*,
+not on string-matching messages (the design panel called this out). All
+inherit the repo's error hierarchy.
+"""
+
+from __future__ import annotations
+
+from ..security.errors import NetworkError, ValidationError
+
+
+class SignerError(ValidationError):
+    """A signing request was malformed, unauthorized, or failed validation."""
+
+
+class SignerDeclined(SignerError):
+    """The spend was declined at the confirmation gate (user said no)."""
+
+
+class SignerUnavailableError(NetworkError):
+    """The agent is not reachable (socket absent, locked, or down).
+
+    A :class:`NetworkError` subclass so callers can fall back to the
+    mnemonic prompt without conflating it with a validation failure.
+    """

--- a/src/pyrxd/agent/hygiene.py
+++ b/src/pyrxd/agent/hygiene.py
@@ -1,0 +1,90 @@
+"""Best-effort process hardening for the signing daemon (load-bearing §6).
+
+The daemon holds the decrypted seed in memory for the unlock window. These
+measures shrink the window in which that seed can leak to disk or another
+process:
+
+* ``mlockall`` — keep pages out of swap (no plaintext seed paged to disk).
+* ``PR_SET_DUMPABLE 0`` — disallow ptrace/attach by other processes and mark
+  the process non-dumpable.
+* ``RLIMIT_CORE = 0`` — no core dump (which would contain the seed) on crash.
+
+All are BEST-EFFORT: a container without ``CAP_IPC_LOCK`` can't ``mlock``, etc.
+Failures are reported, never fatal. The honest limit (documented in the threat
+model): ``SIGKILL`` and hardware faults cannot be scrubbed — these reduce, not
+eliminate, residency risk.
+"""
+
+from __future__ import annotations
+
+import ctypes
+import ctypes.util
+import resource
+from dataclasses import dataclass
+
+_MCL_CURRENT = 1
+_MCL_FUTURE = 2
+_PR_SET_DUMPABLE = 4
+
+
+@dataclass(frozen=True)
+class HardeningReport:
+    """What actually took effect (for logging / the `status` response)."""
+
+    mlock: bool
+    non_dumpable: bool
+    core_dumps_disabled: bool
+
+    def as_dict(self) -> dict:
+        return {
+            "mlock": self.mlock,
+            "non_dumpable": self.non_dumpable,
+            "core_dumps_disabled": self.core_dumps_disabled,
+        }
+
+
+def harden_process() -> HardeningReport:
+    """Apply the hardening measures; return which ones succeeded. Never raises."""
+    return HardeningReport(
+        mlock=_try_mlockall(),
+        non_dumpable=_try_set_non_dumpable(),
+        core_dumps_disabled=_try_disable_core_dumps(),
+    )
+
+
+def _libc() -> ctypes.CDLL | None:
+    name = ctypes.util.find_library("c")
+    if name is None:
+        return None
+    try:
+        return ctypes.CDLL(name, use_errno=True)
+    except OSError:
+        return None
+
+
+def _try_mlockall() -> bool:
+    libc = _libc()
+    if libc is None or not hasattr(libc, "mlockall"):
+        return False
+    try:
+        return libc.mlockall(_MCL_CURRENT | _MCL_FUTURE) == 0
+    except OSError:
+        return False
+
+
+def _try_set_non_dumpable() -> bool:
+    libc = _libc()
+    if libc is None or not hasattr(libc, "prctl"):
+        return False
+    try:
+        return libc.prctl(_PR_SET_DUMPABLE, 0, 0, 0, 0) == 0
+    except OSError:
+        return False
+
+
+def _try_disable_core_dumps() -> bool:
+    try:
+        resource.setrlimit(resource.RLIMIT_CORE, (0, 0))
+        return True
+    except (ValueError, OSError):
+        return False

--- a/src/pyrxd/agent/protocol.py
+++ b/src/pyrxd/agent/protocol.py
@@ -1,0 +1,139 @@
+"""Wire types for the signing-agent protocol.
+
+The CLI (watch-only) builds an unsigned transaction and a
+:class:`SigningRequest` describing which inputs the agent must sign (with
+their derivation coords + full source tx so the agent can verify the
+prevout itself) and which outputs are change (claims the agent re-derives
+and verifies). The agent returns a :class:`SignedResult`.
+
+Everything here is plain data — JSON-serializable for the socket layer,
+and carries no key material.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+from ..constants import SIGHASH
+
+
+@dataclass(frozen=True)
+class InputToSign:
+    """One input the agent must sign.
+
+    ``source_tx_hex`` is the FULL previous transaction; the agent verifies
+    it hashes to the input's outpoint and reads the real prevout
+    value/script from it — it never trusts values embedded in the unsigned
+    tx (prevout-authenticity, C1). ``change``/``index`` are the BIP44
+    chain/index the agent derives the signing key from.
+    """
+
+    input_index: int
+    change: int
+    index: int
+    source_tx_hex: str
+    sighash: int = int(SIGHASH.ALL_FORKID)
+
+    def to_dict(self) -> dict:
+        return {
+            "input_index": self.input_index,
+            "change": self.change,
+            "index": self.index,
+            "source_tx_hex": self.source_tx_hex,
+            "sighash": self.sighash,
+        }
+
+    @classmethod
+    def from_dict(cls, d: dict) -> InputToSign:
+        return cls(
+            input_index=int(d["input_index"]),
+            change=int(d["change"]),
+            index=int(d["index"]),
+            source_tx_hex=str(d["source_tx_hex"]),
+            sighash=int(d.get("sighash", int(SIGHASH.ALL_FORKID))),
+        )
+
+
+@dataclass(frozen=True)
+class ChangeClaim:
+    """A claim that output ``output_index`` is change to the wallet's own
+    ``change``/``index`` key. The agent VERIFIES it by re-deriving that
+    address — a false claim (hiding an external payee as "change") fails
+    verification and the spend is rejected."""
+
+    output_index: int
+    change: int
+    index: int
+
+    def to_dict(self) -> dict:
+        return {"output_index": self.output_index, "change": self.change, "index": self.index}
+
+    @classmethod
+    def from_dict(cls, d: dict) -> ChangeClaim:
+        return cls(output_index=int(d["output_index"]), change=int(d["change"]), index=int(d["index"]))
+
+
+@dataclass(frozen=True)
+class SigningRequest:
+    """An unsigned tx plus everything the agent needs to verify and sign it."""
+
+    unsigned_tx_hex: str
+    inputs: tuple[InputToSign, ...]
+    change_claims: tuple[ChangeClaim, ...] = ()
+
+    def to_dict(self) -> dict:
+        return {
+            "unsigned_tx_hex": self.unsigned_tx_hex,
+            "inputs": [i.to_dict() for i in self.inputs],
+            "change_claims": [c.to_dict() for c in self.change_claims],
+        }
+
+    @classmethod
+    def from_dict(cls, d: dict) -> SigningRequest:
+        return cls(
+            unsigned_tx_hex=str(d["unsigned_tx_hex"]),
+            inputs=tuple(InputToSign.from_dict(i) for i in d["inputs"]),
+            change_claims=tuple(ChangeClaim.from_dict(c) for c in d.get("change_claims", [])),
+        )
+
+
+@dataclass(frozen=True)
+class ExternalOutput:
+    """A non-change output (a real payee), shown to the user before signing."""
+
+    output_index: int
+    dest: str  # human-displayable destination (address/pkh/script summary)
+    amount: int
+
+
+@dataclass(frozen=True)
+class SpendSummary:
+    """What the agent is about to sign — handed to the confirmation gate.
+
+    Derived entirely from the *verified* tx (prevouts checked, change
+    claims re-derived), never from caller-asserted free-form values.
+    """
+
+    external_outputs: tuple[ExternalOutput, ...]
+    total_external: int
+    change_total: int
+    input_total: int
+    fee: int
+    sighash_flags: tuple[int, ...] = field(default_factory=tuple)
+
+
+@dataclass(frozen=True)
+class SignedResult:
+    """The agent's response: a fully-signed, broadcast-ready transaction.
+
+    Carries a transaction only — never key material (enforced invariant).
+    """
+
+    signed_tx_hex: str
+
+    def to_dict(self) -> dict:
+        return {"signed_tx_hex": self.signed_tx_hex}
+
+    @classmethod
+    def from_dict(cls, d: dict) -> SignedResult:
+        return cls(signed_tx_hex=str(d["signed_tx_hex"]))

--- a/src/pyrxd/agent/signer.py
+++ b/src/pyrxd/agent/signer.py
@@ -122,7 +122,20 @@ class AgentSigner:
         # set the sighash before signing so preimage == what we attribute.
         ti.satoshis = prevout.satoshis
         ti.locking_script = prevout.locking_script
-        ti.sighash = SIGHASH(inp.sighash)
+        # v1 signs ONLY ALL_FORKID. NONE/SINGLE/ANYONECANPAY variants commit to
+        # fewer outputs than the confirmation summary shows, so a caller could take
+        # the returned signature, recombine it into a different transaction, and
+        # redirect the funds — while the user approved a benign-looking spend. A
+        # fully wallet-owned normal send has no legitimate use for anything else.
+        # (Compared explicitly, not via SIGHASH(inp.sighash), so an out-of-enum int
+        # is a clean SignerError rather than a leaked ValueError.)
+        if inp.sighash != int(SIGHASH.ALL_FORKID):
+            raise SignerError(
+                f"input {inp.input_index}: agent v1 signs only ALL_FORKID "
+                f"(0x{int(SIGHASH.ALL_FORKID):02x}); got {inp.sighash!r} — other sighash types "
+                "permit fund redirection and are refused"
+            )
+        ti.sighash = SIGHASH.ALL_FORKID
         ti.unlocking_script_template = P2PKH().unlock(privkey)
         # ``from_hex`` leaves unlocking_script as an empty Script (not None), which
         # ``Transaction.sign(bypass=True)`` would skip — reset so this input signs.

--- a/src/pyrxd/agent/signer.py
+++ b/src/pyrxd/agent/signer.py
@@ -1,0 +1,169 @@
+"""The sign-on-behalf signing brain.
+
+Holds an unlocked :class:`~pyrxd.hd.wallet.HdWallet` and turns a
+:class:`SigningRequest` into a signed transaction. The key never leaves
+this object; callers get a signed tx, never key material.
+
+Load-bearing checks (see the plan's § "Load-bearing safety properties"):
+
+* **C1 prevout authenticity** — each input's value+script are read from
+  the *verified* source tx (hashes to the outpoint), never trusted from
+  the unsigned tx the caller supplied. Defeats fake-low-value fee theft.
+* **Ownership** — the derived key must actually own the prevout
+  (pubkey hash == prevout owner pkh), or the request is rejected.
+* **Output attribution + confirmation** — change claims are re-derived
+  and verified; everything else is surfaced as an external payee, and the
+  whole spend goes through a confirmation gate before signing.
+* **Set-then-sign sighash** — the sighash is set on the input before the
+  preimage is computed (the wire format does not carry it; see
+  ``TransactionInput.from_hex``), so what is signed matches what is shown.
+* **Fully-owned only (v1)** — every input must be in the request; the
+  agent refuses to sign a transaction it cannot fully attribute.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+
+from ..constants import SIGHASH
+from ..hash import hash256
+from ..hd.wallet import HdWallet
+from ..script.type import P2PKH
+from ..transaction.transaction import Transaction
+from ..transaction.transaction_output import TransactionOutput
+from ..utils import address_to_public_key_hash
+from .errors import SignerDeclined, SignerError
+from .protocol import ExternalOutput, SignedResult, SigningRequest, SpendSummary
+
+#: Confirmation gate: given the verified spend summary, return True to sign.
+ConfirmFn = Callable[[SpendSummary], bool]
+
+
+def _is_p2pkh(script: bytes) -> bool:
+    return len(script) == 25 and script[:3] == b"\x76\xa9\x14" and script[23:] == b"\x88\xac"
+
+
+def _dest_of(out: TransactionOutput) -> str:
+    """Human-displayable destination for an output (best-effort, structured)."""
+    script = out.locking_script.serialize()
+    if _is_p2pkh(script):
+        return f"p2pkh:{script[3:23].hex()}"
+    if script[:1] == b"\x6a":
+        return "op_return"
+    return f"script:{script[:16].hex()}…"
+
+
+class AgentSigner:
+    """Signs transactions on behalf of an unlocked wallet, without ever
+    exposing the wallet's keys."""
+
+    def __init__(self, wallet: HdWallet) -> None:
+        self._wallet = wallet
+
+    def sign(self, request: SigningRequest, *, confirm: ConfirmFn) -> SignedResult:
+        tx = Transaction.from_hex(bytes.fromhex(request.unsigned_tx_hex))
+        if tx is None:
+            raise SignerError("could not parse the unsigned transaction")
+        if not tx.inputs or not tx.outputs:
+            raise SignerError("transaction has no inputs or no outputs")
+
+        # v1 refuses partially-owned txs: every input must be in the request,
+        # exactly once, so the agent can verify and attribute the whole tx.
+        covered = [i.input_index for i in request.inputs]
+        if sorted(covered) != list(range(len(tx.inputs))):
+            raise SignerError(
+                "agent v1 signs only fully wallet-owned transactions "
+                f"(tx has {len(tx.inputs)} inputs; request covers {sorted(covered)})"
+            )
+
+        for inp in request.inputs:
+            self._verify_and_prepare_input(tx, inp)
+
+        summary = self._summarize(tx, request)
+        if not confirm(summary):
+            raise SignerDeclined("spend declined at the confirmation gate")
+
+        tx.sign(bypass=True)  # signs the inputs we attached templates to
+
+        for inp in request.inputs:
+            if tx.inputs[inp.input_index].unlocking_script is None:
+                raise SignerError(f"input {inp.input_index} was not signed")
+        return SignedResult(signed_tx_hex=tx.serialize().hex())
+
+    # ------------------------------------------------------------------ internals
+
+    def _verify_and_prepare_input(self, tx: Transaction, inp) -> None:
+        if not 0 <= inp.input_index < len(tx.inputs):
+            raise SignerError(f"input_index {inp.input_index} out of range")
+        ti = tx.inputs[inp.input_index]
+
+        src_bytes = bytes.fromhex(inp.source_tx_hex)
+        # C1: the source tx must hash to this input's outpoint txid.
+        if hash256(src_bytes)[::-1].hex() != ti.source_txid:
+            raise SignerError(f"source tx does not match input {inp.input_index} outpoint")
+        src = Transaction.from_hex(src_bytes)
+        if src is None:
+            raise SignerError(f"could not parse source tx for input {inp.input_index}")
+        vout = ti.source_output_index
+        if not 0 <= vout < len(src.outputs):
+            raise SignerError(f"input {inp.input_index} references a non-existent source output")
+        prevout = src.outputs[vout]
+        script = prevout.locking_script.serialize()
+        if not _is_p2pkh(script):
+            raise SignerError(f"input {inp.input_index} is not P2PKH (agent v1 signs P2PKH only)")
+
+        privkey = self._wallet._privkey_for(inp.change, inp.index)
+        if privkey.public_key().hash160() != script[3:23]:
+            raise SignerError(
+                f"derived key (change={inp.change}, index={inp.index}) does not own input {inp.input_index}"
+            )
+
+        # Bind the VERIFIED prevout value/script (not the caller's claim) and
+        # set the sighash before signing so preimage == what we attribute.
+        ti.satoshis = prevout.satoshis
+        ti.locking_script = prevout.locking_script
+        ti.sighash = SIGHASH(inp.sighash)
+        ti.unlocking_script_template = P2PKH().unlock(privkey)
+        # ``from_hex`` leaves unlocking_script as an empty Script (not None), which
+        # ``Transaction.sign(bypass=True)`` would skip — reset so this input signs.
+        ti.unlocking_script = None
+
+    def _summarize(self, tx: Transaction, request: SigningRequest) -> SpendSummary:
+        # Verify each change claim by re-derivation; collect the verified set.
+        change_indices: set[int] = set()
+        for claim in request.change_claims:
+            if not 0 <= claim.output_index < len(tx.outputs):
+                raise SignerError(f"change claim output_index {claim.output_index} out of range")
+            addr = self._wallet._derive_address(claim.change, claim.index)
+            claim_pkh = address_to_public_key_hash(addr)
+            out_script = tx.outputs[claim.output_index].locking_script.serialize()
+            if not _is_p2pkh(out_script) or out_script[3:23] != claim_pkh:
+                raise SignerError(
+                    f"change claim for output {claim.output_index} does not verify "
+                    "(output is not change to the claimed key)"
+                )
+            change_indices.add(claim.output_index)
+
+        external: list[ExternalOutput] = []
+        change_total = 0
+        for idx, out in enumerate(tx.outputs):
+            if idx in change_indices:
+                change_total += out.satoshis
+            else:
+                external.append(ExternalOutput(output_index=idx, dest=_dest_of(out), amount=out.satoshis))
+
+        # All inputs are verified+bound at this point (fully-owned invariant).
+        input_total = sum(int(ti.satoshis) for ti in tx.inputs)
+        total_external = sum(e.amount for e in external)
+        fee = input_total - change_total - total_external
+        if fee < 0:
+            raise SignerError("transaction spends more than its inputs (negative fee)")
+
+        return SpendSummary(
+            external_outputs=tuple(external),
+            total_external=total_external,
+            change_total=change_total,
+            input_total=input_total,
+            fee=fee,
+            sighash_flags=tuple(i.sighash for i in request.inputs),
+        )

--- a/src/pyrxd/agent/transport.py
+++ b/src/pyrxd/agent/transport.py
@@ -1,0 +1,63 @@
+"""Length-prefixed JSON framing for the agent's Unix socket.
+
+A frame is a 4-byte big-endian unsigned length followed by that many bytes of
+UTF-8 JSON. Both sides cap the frame size so a hostile peer cannot make the
+daemon (or the CLI) allocate unbounded memory. This module is pure transport —
+it knows nothing about signing; the request/response *shapes* live in
+:mod:`pyrxd.agent.protocol` and are carried as the JSON body.
+"""
+
+from __future__ import annotations
+
+import json
+import socket
+import struct
+
+from .errors import SignerError
+
+#: Hard cap on a single frame (8 MiB). A normal signing request — an unsigned tx
+#: plus a handful of full source txs — is kilobytes; this is pure abuse defense.
+MAX_FRAME_BYTES = 8 * 1024 * 1024
+
+_LEN = struct.Struct(">I")
+
+
+def send_frame(sock: socket.socket, obj: dict) -> None:
+    """Serialize ``obj`` as JSON and write it as one length-prefixed frame."""
+    body = json.dumps(obj, separators=(",", ":")).encode("utf-8")
+    if len(body) > MAX_FRAME_BYTES:
+        raise SignerError(f"frame too large to send ({len(body)} > {MAX_FRAME_BYTES})")
+    sock.sendall(_LEN.pack(len(body)) + body)
+
+
+def recv_frame(sock: socket.socket) -> dict:
+    """Read exactly one length-prefixed JSON frame and return the decoded dict.
+
+    Raises :class:`SignerError` on a closed/short connection, an over-cap length,
+    or a non-object/invalid JSON body — fail-closed, never a partial parse.
+    """
+    header = _recv_exact(sock, _LEN.size)
+    (length,) = _LEN.unpack(header)
+    if length > MAX_FRAME_BYTES:
+        raise SignerError(f"frame too large ({length} > {MAX_FRAME_BYTES})")
+    body = _recv_exact(sock, length)
+    try:
+        obj = json.loads(body.decode("utf-8"))
+    except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise SignerError(f"malformed frame body: {exc}") from exc
+    if not isinstance(obj, dict):
+        raise SignerError("frame body must be a JSON object")
+    return obj
+
+
+def _recv_exact(sock: socket.socket, n: int) -> bytes:
+    """Read exactly ``n`` bytes or raise — a short read means the peer hung up."""
+    chunks: list[bytes] = []
+    remaining = n
+    while remaining:
+        chunk = sock.recv(remaining)
+        if not chunk:
+            raise SignerError("connection closed mid-frame")
+        chunks.append(chunk)
+        remaining -= len(chunk)
+    return b"".join(chunks)

--- a/src/pyrxd/agent/watch_only.py
+++ b/src/pyrxd/agent/watch_only.py
@@ -1,0 +1,196 @@
+"""CLI-side (watch-only) transaction builder for the signing agent.
+
+Phase 1 of the A′ signing agent (issue #8): the seam that lets the CLI build a
+transaction *without* a private key and hand it to the agent to sign. It builds
+an unsigned P2PKH send plus a :class:`~pyrxd.agent.protocol.SigningRequest` from
+**public material only** — the account ``xpub`` (for address derivation), the
+spendable UTXOs, and each UTXO's full source tx (so the agent can verify the
+prevout itself, C1).
+
+It NEVER derives a private key: addresses come from :meth:`Xpub.ckd`, and the
+signing is deferred entirely to :class:`~pyrxd.agent.signer.AgentSigner`. The
+unsigned tx commits to the outpoints + outputs; the agent reconstructs each
+prevout's value/script from the supplied source tx and signs.
+
+Fee is ESTIMATED from the standard signed-P2PKH input size (the watch-only side
+cannot measure a real signature). The resulting fee tracks ``fee_rate`` closely;
+it is not required to be byte-identical to the in-process ``build_send_tx`` — the
+signing is what must be identical, and that is the agent's job + its conformance
+test (``test_agent_signer``).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from ..hd.bip32 import Xpub
+from ..script.script import Script
+from ..script.type import P2PKH
+from ..security.errors import ValidationError
+from ..transaction.transaction import Transaction
+from ..transaction.transaction_input import TransactionInput
+from ..transaction.transaction_output import TransactionOutput
+from ..utils import validate_address
+from ..wallet import DEFAULT_FEE_RATE, DUST_THRESHOLD
+from .protocol import ChangeClaim, InputToSign, SigningRequest
+
+# Conservative SIGNED sizes (bytes) for fee estimation — the watch-only side has
+# no signature to measure. A P2PKH input is outpoint(36) + seq(4) + scriptlen(1)
+# + scriptSig(~107: DER sig ~72 + compressed pubkey 34); 148 is the standard
+# estimate (and matches build_send_tx's selection cushion). An output is
+# value(8) + scriptlen(1) + P2PKH script(25) = 34; tx overhead ~10.
+_P2PKH_INPUT_VBYTES = 148
+_P2PKH_OUTPUT_VBYTES = 34
+_TX_OVERHEAD_VBYTES = 10
+
+#: BIP44 internal chain (change addresses live here).
+_INTERNAL_CHAIN = 1
+
+
+@dataclass(frozen=True)
+class WatchOnlyUtxo:
+    """A spendable UTXO described by PUBLIC data only.
+
+    ``change``/``index`` are the BIP44 coords of the owning address — the agent
+    re-derives the signing key from them and checks it owns the prevout.
+    ``source_tx_hex`` is the FULL previous transaction; the agent verifies it
+    hashes to ``(txid, vout)`` and reads the real value/script from it (C1).
+    """
+
+    txid: str
+    vout: int
+    value: int
+    change: int
+    index: int
+    source_tx_hex: str
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.value, int) or isinstance(self.value, bool) or self.value <= 0:
+            raise ValidationError("WatchOnlyUtxo.value must be a positive int")
+        for label, val in (("vout", self.vout), ("change", self.change), ("index", self.index)):
+            if not isinstance(val, int) or isinstance(val, bool) or val < 0:
+                raise ValidationError(f"WatchOnlyUtxo.{label} must be a non-negative int")
+        if not self.source_tx_hex:
+            raise ValidationError("WatchOnlyUtxo.source_tx_hex is required (agent verifies the prevout against it)")
+
+
+@dataclass(frozen=True)
+class UnsignedSend:
+    """The watch-only build result: an unsigned tx + the request to sign it."""
+
+    transaction: Transaction
+    request: SigningRequest
+
+
+class WatchOnlyTxBuilder:
+    """Builds unsigned P2PKH sends + signing requests from an account ``xpub``.
+
+    Holds only public material; structurally cannot derive a private key. The
+    account ``xpub`` is the one the agent vends on unlock (``m/44'/<coin>'/<acct>'``),
+    so addresses derived here match exactly what the agent re-derives when it
+    verifies ownership and change claims.
+    """
+
+    def __init__(self, account_xpub: Xpub) -> None:
+        if not isinstance(account_xpub, Xpub):
+            raise ValidationError("account_xpub must be an Xpub (watch-only: no private key)")
+        self._xpub = account_xpub
+
+    def address(self, change: int, index: int) -> str:
+        """The P2PKH address at ``change/index`` — public derivation, no key."""
+        return self._xpub.ckd(change).ckd(index).address()
+
+    def build_send(
+        self,
+        utxos: list[WatchOnlyUtxo],
+        to_address: str,
+        photons: int,
+        *,
+        change_index: int,
+        change_chain: int = _INTERNAL_CHAIN,
+        fee_rate: int = DEFAULT_FEE_RATE,
+    ) -> UnsignedSend:
+        """Build an unsigned send of ``photons`` to ``to_address`` with change to
+        ``change_chain/change_index``. Returns the unsigned tx + a SigningRequest.
+
+        Mirrors :meth:`HdWallet.build_send_tx`'s greedy selection and dust-burn
+        rule, but key-free and with an estimated (not signature-measured) fee.
+        """
+        if not isinstance(photons, int) or isinstance(photons, bool):
+            raise ValidationError("photons must be int")
+        if photons <= 0:
+            raise ValidationError("photons must be > 0")
+        if photons < DUST_THRESHOLD:
+            raise ValidationError(f"photons below dust threshold ({DUST_THRESHOLD})")
+        if not validate_address(to_address):
+            raise ValidationError("to_address is not a valid P2PKH address")
+        if not isinstance(fee_rate, int) or isinstance(fee_rate, bool) or fee_rate <= 0:
+            raise ValidationError("fee_rate must be a positive int")
+        for label, val in (("change_index", change_index), ("change_chain", change_chain)):
+            if not isinstance(val, int) or isinstance(val, bool) or val < 0:
+                raise ValidationError(f"{label} must be a non-negative int")
+        if not utxos:
+            raise ValidationError("Insufficient funds: no UTXOs supplied")
+
+        recipient_script = P2PKH().lock(to_address)
+        change_address = self.address(change_chain, change_index)
+        change_script = P2PKH().lock(change_address)
+
+        per_input_fee = _P2PKH_INPUT_VBYTES * fee_rate
+        base_two_output_fee = (_TX_OVERHEAD_VBYTES + 2 * _P2PKH_OUTPUT_VBYTES) * fee_rate
+
+        # Greedy descending-by-value selection — same shape as build_send_tx.
+        selected = self._select(utxos, photons, fee_rate, per_input_fee, base_two_output_fee)
+        total_in = sum(u.value for u in selected)
+
+        fee = base_two_output_fee + per_input_fee * len(selected)
+        if total_in < photons + fee:
+            raise ValidationError("Insufficient funds after fee")
+        change_value = total_in - photons - fee
+
+        outputs = [TransactionOutput(recipient_script, photons)]
+        change_claims: tuple[ChangeClaim, ...] = ()
+        if change_value >= DUST_THRESHOLD:
+            outputs.append(TransactionOutput(change_script, change_value))
+            change_claims = (ChangeClaim(output_index=1, change=change_chain, index=change_index),)
+        # else: change is dust → burned to fee (single output), matching build_send_tx.
+
+        inputs = [
+            TransactionInput(
+                source_txid=u.txid,
+                source_output_index=u.vout,
+                unlocking_script=Script(b""),  # UNSIGNED — the agent fills this in
+            )
+            for u in selected
+        ]
+        tx = Transaction(tx_inputs=inputs, tx_outputs=outputs)
+
+        request = SigningRequest(
+            unsigned_tx_hex=tx.serialize().hex(),
+            inputs=tuple(
+                InputToSign(input_index=i, change=u.change, index=u.index, source_tx_hex=u.source_tx_hex)
+                for i, u in enumerate(selected)
+            ),
+            change_claims=change_claims,
+        )
+        return UnsignedSend(transaction=tx, request=request)
+
+    def _select(
+        self,
+        utxos: list[WatchOnlyUtxo],
+        photons: int,
+        fee_rate: int,
+        per_input_fee: int,
+        base_two_output_fee: int,
+    ) -> list[WatchOnlyUtxo]:
+        sorted_utxos = sorted(utxos, key=lambda u: u.value, reverse=True)
+        selected: list[WatchOnlyUtxo] = []
+        total_in = 0
+        for u in sorted_utxos:
+            selected.append(u)
+            total_in += u.value
+            if total_in >= photons + base_two_output_fee + per_input_fee * len(selected):
+                break
+        if total_in < photons:
+            raise ValidationError("Insufficient funds for requested amount")
+        return selected

--- a/src/pyrxd/agent/watch_only.py
+++ b/src/pyrxd/agent/watch_only.py
@@ -76,10 +76,15 @@ class WatchOnlyUtxo:
 
 @dataclass(frozen=True)
 class UnsignedSend:
-    """The watch-only build result: an unsigned tx + the request to sign it."""
+    """The watch-only build result: an unsigned tx + the request to sign it.
+
+    ``input_total`` is the summed value of the SELECTED inputs (the builder picks a
+    subset), so the caller can show an accurate fee = input_total − Σ outputs.
+    """
 
     transaction: Transaction
     request: SigningRequest
+    input_total: int
 
 
 class WatchOnlyTxBuilder:
@@ -173,7 +178,7 @@ class WatchOnlyTxBuilder:
             ),
             change_claims=change_claims,
         )
-        return UnsignedSend(transaction=tx, request=request)
+        return UnsignedSend(transaction=tx, request=request, input_total=total_in)
 
     def _select(
         self,

--- a/src/pyrxd/cli/agent_cmds.py
+++ b/src/pyrxd/cli/agent_cmds.py
@@ -1,0 +1,138 @@
+"""``pyrxd agent`` — the local signing agent CLI surface (issue #8, Path A').
+
+Three subcommands:
+
+* ``unlock`` — prompt for the mnemonic once, then hold the unlocked wallet and
+  serve signing requests in the FOREGROUND (this terminal). Per-spend
+  confirmation prompts appear here, on the daemon's own terminal — the channel a
+  hostile same-uid requester cannot drive. Ctrl-C locks (zeroizes) and exits.
+* ``status`` — is an agent live on this wallet's socket? (and its account xpub).
+* ``lock`` — tell a running agent to zeroize and shut down.
+
+The socket lives next to the wallet (``<wallet dir>/agent.sock``) so ``--wallet``
+co-locates it. Foreground is deliberate: a detached daemon has no terminal to
+confirm on, so non-trivial spends would fail closed. Background it with ``&`` in
+the same terminal if you want your shell back — ``/dev/tty`` still reaches you.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import click
+
+from ..agent import AgentClient, AgentDaemon, TtyConfirmer
+from ..agent.daemon import DEFAULT_IDLE_TIMEOUT_S
+from ..hd.wallet import HdWallet
+from ..security.errors import ValidationError
+from .context import CliContext
+from .errors import UserError, WalletDecryptError
+from .format import emit
+from .prompts import prompt_mnemonic_input, prompt_passphrase_input
+
+
+def _socket_path(ctx: CliContext) -> Path:
+    """The agent socket sits next to the wallet file (``--wallet`` co-locates it)."""
+    return ctx.wallet_path.parent / "agent.sock"
+
+
+@click.group(name="agent")
+def agent_group() -> None:
+    """Local signing agent: unlock once, sign on the CLI's behalf (key never leaves it)."""
+
+
+@agent_group.command(name="status")
+@click.pass_obj
+def agent_status(ctx: CliContext) -> None:
+    """Report whether a signing agent is live on this wallet's socket."""
+    sock = _socket_path(ctx)
+    client = AgentClient(sock)
+    live = client.is_live()
+    payload: dict[str, object] = {"live": live, "socket": str(sock)}
+    if live:
+        payload["xpub"] = client.account_xpub()
+
+    if ctx.output_mode == "json":
+        click.echo(emit(payload, mode="json"))
+    elif ctx.output_mode == "quiet":
+        click.echo(emit(payload, mode="quiet", quiet_field="live"))
+    else:
+        click.echo(f"agent: {'LIVE' if live else 'not running'}  ({sock})")
+        if live:
+            click.echo(f"  account xpub: {payload['xpub']}")
+
+
+@agent_group.command(name="lock")
+@click.pass_obj
+def agent_lock(ctx: CliContext) -> None:
+    """Tell a running agent to lock (zeroize the seed) and shut down."""
+    client = AgentClient(_socket_path(ctx))
+    if not client.is_live():
+        click.echo("no agent running (nothing to lock)")
+        return
+    client.lock()
+    click.echo("agent locked (seed zeroized)")
+
+
+@agent_group.command(name="unlock")
+@click.option(
+    "--idle-timeout",
+    type=float,
+    default=DEFAULT_IDLE_TIMEOUT_S,
+    show_default=True,
+    metavar="SECONDS",
+    help="Auto-lock (zeroize) after this many seconds with no activity.",
+)
+@click.option(
+    "--auto-confirm-under",
+    type=int,
+    default=0,
+    show_default=True,
+    metavar="PHOTONS",
+    help="Skip the confirmation prompt for spends whose total to external payees is at/below this. "
+    "0 = always confirm. Spends above the threshold ALWAYS require a keypress.",
+)
+@click.option("--passphrase/--no-passphrase", default=False, help="Prompt for a BIP39 passphrase.")
+@click.pass_obj
+def agent_unlock(ctx: CliContext, idle_timeout: float, auto_confirm_under: int, passphrase: bool) -> None:
+    """Unlock the wallet and hold it in a foreground signing agent.
+
+    Prompts for the mnemonic once, then serves signing requests on
+    ``<wallet dir>/agent.sock`` until you press Ctrl-C (or the idle timeout
+    fires). Confirmation prompts for each non-trivial spend appear in THIS
+    terminal — keep it where you can see it.
+    """
+    if not ctx.wallet_path.exists():
+        raise UserError(
+            f"no wallet at {ctx.wallet_path}",
+            cause="the file does not exist",
+            fix="run `pyrxd wallet new` to create one, or pass --wallet PATH",
+        )
+    mnemonic = prompt_mnemonic_input()
+    if not mnemonic:
+        raise UserError("mnemonic is required", cause="no input received", fix="enter the wallet's BIP39 mnemonic")
+    passphrase_str = ""  # nosec B105 — empty string is the BIP39 spec default (no passphrase)
+    if passphrase:
+        passphrase_str = prompt_passphrase_input(optional=False)
+    try:
+        wallet = HdWallet.load(ctx.wallet_path, mnemonic, passphrase_str)
+    except (ValidationError, ValueError) as exc:
+        raise WalletDecryptError() from exc
+
+    sock = _socket_path(ctx)
+    daemon = AgentDaemon(
+        wallet,
+        socket_path=sock,
+        confirm=TtyConfirmer(auto_confirm_under=auto_confirm_under),
+        idle_timeout_s=idle_timeout,
+    )
+    click.echo(f"pyrxd agent: unlocked. Serving on {sock}.")
+    click.echo("  Per-spend confirmations appear in THIS terminal. Ctrl-C to lock and exit.")
+    try:
+        daemon.serve_forever()
+    except KeyboardInterrupt:
+        daemon.lock()
+        click.echo("\nagent locked (seed zeroized).")
+    else:
+        # serve_forever returns when locked (idle auto-lock or a `lock` request).
+        click.echo("agent locked (seed zeroized).")

--- a/src/pyrxd/cli/main.py
+++ b/src/pyrxd/cli/main.py
@@ -180,8 +180,9 @@ def run() -> None:
 # and that breaks static analysis even though Python's import system
 # tolerates it at runtime.
 
-from . import glyph_cmds, query_cmds, regtest_cmds, setup_cmd, wallet_cmds  # noqa: E402
+from . import agent_cmds, glyph_cmds, query_cmds, regtest_cmds, setup_cmd, wallet_cmds  # noqa: E402
 
+cli.add_command(agent_cmds.agent_group)
 cli.add_command(glyph_cmds.glyph_group)
 cli.add_command(query_cmds.address_cmd)
 cli.add_command(query_cmds.balance_cmd)

--- a/src/pyrxd/cli/wallet_cmds.py
+++ b/src/pyrxd/cli/wallet_cmds.py
@@ -16,7 +16,9 @@ from typing import cast
 
 import click
 
+from ..agent import AgentClient, SignerDeclined, WatchOnlyTxBuilder, collect_watch_only_utxos
 from ..constants import Network
+from ..hd.bip32 import Xpub
 from ..hd.bip39 import mnemonic_from_entropy
 from ..hd.discovery import DEFAULT_ACCOUNTS, DEFAULT_COIN_TYPES, coin_type_label, discover
 from ..hd.wallet import HdWallet
@@ -587,6 +589,179 @@ def wallet_sweep(
     else:
         click.echo(f"\nSwept {format_photons(cast(int, result['swept_photons']))} to {to_address}")
         click.echo(f"Transaction: {result['txid']}")
+
+
+def _agent_socket(ctx: CliContext):
+    """The signing-agent socket co-located with the wallet (see `pyrxd agent`)."""
+    return ctx.wallet_path.parent / "agent.sock"
+
+
+def _send_summary(ctx: CliContext, *, to_address: str, amount: int, fee: int, inputs: int, signer: str) -> bool:
+    """Show the spend and (for the in-process path) get y/N. The agent path does
+    its OWN authoritative confirmation on the daemon's terminal, so it only displays."""
+    lines = [
+        "\n  Send:",
+        f"    to address:  {to_address}",
+        f"    amount:      {format_photons(amount)}",
+        f"    network fee: {format_photons(fee)}",
+        f"    inputs:      {inputs} UTXO(s)",
+        f"    signed by:   {signer}",
+        "",
+    ]
+    if signer == "agent":
+        for line in lines:
+            click.echo(line)
+        click.echo("  Approve the spend in the agent's terminal to broadcast.")
+        return True
+    return confirm_action(lines, ctx=ctx, prompt_text="Broadcast this send?")
+
+
+@wallet_group.command(name="send")
+@click.option("--to", "to_address", required=True, help="Destination Radiant P2PKH address you intend to pay.")
+@click.option("--amount", type=int, required=True, metavar="PHOTONS", help="Amount to send, in photons.")
+@click.option("--fee-rate", type=int, default=DEFAULT_FEE_RATE, show_default=True, help="Fee rate (photons per kB).")
+@click.option(
+    "--passphrase/--no-passphrase", default=False, help="Prompt for the BIP39 passphrase (in-process fallback only)."
+)
+@click.pass_obj
+def wallet_send(ctx: CliContext, to_address: str, amount: int, fee_rate: int, passphrase: bool) -> None:
+    """Send photons from this wallet's default account.
+
+    If a signing agent is unlocked (``pyrxd agent unlock``), the transaction is
+    built watch-only (from the account xpub) and signed by the agent — no mnemonic
+    prompt, and you approve the spend in the agent's terminal. Otherwise you are
+    prompted for the mnemonic and the transaction is signed in-process.
+    """
+    if not isinstance(amount, int) or amount <= 0:
+        raise UserError("--amount must be a positive integer (photons)")
+    if fee_rate <= 0:
+        raise UserError("--fee-rate must be a positive integer (photons per kB)")
+    ok, why = ctx.is_destructive_mode_safe()
+    if not ok:
+        raise UserError(why or "destructive op without --yes in --json mode")
+    if not validate_address(to_address, network=Network(ctx.network)):
+        raise UserError(
+            "invalid --to address",
+            cause=f"not a valid {ctx.network} Radiant P2PKH address",
+            fix=f"pass a {ctx.network} address" + (" (starts with 1)" if ctx.network == "mainnet" else ""),
+        )
+
+    if AgentClient(_agent_socket(ctx)).is_live():
+        result = _send_via_agent(ctx, to_address, amount, fee_rate)
+    else:
+        result = _send_in_process(ctx, to_address, amount, fee_rate, passphrase)
+
+    if ctx.output_mode == "json":
+        click.echo(emit(result, mode="json"))
+    elif ctx.output_mode == "quiet":
+        click.echo(emit(result, mode="quiet", quiet_field="txid"))
+    else:
+        click.echo(f"\nSent {format_photons(amount)} to {to_address} (signed by {result['signer']})")
+        click.echo(f"Transaction: {result['txid']}")
+
+
+def _send_via_agent(ctx: CliContext, to_address: str, amount: int, fee_rate: int) -> dict[str, object]:
+    """Build watch-only from the agent's xpub, let the agent sign, broadcast."""
+    client = AgentClient(_agent_socket(ctx))
+    xpub = Xpub(client.account_xpub())
+    builder = WatchOnlyTxBuilder(xpub)
+
+    async def _run() -> dict[str, object]:
+        ex = ctx.make_client()
+        async with ex:
+            scan = await collect_watch_only_utxos(xpub, ex)
+            if not scan.utxos:
+                raise UserError(
+                    "no spendable funds in this wallet's default account",
+                    cause="the watch-only scan found no UTXOs",
+                    fix="fund the wallet, or check you unlocked the right account",
+                )
+            built = builder.build_send(
+                scan.utxos, to_address, amount, change_index=scan.next_change_index, fee_rate=fee_rate
+            )
+            fee = built.input_total - sum(o.satoshis for o in built.transaction.outputs)
+            _send_summary(
+                ctx, to_address=to_address, amount=amount, fee=fee, inputs=len(built.request.inputs), signer="agent"
+            )
+            try:
+                signed = client.sign(built.request)
+            except SignerDeclined as exc:
+                raise UserError(
+                    "spend declined at the agent", cause=str(exc), fix="approve the spend, or send a different amount"
+                ) from exc
+            txid = await ex.broadcast(bytes.fromhex(signed.signed_tx_hex))
+            return {
+                "txid": str(txid),
+                "to": to_address,
+                "amount_photons": amount,
+                "fee_photons": fee,
+                "signer": "agent",
+            }
+
+    return _run_async(ctx, _run())
+
+
+def _send_in_process(
+    ctx: CliContext, to_address: str, amount: int, fee_rate: int, passphrase: bool
+) -> dict[str, object]:
+    """The fallback: prompt for the mnemonic and sign in-process (no agent)."""
+    if not ctx.wallet_path.exists():
+        raise UserError(
+            f"no wallet at {ctx.wallet_path}",
+            cause="the file does not exist",
+            fix="run `pyrxd wallet new` to create one, or unlock an agent with `pyrxd agent unlock`",
+        )
+    mnemonic = prompt_mnemonic_input()
+    if not mnemonic:
+        raise UserError("mnemonic is required", cause="no input received", fix="enter the wallet's BIP39 mnemonic")
+    passphrase_str = ""  # nosec B105 — empty string is the BIP39 spec default (no passphrase)
+    if passphrase:
+        passphrase_str = prompt_passphrase_input(optional=False)
+    try:
+        wallet = HdWallet.load(ctx.wallet_path, mnemonic, passphrase_str)
+    except (ValidationError, ValueError) as exc:
+        raise WalletDecryptError() from exc
+
+    async def _run() -> dict[str, object]:
+        ex = ctx.make_client()
+        async with ex:
+            await wallet.refresh(ex)
+            triples = await wallet.collect_spendable(ex)
+            if not triples:
+                raise UserError(
+                    "no spendable funds in this wallet",
+                    cause="the scan found no UTXOs",
+                    fix="fund the wallet first",
+                )
+            tx = wallet.build_send_tx(triples, to_address, amount, fee_rate=fee_rate)
+            input_total = sum(int(inp.satoshis) for inp in tx.inputs)
+            fee = input_total - sum(o.satoshis for o in tx.outputs)
+            if not _send_summary(
+                ctx, to_address=to_address, amount=amount, fee=fee, inputs=len(tx.inputs), signer="wallet (in-process)"
+            ):
+                raise UserError("aborted by user", cause="confirmation declined", fix="re-run when ready to broadcast")
+            txid = await ex.broadcast(tx.serialize())
+            return {
+                "txid": str(txid),
+                "to": to_address,
+                "amount_photons": amount,
+                "fee_photons": fee,
+                "signer": "in-process",
+            }
+
+    return _run_async(ctx, _run())
+
+
+def _run_async(ctx: CliContext, coro) -> dict[str, object]:
+    """Run an async send body, mapping NetworkError to the CLI boundary error."""
+    try:
+        return asyncio.run(coro)
+    except NetworkError as exc:
+        raise NetworkBoundaryError(
+            "could not reach ElectrumX",
+            cause=str(exc),
+            fix=f"check that {ctx.electrumx_url} is reachable, or use --electrumx URL",
+        ) from exc
 
 
 # Confirmation helper used by Cut 1 destructive ops outside this module.

--- a/src/pyrxd/fee_models/satoshis_per_kilobyte.py
+++ b/src/pyrxd/fee_models/satoshis_per_kilobyte.py
@@ -27,11 +27,16 @@ class SatoshisPerKilobyte(FeeModel):
         """
 
         def get_varint_size(i: int) -> int:
-            if i > 2**32:
+            # Bitcoin CompactSize boundaries are inclusive at the lower edge:
+            # < 0xFD -> 1 byte, <= 0xFFFF -> 3, <= 0xFFFFFFFF -> 5, else 9. Using
+            # >= (not >) so the exact boundary values 253 / 2**16 / 2**32 are sized
+            # to the wider encoding they actually require (a 2-byte underestimate
+            # otherwise — harmless in practice, but wrong at the wire boundary).
+            if i >= 2**32:
                 return 9
-            elif i > 2**16:
+            elif i >= 2**16:
                 return 5
-            elif i > 253:
+            elif i >= 253:
                 return 3
             else:
                 return 1

--- a/src/pyrxd/keys.py
+++ b/src/pyrxd/keys.py
@@ -215,6 +215,14 @@ class PrivateKey:
         Low-s enforcement: coincurve's sign() calls libsecp256k1 which
         normalises signatures to low-s (SECP256K1_EC_NORMALIZED) by default.
         For custom k, _sign_custom_k() explicitly enforces low-s.
+
+        .. warning::
+            Passing an explicit ``k`` bypasses RFC 6979 deterministic-nonce
+            generation. ECDSA leaks the private key if the same ``k`` signs two
+            different messages under the same key. Only supply ``k`` for an
+            R-puzzle (see :meth:`pyrxd.script.type.RPuzzle.unlock`) and only with a
+            throwaway key that signs nothing else. Leave ``k`` as ``None`` for all
+            normal signing — libsecp256k1's deterministic nonce is the safe path.
         """
         if k is not None:
             return self._sign_custom_k(message, hasher, k)

--- a/src/pyrxd/network/bitcoin.py
+++ b/src/pyrxd/network/bitcoin.py
@@ -116,7 +116,7 @@ async def _check_response_size(response: aiohttp.ClientResponse) -> bytes:
 async def _get_json(session: aiohttp.ClientSession, url: str) -> Any:
     """GET *url*, parse JSON, enforce size limit, raise NetworkError on failure."""
     try:
-        async with session.get(url) as resp:
+        async with session.get(url, allow_redirects=False) as resp:
             body = await _check_response_size(resp)
             if resp.status != 200:
                 raise NetworkError(f"HTTP request failed with status {resp.status}")
@@ -134,7 +134,7 @@ async def _get_json(session: aiohttp.ClientSession, url: str) -> Any:
 async def _get_hex_bytes(session: aiohttp.ClientSession, url: str, expected_len: int | None = None) -> bytes:
     """GET *url*, decode hex body, return raw bytes."""
     try:
-        async with session.get(url) as resp:
+        async with session.get(url, allow_redirects=False) as resp:
             body = await _check_response_size(resp)
             if resp.status != 200:
                 raise NetworkError(f"HTTP request failed with status {resp.status}")
@@ -187,7 +187,7 @@ class MempoolSpaceSource(BtcDataSource):
         session = await self._get_session()
         url = self._url("blocks/tip/height")
         try:
-            async with session.get(url) as resp:
+            async with session.get(url, allow_redirects=False) as resp:
                 body = await _check_response_size(resp)
                 if resp.status != 200:
                     raise NetworkError(f"HTTP {resp.status} fetching tip height")
@@ -204,7 +204,7 @@ class MempoolSpaceSource(BtcDataSource):
         session = await self._get_session()
         url = self._url(f"block-height/{_safe_int_path(height)}")
         try:
-            async with session.get(url) as resp:
+            async with session.get(url, allow_redirects=False) as resp:
                 body = await _check_response_size(resp)
                 if resp.status != 200:
                     raise NetworkError(f"HTTP {resp.status} fetching block hash")
@@ -274,7 +274,7 @@ class MempoolSpaceSource(BtcDataSource):
         # Fetch raw hex.
         hex_url = self._url(f"tx/{_safe_txid_path(txid)}/hex")
         try:
-            async with session.get(hex_url) as resp:
+            async with session.get(hex_url, allow_redirects=False) as resp:
                 body = await _check_response_size(resp)
                 if resp.status != 200:
                     raise NetworkError(f"HTTP {resp.status} fetching raw tx")
@@ -372,7 +372,7 @@ class BlockstreamSource(BtcDataSource):
         session = await self._get_session()
         url = self._url("blocks/tip/height")
         try:
-            async with session.get(url) as resp:
+            async with session.get(url, allow_redirects=False) as resp:
                 body = await _check_response_size(resp)
                 if resp.status != 200:
                     raise NetworkError(f"HTTP {resp.status} fetching tip height")
@@ -389,7 +389,7 @@ class BlockstreamSource(BtcDataSource):
         session = await self._get_session()
         url = self._url(f"block-height/{_safe_int_path(height)}")
         try:
-            async with session.get(url) as resp:
+            async with session.get(url, allow_redirects=False) as resp:
                 body = await _check_response_size(resp)
                 if resp.status != 200:
                     raise NetworkError(f"HTTP {resp.status} fetching block hash")
@@ -451,7 +451,7 @@ class BlockstreamSource(BtcDataSource):
 
         hex_url = self._url(f"tx/{_safe_txid_path(txid)}/hex")
         try:
-            async with session.get(hex_url) as resp:
+            async with session.get(hex_url, allow_redirects=False) as resp:
                 body = await _check_response_size(resp)
                 if resp.status != 200:
                     raise NetworkError(f"HTTP {resp.status} fetching raw tx")
@@ -569,7 +569,7 @@ class BitcoinCoreRpcSource(BtcDataSource):
             "params": params,
         }
         try:
-            async with session.post(self._url, json=payload) as resp:
+            async with session.post(self._url, json=payload, allow_redirects=False) as resp:
                 body = await _check_response_size(resp)
                 if resp.status not in (200, 500):
                     raise NetworkError(f"RPC HTTP error: {resp.status}")
@@ -896,7 +896,7 @@ class _MempoolHttpClient:
     async def tip_height(self) -> int:
         s = await self.session()
         try:
-            async with s.get(self.url("blocks/tip/height")) as resp:
+            async with s.get(self.url("blocks/tip/height"), allow_redirects=False) as resp:
                 body = await _check_response_size(resp)
                 if resp.status != 200:
                     raise NetworkError(f"HTTP {resp.status} fetching tip height")
@@ -942,7 +942,7 @@ class MempoolSpaceBroadcaster:
         raw = bytes(raw_tx)
         s = await self._http.session()
         try:
-            async with s.post(self._http.url("tx"), data=raw.hex()) as resp:
+            async with s.post(self._http.url("tx"), data=raw.hex(), allow_redirects=False) as resp:
                 body = (await _check_response_size(resp)).decode("ascii", "replace").strip()
                 if resp.status == 200:
                     # mempool.space returns the txid as the body on success.

--- a/src/pyrxd/script/type.py
+++ b/src/pyrxd/script/type.py
@@ -231,7 +231,7 @@ class RPuzzle(ScriptTemplate):
     def unlock(
         self,
         k: int,
-        private_key: PrivateKey | None = PrivateKey(),
+        private_key: PrivateKey | None = None,
         sign_outputs: str = "all",
         anyone_can_pay: bool = False,
     ):
@@ -239,11 +239,25 @@ class RPuzzle(ScriptTemplate):
         Creates a function that generates an R puzzle unlocking script along with its signature and length estimation.
 
         :param k: The K-value used to unlock the R-puzzle.
-        :param private_key: The private key used for signing the transaction.
+        :param private_key: The private key used for signing the transaction. When
+            omitted, a FRESH throwaway key is generated per call (see the security
+            note below) — never a shared module-level default.
         :param sign_outputs: The signature scope for outputs ('all', 'none', 'single').
         :param anyone_can_pay: Flag indicating if the signature allows for other inputs to be added later.
         :returns: An object containing the `sign` and `estimate_length` functions.
+
+        .. warning::
+            **R-puzzles reuse the nonce ``k`` by construction.** ECDSA leaks the
+            private key if the same ``k`` signs two different messages under the
+            same key (``d = (s1*k - z1) / r``). So ``private_key`` MUST be a
+            throwaway key that signs nothing else — never a key that holds (or will
+            hold) funds, and never reused across two R-puzzle inputs with the same
+            ``k``. The default now generates a fresh key per call to make the safe
+            path the easy one; previously the default was a single module-level key
+            shared across every call (a mutable-default-argument footgun).
         """
+        if private_key is None:
+            private_key = PrivateKey()
 
         def sign(tx, input_index) -> Script:
             sighash = SIGHASH.FORKID

--- a/tests/cli/test_agent_cmds.py
+++ b/tests/cli/test_agent_cmds.py
@@ -1,0 +1,101 @@
+"""CLI tests for ``pyrxd agent status|lock|unlock`` (Phase 5, issue #8 A').
+
+status/lock are exercised against a real AgentDaemon started in a thread on the
+wallet-co-located socket; unlock's error paths are checked via CliRunner (the
+serving path itself is covered by test_agent_daemon).
+"""
+
+from __future__ import annotations
+
+import json
+import socket
+import threading
+import time
+from pathlib import Path
+
+from click.testing import CliRunner
+
+from pyrxd.agent import AgentDaemon
+from pyrxd.cli.main import cli
+from pyrxd.hd.bip32 import Xpub
+from pyrxd.hd.wallet import HdWallet
+
+TEST_MNEMONIC = "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about"
+_ACCEPT = lambda _s: True  # noqa: E731
+
+
+def _start_daemon_on(sock_path: Path) -> tuple[AgentDaemon, threading.Thread]:
+    daemon = AgentDaemon(HdWallet.from_mnemonic(TEST_MNEMONIC), socket_path=sock_path, confirm=_ACCEPT, harden=False)
+    t = threading.Thread(target=daemon.serve_forever, daemon=True)
+    t.start()
+    deadline = time.monotonic() + 3.0
+    while time.monotonic() < deadline:
+        if sock_path.exists():
+            probe = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+            probe.settimeout(0.2)
+            try:
+                probe.connect(str(sock_path))
+                probe.close()
+                return daemon, t
+            except OSError:
+                pass
+        time.sleep(0.02)
+    raise RuntimeError("daemon did not come up")
+
+
+def test_status_reports_not_running(runner: CliRunner, tmp_path: Path) -> None:
+    result = runner.invoke(cli, ["--wallet", str(tmp_path / "wallet.dat"), "agent", "status"])
+    assert result.exit_code == 0, result.output
+    assert "not running" in result.output
+
+
+def test_status_reports_live_with_xpub(runner: CliRunner, tmp_path: Path) -> None:
+    daemon, t = _start_daemon_on(tmp_path / "agent.sock")
+    try:
+        result = runner.invoke(cli, ["--wallet", str(tmp_path / "wallet.dat"), "agent", "status"])
+        assert result.exit_code == 0, result.output
+        assert "LIVE" in result.output
+        expected_xpub = str(Xpub.from_xprv(HdWallet.from_mnemonic(TEST_MNEMONIC)._xprv))
+        assert expected_xpub in result.output
+    finally:
+        daemon.lock()
+        t.join(timeout=3)
+
+
+def test_status_json_shape(runner: CliRunner, tmp_path: Path) -> None:
+    daemon, t = _start_daemon_on(tmp_path / "agent.sock")
+    try:
+        result = runner.invoke(cli, ["--json", "--wallet", str(tmp_path / "wallet.dat"), "agent", "status"])
+        assert result.exit_code == 0, result.output
+        payload = json.loads(result.output)
+        assert payload["live"] is True
+        assert payload["xpub"] == str(Xpub.from_xprv(HdWallet.from_mnemonic(TEST_MNEMONIC)._xprv))
+    finally:
+        daemon.lock()
+        t.join(timeout=3)
+
+
+def test_lock_when_not_running(runner: CliRunner, tmp_path: Path) -> None:
+    result = runner.invoke(cli, ["--wallet", str(tmp_path / "wallet.dat"), "agent", "lock"])
+    assert result.exit_code == 0, result.output
+    assert "nothing to lock" in result.output
+
+
+def test_lock_stops_a_running_agent(runner: CliRunner, tmp_path: Path) -> None:
+    daemon, t = _start_daemon_on(tmp_path / "agent.sock")
+    try:
+        result = runner.invoke(cli, ["--wallet", str(tmp_path / "wallet.dat"), "agent", "lock"])
+        assert result.exit_code == 0, result.output
+        assert "locked" in result.output
+        t.join(timeout=3)
+        assert daemon.locked is True
+        assert not (tmp_path / "agent.sock").exists()
+    finally:
+        daemon.lock()
+        t.join(timeout=3)
+
+
+def test_unlock_without_wallet_file_errors(runner: CliRunner, tmp_path: Path) -> None:
+    result = runner.invoke(cli, ["--wallet", str(tmp_path / "missing.dat"), "agent", "unlock"])
+    assert result.exit_code != 0
+    assert "no wallet" in result.output.lower()

--- a/tests/cli/test_wallet_send.py
+++ b/tests/cli/test_wallet_send.py
@@ -1,0 +1,131 @@
+"""Tests for `pyrxd wallet send` — agent-when-live / mnemonic-prompt fallback (#8 A')."""
+
+from __future__ import annotations
+
+import socket
+import threading
+import time
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from click.testing import CliRunner
+
+from pyrxd.agent import AgentDaemon
+from pyrxd.cli.config import Config
+from pyrxd.cli.context import CliContext
+from pyrxd.cli.wallet_cmds import wallet_group
+from pyrxd.hd.wallet import HdWallet
+from pyrxd.network.electrumx import UtxoRecord, script_hash_for_address
+from pyrxd.script.type import P2PKH
+from pyrxd.transaction.transaction import Transaction
+from pyrxd.transaction.transaction_output import TransactionOutput
+
+MNEMONIC = "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about"
+DEST = "1LqBGSKuX5yYUonjxT5qGfpUsXKYYWeabA"  # canonical abandon-seed coin-0 address
+_ACCEPT = lambda _s: True  # noqa: E731
+
+
+@pytest.fixture
+def runner() -> CliRunner:
+    return CliRunner()
+
+
+def _ctx(wallet_path: Path, client: MagicMock, *, output_mode: str = "human", yes: bool = False) -> CliContext:
+    return CliContext(
+        config=Config(network="mainnet", electrumx="wss://test/", fee_rate=10_000, wallet_path=wallet_path),
+        network="mainnet",
+        electrumx_url="wss://test/",
+        fee_rate=10_000,
+        wallet_path=wallet_path,
+        output_mode=output_mode,
+        yes=yes,
+        client_factory=lambda: client,
+    )
+
+
+def _funded_client_for(addr: str, *, value: int = 100_000_000) -> MagicMock:
+    """Mock ElectrumX: *addr* has history + one UTXO whose source tx pays it."""
+    src = Transaction()
+    src.add_output(TransactionOutput(P2PKH().lock(addr), value))
+    src_txid = src.txid()
+    target_sh = script_hash_for_address(addr)
+
+    async def _history(sh):
+        return [{"tx_hash": src_txid}] if sh == target_sh else []
+
+    async def _utxos(sh):
+        return [UtxoRecord(tx_hash=src_txid, tx_pos=0, value=value, height=800_000)] if sh == target_sh else []
+
+    async def _get_tx(_txid):
+        return src.serialize()
+
+    client = MagicMock()
+    client.get_history = _history
+    client.get_utxos = _utxos
+    client.get_transaction = _get_tx
+    client.broadcast = AsyncMock(return_value="cd" * 32)
+    client.__aenter__ = AsyncMock(return_value=client)
+    client.__aexit__ = AsyncMock(return_value=None)
+    return client
+
+
+def _start_daemon(wallet: HdWallet, sock_path: Path) -> tuple[AgentDaemon, threading.Thread]:
+    daemon = AgentDaemon(wallet, socket_path=sock_path, confirm=_ACCEPT, harden=False)
+    t = threading.Thread(target=daemon.serve_forever, daemon=True)
+    t.start()
+    deadline = time.monotonic() + 3.0
+    while time.monotonic() < deadline:
+        if sock_path.exists():
+            probe = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+            probe.settimeout(0.2)
+            try:
+                probe.connect(str(sock_path))
+                probe.close()
+                return daemon, t
+            except OSError:
+                pass
+        time.sleep(0.02)
+    raise RuntimeError("daemon did not come up")
+
+
+def test_send_via_agent_when_live(runner: CliRunner, tmp_path: Path) -> None:
+    wallet = HdWallet.from_mnemonic(MNEMONIC)
+    funded_addr = wallet._derive_address(0, 0)
+    client = _funded_client_for(funded_addr)
+    ctx = _ctx(tmp_path / "wallet.dat", client)
+
+    daemon, t = _start_daemon(wallet, tmp_path / "agent.sock")
+    try:
+        result = runner.invoke(wallet_group, ["send", "--to", DEST, "--amount", "10000000"], obj=ctx)
+        assert result.exit_code == 0, result.output
+        assert "signed by agent" in result.output
+        client.broadcast.assert_awaited_once()
+    finally:
+        daemon.lock()
+        t.join(timeout=3)
+
+
+def test_send_falls_back_to_in_process_when_no_agent(runner: CliRunner, tmp_path: Path) -> None:
+    # No daemon running and no wallet file → the in-process branch is taken and
+    # reports the missing wallet (proves it did NOT try the agent path).
+    client = _funded_client_for(HdWallet.from_mnemonic(MNEMONIC)._derive_address(0, 0))
+    ctx = _ctx(tmp_path / "missing.dat", client)
+    result = runner.invoke(wallet_group, ["send", "--to", DEST, "--amount", "10000000"], obj=ctx)
+    assert result.exit_code != 0
+    assert "no wallet" in result.output.lower()
+    client.broadcast.assert_not_awaited()
+
+
+def test_rejects_nonpositive_amount(runner: CliRunner, tmp_path: Path) -> None:
+    ctx = _ctx(tmp_path / "wallet.dat", _funded_client_for(DEST))
+    result = runner.invoke(wallet_group, ["send", "--to", DEST, "--amount", "0"], obj=ctx)
+    assert result.exit_code != 0
+    assert "amount" in result.output.lower()
+
+
+def test_rejects_bad_destination(runner: CliRunner, tmp_path: Path) -> None:
+    ctx = _ctx(tmp_path / "wallet.dat", _funded_client_for(DEST))
+    result = runner.invoke(wallet_group, ["send", "--to", "not-an-address", "--amount", "10000000"], obj=ctx)
+    assert result.exit_code != 0
+    assert "address" in result.output.lower()

--- a/tests/test_agent_daemon.py
+++ b/tests/test_agent_daemon.py
@@ -297,3 +297,32 @@ def test_idle_autolock_fires(tmp_path) -> None:
         time.sleep(0.05)
     t.join(timeout=3)
     assert daemon.locked is True
+
+
+def test_concurrent_clients_all_get_valid_responses(tmp_path) -> None:
+    """The serial accept loop must service many simultaneous clients correctly
+    (each connection one request/response) — none dropped or cross-talked."""
+    sock_path = tmp_path / "agent.sock"
+    daemon = AgentDaemon(_wallet(), socket_path=sock_path, confirm=_ACCEPT, harden=False)
+    t = _start(daemon)
+    try:
+        expected_xpub = str(Xpub.from_xprv(_wallet()._xprv))
+        results: list[str] = []
+        errors: list[Exception] = []
+
+        def _query() -> None:
+            try:
+                results.append(AgentClient(sock_path).account_xpub())
+            except Exception as exc:  # record for the assertion
+                errors.append(exc)
+
+        threads = [threading.Thread(target=_query) for _ in range(8)]
+        for th in threads:
+            th.start()
+        for th in threads:
+            th.join(timeout=5)
+        assert not errors, errors
+        assert results == [expected_xpub] * 8
+    finally:
+        daemon.lock()
+        t.join(timeout=3)

--- a/tests/test_agent_daemon.py
+++ b/tests/test_agent_daemon.py
@@ -1,0 +1,299 @@
+"""Tests for the agent transport, confirmation UI, process hygiene, and the
+Unix-socket daemon + client (Phase 4, issue #8 A').
+
+The daemon tests run a real AF_UNIX server in a thread against a tmp-dir socket
+(no docker, deterministic). They cover the round-trip (status/xpub/sign), the
+declined-confirmation path, socket permissions (0700 dir / 0600 socket), the
+fallback when the agent is down, on-demand lock (seed zeroized), and — as pure
+unit checks — peer authorization and the idle auto-lock predicate.
+"""
+
+from __future__ import annotations
+
+import io
+import os
+import socket
+import stat
+import threading
+import time
+
+import pytest
+
+from pyrxd.agent import (
+    AgentClient,
+    AgentDaemon,
+    SignerDeclined,
+    SignerError,
+    SignerUnavailableError,
+    SigningRequest,
+    TtyConfirmer,
+    WatchOnlyTxBuilder,
+    WatchOnlyUtxo,
+    format_spend_summary,
+)
+from pyrxd.agent import confirm as confirm_mod
+from pyrxd.agent.hygiene import HardeningReport, harden_process
+from pyrxd.agent.protocol import ExternalOutput, SpendSummary
+from pyrxd.agent.transport import MAX_FRAME_BYTES, recv_frame, send_frame
+from pyrxd.hd.bip32 import Xpub
+from pyrxd.hd.wallet import HdWallet
+from pyrxd.keys import PrivateKey
+from pyrxd.script.type import P2PKH
+from pyrxd.security.errors import KeyMaterialError
+from pyrxd.transaction.transaction import Transaction
+from pyrxd.transaction.transaction_output import TransactionOutput
+
+TEST_MNEMONIC = "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about"
+_ACCEPT = lambda _s: True  # noqa: E731
+_REJECT = lambda _s: False  # noqa: E731
+_RECIPIENT_ADDR = PrivateKey().public_key().address()
+
+
+def _wallet() -> HdWallet:
+    return HdWallet.from_mnemonic(TEST_MNEMONIC)
+
+
+def _utxo(w: HdWallet, change: int, index: int, value: int) -> WatchOnlyUtxo:
+    src = Transaction()
+    src.add_output(TransactionOutput(P2PKH().lock(w._derive_address(change, index)), value))
+    return WatchOnlyUtxo(
+        txid=src.txid(), vout=0, value=value, change=change, index=index, source_tx_hex=src.serialize().hex()
+    )
+
+
+def _signing_request(w: HdWallet) -> SigningRequest:
+    builder = WatchOnlyTxBuilder(Xpub.from_xprv(w._xprv))
+    utxos = [_utxo(w, 0, 0, 100_000_000)]
+    return builder.build_send(utxos, _RECIPIENT_ADDR, photons=10_000_000, change_index=0).request
+
+
+def _start(daemon: AgentDaemon) -> threading.Thread:
+    t = threading.Thread(target=daemon.serve_forever, daemon=True)
+    t.start()
+    deadline = time.monotonic() + 3.0
+    while time.monotonic() < deadline:
+        if daemon._socket_path.exists():
+            probe = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+            probe.settimeout(0.2)
+            try:
+                probe.connect(str(daemon._socket_path))
+                probe.close()
+                return t
+            except OSError:
+                pass
+        time.sleep(0.02)
+    raise RuntimeError("daemon did not come up")
+
+
+# ─────────────────────────────── transport ────────────────────────────────────
+
+
+def test_frame_roundtrip() -> None:
+    a, b = socket.socketpair()
+    try:
+        send_frame(a, {"op": "status", "n": 7})
+        assert recv_frame(b) == {"op": "status", "n": 7}
+    finally:
+        a.close()
+        b.close()
+
+
+def test_recv_rejects_oversize_length() -> None:
+    a, b = socket.socketpair()
+    try:
+        a.sendall((MAX_FRAME_BYTES + 1).to_bytes(4, "big"))
+        with pytest.raises(SignerError, match="frame too large"):
+            recv_frame(b)
+    finally:
+        a.close()
+        b.close()
+
+
+def test_recv_raises_on_closed_connection() -> None:
+    a, b = socket.socketpair()
+    a.close()
+    try:
+        with pytest.raises(SignerError, match="closed mid-frame"):
+            recv_frame(b)
+    finally:
+        b.close()
+
+
+def test_recv_rejects_non_object_body() -> None:
+    a, b = socket.socketpair()
+    try:
+        body = b"[1,2,3]"
+        a.sendall(len(body).to_bytes(4, "big") + body)
+        with pytest.raises(SignerError, match="must be a JSON object"):
+            recv_frame(b)
+    finally:
+        a.close()
+        b.close()
+
+
+# ──────────────────────────── confirmation UI ──────────────────────────────────
+
+
+def _summary(total_external: int) -> SpendSummary:
+    return SpendSummary(
+        external_outputs=(ExternalOutput(output_index=0, dest="p2pkh:deadbeef", amount=total_external),),
+        total_external=total_external,
+        change_total=5,
+        input_total=total_external + 105,
+        fee=100,
+        sighash_flags=(0x41,),
+    )
+
+
+def test_format_spend_summary_shows_payees_and_fee() -> None:
+    text = format_spend_summary(_summary(120_000))
+    assert "120,000" in text
+    assert "p2pkh:deadbeef" in text
+    assert "fee" in text and "0x41" in text
+
+
+def test_tty_confirmer_auto_confirms_under_threshold() -> None:
+    # total_external (100) <= threshold (100) → approved without touching any tty.
+    assert TtyConfirmer(auto_confirm_under=100)(_summary(100)) is True
+
+
+def test_tty_confirmer_reads_yes_no(monkeypatch: pytest.MonkeyPatch) -> None:
+    class _FakeTty(io.StringIO):
+        def __init__(self, answer: str) -> None:
+            super().__init__(answer)
+            self.written = ""
+
+        def write(self, s: str) -> int:  # capture prompt, count chars
+            self.written += s
+            return len(s)
+
+    for answer, expected in [("y\n", True), ("yes\n", True), ("n\n", False), ("\n", False)]:
+        fake = _FakeTty(answer)
+        # readline must return the answer; StringIO seeded with prompt-as-buffer won't,
+        # so back it with a separate read buffer.
+        fake.seek(0)
+        monkeypatch.setattr(confirm_mod, "open", lambda *_a, _f=fake, **_k: _f, raising=False)
+        assert TtyConfirmer(auto_confirm_under=0)(_summary(120_000)) is expected
+
+
+def test_tty_confirmer_fails_closed_without_tty(monkeypatch: pytest.MonkeyPatch) -> None:
+    def _no_tty(*_a, **_k):
+        raise OSError("no controlling tty")
+
+    monkeypatch.setattr(confirm_mod, "open", _no_tty, raising=False)
+    assert TtyConfirmer(auto_confirm_under=0)(_summary(120_000)) is False
+
+
+# ──────────────────────────────── hygiene ──────────────────────────────────────
+
+
+def test_harden_process_returns_report_without_raising() -> None:
+    report = harden_process()
+    assert isinstance(report, HardeningReport)
+    d = report.as_dict()
+    assert set(d) == {"mlock", "non_dumpable", "core_dumps_disabled"}
+    assert all(isinstance(v, bool) for v in d.values())
+
+
+# ──────────────────────────── daemon policy (pure) ─────────────────────────────
+
+
+def test_peer_authorized_only_for_owner_uid() -> None:
+    d = AgentDaemon(_wallet(), socket_path="/tmp/unused.sock", confirm=_ACCEPT, harden=False)
+    assert d._peer_authorized(os.getuid()) is True
+    assert d._peer_authorized(os.getuid() + 1) is False
+
+
+def test_should_autolock_after_idle() -> None:
+    now = [1000.0]
+    d = AgentDaemon(
+        _wallet(),
+        socket_path="/tmp/unused.sock",
+        confirm=_ACCEPT,
+        idle_timeout_s=60.0,
+        clock=lambda: now[0],
+        harden=False,
+    )
+    assert d._should_autolock(1000.0 + 59.0) is False
+    assert d._should_autolock(1000.0 + 60.0) is True
+    d.lock()
+    assert d._should_autolock(1000.0 + 10_000.0) is False  # already locked → no re-lock
+
+
+# ─────────────────────────── daemon ⇄ client (real socket) ─────────────────────
+
+
+def test_daemon_client_status_xpub_and_sign(tmp_path) -> None:
+    w = _wallet()
+    sock_path = tmp_path / "agent" / "agent.sock"
+    daemon = AgentDaemon(w, socket_path=sock_path, confirm=_ACCEPT, harden=False)
+    t = _start(daemon)
+    try:
+        client = AgentClient(sock_path)
+        assert client.is_live() is True
+        assert client.account_xpub() == str(Xpub.from_xprv(_wallet()._xprv))
+
+        result = client.sign(_signing_request(_wallet()))
+        signed = Transaction.from_hex(bytes.fromhex(result.signed_tx_hex))
+        assert signed is not None
+        assert all(ti.unlocking_script and ti.unlocking_script.serialize() != b"" for ti in signed.inputs)
+    finally:
+        daemon.lock()
+        t.join(timeout=3)
+
+
+def test_socket_permissions_are_locked_down(tmp_path) -> None:
+    sock_path = tmp_path / "agent" / "agent.sock"
+    daemon = AgentDaemon(_wallet(), socket_path=sock_path, confirm=_ACCEPT, harden=False)
+    t = _start(daemon)
+    try:
+        assert stat.S_IMODE(os.stat(sock_path).st_mode) == 0o600
+        assert stat.S_IMODE(os.stat(sock_path.parent).st_mode) == 0o700
+    finally:
+        daemon.lock()
+        t.join(timeout=3)
+
+
+def test_declined_confirmation_propagates(tmp_path) -> None:
+    sock_path = tmp_path / "agent.sock"
+    daemon = AgentDaemon(_wallet(), socket_path=sock_path, confirm=_REJECT, harden=False)
+    t = _start(daemon)
+    try:
+        with pytest.raises(SignerDeclined):
+            AgentClient(sock_path).sign(_signing_request(_wallet()))
+    finally:
+        daemon.lock()
+        t.join(timeout=3)
+
+
+def test_client_against_missing_agent_is_unavailable(tmp_path) -> None:
+    client = AgentClient(tmp_path / "nope.sock")
+    assert client.is_live() is False
+    with pytest.raises(SignerUnavailableError):
+        client.sign(_signing_request(_wallet()))
+
+
+def test_lock_zeroizes_seed_and_stops(tmp_path) -> None:
+    w = _wallet()
+    sock_path = tmp_path / "agent.sock"
+    daemon = AgentDaemon(w, socket_path=sock_path, confirm=_ACCEPT, harden=False)
+    t = _start(daemon)
+    AgentClient(sock_path).lock()
+    t.join(timeout=3)
+    assert daemon.locked is True
+    assert not sock_path.exists()  # socket cleaned up
+    with pytest.raises(KeyMaterialError):  # seed scrubbed → access after zeroize raises
+        w._seed.unsafe_raw_bytes()
+
+
+def test_idle_autolock_fires(tmp_path) -> None:
+    sock_path = tmp_path / "agent.sock"
+    daemon = AgentDaemon(
+        _wallet(), socket_path=sock_path, confirm=_ACCEPT, idle_timeout_s=0.2, poll_interval_s=0.05, harden=False
+    )
+    t = _start(daemon)
+    deadline = time.monotonic() + 3.0
+    while time.monotonic() < deadline and not daemon.locked:
+        time.sleep(0.05)
+    t.join(timeout=3)
+    assert daemon.locked is True

--- a/tests/test_agent_discover.py
+++ b/tests/test_agent_discover.py
@@ -1,0 +1,105 @@
+"""Tests for watch-only UTXO discovery from an account xpub (issue #8 A')."""
+
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import MagicMock
+
+import pytest
+
+from pyrxd.agent import WatchOnlyTxBuilder, collect_watch_only_utxos
+from pyrxd.agent.signer import AgentSigner
+from pyrxd.hash import hash256
+from pyrxd.hd.bip32 import Xpub
+from pyrxd.hd.wallet import HdWallet
+from pyrxd.keys import PrivateKey
+from pyrxd.network.electrumx import UtxoRecord, script_hash_for_address
+from pyrxd.script.type import P2PKH
+from pyrxd.security.errors import ValidationError
+from pyrxd.transaction.transaction import Transaction
+from pyrxd.transaction.transaction_output import TransactionOutput
+
+MNEMONIC = "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about"
+
+
+def _wallet() -> HdWallet:
+    return HdWallet.from_mnemonic(MNEMONIC)
+
+
+def _src_for(addr: str, value: int) -> Transaction:
+    tx = Transaction()
+    tx.add_output(TransactionOutput(P2PKH().lock(addr), value))
+    return tx
+
+
+def _client_with_funds_at(funded: dict[str, Transaction], *, value: int = 100_000_000) -> MagicMock:
+    """Mock ElectrumX: each address in *funded* has history + one UTXO from the given source tx."""
+    by_sh = {script_hash_for_address(a): (a, src) for a, src in funded.items()}
+    by_txid = {src.txid(): src for src in funded.values()}
+
+    async def _history(sh):
+        return [{"tx_hash": "ab" * 32}] if sh in by_sh else []
+
+    async def _utxos(sh):
+        if sh not in by_sh:
+            return []
+        _addr, src = by_sh[sh]
+        return [UtxoRecord(tx_hash=src.txid(), tx_pos=0, value=value, height=800_000)]
+
+    async def _get_tx(txid):
+        return by_txid[str(txid)].serialize()
+
+    client = MagicMock()
+    client.get_history = _history
+    client.get_utxos = _utxos
+    client.get_transaction = _get_tx
+    return client
+
+
+def test_collect_finds_utxo_with_coords_and_source_tx() -> None:
+    w = _wallet()
+    xpub = Xpub.from_xprv(w._xprv)
+    addr = w._derive_address(0, 0)
+    client = _client_with_funds_at({addr: _src_for(addr, 100_000_000)})
+
+    scan = asyncio.run(collect_watch_only_utxos(xpub, client, gap_limit=3))
+
+    assert len(scan.utxos) == 1
+    u = scan.utxos[0]
+    assert (u.change, u.index) == (0, 0)
+    assert u.value == 100_000_000
+    # The source tx hashes to the UTXO outpoint (the agent's C1 check will pass).
+    assert hash256(bytes.fromhex(u.source_tx_hex))[::-1].hex() == u.txid
+
+
+def test_collect_reports_next_change_index() -> None:
+    w = _wallet()
+    xpub = Xpub.from_xprv(w._xprv)
+    # Fund external (0,0) and internal (1,0) → next change index should be 1.
+    funded = {
+        w._derive_address(0, 0): _src_for(w._derive_address(0, 0), 50_000_000),
+        w._derive_address(1, 0): _src_for(w._derive_address(1, 0), 25_000_000),
+    }
+    scan = asyncio.run(collect_watch_only_utxos(xpub, _client_with_funds_at(funded), gap_limit=3))
+    assert {(u.change, u.index) for u in scan.utxos} == {(0, 0), (1, 0)}
+    assert scan.next_change_index == 1
+
+
+def test_collected_utxos_are_signable_by_agent() -> None:
+    """End-to-end: discovery → build_send → agent signs (ownership + C1 all derived consistently)."""
+    w = _wallet()
+    xpub = Xpub.from_xprv(w._xprv)
+    addr = w._derive_address(0, 0)
+    client = _client_with_funds_at({addr: _src_for(addr, 100_000_000)})
+    scan = asyncio.run(collect_watch_only_utxos(xpub, client, gap_limit=3))
+
+    built = WatchOnlyTxBuilder(xpub).build_send(
+        scan.utxos, PrivateKey().public_key().address(), photons=10_000_000, change_index=scan.next_change_index
+    )
+    result = AgentSigner(w).sign(built.request, confirm=lambda _s: True)
+    assert Transaction.from_hex(bytes.fromhex(result.signed_tx_hex)) is not None
+
+
+def test_rejects_non_xpub() -> None:
+    with pytest.raises(ValidationError, match="Xpub"):
+        asyncio.run(collect_watch_only_utxos("nope", MagicMock()))  # type: ignore[arg-type]

--- a/tests/test_agent_signer.py
+++ b/tests/test_agent_signer.py
@@ -146,6 +146,38 @@ def test_rejects_unowned_input() -> None:
         AgentSigner(w).sign(wrong, confirm=_ACCEPT)
 
 
+def test_rejects_non_all_forkid_sighash() -> None:
+    # Sighash-downgrade defence: a request that asks the agent to sign an input with
+    # NONE/SINGLE/ANYONECANPAY is refused. Those commit to fewer outputs than the
+    # confirmation summary shows, so the caller could recombine the returned signature
+    # into a different tx and redirect the funds.
+    from pyrxd.constants import SIGHASH
+
+    w, req, _u, _s = _scenario()
+    downgraded = SigningRequest(
+        unsigned_tx_hex=req.unsigned_tx_hex,
+        inputs=(
+            InputToSign(0, 0, 0, req.inputs[0].source_tx_hex, sighash=int(SIGHASH.NONE_ANYONECANPAY_FORKID)),
+            req.inputs[1],
+        ),
+        change_claims=req.change_claims,
+    )
+    with pytest.raises(SignerError, match="ALL_FORKID"):
+        AgentSigner(w).sign(downgraded, confirm=_ACCEPT)
+
+
+def test_rejects_out_of_enum_sighash() -> None:
+    # A malformed sighash int is a clean SignerError, not a leaked ValueError.
+    w, req, _u, _s = _scenario()
+    bad = SigningRequest(
+        unsigned_tx_hex=req.unsigned_tx_hex,
+        inputs=(InputToSign(0, 0, 0, req.inputs[0].source_tx_hex, sighash=0x99), req.inputs[1]),
+        change_claims=req.change_claims,
+    )
+    with pytest.raises(SignerError, match="ALL_FORKID"):
+        AgentSigner(w).sign(bad, confirm=_ACCEPT)
+
+
 def test_rejects_partial_tx() -> None:
     # A tx with an input the request doesn't cover is refused (v1 fully-owned only).
     w, req, _u, _s = _scenario()

--- a/tests/test_agent_signer.py
+++ b/tests/test_agent_signer.py
@@ -1,0 +1,198 @@
+"""Tests for the sign-on-behalf agent core (issue #8, Path A').
+
+Covers the Phase-0 byte-identical invariant (now permanent) and the
+load-bearing security checks: prevout authenticity, ownership, output
+attribution + confirmation, fully-owned-only, and never-return-key.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from pyrxd.agent import (
+    AgentSigner,
+    ChangeClaim,
+    InputToSign,
+    SignerDeclined,
+    SignerError,
+    SigningRequest,
+    SpendSummary,
+)
+from pyrxd.hd.wallet import HdWallet
+from pyrxd.keys import PrivateKey
+from pyrxd.script.type import P2PKH
+from pyrxd.transaction.transaction import Transaction
+from pyrxd.transaction.transaction_input import TransactionInput
+from pyrxd.transaction.transaction_output import TransactionOutput
+
+TEST_MNEMONIC = "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about"
+_ACCEPT = lambda _summary: True  # noqa: E731 — terse confirm stub for tests
+
+
+def _wallet() -> HdWallet:
+    return HdWallet.from_mnemonic(TEST_MNEMONIC)
+
+
+def _src(wallet: HdWallet, change: int, index: int, value: int) -> Transaction:
+    """A synthetic source tx whose output[0] pays the wallet's (change,index) address."""
+    tx = Transaction()
+    tx.add_output(TransactionOutput(P2PKH().lock(wallet._derive_address(change, index)), value))
+    return tx
+
+
+def _unsigned_input(src: Transaction, vout: int) -> TransactionInput:
+    ti = TransactionInput(source_txid=src.txid(), source_output_index=vout)
+    ti.satoshis = src.outputs[vout].satoshis
+    ti.locking_script = src.outputs[vout].locking_script
+    return ti
+
+
+def _scenario():
+    """Two wallet inputs → one external payee + one change output."""
+    w = _wallet()
+    src0 = _src(w, 0, 0, 100_000)
+    src1 = _src(w, 0, 1, 50_000)
+    payee_pkh = PrivateKey().public_key().hash160()  # a genuinely external destination
+
+    unsigned = Transaction()
+    unsigned.add_input(_unsigned_input(src0, 0))
+    unsigned.add_input(_unsigned_input(src1, 0))
+    unsigned.add_output(TransactionOutput(P2PKH().lock(payee_pkh), 120_000))  # out0 external
+    unsigned.add_output(TransactionOutput(P2PKH().lock(w._derive_address(1, 0)), 29_000))  # out1 change; fee 1000
+
+    req = SigningRequest(
+        unsigned_tx_hex=unsigned.serialize().hex(),
+        inputs=(
+            InputToSign(0, 0, 0, src0.serialize().hex()),
+            InputToSign(1, 0, 1, src1.serialize().hex()),
+        ),
+        change_claims=(ChangeClaim(output_index=1, change=1, index=0),),
+    )
+    return w, req, unsigned, (src0, src1)
+
+
+def _sign_in_cli(wallet: HdWallet, srcs, unsigned: Transaction) -> str:
+    """Today's path: keys present, sign in-process. Used for byte-identical check."""
+    tx = Transaction()
+    coords = [(0, 0), (0, 1)]
+    for src, (c, i) in zip(srcs, coords):
+        ti = _unsigned_input(src, 0)
+        ti.unlocking_script_template = P2PKH().unlock(wallet._privkey_for(c, i))
+        tx.add_input(ti)
+    for out in unsigned.outputs:
+        tx.add_output(out)
+    tx.sign(bypass=True)
+    return tx.serialize().hex()
+
+
+# ─────────────────────────────── happy path ──────────────────────────────────
+
+
+def test_signs_and_is_byte_identical_to_in_cli() -> None:
+    w, req, unsigned, srcs = _scenario()
+    result = AgentSigner(w).sign(req, confirm=_ACCEPT)
+    assert result.signed_tx_hex == _sign_in_cli(w, srcs, unsigned)
+
+
+def test_confirmation_summary_is_accurate() -> None:
+    w, req, _unsigned, _srcs = _scenario()
+    seen: list[SpendSummary] = []
+
+    def capture(s: SpendSummary) -> bool:
+        seen.append(s)
+        return True
+
+    AgentSigner(w).sign(req, confirm=capture)
+    s = seen[0]
+    assert s.input_total == 150_000
+    assert s.change_total == 29_000
+    assert s.total_external == 120_000
+    assert s.fee == 1_000
+    assert [e.amount for e in s.external_outputs] == [120_000]
+    assert s.external_outputs[0].output_index == 0
+
+
+def test_decline_raises_and_does_not_sign() -> None:
+    w, req, _u, _s = _scenario()
+    with pytest.raises(SignerDeclined):
+        AgentSigner(w).sign(req, confirm=lambda _s: False)
+
+
+# ─────────────────────────── load-bearing rejections ─────────────────────────
+
+
+def test_rejects_source_tx_outpoint_mismatch() -> None:
+    # C1: a source tx that doesn't hash to the input's outpoint is rejected.
+    w, req, _u, _s = _scenario()
+    bogus_src = _src(w, 0, 0, 999_999).serialize().hex()  # different tx → different txid
+    tampered = SigningRequest(
+        unsigned_tx_hex=req.unsigned_tx_hex,
+        inputs=(InputToSign(0, 0, 0, bogus_src), req.inputs[1]),
+        change_claims=req.change_claims,
+    )
+    with pytest.raises(SignerError, match="does not match input 0 outpoint"):
+        AgentSigner(w).sign(tampered, confirm=_ACCEPT)
+
+
+def test_rejects_unowned_input() -> None:
+    # Wrong derivation coords → derived key does not own the prevout.
+    w, req, _u, _s = _scenario()
+    wrong = SigningRequest(
+        unsigned_tx_hex=req.unsigned_tx_hex,
+        inputs=(InputToSign(0, 0, 7, req.inputs[0].source_tx_hex), req.inputs[1]),  # index 7 != 0
+        change_claims=req.change_claims,
+    )
+    with pytest.raises(SignerError, match="does not own input 0"):
+        AgentSigner(w).sign(wrong, confirm=_ACCEPT)
+
+
+def test_rejects_partial_tx() -> None:
+    # A tx with an input the request doesn't cover is refused (v1 fully-owned only).
+    w, req, _u, _s = _scenario()
+    missing = SigningRequest(
+        unsigned_tx_hex=req.unsigned_tx_hex,
+        inputs=(req.inputs[0],),  # only covers input 0, tx has 2
+        change_claims=req.change_claims,
+    )
+    with pytest.raises(SignerError, match="fully wallet-owned"):
+        AgentSigner(w).sign(missing, confirm=_ACCEPT)
+
+
+def test_rejects_false_change_claim() -> None:
+    # Claiming the external payee (out0) as change must fail verification.
+    w, req, _u, _s = _scenario()
+    lying = SigningRequest(
+        unsigned_tx_hex=req.unsigned_tx_hex,
+        inputs=req.inputs,
+        change_claims=(ChangeClaim(output_index=0, change=1, index=0),),  # out0 is the payee, not change
+    )
+    with pytest.raises(SignerError, match="does not verify"):
+        AgentSigner(w).sign(lying, confirm=_ACCEPT)
+
+
+def test_unclaimed_change_is_shown_as_external() -> None:
+    # If the real change output isn't claimed, it must surface as external
+    # (so the confirmation gate shows it), never silently hidden.
+    w, req, _u, _s = _scenario()
+    no_claims = SigningRequest(unsigned_tx_hex=req.unsigned_tx_hex, inputs=req.inputs, change_claims=())
+    seen: list[SpendSummary] = []
+    AgentSigner(w).sign(no_claims, confirm=lambda s: bool(seen.append(s)) or True)
+    assert seen[0].change_total == 0
+    assert seen[0].total_external == 149_000  # both outputs treated external
+
+
+# ─────────────────────────────── invariants ──────────────────────────────────
+
+
+def test_never_returns_key_material() -> None:
+    w, req, _u, _s = _scenario()
+    result = AgentSigner(w).sign(req, confirm=_ACCEPT)
+    for c, i in [(0, 0), (0, 1)]:
+        secret_hex = w._privkey_for(c, i).serialize().hex()
+        assert secret_hex not in result.signed_tx_hex
+
+
+def test_request_dict_roundtrip() -> None:
+    _w, req, _u, _s = _scenario()
+    again = SigningRequest.from_dict(req.to_dict())
+    assert again == req

--- a/tests/test_agent_watch_only.py
+++ b/tests/test_agent_watch_only.py
@@ -1,0 +1,177 @@
+"""Tests for the watch-only tx builder (Phase 1, issue #8 A').
+
+Proves the Phase-0(a) gate: the CLI can build a valid send transaction from
+PUBLIC material (the account xpub + UTXOs + source txs) with signing deferred,
+and the resulting SigningRequest is consumed end-to-end by AgentSigner (which
+re-derives keys and signs). The builder never touches a private key.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from pyrxd.agent import AgentSigner, ChangeClaim, WatchOnlyTxBuilder, WatchOnlyUtxo
+from pyrxd.hd.bip32 import Xpub
+from pyrxd.hd.wallet import HdWallet
+from pyrxd.keys import PrivateKey
+from pyrxd.script.type import P2PKH
+from pyrxd.security.errors import ValidationError
+from pyrxd.transaction.transaction import Transaction
+from pyrxd.transaction.transaction_output import TransactionOutput
+
+TEST_MNEMONIC = "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about"
+_ACCEPT = lambda _summary: True  # noqa: E731 — terse confirm stub for tests
+_RECIPIENT_ADDR = PrivateKey().public_key().address()  # arbitrary external payee
+
+
+def _wallet() -> HdWallet:
+    return HdWallet.from_mnemonic(TEST_MNEMONIC)
+
+
+def _account_xpub(w: HdWallet) -> Xpub:
+    """The account-level xpub the agent would vend on unlock (no private key)."""
+    return Xpub.from_xprv(w._xprv)
+
+
+def _src(w: HdWallet, change: int, index: int, value: int) -> Transaction:
+    """A synthetic source tx whose output[0] pays the wallet's (change,index) address."""
+    tx = Transaction()
+    tx.add_output(TransactionOutput(P2PKH().lock(w._derive_address(change, index)), value))
+    return tx
+
+
+def _utxo(w: HdWallet, change: int, index: int, value: int, *, vout: int = 0) -> WatchOnlyUtxo:
+    src = _src(w, change, index, value)
+    return WatchOnlyUtxo(
+        txid=src.txid(), vout=vout, value=value, change=change, index=index, source_tx_hex=src.serialize().hex()
+    )
+
+
+# ───────────────────────────── foundational invariant ─────────────────────────
+
+
+def test_xpub_address_matches_wallet_private_derivation() -> None:
+    """The watch-only xpub derivation must match the wallet's private derivation,
+    or the agent's ownership/change-claim checks (which re-derive) would reject."""
+    w = _wallet()
+    builder = WatchOnlyTxBuilder(_account_xpub(w))
+    for change, index in [(0, 0), (0, 5), (1, 0), (1, 3)]:
+        assert builder.address(change, index) == w._derive_address(change, index)
+
+
+def test_rejects_non_xpub() -> None:
+    with pytest.raises(ValidationError, match="Xpub"):
+        WatchOnlyTxBuilder("not an xpub")  # type: ignore[arg-type]
+
+
+# ──────────────────────────────── build shape ─────────────────────────────────
+
+
+def test_builds_unsigned_send_from_public_material() -> None:
+    w = _wallet()
+    builder = WatchOnlyTxBuilder(_account_xpub(w))
+    utxos = [_utxo(w, 0, 0, 100_000_000), _utxo(w, 0, 1, 50_000_000)]
+
+    # photons=10M is covered by the single 100M utxo (after fee) → one input selected.
+    result = builder.build_send(utxos, _RECIPIENT_ADDR, photons=10_000_000, change_index=0)
+    tx = result.transaction
+
+    # Recipient is output 0 for exactly `photons`; change output 1 pays a wallet addr.
+    assert tx.outputs[0].satoshis == 10_000_000
+    assert tx.outputs[0].locking_script.serialize() == P2PKH().lock(_RECIPIENT_ADDR).serialize()
+    assert len(tx.outputs) == 2
+    assert tx.outputs[1].locking_script.serialize() == P2PKH().lock(w._derive_address(1, 0)).serialize()
+
+    # Every input is UNSIGNED (empty scriptSig) — the agent fills these in.
+    for ti in tx.inputs:
+        assert not ti.unlocking_script or ti.unlocking_script.serialize() == b""
+
+    # The request carries derivation coords (1-to-1 with inputs) + a change claim.
+    assert len(result.request.inputs) == len(tx.inputs) == 1
+    assert [(i.change, i.index) for i in result.request.inputs] == [(0, 0)]
+    assert result.request.change_claims == (ChangeClaim(output_index=1, change=1, index=0),)
+
+
+def test_builder_needs_only_an_xpub_string_no_wallet() -> None:
+    """Structural proof of 'watch-only': build from a bare xpub string — no HdWallet,
+    no seed, no private key available to the builder at all."""
+    w = _wallet()
+    xpub_str = str(_account_xpub(w))  # serialize to base58 and reconstruct from public data
+    builder = WatchOnlyTxBuilder(Xpub(xpub_str))
+    utxos = [_utxo(w, 0, 0, 100_000_000)]
+    result = builder.build_send(utxos, _RECIPIENT_ADDR, photons=10_000_000, change_index=0)
+    assert result.transaction.outputs[0].satoshis == 10_000_000
+
+
+# ─────────────────────────── end-to-end through the agent ─────────────────────
+
+
+def test_agent_signs_watch_only_request_end_to_end() -> None:
+    """The headline Phase-1 gate: a watch-only-built request is fully consumable by
+    the agent — ownership, prevout (C1), and change-claim checks all pass, and the
+    agent returns a fully-signed tx that preserves the built outpoints and outputs."""
+    w = _wallet()
+    builder = WatchOnlyTxBuilder(_account_xpub(w))
+    utxos = [_utxo(w, 0, 0, 100_000_000), _utxo(w, 0, 1, 50_000_000)]
+    photons = 120_000_000  # forces BOTH utxos to be selected
+
+    built = builder.build_send(utxos, _RECIPIENT_ADDR, photons=photons, change_index=0)
+    result = AgentSigner(w).sign(built.request, confirm=_ACCEPT)
+
+    signed = Transaction.from_hex(bytes.fromhex(result.signed_tx_hex))
+    assert signed is not None
+    # Every input is now signed and the outpoints are unchanged.
+    assert len(signed.inputs) == 2
+    for built_in, signed_in in zip(built.transaction.inputs, signed.inputs, strict=True):
+        assert signed_in.unlocking_script is not None and signed_in.unlocking_script.serialize() != b""
+        assert signed_in.source_txid == built_in.source_txid
+        assert signed_in.source_output_index == built_in.source_output_index
+    # Outputs preserved verbatim (recipient amount + change to a wallet address).
+    assert [(o.satoshis, o.locking_script.serialize()) for o in signed.outputs] == [
+        (o.satoshis, o.locking_script.serialize()) for o in built.transaction.outputs
+    ]
+    # Fee is positive and tracks the rate (estimated, not exact): inputs − outputs.
+    fee = sum(u.value for u in utxos) - sum(o.satoshis for o in signed.outputs)
+    assert fee > 0
+
+
+def test_dust_change_is_burned_to_fee() -> None:
+    """When change would be below dust, the builder emits a single output (no change
+    claim), matching build_send_tx — and the agent still signs it."""
+    w = _wallet()
+    builder = WatchOnlyTxBuilder(_account_xpub(w))
+    utxos = [_utxo(w, 0, 0, 10_000_000)]
+    # fee_rate=1: 1-input/2-output estimate ≈ 226; pick photons so the residual < DUST(546).
+    built = builder.build_send(utxos, _RECIPIENT_ADDR, photons=9_999_700, change_index=0, fee_rate=1)
+
+    assert len(built.transaction.outputs) == 1, "dust change must be burned to fee"
+    assert built.request.change_claims == ()
+    result = AgentSigner(w).sign(built.request, confirm=_ACCEPT)
+    assert Transaction.from_hex(bytes.fromhex(result.signed_tx_hex)) is not None
+
+
+# ───────────────────────────────── validation ─────────────────────────────────
+
+
+def test_insufficient_funds_raises() -> None:
+    w = _wallet()
+    builder = WatchOnlyTxBuilder(_account_xpub(w))
+    utxos = [_utxo(w, 0, 0, 1_000_000)]
+    with pytest.raises(ValidationError, match="Insufficient funds"):
+        builder.build_send(utxos, _RECIPIENT_ADDR, photons=10_000_000, change_index=0)
+
+
+def test_no_utxos_raises() -> None:
+    w = _wallet()
+    builder = WatchOnlyTxBuilder(_account_xpub(w))
+    with pytest.raises(ValidationError, match="no UTXOs"):
+        builder.build_send([], _RECIPIENT_ADDR, photons=10_000_000, change_index=0)
+
+
+@pytest.mark.parametrize("bad", [0, -1, 545])
+def test_rejects_bad_photons(bad: int) -> None:
+    w = _wallet()
+    builder = WatchOnlyTxBuilder(_account_xpub(w))
+    utxos = [_utxo(w, 0, 0, 100_000_000)]
+    with pytest.raises(ValidationError):
+        builder.build_send(utxos, _RECIPIENT_ADDR, photons=bad, change_index=0)


### PR DESCRIPTION
Closes the bulk of #8 (mnemonic re-entry per command). Implements **Path A′** from the design doc: a local **sign-on-behalf** agent. The daemon holds the unlocked wallet and signs transactions the CLI builds *watch-only* — the key never leaves the daemon. Reaching the socket lets a caller *request* a signature (gated by per-spend confirmation), never *take* the key. This is **security-sensitive** and **pre-audit** (no third-party review yet).

### What's here (design + core were already on the branch; this adds the rest)
- **Phase 1 — watch-only tx seam** (`agent/watch_only.py`): build an unsigned P2PKH send + `SigningRequest` from the account **xpub** + UTXOs + source txs, with **no private key**. Separate module; the in-process `build_send_tx` hot path is untouched.
- **Phase 4 — transport + daemon + client + confirm + hygiene**: length-prefixed JSON framing (8 MiB cap); `AgentDaemon` with `0700` dir + `0600` socket + `SO_PEERCRED` uid==owner, stale-socket cleanup + single-instance probe, idle auto-lock + on-demand lock (seed zeroized); `AgentClient` (typed `SignerUnavailableError` fallback); per-spend confirmation on the daemon's **own `/dev/tty`** (fails closed without one); best-effort `mlock`/`PR_SET_DUMPABLE 0`/no-core-dumps.
- **Phase 5 — CLI**: `pyrxd agent unlock | status | lock` (foreground daemon; confirmations appear in that terminal).
- **Phase 6 — threat model**: issue-#8 section (asset A11, scenarios S18 same-uid abuse / S19 prevout-lie + sighash-downgrade, control rows), resolving the former "no agent process" gap.

### Acceptance criteria (#8)
- [x] `pyrxd agent unlock/lock/status`
- [x] Agent signs on behalf and **never returns key material** (conformance-tested)
- [x] Prevout authenticity enforced (lying about an input's value is rejected)
- [x] Non-trivial spends require interactive confirmation (accept + reject tested)
- [x] Auto-lock zeroizes the seed
- [x] Socket `0700`+`0600`+`SO_PEERCRED`; wrong-uid refused (peer-auth tested)
- [x] Documented threat model + auth analysis
- [x] Byte-identical signatures vs the in-CLI path (permanent regression test)
- [ ] **Deferred:** wallet-touching commands auto-route through the agent. Agent v1 signs **P2PKH only**; the existing spending commands are `sweep` (send_max — needs a watch-only send_max builder) and the glyph covenant commands (out of v1 scope). Routing + the watch-only sweep builder is the remaining work.

### Tests
New: watch-only builder (11), daemon/transport/confirm/hygiene (18), CLI agent (6), plus the existing signer suite (12). Full `task ci` green: 4113 passed, coverage 87.8%, bandit + mypy + private-links clean.

### Not in scope (Path B / deferred)
Generalized `Signer` seam + Ledger backend; gravity/HTLC agent signing; remote/networked agent; seed vending (the rejected anti-pattern). External audit remains the hard gate before real-value reliance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)