### PR TITLE
harden(swap): residual audit follow-ups — 4 LOWs (R1–R4)

### DIFF
--- a/src/pyrxd/eth_wallet/htlc_leg.py
+++ b/src/pyrxd/eth_wallet/htlc_leg.py
@@ -234,11 +234,15 @@ class EthHtlcContractLeg:
             raise ValidationError("on-chain timeout != negotiated timeout")
         # EOA-only claimant/refundee: empty code == EOA. A contract recipient that reverts on
         # receive would lock the funds via the HTLC's require(ok) on the ETH transfer.
-        if await self._rpc.get_code(locator.claimant):
+        # Pin these to the SAME block as the code/immutables reads above (audit LOW-R1): at
+        # 'finalized' the EOA-ness of claimant/refundee and the funded balance must be read at the
+        # non-reorgable checkpoint too, not the reorg-able tip — else a reorg could flip an EOA to a
+        # reverting contract, or show a balance the finalized state does not have.
+        if await self._rpc.get_code(locator.claimant, block_identifier):
             raise ValidationError("claimant has contract code (not an EOA); a reverting recipient could lock funds")
-        if await self._rpc.get_code(locator.refundee):
+        if await self._rpc.get_code(locator.refundee, block_identifier):
             raise ValidationError("refundee has contract code (not an EOA); a reverting recipient could lock funds")
-        bal = await self._rpc.get_balance(locator.contract_address)
+        bal = await self._rpc.get_balance(locator.contract_address, block_identifier)
         # Lower bound, not exact-equal (red-team LOW): an attacker can force-send 1 wei (selfdestruct
         # / coinbase) to a contract, so an `== expected` check is griefable into a permanent verify
         # failure. Reject UNDER-funding; tolerate dust over-funding (any extra ETH is paid to whoever

--- a/src/pyrxd/gravity/watch/adapters.py
+++ b/src/pyrxd/gravity/watch/adapters.py
@@ -176,6 +176,16 @@ class MultiSourceRxdChainSource:
         self._sources = sources
         self._quorum = quorum
 
+    @property
+    def corroborated(self) -> bool:
+        """True iff this is a genuine multi-source quorum (>= 2 sources AND quorum >= 2).
+
+        The :class:`ChainObserver` reads this to STRUCTURALLY justify ``rxd_corroborated=True``
+        — so corroboration cannot be asserted over a single source (audit LOW-R2). A single
+        source (or quorum 1) is not corroboration however the flag is set.
+        """
+        return self._quorum >= 2 and len(self._sources) >= self._quorum
+
     async def _gather(self, coro_fn) -> list:
         """Run ``coro_fn`` on every source; return only the successful (non-Exception)
         results. A failing source is dropped — it never fails the whole read."""

--- a/src/pyrxd/gravity/watch/daemon.py
+++ b/src/pyrxd/gravity/watch/daemon.py
@@ -103,6 +103,7 @@ async def run_loop(
     while not (stop is not None and stop.is_set()):
         if max_iterations is not None and iterations >= max_iterations:
             break
+        tick_timed_out = False
         try:
             if tick_timeout_s is None:
                 results = await reconciler.tick()
@@ -110,13 +111,20 @@ async def run_loop(
                 results = await asyncio.wait_for(reconciler.tick(), timeout=tick_timeout_s)
         except (asyncio.TimeoutError, TimeoutError):
             logger.error(
-                "watchtower tick %d exceeded %.0fs budget (slow source?) — degraded; emitting alive heartbeat",
+                "watchtower tick %d exceeded %.0fs budget (slow source?) — degraded; SKIPPING the "
+                "heartbeat so the cross-process dead-man's-switch sees staleness if this persists",
                 iterations + 1,
                 tick_timeout_s,
             )
             results = []
+            tick_timed_out = True
         iterations += 1
-        if on_heartbeat is not None:
+        # LOW-R3: only beat on a tick that actually OBSERVED the chain. A timed-out (blind) tick must
+        # NOT refresh the cross-process heartbeat — else a slow-loris source that wedges every tick
+        # keeps the age-only dead-man's-switch reporting ALIVE while the tower sees nothing. A
+        # PERSISTENT timeout → no fresh beats → the switch goes stale and pages; a single transient
+        # timeout is harmless (the next good tick beats well within max_silence).
+        if on_heartbeat is not None and not tick_timed_out:
             try:
                 on_heartbeat(iterations, results)
             except Exception:  # a heartbeat-sink failure must not crash the reconcile loop

--- a/src/pyrxd/gravity/watch/quorum.py
+++ b/src/pyrxd/gravity/watch/quorum.py
@@ -158,6 +158,19 @@ class ChainObserver(Observer):
     ) -> None:
         if not isinstance(rxd_corroborated, bool):
             raise ValidationError("ChainObserver.rxd_corroborated must be bool")
+        # LOW-R2: bind corroboration to STRUCTURE, not just a free bool. Asserting
+        # rxd_corroborated=True clears low_corroboration on every observation (which lets the
+        # autonomous refund act on a single RXD read), so it must be backed by an actual
+        # multi-source quorum. Require the rxd source to declare itself corroborated (a genuine
+        # >= 2-source quorum, see MultiSourceRxdChainSource.corroborated); a single source cannot
+        # assert it however the flag is passed. (accept_single_source remains the explicit,
+        # logged dust opt-in on the executor for the deliberate single-source case.)
+        if rxd_corroborated and not bool(getattr(rxd, "corroborated", False)):
+            raise ValidationError(
+                "rxd_corroborated=True requires a multi-source RXD quorum (the source must expose "
+                "corroborated=True, e.g. MultiSourceRxdChainSource with quorum>=2); a single source "
+                "cannot assert corroboration. Use a real quorum, or leave rxd_corroborated=False."
+            )
         if btc is None and eth is None:
             raise ValidationError("ChainObserver requires at least one counter-leg source (btc and/or eth)")
         self._btc = btc

--- a/src/pyrxd/network/bitcoin.py
+++ b/src/pyrxd/network/bitcoin.py
@@ -951,7 +951,12 @@ class MempoolSpaceBroadcaster:
                     except ValidationError:
                         raise NetworkError("broadcast returned a non-txid body")
                 low = body.lower()
-                if any(m in low for m in ("already", "txn-already-known", "in block chain", "in mempool")):
+                # Idempotent success = the tx is ALREADY PRESENT (re-broadcast is a no-op). Match only
+                # SPECIFIC present-phrases, NOT a bare "already" (audit LOW-R4): a conflict/rejection like
+                # "inputs already spent" (the counterparty spent the HTLC output first) contains "already"
+                # but is NOT a success — misreading it would return a txid for a tx that never landed.
+                # Anything not unambiguously "already present" is fail-closed.
+                if any(m in low for m in ("txn-already-known", "already in block chain", "already in mempool")):
                     # Idempotent success — derive the txid locally (no node on mainnet).
                     return btc_txid_from_raw(raw)
                 raise NetworkError(f"broadcast rejected (HTTP {resp.status})")

--- a/tests/test_eth_leg.py
+++ b/tests/test_eth_leg.py
@@ -506,6 +506,7 @@ class _RecordingRpc:
 
 
 async def test_verify_funded_pins_eoa_and_balance_reads_to_the_block():
+    pytest.importorskip("web3")  # verify_funded requires web3 (optional dep; absent in the base CI env)
     from web3 import Web3
 
     loc = EthHtlcLocator(

--- a/tests/test_eth_leg.py
+++ b/tests/test_eth_leg.py
@@ -443,3 +443,89 @@ async def test_fund_rejects_timeout_mismatch_with_terms(monkeypatch):
 
     with pytest.raises(ValidationError, match="must agree"):
         await leg.fund(_TermsMismatch())
+
+
+# -- LOW-R1: verify_funded must pin the EOA get_code + balance reads to the SAME block ------
+
+
+class _RecordingRpc:
+    """Fake EthRpc recording the block_identifier each read is pinned to. Returns values that pass
+    verify_funded (claimant/refundee EOAs => empty code; balance == expected; immutables match)."""
+
+    def __init__(self, locator, amount_wei):
+        self._loc = locator
+        self._amount = amount_wei
+        self.code_block_ids: dict[str, object] = {}
+        self.balance_block_id: object = "UNSET"
+        from web3 import Web3
+
+        loc = locator
+
+        class _Getter:
+            def __init__(self, val):
+                self._val = val
+
+            async def call(self, *, block_identifier=None):
+                return self._val
+
+        class _Functions:
+            def hashlock(self):
+                return _Getter(loc.hashlock_bytes)
+
+            def claimant(self):
+                return _Getter(Web3.to_checksum_address(loc.claimant))
+
+            def refundee(self):
+                return _Getter(Web3.to_checksum_address(loc.refundee))
+
+            def timeout(self):
+                return _Getter(loc.timeout)
+
+        class _Eth:
+            def contract(self, address=None, abi=None):
+                class _C:
+                    functions = _Functions()
+
+                return _C()
+
+        class _W3:
+            eth = _Eth()
+
+        self.w3 = _W3()
+
+    async def assert_chain(self):
+        return None
+
+    async def get_code(self, address, block_identifier=None):
+        self.code_block_ids[address] = block_identifier
+        return b"\x60\x00" if address == self._loc.contract_address else b""  # contract has code; EOAs empty
+
+    async def get_balance(self, address, block_identifier=None):
+        self.balance_block_id = block_identifier
+        return self._amount
+
+
+async def test_verify_funded_pins_eoa_and_balance_reads_to_the_block():
+    from web3 import Web3
+
+    loc = EthHtlcLocator(
+        chain_id=11155111,
+        contract_address=Web3.to_checksum_address("0x" + "33" * 20),
+        deploy_tx_hash="0x" + "de" * 32,
+        hashlock="0x" + "ab" * 32,
+        claimant=Web3.to_checksum_address("0x" + "11" * 20),
+        refundee=Web3.to_checksum_address("0x" + "22" * 20),
+        timeout=4_000_000_000,
+        amount_wei=10**15,
+    )
+    rpc = _RecordingRpc(loc, loc.amount_wei)
+    leg = EthHtlcContractLeg(rpc=rpc, signing_key=PrivateKeyMaterial.generate(), chain_id=11155111, artifact=_ART)
+    leg._runtime_code_matches = lambda code: True  # bypass artifact-bytecode match; we test the PINNING
+
+    await leg.verify_funded(loc, expected_amount_wei=loc.amount_wei, block_identifier="finalized")
+
+    # The fix: the two EOA code reads AND the balance read honour the pin (were 'latest'/None before).
+    assert rpc.code_block_ids[loc.claimant] == "finalized"
+    assert rpc.code_block_ids[loc.refundee] == "finalized"
+    assert rpc.balance_block_id == "finalized"
+    assert rpc.code_block_ids[loc.contract_address] == "finalized"  # the core code read (already pinned)

--- a/tests/test_mempool_adapters.py
+++ b/tests/test_mempool_adapters.py
@@ -76,6 +76,35 @@ async def test_broadcast_idempotent_already_known_derives_txid_locally():
     assert await b.broadcast(raw) == txid
 
 
+async def test_broadcast_present_phrases_are_idempotent_success():
+    # LOW-R4: the specific "already present" phrases each derive the txid locally (no-op re-broadcast).
+    raw, txid = _claim_vec()
+    for body in (
+        "sendrawtransaction: txn-already-known",
+        "Transaction already in block chain",
+        "txn-already-in-mempool: already in mempool",
+    ):
+        b = MempoolSpaceBroadcaster()
+        b._http.session = AsyncMock(return_value=_session_posting(_post_resp(400, body)))
+        assert await b.broadcast(raw) == txid, body
+
+
+async def test_broadcast_already_spent_conflict_is_fail_closed():
+    # LOW-R4: a rejection containing the bare word "already" but meaning a DOUBLE-SPEND/conflict
+    # (the counterparty spent the HTLC output first) must NOT be misread as idempotent success —
+    # else broadcast() would return a txid for a tx that never landed. Fail-closed.
+    raw, _ = _claim_vec()
+    for body in (
+        "bad-txns-inputs-missingorspent",
+        "sendrawtransaction: inputs already spent by another transaction",
+        "txn-mempool-conflict",
+    ):
+        b = MempoolSpaceBroadcaster()
+        b._http.session = AsyncMock(return_value=_session_posting(_post_resp(400, body)))
+        with pytest.raises(NetworkError, match="broadcast rejected"):
+            await b.broadcast(raw)
+
+
 async def test_broadcast_rejects_empty():
     b = MempoolSpaceBroadcaster()
     with pytest.raises(ValidationError, match="non-empty bytes"):

--- a/tests/test_watch_daemon.py
+++ b/tests/test_watch_daemon.py
@@ -105,9 +105,11 @@ async def test_run_loop_heartbeat_sink_failure_does_not_crash():
     assert n == 2  # loop survived despite the sink raising every tick
 
 
-async def test_run_loop_tick_timeout_emits_degraded_heartbeat():
-    # red-team #8: a tick that exceeds the watchdog budget must not block past the deadman window;
-    # the loop times it out, emits an alive (empty) heartbeat, and continues.
+async def test_run_loop_tick_timeout_skips_heartbeat():
+    # LOW-R3: a tick that exceeds the watchdog budget is "blind" — it must NOT refresh the
+    # cross-process heartbeat, so a slow-loris source that wedges every tick lets the age-only
+    # dead-man's-switch go stale and PAGE (rather than reporting a healthy-but-blind tower). The
+    # loop still times the tick out and continues; it just emits no beat for the blind tick.
     class _SlowStore:
         async def list_active(self):
             await asyncio.sleep(10)  # longer than the tick budget
@@ -126,4 +128,4 @@ async def test_run_loop_tick_timeout_emits_degraded_heartbeat():
         tick_timeout_s=0.01,
     )
     assert n == 1
-    assert beats == [0]  # degraded (empty) but ALIVE heartbeat still emitted
+    assert beats == []  # blind (timed-out) tick emits NO heartbeat → deadman sees staleness if it persists

--- a/tests/test_watch_quorum.py
+++ b/tests/test_watch_quorum.py
@@ -91,9 +91,10 @@ class FakeBtc:
 
 
 class FakeRxd:
-    def __init__(self, tip: int, cov_confs: int | None = None):
+    def __init__(self, tip: int, cov_confs: int | None = None, *, corroborated: bool = False):
         self._tip = tip
         self._cov = cov_confs
+        self.corroborated = corroborated  # mirrors MultiSourceRxdChainSource.corroborated (LOW-R2)
 
     async def tip_height(self):
         return self._tip
@@ -152,14 +153,21 @@ async def test_bogus_covenant_confs_guarded_to_none():
     assert obs.asset_locked_at_height is None
 
 
-async def test_corroboration_flag_toggles():
+async def test_corroboration_flag_requires_structural_quorum():
+    # LOW-R2: rxd_corroborated must be backed by a real multi-source quorum, not a free bool.
     btc = FakeBtc(BtcClaimStatus(claimed=False))
-    rxd = FakeRxd(tip=200, cov_confs=101)
+    single = FakeRxd(tip=200, cov_confs=101)  # corroborated=False (a single source)
+    # default (single source) → low_corroboration flagged
     assert (
-        await ChainObserver(btc=btc, rxd=rxd, rxd_corroborated=False).observe("s", _record())
+        await ChainObserver(btc=btc, rxd=single, rxd_corroborated=False).observe("s", _record())
     ).low_corroboration is True
+    # asserting corroboration over a non-corroborated source is REFUSED at construction
+    with pytest.raises(ValidationError, match="multi-source RXD quorum"):
+        ChainObserver(btc=btc, rxd=single, rxd_corroborated=True)
+    # a genuinely corroborated (quorum) source clears the flag
+    quorum_rxd = FakeRxd(tip=200, cov_confs=101, corroborated=True)
     assert (
-        await ChainObserver(btc=btc, rxd=rxd, rxd_corroborated=True).observe("s", _record())
+        await ChainObserver(btc=btc, rxd=quorum_rxd, rxd_corroborated=True).observe("s", _record())
     ).low_corroboration is False
 
 


### PR DESCRIPTION
A second, residual single-context audit pass (the in-scope modules the whole-stack pass left unread: `eth_wallet/`, the SPV primitive, the watch-quorum layer, and `network/bitcoin.py`) found **no CRITICAL/HIGH/MEDIUM** and **verified the prior MEDIUM-1 premise from source**. The four LOWs it surfaced — all defense-in-depth, none with a proven loss path — are fixed here. (Detailed exploit narratives + the cross-module invariant map live in a local working doc, not committed.)

- **R1 — ETH verify→lock reorg pin.** `verify_funded` now threads `block_identifier` into the two EOA `get_code` reads + the balance read (`eth_wallet/htlc_leg.py:237/239/241`); they read `'latest'` before, so at a `'finalized'` re-verify the EOA-ness of claimant/refundee and the funded balance were read at the reorg-able tip. The "all reads honour the pin" docstring is now accurate. Directly tightens the MEDIUM-1 fix.
- **R2 — single-source autonomy backstop.** `ChainObserver` now refuses `rxd_corroborated=True` unless the RXD source declares `corroborated=True` (a real ≥2-source quorum; `MultiSourceRxdChainSource.corroborated` added). Corroboration can no longer be asserted over a single source; `accept_single_source` stays the explicit, logged dust opt-in.
- **R3 — watchtower liveness.** A timed-out (blind) tick no longer emits a fresh "alive" heartbeat (`watch/daemon.py`), so a sustained slow-loris source that wedges every tick lets the age-only cross-process dead-man's-switch go stale and page — instead of reporting a healthy-but-blind tower. A single transient timeout is harmless.
- **R4 — BTC broadcast trust boundary.** The broadcaster idempotency match drops the bare `"already"` token for the specific present-phrases (`network/bitcoin.py`). An `"inputs already spent"` conflict (counterparty spent the HTLC output first) now fails closed rather than being misread as a successful self-broadcast.

### Tests
+R1 (recording-rpc asserts all three reads are pinned), +R4 (present-phrase success / conflict fail-closed), updated R2 (structural-quorum requirement) and R3 (blind tick emits no beat). Full `task ci` green: 4136 passed, coverage 87.6%, bandit/mypy/private-links clean.

Residual for the external engagement (unchanged): the live-node MEDIUM-1/R1 reorg test, a genuine two-party adversarial run, and the cross-repo (pyrxd-eth-htlc) coherence pass. External audit remains the hard gate before real value.

🤖 Generated with [Claude Code](https://claude.com/claude-code)