### PR TITLE
harden(swap): whole-stack audit follow-ups (MEDIUM-1 + 3 LOW)

### DIFF
--- a/scripts/eth_swap_grief_run.py
+++ b/scripts/eth_swap_grief_run.py
@@ -133,7 +133,11 @@ async def run(args) -> None:
         radiant_leg=rxd_leg,
         indexer=None,
         seen_store=InMemSeen(),
-        config=CoordinatorConfig(margin_policy=_policy(args), accept_nondurable_seen=True),
+        # accept_estimated_eth_margins: operator-gated DUST griefing run; consciously accepts
+        # estimated-margin risk on negligible value (MEDIUM-1). Non-dust value → measured policy.
+        config=CoordinatorConfig(
+            margin_policy=_policy(args), accept_nondurable_seen=True, accept_estimated_eth_margins=True
+        ),
     )
 
     try:

--- a/scripts/eth_swap_run.py
+++ b/scripts/eth_swap_run.py
@@ -318,9 +318,7 @@ async def run_sepolia_dust(args: argparse.Namespace) -> None:
             if not args.nft_owner_wif:
                 raise SystemExit("--nft-reuse-reveal-txid requires --nft-owner-wif (to spend the singleton)")
             print(f"\n  --- NFT path: REUSING already-minted NFT at reveal {args.nft_reuse_reveal_txid} (no mint) ---")
-            minted = load_minted_nft(
-                rxd_client, reveal_txid=args.nft_reuse_reveal_txid, owner_wif=args.nft_owner_wif
-            )
+            minted = load_minted_nft(rxd_client, reveal_txid=args.nft_reuse_reveal_txid, owner_wif=args.nft_owner_wif)
         else:
             print("\n  --- NFT path: minting a fresh throwaway NFT on RXD MAINNET (commit→reveal, real-value) ---")
             minted = mint_nft_inline(
@@ -423,7 +421,10 @@ async def run_sepolia_dust(args: argparse.Namespace) -> None:
         else:
             indexer = SshTrHttpRefAdapter(chain_io=chain_io, ssh_host=args.rxd_ssh_host, api_base=args.rxd_api_base)
             print(f"  REF gate: REST SshTrHttpRefAdapter via ssh {args.rxd_ssh_host} -> {args.rxd_api_base}")
-    cfg = CoordinatorConfig(margin_policy=policy, accept_nondurable_seen=True)
+    # accept_estimated_eth_margins: this is an operator-gated DUST run that consciously
+    # accepts estimated-margin risk (is_measured=False) on negligible value (MEDIUM-1). A
+    # real (non-dust) value-bearing ETH swap MUST use MarginPolicy.measured(...) instead.
+    cfg = CoordinatorConfig(margin_policy=policy, accept_nondurable_seen=True, accept_estimated_eth_margins=True)
     coord = SwapCoordinator(
         record=SwapRecord(state=SwapState.NEGOTIATED, terms=terms),
         counter_leg=eth_leg,
@@ -589,15 +590,31 @@ def _args() -> argparse.Namespace:
     ap.add_argument("--asset-variant", choices=("rxd", "nft", "ft"), default="rxd")
     ap.add_argument("--ft-name", default="ETH-RXD-REAL-FT")
     ap.add_argument("--ft-ticker", default="ERFT")
-    ap.add_argument("--ft-premine-photons", type=int, default=10_000_000)  # FT supply = covenant-locked amount (1 photon = 1 unit)
-    ap.add_argument("--ft-reuse-reveal-txid", default="", help="reuse an already-minted FT at this reveal txid (skip minting)")
-    ap.add_argument("--ft-owner-wif", default="", help="owner WIF for --ft-reuse-reveal-txid (spends the FT into the covenant)")
-    ap.add_argument("--rxd-indexer-ws", default="", help="OPTIONAL glyph-enabled ElectrumX ws/wss URL for the NFT REF gate; if omitted, resolve via the REST api over ssh-tr")
+    ap.add_argument(
+        "--ft-premine-photons", type=int, default=10_000_000
+    )  # FT supply = covenant-locked amount (1 photon = 1 unit)
+    ap.add_argument(
+        "--ft-reuse-reveal-txid", default="", help="reuse an already-minted FT at this reveal txid (skip minting)"
+    )
+    ap.add_argument(
+        "--ft-owner-wif", default="", help="owner WIF for --ft-reuse-reveal-txid (spends the FT into the covenant)"
+    )
+    ap.add_argument(
+        "--rxd-indexer-ws",
+        default="",
+        help="OPTIONAL glyph-enabled ElectrumX ws/wss URL for the NFT REF gate; if omitted, resolve via the REST api over ssh-tr",
+    )
     ap.add_argument("--rxd-indexer-insecure", action="store_true", help="allow a non-TLS RXinDexer ws")
     ap.add_argument("--rxd-ssh-host", default="tr", help="ssh host for the RXinDexer REST REF gate (default tr)")
     ap.add_argument("--rxd-api-base", default="http://127.0.0.1:8000", help="RXinDexer REST api base on the ssh host")
-    ap.add_argument("--nft-reuse-reveal-txid", default="", help="reuse an already-minted NFT at this reveal txid (skip minting)")
-    ap.add_argument("--nft-owner-wif", default="", help="owner WIF for --nft-reuse-reveal-txid (spends the singleton into the covenant)")
+    ap.add_argument(
+        "--nft-reuse-reveal-txid", default="", help="reuse an already-minted NFT at this reveal txid (skip minting)"
+    )
+    ap.add_argument(
+        "--nft-owner-wif",
+        default="",
+        help="owner WIF for --nft-reuse-reveal-txid (spends the singleton into the covenant)",
+    )
     ap.add_argument("--nft-name", default="ETH-RXD-REAL-NFT")
     ap.add_argument("--nft-carrier-photons", type=int, default=1_000_000)  # carrier the covenant pins
     ap.add_argument("--nft-commit-photons", type=int, default=20_000_000)  # mint commit funding

--- a/src/pyrxd/gravity/swap_coordinator.py
+++ b/src/pyrxd/gravity/swap_coordinator.py
@@ -473,13 +473,21 @@ def should_taker_refund_proactively(
     maker_has_claimed_btc: bool,
     block_interval_s: float = 600.0,
 ) -> bool:
-    """Return True once the taker MUST refund the asset rather than keep waiting.
+    """Return True once the refund window is near and the taker must act rather than wait.
 
-    The dominant adversarial risk: because ``t_BTC > t_RXD``, a malicious maker can
-    withhold their BTC claim until *after* ``t_RXD`` opens, then claim BTC (revealing
-    ``p``) AND refund the asset — the taker loses both. The defense (C1): treat
-    "maker has not claimed and ``t_RXD - N`` is approaching" as a trigger to refund
-    the asset proactively, NEVER a reason to keep waiting.
+    This is a TIMING PREDICATE only — "the maker has not claimed and ``t_RXD - N`` is
+    approaching" — NOT a prescription of which refund to run. The dominant adversarial
+    risk it guards: because ``t_BTC > t_RXD``, a malicious maker can withhold the BTC
+    claim until after ``t_RXD`` opens, then claim BTC (revealing ``p``) AND CSV-refund
+    the asset, taking both. Treat the trigger as "stop waiting", never "keep waiting".
+
+    IMPORTANT — what the taker DOES when this fires is :meth:`mutual_refund` (both legs
+    unwind once both timeouts elapse), NOT an asset-only refund. The asset CSV refund
+    pays the MAKER (the maker owns the covenant), so a taker that "refunds the asset
+    proactively" strands itself — see :meth:`maybe_refund_asset_on_maker_stall` (a
+    maker-only primitive) and ``gravity.watch.decide`` (FSM finding #2, 2026-06-09).
+    An earlier version of this docstring described that superseded asset-only model;
+    do not re-wire it.
 
     Returns False once the maker has claimed (``p`` is now public — the taker should
     instead scrape it and claim the asset). ``safety_window_blocks`` is the ``N``
@@ -706,6 +714,15 @@ class CoordinatorConfig:
     # runbook (the dust harness); a long-lived / multi-process deployment needs a
     # durable store (audit track), not this flag.
     accept_nondurable_seen: bool = False
+    # Explicit opt-in to run a VALUE-BEARING ETH (finalized-checkpoint) counter-leg swap
+    # with an ESTIMATED (is_measured=False) margin policy. is_measured gates TWO ETH
+    # defenses — the verify->lock 'finalized' reorg pin (a 'latest' re-verify cannot catch
+    # a reorg that re-deploys a different contract at the same CREATE address) and the
+    # proactive-refund N-floor — so the coordinator refuses a value-bearing ETH swap on an
+    # estimated policy unless this is set (whole-stack audit MEDIUM-1). Acceptable only for
+    # an operator-gated DUST run that consciously accepts estimated-margin risk on
+    # negligible value; a real (non-dust) value-bearing ETH swap MUST use a measured policy.
+    accept_estimated_eth_margins: bool = False
     # Min confirmations a gating credential's live UTXO must have (reorg safety),
     # when a swap sets terms.credential_ref. Mirrors min_ref_confirmations.
     min_credential_confirmations: int = 6
@@ -724,6 +741,8 @@ class CoordinatorConfig:
             raise ValidationError("min_credential_confirmations must be a non-negative int")
         if not isinstance(self.accept_nondurable_seen, bool):
             raise ValidationError("accept_nondurable_seen must be a bool")
+        if not isinstance(self.accept_estimated_eth_margins, bool):
+            raise ValidationError("accept_estimated_eth_margins must be a bool")
 
 
 def _serialized_step(method):
@@ -835,6 +854,28 @@ class SwapCoordinator:
                 "free-option window (SEEN-1). Use a durable SeenStore (durable=True), or pass "
                 "CoordinatorConfig(accept_nondurable_seen=True) to consciously accept "
                 "non-durability for a single-process, single-shot, fresh-H-per-run runbook."
+            )
+        # MEDIUM-1 (whole-stack audit): a VALUE-BEARING ETH counter-leg swap on an ESTIMATED
+        # policy silently runs in the weak mode of two defenses — the verify->lock 'finalized'
+        # reorg pin (_assert_eth_counter_funding_verified re-verifies at 'latest' when
+        # is_measured=False) and the proactive-refund N-floor (both gated on is_measured).
+        # Unlike the BTC path, nothing else couples value↔measured for ETH, and a 'latest'
+        # re-verify cannot catch a reorg re-deploying a different contract at the same CREATE
+        # address in the verify->lock window → one-sided maker loss. Refuse it unless the
+        # operator consciously accepts estimated margins (dust runs); fail-closed at setup so a
+        # future value-bearing ETH run cannot inherit is_measured=False by accident.
+        if (
+            value_bearing
+            and record.terms.counter_chain != "btc"
+            and not config.margin_policy.is_measured
+            and not config.accept_estimated_eth_margins
+        ):
+            raise ValidationError(
+                "value-bearing ETH counter-leg swap with an ESTIMATED margin policy "
+                "(is_measured=False): the verify->lock 'finalized' reorg pin AND the "
+                "proactive-refund N-floor are both disabled (MEDIUM-1). Use MarginPolicy.measured(...), "
+                "or pass CoordinatorConfig(accept_estimated_eth_margins=True) to consciously accept "
+                "estimated-margin risk on an operator-gated dust run."
             )
         # ETH (finalized-checkpoint) counter leg requires a finalization window on the policy
         # (audit finality/fsm fail-closed-at-setup): the reorg gate's no-depth WAIT-branch
@@ -1280,6 +1321,7 @@ class SwapCoordinator:
         await self._persist_record(self.record, shield=True)
         return self.record
 
+    @_serialized_step
     async def maker_claims_btc(self, preimage: SecretBytes) -> SwapRecord:
         """Maker spends the BTC claim leaf with ``p`` (revealing it), then zeroizes p.
 

--- a/src/pyrxd/gravity/watch/decide.py
+++ b/src/pyrxd/gravity/watch/decide.py
@@ -351,7 +351,7 @@ def decide(
         if refund_due:
             return Decision(
                 Intent.PAGE_REFUND,
-                reason="maker has not claimed and t_rxd maturity approaching — prepare to mutual_refund (broadcast once both timeouts elapse)",
+                reason="maker has not claimed and t_rxd maturity approaching — prepare to mutual_refund. The deadline shown is t_rxd, when the maker's CSV refund opens (the danger), NOT a mutual_refund deadline: mutual_refund's counter leg cannot mature until t_btc > t_rxd, so broadcast it once BOTH timeouts have elapsed",
                 recommended_action="mutual_refund",
                 deadline_rxd_height=deadline,
                 low_corroboration=corr,
@@ -538,7 +538,7 @@ def _decide_eth(
         if refund_due:
             return Decision(
                 Intent.PAGE_REFUND,
-                reason="maker has not claimed and t_rxd maturity approaching — prepare to mutual_refund (broadcast once both timeouts elapse)",
+                reason="maker has not claimed and t_rxd maturity approaching — prepare to mutual_refund. The deadline shown is t_rxd, when the maker's CSV refund opens (the danger), NOT a mutual_refund deadline: mutual_refund's counter leg cannot mature until t_btc > t_rxd, so broadcast it once BOTH timeouts have elapsed",
                 recommended_action="mutual_refund",
                 deadline_rxd_height=deadline,
                 low_corroboration=corr,

--- a/tests/test_swap_coordinator.py
+++ b/tests/test_swap_coordinator.py
@@ -2198,3 +2198,70 @@ async def test_eth_post_confirm_reverify_failure_refuses_both_locked():
         await coord.post_asset_lock_revalidate(await rxd.expected_covenant_scriptpubkey(terms), now_unix_s=_NOW)
     assert coord.record.state is SwapState.BTC_LOCKED  # did NOT advance
     assert rxd.claimed_with is None
+
+
+# ---------------------------------------------------------------------------
+# MEDIUM-1 (whole-stack audit): value-bearing ETH leg must not silently run on
+# an estimated policy (which disables the verify->lock 'finalized' reorg pin +
+# the proactive-refund N-floor). Refuse at construction unless explicitly accepted.
+# ---------------------------------------------------------------------------
+
+
+def _value_bearing_radiant() -> FakeRadiantLeg:
+    rl = FakeRadiantLeg()
+    rl.network = "mainnet"  # not in AUDIT_CLEARED_NETWORKS => value-bearing
+    return rl
+
+
+def _construct_eth_coord(*, policy, accept_estimated=False, radiant_leg=None, window=8):
+    h = hashlib.sha256(os.urandom(32)).digest()
+    return SwapCoordinator(
+        record=SwapRecord(state=SwapState.NEGOTIATED, terms=_eth_terms(hashlock=h)),
+        counter_leg=FakeEthLeg(preimage=SecretBytes(os.urandom(32)), verdict=_final()),
+        radiant_leg=radiant_leg if radiant_leg is not None else _value_bearing_radiant(),
+        indexer=FakeIndexer(),
+        seen_store=FakeSeenStore(),
+        config=CoordinatorConfig(
+            margin_policy=policy,
+            accept_nondurable_seen=True,
+            accept_estimated_eth_margins=accept_estimated,
+            maker_stall_safety_window_blocks=window,
+        ),
+    )
+
+
+def test_value_bearing_eth_estimated_policy_refused():
+    # is_measured=False on a value-bearing ETH swap, no explicit opt-in -> refused.
+    with pytest.raises(ValidationError, match="value-bearing ETH"):
+        _construct_eth_coord(policy=_eth_finality_policy(is_measured=False))
+
+
+def test_value_bearing_eth_estimated_allowed_with_explicit_optin():
+    # Conscious dust-run acceptance (accept_estimated_eth_margins=True) -> constructs.
+    coord = _construct_eth_coord(policy=_eth_finality_policy(is_measured=False), accept_estimated=True)
+    assert coord is not None
+
+
+def test_value_bearing_eth_allowed_when_measured():
+    # A measured policy is the proper fix path; window>=N-floor (8) -> constructs.
+    coord = _construct_eth_coord(policy=_eth_finality_policy(is_measured=True), window=8)
+    assert coord is not None
+
+
+def test_non_value_bearing_eth_estimated_unaffected():
+    # No mainnet leg tag -> not value-bearing -> the MEDIUM-1 guard does not fire.
+    coord = _construct_eth_coord(policy=_eth_finality_policy(is_measured=False), radiant_leg=FakeRadiantLeg())
+    assert coord is not None
+
+
+def test_value_bearing_btc_estimated_unaffected():
+    # The guard is ETH-specific; a value-bearing BTC swap on an estimated policy still constructs.
+    coord = SwapCoordinator(
+        record=SwapRecord(state=SwapState.NEGOTIATED, terms=_terms()),
+        btc_leg=FakeBtcLeg(),
+        radiant_leg=_value_bearing_radiant(),
+        indexer=FakeIndexer(),
+        seen_store=FakeSeenStore(),
+        config=CoordinatorConfig(margin_policy=MarginPolicy.estimated(), accept_nondurable_seen=True),
+    )
+    assert coord is not None


### PR DESCRIPTION
A single-context whole-stack audit of the swap/HTLC core (gravity / spv / btc_wallet / eth_wallet + operational harnesses) found **no surviving CRITICAL/HIGH**, one cross-module MEDIUM, and three LOWs. This PR fixes all four. (Detailed exploit narratives + the cross-module invariant map are kept in a local working doc, not committed.)

### MEDIUM-1 — value-bearing ETH leg silently ran two defenses in weak mode (cross-module / gate-bypass)
`is_measured=False` disables both the verify→lock `'finalized'` reorg pin (`_assert_eth_counter_funding_verified` re-verifies at `'latest'` — confirmed: `block_identifier=None` → `'latest'` at `eth_wallet/htlc_leg.py:222`) and the ETH proactive-refund N-floor. Unlike the BTC path, nothing coupled value↔measured for ETH, and both ETH dust harnesses set `is_measured=False` on mainnet RXD. A reorg replacing the taker's contract in the verify→lock window → one-sided maker loss.

**Fix:** the coordinator now refuses a value-bearing ETH swap on an estimated policy unless `CoordinatorConfig(accept_estimated_eth_margins=True)` — mirroring the existing `accept_nondurable_seen` (SEEN-1) guard and reusing the `_leg_is_value_bearing` detection already computed at construction. The two dust harnesses set the explicit flag (operator-gated, negligible value); a real value-bearing ETH swap must use `MarginPolicy.measured(...)`. Fail-closed at setup, so a future value-bearing ETH run can't inherit `is_measured=False` by accident.

### LOWs
- **LOW-1** — added `@_serialized_step` to `maker_claims_btc` (the only FSM-advancing method missing it).
- **LOW-2** — rewrote the `should_taker_refund_proactively` docstring: it's a timing predicate; the taker's action is `mutual_refund`, never the maker-only asset refund (the superseded C1 model).
- **LOW-3** — watchtower maker-stall page reason now clarifies the shown deadline is the maker's CSV-refund (danger) opening at `t_rxd`, **not** a `mutual_refund` deadline (whose BTC leg matures only at `t_btc > t_rxd`) — an artifact of the FSM-finding-#2 fix (#189).

### Tests
+5 MEDIUM-1 construction tests (refuse / explicit opt-in / measured / non-value-bearing / BTC-unaffected). Full `task ci` green: 4133 passed, coverage 87.6%, bandit/mypy/private-links clean.

Residual for the external engagement (audit could not cover): live-node consensus behavior, genuine two-party execution, and the `eth_wallet/` / `spv/` / watch-quorum modules not read this pass. External audit remains the hard gate before real value.

🤖 Generated with [Claude Code](https://claude.com/claude-code)