### PR TITLE
harden(swap): rename stall predicate + reorg-pin tests (audit follow-ups)

### DIFF
--- a/src/pyrxd/gravity/eth_rxd_timelock.py
+++ b/src/pyrxd/gravity/eth_rxd_timelock.py
@@ -16,7 +16,7 @@ only starts counting once the covenant is MINED. This module bridges the two:
   creates (a maker withholding its claim until past the RXD refund, then claiming AND
   refunding) is mitigated by the proactive asset-refund + the cross-clock margin coupling, not
   by the timelock alone — see
-  :func:`pyrxd.gravity.swap_coordinator.should_taker_refund_proactively`.
+  :func:`pyrxd.gravity.swap_coordinator.taker_refund_window_open`.
 
   RESIDUAL FREE-OPTION (red-team HIGH, NOT fully closed pre-audit). The reveal-on-the-long-leg
   free-option is INHERENT to this swap shape and is only BOUNDED here, not eliminated. Honest

--- a/src/pyrxd/gravity/swap_coordinator.py
+++ b/src/pyrxd/gravity/swap_coordinator.py
@@ -82,7 +82,8 @@ __all__ = [
     "assess_claim_finality",
     "generate_secret",
     "measure_margin_from_btc_block_times",
-    "should_taker_refund_proactively",
+    "should_taker_refund_proactively",  # deprecated alias of taker_refund_window_open
+    "taker_refund_window_open",
 ]
 
 logger = logging.getLogger(__name__)
@@ -464,7 +465,7 @@ def generate_secret() -> tuple[SecretBytes, bytes]:
 # ---------------------------------------------------------------------------
 
 
-def should_taker_refund_proactively(
+def taker_refund_window_open(
     *,
     now_block_height: int,
     asset_locked_at_height: int,
@@ -473,10 +474,12 @@ def should_taker_refund_proactively(
     maker_has_claimed_btc: bool,
     block_interval_s: float = 600.0,
 ) -> bool:
-    """Return True once the refund window is near and the taker must act rather than wait.
+    """Return True once the taker's act-now window is open: ``t_RXD - N`` reached, maker silent.
 
     This is a TIMING PREDICATE only — "the maker has not claimed and ``t_RXD - N`` is
-    approaching" — NOT a prescription of which refund to run. The dominant adversarial
+    approaching" — NOT a prescription of which refund to run. (Formerly named
+    ``should_taker_refund_proactively``; renamed because the name described an action
+    while the predicate only describes this window — deferred from PR #189.) The dominant adversarial
     risk it guards: because ``t_BTC > t_RXD``, a malicious maker can withhold the BTC
     claim until after ``t_RXD`` opens, then claim BTC (revealing ``p``) AND CSV-refund
     the asset, taking both. Treat the trigger as "stop waiting", never "keep waiting".
@@ -505,6 +508,10 @@ def should_taker_refund_proactively(
     # Act once we are within `safety_window_blocks` of that maturity.
     maturity = asset_locked_at_height + rxd_blocks
     return now_block_height >= (maturity - safety_window_blocks)
+
+
+# Deprecated alias (pre-0.8.0 public name); will be removed in a future release.
+should_taker_refund_proactively = taker_refund_window_open
 
 
 # ---------------------------------------------------------------------------
@@ -1622,7 +1629,7 @@ class SwapCoordinator:
             raise ValidationError(
                 f"maybe_refund_asset_on_maker_stall only valid from BOTH_LOCKED, not {self.record.state.value}"
             )
-        trigger = should_taker_refund_proactively(
+        trigger = taker_refund_window_open(
             now_block_height=now_block_height,
             asset_locked_at_height=asset_locked_at_height,
             t_rxd=self.record.terms.t_rxd,

--- a/src/pyrxd/gravity/watch/README.md
+++ b/src/pyrxd/gravity/watch/README.md
@@ -18,7 +18,7 @@ RecordStore ─┐                                    ┌─ AlertChannel (authe
         Reconciler.tick()  →  decide()  →  DedupAlerter.handle() → Page
              ▲                  ▲
    ChainObserver.observe() ─────┘   (consumes assess_claim_finality +
-   (BtcClaimSource + RxdChainSource) should_taker_refund_proactively — never re-derives)
+   (BtcClaimSource + RxdChainSource) taker_refund_window_open — never re-derives)
 ```
 
 - **`decide.py`** — pure `decide(record, observations, policy, safety_window_blocks) → Decision`.

--- a/src/pyrxd/gravity/watch/__init__.py
+++ b/src/pyrxd/gravity/watch/__init__.py
@@ -12,7 +12,7 @@ operational entrypoints live in ``scripts/watchtower_run.py`` (the tower) and
 ``scripts/watchtower_deadman.py`` (the independent dead-man's-switch monitor).
 
 The decision core (:func:`decide`) CONSUMES the audited gate functions
-``assess_claim_finality`` and ``should_taker_refund_proactively`` from
+``assess_claim_finality`` and ``taker_refund_window_open`` from
 ``swap_coordinator`` — it never re-derives finality. That is the audit-relevant
 invariant: the watchtower is a driver, not a second finality brain.
 """

--- a/src/pyrxd/gravity/watch/decide.py
+++ b/src/pyrxd/gravity/watch/decide.py
@@ -5,7 +5,7 @@
 coordinator step the operator should run, and the deadline. It is **pure**: no
 chain calls, no I/O, exhaustively unit-testable, and it **consumes** the audited
 gate (``assess_claim_finality``) and the maker-stall predicate
-(``should_taker_refund_proactively``) rather than re-deriving them.
+(``taker_refund_window_open``) rather than re-deriving them.
 
 Key safety rules (mirrors the live coordinator, never routes around it):
 * Chain truth dominates a lagging record: if the maker's counter-leg claim is
@@ -37,7 +37,7 @@ from pyrxd.gravity.swap_coordinator import (
     ClaimFinality,
     MarginPolicy,
     assess_claim_finality,
-    should_taker_refund_proactively,
+    taker_refund_window_open,
 )
 from pyrxd.gravity.swap_state import SwapRecord, SwapState, is_terminal
 from pyrxd.security.errors import ValidationError
@@ -331,7 +331,7 @@ def decide(
             return Decision(Intent.WATCH, reason="asset lock height not yet observed", low_corroboration=corr)
         deadline = _refund_opens_at(policy, terms, obs.asset_locked_at_height)
         try:
-            refund_due = should_taker_refund_proactively(
+            refund_due = taker_refund_window_open(
                 now_block_height=obs.now_rxd_height,
                 asset_locked_at_height=obs.asset_locked_at_height,
                 t_rxd=terms.t_rxd,
@@ -416,7 +416,7 @@ def _decide_eth(
       (``swap_coordinator.py`` — the taker's value sits in the ETH HTLC it does not touch); ``mutual_refund``
       unwinds BOTH legs once their timeouts elapse.
     * **The maker-claim trigger is ``eth_claim_detected``** (an ETH claim tx observed) instead of a
-      spent BTC funding outpoint. ``should_taker_refund_proactively`` is chain-agnostic (it keys purely
+      spent BTC funding outpoint. ``taker_refund_window_open`` is chain-agnostic (it keys purely
       on RXD heights) and is reused unchanged.
 
     Alert-only: like the BTC branch it broadcasts nothing and only names the coordinator step.
@@ -519,7 +519,7 @@ def _decide_eth(
             return Decision(Intent.WATCH, reason="asset lock height not yet observed", low_corroboration=corr)
         deadline = _refund_opens_at(policy, terms, obs.asset_locked_at_height)
         try:
-            refund_due = should_taker_refund_proactively(
+            refund_due = taker_refund_window_open(
                 now_block_height=obs.now_rxd_height,
                 asset_locked_at_height=obs.asset_locked_at_height,
                 t_rxd=terms.t_rxd,

--- a/tests/test_eth_leg.py
+++ b/tests/test_eth_leg.py
@@ -530,3 +530,26 @@ async def test_verify_funded_pins_eoa_and_balance_reads_to_the_block():
     assert rpc.code_block_ids[loc.refundee] == "finalized"
     assert rpc.balance_block_id == "finalized"
     assert rpc.code_block_ids[loc.contract_address] == "finalized"  # the core code read (already pinned)
+
+
+def test_runtime_code_mask_gap_documented_and_empty_code_fails_closed():
+    """Pin the EXACT shape of the _runtime_code_matches masking gap (audit eth_leg_web3 LOW /
+    MEDIUM-1 residual): every committed-ZERO byte is masked — a superset of the immutable slots —
+    so a contract whose logic differs ONLY at committed-zero positions passes this gate. That is
+    why the gate alone cannot prove "no modified logic" and the 'finalized' verify pin is the live
+    backstop (staged for real in test_eth_leg_anvil_integration.py's reorg test). Also pins the
+    fail-closed cases the backstop relies on: empty code (a reorged-out deploy read at the
+    finalized checkpoint) and any non-zero-position or length deviation must be rejected."""
+    # offsets:                0     1     2     3     4
+    runtime = bytes.fromhex("600060ff00")  # committed zeros at offsets 1 and 4
+    art = {"abi": [], "bytecode": "0x00", "runtime_bytecode": "0x" + runtime.hex()}
+    leg = EthHtlcContractLeg(rpc=object(), signing_key=PrivateKeyMaterial.generate(), chain_id=1, artifact=art)
+
+    assert leg._runtime_code_matches(runtime)  # exact match passes
+    # THE GAP: a byte swapped in at a committed-zero position is NOT verified (masked superset).
+    assert leg._runtime_code_matches(bytes.fromhex("604260ff00"))
+    assert leg._runtime_code_matches(bytes.fromhex("600060ff42"))
+    # Fail-closed: non-zero-position deviation, length mismatch, and the reorged-out empty read.
+    assert not leg._runtime_code_matches(bytes.fromhex("600060fe00"))
+    assert not leg._runtime_code_matches(runtime + b"\x00")
+    assert not leg._runtime_code_matches(b"")

--- a/tests/test_eth_leg_anvil_integration.py
+++ b/tests/test_eth_leg_anvil_integration.py
@@ -58,13 +58,12 @@ def _free_port() -> int:
     return port
 
 
-@pytest.fixture()
-def anvil_url():
-    """Start a fresh, isolated anvil per test (so evm_increaseTime cannot leak across tests)."""
+def _start_anvil(*extra_args: str):
+    """Start a fresh, isolated anvil (so evm_increaseTime cannot leak across tests); yield its URL."""
     port = _free_port()
     url = f"http://127.0.0.1:{port}"
     proc = subprocess.Popen(
-        ["anvil", "--port", str(port), "--chain-id", str(_CHAIN_ID), "--silent"],
+        ["anvil", "--port", str(port), "--chain-id", str(_CHAIN_ID), "--silent", *extra_args],
         stdout=subprocess.DEVNULL,
         stderr=subprocess.DEVNULL,
     )
@@ -86,6 +85,20 @@ def anvil_url():
             proc.wait(timeout=5)
         except Exception:
             proc.kill()
+
+
+@pytest.fixture()
+def anvil_url():
+    yield from _start_anvil()
+
+
+@pytest.fixture()
+def anvil_url_fast_finality():
+    """Anvil with a 1-slot epoch so the 'finalized' tag lags the head by only ~2 blocks —
+    small enough to drive finality forward with a few evm_mine calls (default epoch = 32
+    slots → a 64-block lag), while still leaving a real non-finalized window at the tip
+    for the reorg test to attack."""
+    yield from _start_anvil("--slots-in-an-epoch", "1")
 
 
 def _legs(url: str):
@@ -203,5 +216,68 @@ async def test_refund_after_timeout_and_claim_blocked_when_expired(anvil_url):
         refund_tx = await taker.refund(locator)
         receipt = await rpc.wait_receipt(refund_tx)
         assert int(receipt.get("status", 0)) == 1
+    finally:
+        await rpc.close()
+
+
+async def test_finalized_pin_rejects_reorg_swapped_in_contract(anvil_url_fast_finality):
+    """MEDIUM-1 residual (whole-stack audit 2026-06-10): stage the verify→lock reorg substitution
+    on a real EVM and prove the 'finalized' pin is the live backstop for the runtime-mask gap.
+
+    Attack model: the taker's deploy is reorged out inside the verify→lock window and a DIFFERENT
+    deployment lands at the SAME (deployer, nonce) CREATE address. _runtime_code_matches masks
+    every committed-zero byte (see test_eth_leg.py's mask-gap test), so a swapped-in contract can
+    evade the 'latest' checks — the maker's pre-lock re-verify at 'finalized' is what closes this.
+
+    Asserts: (a) 'latest' ACCEPTS the swapped-in contract (it cannot tell the substitution
+    happened); (b) 'finalized' REJECTS it — the checkpoint predates the replacement, the code
+    read returns empty, fail closed; (c) the balance read honours the pin too (LOW-R1 residual);
+    (d) once the replacement itself finalizes, the SAME pinned verify passes — (b) rejected the
+    reorg, not a broken tag."""
+    rpc, taker, _maker = _legs(anvil_url_fast_finality)
+    try:
+        _, h = _secret()
+        timeout = await _now_plus(rpc, 3600)
+        snap = (await rpc.w3.provider.make_request("evm_snapshot", []))["result"]
+        locator = await taker.fund(
+            hashlock=h, claimant=_ADDR_MAKER, refundee=_ADDR_TAKER, timeout=timeout, amount_wei=_AMOUNT_WEI
+        )
+        # The taker's fund-time self-verify at 'latest' (the real protocol step) passes.
+        await taker.verify_funded(locator, expected_amount_wei=_AMOUNT_WEI)
+
+        # REORG: revert to the pre-deploy snapshot — the deploy is un-mined, nonce restored.
+        assert (await rpc.w3.provider.make_request("evm_revert", [snap]))["result"] is True
+        assert await rpc.get_code(locator.contract_address) == b""  # the honest deploy is gone
+
+        # The replacement: same negotiated immutables (so the getter binding cannot see it) but
+        # over-funded by 1 wei — a provably DIFFERENT deployment (different tx hash) at the SAME
+        # (deployer, nonce) CREATE address.
+        replacement = await taker.fund(
+            hashlock=h, claimant=_ADDR_MAKER, refundee=_ADDR_TAKER, timeout=timeout, amount_wei=_AMOUNT_WEI + 1
+        )
+        assert replacement.contract_address == locator.contract_address
+        assert replacement.deploy_tx_hash != locator.deploy_tx_hash
+
+        # Precondition for (b): the finalized checkpoint predates the replacement's block.
+        fin = await rpc.w3.eth.get_block("finalized")
+        rec = await rpc.w3.eth.get_transaction_receipt(replacement.deploy_tx_hash)
+        assert int(fin["number"]) < int(rec["blockNumber"])
+
+        # (a) 'latest' accepts the swapped-in contract against the ORIGINAL locator — blind.
+        await taker.verify_funded(locator, expected_amount_wei=_AMOUNT_WEI)
+        # (b) 'finalized' fails closed: empty code at the checkpoint → runtime-logic mismatch.
+        with pytest.raises(ValidationError, match="runtime logic"):
+            await taker.verify_funded(locator, expected_amount_wei=_AMOUNT_WEI, block_identifier="finalized")
+        # (c) LOW-R1 residual: the balance read honours the pin (0 at the checkpoint, funded at tip).
+        assert await rpc.get_balance(locator.contract_address, "finalized") == 0
+        assert await rpc.get_balance(locator.contract_address) == _AMOUNT_WEI + 1
+
+        # (d) Control: mine past the finality lag; the same pinned verify now passes — proving
+        # (b)'s rejection came from the reorg window, not from a broken/always-stale tag.
+        for _ in range(4):
+            await rpc.w3.provider.make_request("evm_mine", [])
+        fin2 = await rpc.w3.eth.get_block("finalized")
+        assert int(fin2["number"]) >= int(rec["blockNumber"])
+        await taker.verify_funded(locator, expected_amount_wei=_AMOUNT_WEI, block_identifier="finalized")
     finally:
         await rpc.close()

--- a/tests/test_swap_coordinator.py
+++ b/tests/test_swap_coordinator.py
@@ -42,7 +42,7 @@ from pyrxd.gravity.swap_coordinator import (
     assess_claim_finality,
     generate_secret,
     measure_margin_from_btc_block_times,
-    should_taker_refund_proactively,
+    taker_refund_window_open,
 )
 from pyrxd.gravity.swap_state import (
     NegotiatedTerms,
@@ -643,14 +643,14 @@ async def test_taker_refuses_to_fund_on_failed_gate():
 def test_should_refund_proactively_only_near_maturity():
     t_rxd = t.Timelock(72, t.TimeUnit.BLOCKS)
     # locked at 1000; maturity = 1072; window = 6 -> act at >= 1066.
-    assert not should_taker_refund_proactively(
+    assert not taker_refund_window_open(
         now_block_height=1050,
         asset_locked_at_height=1000,
         t_rxd=t_rxd,
         safety_window_blocks=6,
         maker_has_claimed_btc=False,
     )
-    assert should_taker_refund_proactively(
+    assert taker_refund_window_open(
         now_block_height=1066,
         asset_locked_at_height=1000,
         t_rxd=t_rxd,
@@ -661,13 +661,21 @@ def test_should_refund_proactively_only_near_maturity():
 
 def test_should_not_refund_if_maker_already_claimed():
     # Once p is public the taker should scrape+claim, not refund.
-    assert not should_taker_refund_proactively(
+    assert not taker_refund_window_open(
         now_block_height=2000,
         asset_locked_at_height=1000,
         t_rxd=t.Timelock(72, t.TimeUnit.BLOCKS),
         safety_window_blocks=6,
         maker_has_claimed_btc=True,
     )
+
+
+def test_proactive_refund_deprecated_alias_points_at_renamed_predicate():
+    # The pre-0.8.0 name stays importable (deprecated alias) and IS the renamed predicate.
+    from pyrxd.gravity import swap_coordinator as sc
+
+    assert sc.should_taker_refund_proactively is sc.taker_refund_window_open
+    assert "should_taker_refund_proactively" in sc.__all__
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_watch_decide.py
+++ b/tests/test_watch_decide.py
@@ -4,7 +4,7 @@ Pure, no chain/network. Covers every Intent branch, the chain-truth-dominates ru
 (claim race assessed from BOTH_LOCKED, not just SECRET_REVEALED), fail-closed paths
 (missing depth, lying ``now < lock``), and low-corroboration propagation. The
 finality-gate math is exercised indirectly — decide() consumes the real
-``assess_claim_finality`` / ``should_taker_refund_proactively``, never a re-derivation.
+``assess_claim_finality`` / ``taker_refund_window_open``, never a re-derivation.
 """
 
 from __future__ import annotations

--- a/tests/test_xchain_eth_adversarial_e2e.py
+++ b/tests/test_xchain_eth_adversarial_e2e.py
@@ -42,7 +42,7 @@ import hashlib
 import os
 
 from pyrxd.gravity.htlc_covenant import build_htlc_covenant_rxd
-from pyrxd.gravity.swap_coordinator import should_taker_refund_proactively
+from pyrxd.gravity.swap_coordinator import taker_refund_window_open
 from pyrxd.gravity.swap_state import SwapState
 from pyrxd.security.errors import NetworkError, ValidationError
 
@@ -122,7 +122,7 @@ class TestEthAdversarial:
             #    safety window the C1 trigger must NOT fire (the taker keeps waiting, correctly).
             n = coord.config.maker_stall_safety_window_blocks
             assert (
-                should_taker_refund_proactively(
+                taker_refund_window_open(
                     now_block_height=asset_locked_at + 1,
                     asset_locked_at_height=asset_locked_at,
                     t_rxd=terms.t_rxd,
@@ -137,7 +137,7 @@ class TestEthAdversarial:
             #    trigger must now FIRE ("stop waiting — the maker is stalling").
             node.rxd_mine(terms.t_rxd.value - n)
             assert (
-                should_taker_refund_proactively(
+                taker_refund_window_open(
                     now_block_height=int(node.rxd("getblockcount")),
                     asset_locked_at_height=asset_locked_at,
                     t_rxd=terms.t_rxd,


### PR DESCRIPTION
Closes the three remaining code-touching items from the 2026-06-10 whole-stack / residual audit follow-ups. All three are **test-and-naming hardening — no behavioural change** to the swap state machine; the prior PRs (#192 MEDIUM-1 + 3 LOW, #193 R1–R4) fixed the live code, this PR settles the residual *test coverage* and a deferred rename.

## 1. Predicate rename (deferred from #189)
`should_taker_refund_proactively` named an *action*, but after the BTC maker-stall fix it only describes a **timing window** — the taker's act-now point; the action it triggers is always `mutual_refund`, never an asset-only refund. Renamed to **`taker_refund_window_open`** across the coordinator, the watchtower decision core (`watch/decide.py`, `watch/__init__.py`, `watch/README.md`), and the timelock docstring.

The old name stays as a **deprecated module-level alias** (kept in `__all__`) so no downstream import breaks; a regression test pins `should_taker_refund_proactively is taker_refund_window_open`.

## 2. MEDIUM-1 residual — `'finalized'` reorg-pin test on a real EVM
The whole-stack audit's open item: prove the `'finalized'` verify pin is the live backstop for the `_runtime_code_matches` masking gap, against a real EVM rather than by argument.

New `test_finalized_pin_rejects_reorg_swapped_in_contract` (Anvil, `--slots-in-an-epoch 1` for a short finality lag) stages the verify→lock substitution:
snapshot → taker funds + self-verifies at `'latest'` → `evm_revert` (deploy un-mined) → a **different** deployment lands at the **same** `(deployer, nonce)` CREATE address. It asserts:
- **(a)** `'latest'` **accepts** the swapped-in contract (it cannot tell the substitution happened — the gap is real);
- **(b)** `'finalized'` **rejects** it (empty code at the checkpoint → runtime-logic mismatch, fail closed);
- **(c)** the balance read honours the pin too (the **LOW-R1** residual);
- **(d)** once the replacement itself finalizes, the same pinned verify passes — proving (b) rejected the reorg window, not a permanently-stale tag.

## 3. Mask-gap unit test
`test_runtime_code_mask_gap_documented_and_empty_code_fails_closed` pins the exact shape of the gap the integration test backstops: a byte swapped in at a committed-**zero** position is **not** verified (the mask is a superset of the immutable slots), while a non-zero-position deviation, a length mismatch, and an empty (reorged-out) read all fail closed.

## Verification
`task ci` in an isolated worktree: **4123 passed, 86 skipped, 1 xfailed**; lint / format / typecheck / private-links all green. New Anvil integration test: **5 passed** locally (anvil 1.7.1). The local coverage-gate number is the known fresh-worktree double-count artifact (editable install counts both the main-repo and worktree `src`); the touched modules read 82%+ per-package and CI runs on a clean checkout.

Detailed exploit narratives + the cross-module invariant map remain in a local working doc (not committed), consistent with #192/#193.