### PR TITLE
feat(devnet): finish Tier-1 on-ramp + bump Radiant-Core v2.3.0→v3.1.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,11 +92,17 @@ jobs:
           poetry run python examples/regtest_quickstart.py | tee /tmp/quickstart.out
           grep -q "NFT minted on regtest" /tmp/quickstart.out
           poetry run pyrxd regtest down
-      - name: RXD covenant consensus suites on the pinned node
+      - name: RXD covenant spend under consensus on the pinned node
         env:
           RADIANT_REGTEST: "1"
+        # The covenant spend paths (HTLC + soulbound) validated against the real
+        # node's script interpreter — this is the gate that catches a Radiant-Core
+        # bump breaking covenant validation. The exhaustive nBits/bin2num
+        # differential matrix (test_spv_covenant_differential_regtest.py) is
+        # deliberately NOT run here: it needs pre-ground pure-Python PoW chains
+        # (tests/_regtest_grind_chains.py), the multi-minute cost PR #140 removed
+        # from CI on purpose. Run that matrix locally before a version bump.
         run: |
           poetry run pytest -o "addopts=" -m integration \
             tests/test_htlc_regtest_e2e.py \
-            tests/test_soulbound_covenant_regtest.py \
-            tests/test_spv_covenant_differential_regtest.py
+            tests/test_soulbound_covenant_regtest.py

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,3 +62,41 @@ jobs:
         run: poetry run bandit -r src/ -c pyproject.toml
       - name: Type check
         run: poetry run mypy src/pyrxd/security/
+
+  quickstart:
+    # Tier-1 North Star gate: a fresh dev goes from `pip install` to a minted Glyph
+    # token on a local regtest chain. This job builds the regtest image from the
+    # official Radiant-Core release (the same Dockerfile `pyrxd regtest setup` uses)
+    # and runs that exact path + the RXD covenant consensus suites, so the quickstart
+    # and the covenant validation can't silently rot between releases. Kept separate
+    # from `test` so the fast unit gate stays fast (this one builds a docker image).
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6
+        with:
+          python-version: "3.12"
+      - name: Build the regtest node image (official Radiant-Core release binary)
+        run: |
+          docker build -f docker/regtest.Dockerfile \
+            --build-arg RADIANT_VERSION=v3.1.1 \
+            -t radiant-core:v3.1.1-amd64 .
+      - name: Install Poetry
+        run: pip install -r ci/poetry-pin.txt --require-hashes
+      - name: Install dependencies
+        run: poetry install --sync --no-interaction
+      - name: North Star — pip→regtest up→mint a Glyph→assert confirmed
+        run: |
+          set -euo pipefail
+          poetry run pyrxd regtest up --fresh
+          poetry run python examples/regtest_quickstart.py | tee /tmp/quickstart.out
+          grep -q "NFT minted on regtest" /tmp/quickstart.out
+          poetry run pyrxd regtest down
+      - name: RXD covenant consensus suites on the pinned node
+        env:
+          RADIANT_REGTEST: "1"
+        run: |
+          poetry run pytest -o "addopts=" -m integration \
+            tests/test_htlc_regtest_e2e.py \
+            tests/test_soulbound_covenant_regtest.py \
+            tests/test_spv_covenant_differential_regtest.py

--- a/docker/regtest.Dockerfile
+++ b/docker/regtest.Dockerfile
@@ -1,0 +1,66 @@
+# Regtest Radiant-Core node for local pyrxd development (`pyrxd regtest`).
+#
+# Wraps an OFFICIAL Radiant-Core release binary — we do not fork, patch, or
+# recompile the node; we fetch the published linux-x64 daemon and verify its
+# SHA-256 against the release's signed checksum file. This is the committed,
+# reproducible replacement for the previously ad-hoc `radiant-core:*-amd64`
+# image that was built outside the repo and that a fresh developer could not
+# obtain.
+#
+# Build (pin to the latest Radiant-Core release):
+#     docker build -f docker/regtest.Dockerfile \
+#         --build-arg RADIANT_VERSION=v3.1.1 \
+#         -t radiant-core:v3.1.1-amd64 .
+#
+# `pyrxd regtest setup` builds this for you; `pyrxd regtest up` then runs it.
+# The container is regtest-only, binds RPC to 127.0.0.1, and is reached solely
+# via `docker exec radiant-cli` — never exposed to the network.
+#
+# Base: ubuntu:22.04 is chosen deliberately — the release binary dynamically
+# links Boost 1.74 (22.04's default) and needs GLIBC >= 2.34 (22.04 ships
+# 2.35). Debian bullseye's glibc (2.31) is too old; bookworm's Boost (1.81) is
+# the wrong soname. Measured with `ldd`/`objdump -T` on the v3.1.x daemon.
+
+FROM ubuntu:22.04
+
+ARG RADIANT_VERSION=v3.1.1
+ARG RADIANT_TARBALL=radiant-${RADIANT_VERSION}-linux-x64.tar.gz
+ARG RADIANT_BASEURL=https://github.com/Radiant-Core/Radiant-Core/releases/download/${RADIANT_VERSION}
+
+# Runtime shared libraries the daemon links against (measured via ldd).
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        ca-certificates \
+        wget \
+        libboost-chrono1.74.0 \
+        libboost-filesystem1.74.0 \
+        libboost-system1.74.0 \
+        libboost-thread1.74.0 \
+        libdb5.3++ \
+        libevent-2.1-7 \
+        libevent-pthreads-2.1-7 \
+        libminiupnpc17 \
+        libsodium23 \
+        libssl3 \
+        libzmq5 \
+    && rm -rf /var/lib/apt/lists/*
+
+# Fetch the official release daemon + cli, verify integrity against the
+# release checksum file, install only the two binaries the devnet uses.
+RUN set -eux; \
+    cd /tmp; \
+    wget -q "${RADIANT_BASEURL}/${RADIANT_TARBALL}"; \
+    wget -q "${RADIANT_BASEURL}/SHA256SUMS.txt"; \
+    grep " ${RADIANT_TARBALL}\$" SHA256SUMS.txt | sha256sum -c -; \
+    tar xzf "${RADIANT_TARBALL}"; \
+    install -m0755 "radiant-${RADIANT_VERSION}-linux-x64/radiantd" /usr/local/bin/radiantd; \
+    install -m0755 "radiant-${RADIANT_VERSION}-linux-x64/radiant-cli" /usr/local/bin/radiant-cli; \
+    rm -rf /tmp/*
+
+# Smoke-test that the binary actually runs in this base (catches a missing lib
+# at build time rather than at `regtest up`).
+RUN radiantd --version
+
+# The devnet driver overrides the entrypoint and passes -regtest flags
+# (see pyrxd/devnet.py); this default makes the image runnable standalone too.
+ENTRYPOINT ["radiantd"]
+CMD ["-regtest", "-server", "-printtoconsole"]

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,0 +1,91 @@
+# pyrxd roadmap — recommended implementation order
+
+_Written 2026-06-07; committed (sanitized for the public repo) 2026-06-11. Synthesizes the 24 plans in
+`docs/plans/`, open issues (#123/#44/#10/#8), the CLI-fuzz PR, and two 2026-06-07 expert-panel reviews
+(bridged-asset feasibility + swap-marketplace demand)._
+
+**Status delta since 2026-06-07:** Tier 0.1 is done (#175 CLI fuzz and the FT↔ETH swap PR both merged);
+3.2 HD multipath recovery shipped (#158); 3.3 dmint subpackage split shipped (#109); watchtower v2
+(dust-capped BTC refund) + alert-only ETH watching shipped (see `src/pyrxd/gravity/watch/README.md`);
+issue #123 is closed. Tier 0.2/0.3 and all of Tier 1 remain open.
+
+## Framing (what this project actually is)
+
+pyrxd is a **low-mcap, community-driven** project. The near-term goal is **to attract developers to build
+on Radiant** — not to ship real-value production rails. Two consequences set the entire order:
+
+1. **An external audit is a *future* item, not a gate on near-term work.** The audit only blocks
+   *real-value mainnet* swaps. Devs build on **testnet/regtest, where there is no audit gate** — so the
+   whole developer platform can be built and shipped now, with the audit deferred until there's budget
+   and a production reason.
+2. **Devs come for usable, documented, Radiant-*unique* primitives and a fast time-to-first-success** —
+   not a production exchange. So developer experience (DX), packaged primitives, examples, and local
+   testnet tooling rank *above* production features.
+
+The panels' core lesson still holds, just re-pointed: **don't over-build speculative infrastructure —
+ship usable primitives, see what devs actually build, support that.** The "demand" to validate is now
+*developer* demand (adoption, forks, people building), measured by shipping + showcasing, not a
+real-money market.
+
+---
+
+## TIER 0 — Clear the deck (days; cheap; do now)
+
+| # | Item | Why |
+|---|------|-----|
+| 0.1 | ~~Merge/close in-flight PRs (FT↔ETH swap; **#175** CLI fuzz)~~ ✅ done | Don't carry open branches forward. |
+| 0.2 | Cleanup: refund the orphaned ETH HTLC after timeout; retire the exposed test key | Hygiene; finish the FT-swap run cleanly. |
+| 0.3 | **#44** security baseline (harden the 4 public repos) | Cheap, finishes a started sweep; a clean repo is itself a dev-attractor. |
+
+## TIER 1 — The developer on-ramp (the new #1 — this is how you attract devs)
+
+| # | Item | Why it's #1 |
+|---|------|-------------|
+| 1.1 | **Packaging + 5-minute quickstart + runnable examples.** `pip install pyrxd` → issue a Glyph FT/NFT, build a covenant, run a swap **on regtest** in <20 lines, each a copy-paste example. | **Time-to-first-success is the single biggest dev-attractor.** A dev who mints a token in 5 minutes stays; one who fights setup leaves. No audit, no real value — pure DX. |
+| 1.2 | **One-command local regtest + a testnet faucet/guide.** | Where devs actually start. Frictionless iteration with zero real-value/audit concerns. The sandbox is the funnel. |
+| 1.3 | **Clean, typed, documented SDK surface** for the primitives (Glyph tokens, covenants, SPV, swap legs) + an API reference. | Reduces integration friction; signals a maintained, buildable library. |
+| 1.4 | **Showcase the differentiators.** Publish the cross-chain swap demos (live txids + the Discord post), an examples gallery, and a "what you can build on Radiant" page. | Proof + inspiration is what pulls builders in. The hard demos are already done — package and broadcast them. |
+
+Sprint-level breakdown: `docs/plans/2026-06-07-sprint-tier1-dev-onramp.md`.
+
+## TIER 2 — Package the Radiant-unique primitives as reusable, testnet-ready library features
+
+These are the "wow, Radiant can do that?" capabilities. Shipped as **library + regtest/testnet**, they
+attract devs **without the audit gate** (no real value moves).
+
+| # | Item | Why here |
+|---|------|----------|
+| 2.1 | **Cross-chain atomic swap as a clean library primitive** (regtest/testnet-first): the coordinator + legs packaged for devs to embed. | The headline capability — trustless RXD/Glyph ↔ ETH proven live. As a *library* it's a magnet for cross-chain builders. |
+| 2.2 | **#123 same-chain swap API** (SIGHASH_SINGLE\|ANYONECANPAY / RSWP builder — Glyph↔Glyph/RXD). | A composable Radiant-native building block; lower risk (same-chain, no counter-leg). |
+| 2.3 | **Base + Bitcoin-family counter-legs as testnet capability** (Base native-ETH leg + Litecoin cheapest first; then USDC/DOGE/BCH). | "Swap RXD/Glyphs against ETH/USDC/BTC" is a headline that attracts cross-chain devs; on testnet it needs no audit. |
+| 2.4 | **Token + covenant building blocks** documented as composable primitives (FT/NFT/dMint standards, the covenant builders, the REF gate). | The genuinely differentiated tech — native tokens + covenants on a UTXO chain — made easy to build on. |
+
+## TIER 3 — Contributor & user quality (ongoing; makes the project healthy and adoptable)
+
+| # | Item | Why |
+|---|------|-----|
+| 3.1 | **CLI hardening + UX**: ~~**#175/#10** fuzz~~ ✅, **#8** mnemonic re-entry / agent-unlock pattern. | A solid CLI is many devs' first touch. |
+| 3.2 | ~~**HD wallet multipath recovery**~~ ✅ shipped (#158). | Wallet robustness; user trust. |
+| 3.3 | ~~**dmint `dmint.py` subpackage split**~~ ✅ shipped (#109) + general refactors. | Contributor code-health — a clean codebase attracts contributors. |
+| 3.4 | **Watchtower** (operator tooling; v1 + dust-capped v2 + alert-only ETH shipped; broader autonomy later). | Operational tooling for anyone running swaps. |
+| 3.5 | **Docs depth + CONTRIBUTING + architecture overview.** | Lowers the barrier to *contributing*, not just consuming. |
+
+## TIER 4 — Production / real-value / future (deferred: needs audit + budget + demand + legal)
+
+| # | Item | Why deferred |
+|---|------|--------------|
+| 4.1 | **External security audit** of the swap trust boundary. | A *future* item — commission when there's budget and a real-value production reason. Until then, keep mainnet to deliberate dust demos. |
+| 4.2 | **Real-value mainnet swaps / an RFQ desk / a real market.** | Audit-gated *and* demand-gated (the marketplace panel: start with a concierge test, mind the HTLC free-option). Not the near-term goal. |
+| 4.3 | **A bridged stablecoin on Radiant** (federated-first; SPV-trustless later). | Demand-gated *and* regulated — build only once a native-asset economy needs a standing dollar; a regulated product needing a legal entity, not a covenant. |
+| 4.4 | **Bridged-BTC research; NFT swap covenant; more counter-chains (Solana/Cosmos).** | Research-/capital-/demand-gated; pursue with a specific reason. |
+
+---
+
+## The spine in one line
+**Clear the deck → build the developer on-ramp (DX + examples + local testnet + showcase) → package the
+Radiant-unique primitives (swaps, tokens, covenants) as testnet-ready library features → keep the
+codebase contributor-friendly → and defer all real-value/audited/regulated production (the RFQ market,
+bridged assets, the audit itself) to the future, when adoption + budget justify it.**
+
+The pivot from a production roadmap: **attract builders with great primitives on testnet now; the
+audit and real-value rails come after there are devs and a reason to need them.**

--- a/docs/how-to/index.md
+++ b/docs/how-to/index.md
@@ -8,6 +8,7 @@ you already know the basics and want a focused answer to "how do I X."
 
 broadcast-a-transaction
 recover-funds-across-wallet-paths
+use-the-public-testnet
 migrate-0.4-to-0.5
 verify-an-spv-proof
 spv-verification-pitfalls
@@ -25,6 +26,10 @@ spv-verification-pitfalls
   the BIP44 coin-type/account paths (Photonic, Chainbow, Electron, Tangem) to
   find which derivation actually holds the money. Read-only; `pyrxd wallet
   recover --scan` or the `pyrxd.hd.discover` API.
+- **[Use the public Radiant testnet](use-the-public-testnet.md)** — when to
+  graduate from the local regtest quickstart to the shared public testnet, how to
+  run `radiantd -testnet`, point pyrxd at it, and get testnet coins from the
+  (best-effort, community-run) faucet. For most work, stay on regtest.
 - **[Migrate from pyrxd 0.4.x to 0.5.0](migrate-0.4-to-0.5.md)** — three
   breaking signature changes on the V1 dMint mint path, with
   before/after snippets. Read this first if you upgraded from a 0.4.x

--- a/docs/how-to/use-the-public-testnet.md
+++ b/docs/how-to/use-the-public-testnet.md
@@ -1,0 +1,68 @@
+# Use the public Radiant testnet
+
+The [5-minute quickstart](../tutorials/quickstart.md) runs on **regtest** — a
+private chain on your own machine. That is the recommended way to build and
+iterate: it's deterministic, free, needs no peers, and you mine and fund blocks
+yourself with `pyrxd regtest mine` / `pyrxd regtest fund`. Reach for the public
+**testnet** only when you specifically need a *shared* network — testing against
+other people's transactions, a wallet, or an indexer over real P2P/finality.
+
+> **Reliability note (verified 2026-06-11).** Radiant's public testnet faucet is
+> community-run and was returning a gateway error when this guide was written.
+> Regtest has **no** external dependency and is the path that always works; treat
+> testnet as best-effort. If the faucet below is down, ask in the official
+> Radiant channels (linked from <https://radiantblockchain.org>) for the current
+> testnet faucet — do not assume a specific URL is canonical.
+
+## 1. Get a testnet-capable node binary
+
+Testnet runs the same `radiantd` as mainnet, selected with `-testnet`. Download
+the latest official release binary from
+[Radiant-Core releases](https://github.com/Radiant-Core/Radiant-Core/releases)
+(the `radiant-<version>-linux-x64.tar.gz` daemon bundle), or use the Radiant Core
+GUI. Run it on testnet:
+
+```console
+$ radiantd -testnet -server -txindex=1 \
+    -rpcuser=you -rpcpassword=change-me -rpcbind=127.0.0.1 -rpcallowip=127.0.0.1
+```
+
+The `SCRIPT_SECURITY_UPGRADE` consensus rules (the 64 MB per-script stack budget
+added in v3.1.x) are **already active on testnet from block 1**, so testnet is
+the closest public mirror of post-upgrade mainnet behaviour — a good reason to
+validate covenant-heavy work here before mainnet.
+
+## 2. Point pyrxd at testnet
+
+pyrxd's CLI config takes a `network` of `mainnet | testnet | regtest`
+(`~/.pyrxd/config.toml`, see `pyrxd.cli.config`). Set `network = "testnet"` and
+put your testnet node's RPC/ElectrumX endpoints under `[networks.testnet]`.
+Testnet addresses use the testnet version bytes, so a key reconstructed with
+`PrivateKey(wif)` from a testnet wallet derives a testnet address — the same flow
+as the quickstart, just on the shared chain.
+
+## 3. Fund a testnet address
+
+Testnet coins have no value and come from a faucet (you can't mine them on demand
+the way `pyrxd regtest fund` does on your private chain). The community faucet has
+been hosted at `faucet-testnet.radiant4people.com` (the mainnet sibling,
+`faucet.radiant4people.com`, was live at the time of writing). Paste a testnet
+address; if the faucet is unavailable, the official Radiant Discord is the place
+to ask for testnet RXD or the current faucet endpoint.
+
+Once funded, every other recipe — minting a Glyph, building a covenant, running a
+swap leg — works the same as on regtest; only the network and the source of coins
+change.
+
+## When to use which
+
+| | regtest (quickstart) | public testnet |
+|---|---|---|
+| Coins | `pyrxd regtest fund` (instant, unlimited) | community faucet (best-effort) |
+| Blocks | you mine (`pyrxd regtest mine`) | shared, ~real timing |
+| Peers / P2P | none (isolated) | real network |
+| Determinism | total | none |
+| Best for | building & iterating, CI, the quickstart | shared-network / wallet / indexer testing |
+
+For almost all development, **stay on regtest**. Graduate to testnet only for the
+shared-network behaviour regtest can't give you.

--- a/docs/plans/2026-06-07-sprint-tier1-dev-onramp.md
+++ b/docs/plans/2026-06-07-sprint-tier1-dev-onramp.md
@@ -1,0 +1,82 @@
+---
+title: Sprint — Tier 1 developer on-ramp (make pyrxd irresistible to a new dev)
+type: sprint
+date: 2026-06-07
+status: sprint plan — expands ROADMAP.md Tier 1; testnet/regtest only, NO audit gate, NO real value
+parent: docs/ROADMAP.md
+---
+
+# 🏃 Sprint: the developer on-ramp
+
+## North Star (sprint Definition of Done)
+A developer who has never touched Radiant can:
+1. `pip install pyrxd`
+2. run **one command** to get a funded local regtest chain
+3. **mint a Glyph token and run a swap from a copy-paste quickstart**
+
+…in **under 30 minutes**, entirely on regtest — no real value, no audit, no docker spelunking.
+When a fresh clone + the quickstart achieves that (and CI proves it), the sprint is done.
+
+## Grounded gaps (what's missing today)
+- SDK public surface is **7 export lines** — the headline primitives (`SwapCoordinator`, covenant
+  builders, SPV verify, keys) are buried in submodules.
+- **No dev-facing regtest** — only the in-test `_RegtestNode` in `tests/test_htlc_regtest_e2e.py`.
+- 9 `examples/` exist but are **scattered with no guided path**; `docs/tutorials/` is ~empty.
+- Packaging is fine (`pyrxd` console script, v0.6.1); `docs/how-to/` guides are good — build on them.
+
+## Tasks (sized S/M/L; sequence below)
+
+### S1 · Curate the SDK public surface — **M**
+Export the ~8 things a builder actually needs from a clean top level (extend `pyrxd/__init__.py` or add
+a `pyrxd.sdk` namespace): `GlyphBuilder` (have), the covenant builders (`build_htlc_covenant_ft/nft/rxd`),
+`SwapCoordinator` + the legs, `verify_ref_authenticity`, the SPV `verify_payment`, key/HD basics.
+- **Acceptance:** `from pyrxd import <primitive>` gives a dev the headline capabilities without
+  spelunking; each has a docstring; nothing private/internal leaks into the public namespace.
+
+### S2 · One-command dev regtest + faucet — **M**  *(highest-leverage; the funnel)*
+Promote the in-test `_RegtestNode` into a dev-facing helper: a `pyrxd.devnet` module + CLI verbs
+(`pyrxd regtest up | down | mine <n> | fund <addr>`), wrapping the `radiant-core:v2.3.0` regtest docker
++ a mine-to-address faucet. Print connection info + a pre-funded key on `up`.
+- **Acceptance:** one command → a running, funded regtest a dev can broadcast to; `down` cleans up;
+  works on a fresh machine with only docker installed.
+
+### S3 · The 5-minute quickstart — **M**  *(depends on S1 + S2)*
+`docs/quickstart.md` + a single runnable `examples/quickstart.py`: pip install → `regtest up` → mint a
+Glyph FT → transfer it → (stretch) a regtest swap. Copy-paste, end-to-end, **verified in CI**.
+- **Acceptance:** a fresh clone + the quickstart hits the North Star in <30 min; a CI job runs it green.
+
+### S4 · Audit + index the 9 existing examples — **M**
+Make each `examples/*.py` runnable on regtest (or clearly labeled testnet/mainnet), add a header
+(what it shows + how to run), and an `examples/README.md` index: *start here → quickstart; then tokens,
+swaps, dmint, SPV.*
+- **Acceptance:** every example runs or is clearly labeled; the index gives a guided path, not a pile.
+
+### S5 · The showcase page — **S**
+`docs/showcase.md` "What you can build on Radiant": the **live cross-chain swap demos** (real txids from
+this week — BTC/NFT/FT ↔ ETH), native tokens, covenants, each linking to a runnable example.
+- **Acceptance:** a link-rich, proof-backed page a dev lands on and thinks "I want to build this."
+
+### S6 · API reference build — **S**  *(depends on S1)*
+Ensure the curated surface has docstrings and the existing Sphinx setup (`docs/_build`) renders a clean
+**API reference** for the public namespace; wire it into CI/publish.
+- **Acceptance:** a buildable/hosted API ref covering the public SDK surface.
+
+## Sequence
+```
+S1 (SDK surface) ─┐
+                  ├─► S3 (quickstart) ─► S4 (examples) ─► S5 (showcase)
+S2 (dev regtest) ─┘                                   └─► S6 (API ref, after S1)
+```
+Do **S1 + S2 in parallel first** (the foundation). S3 is the keystone (it's the North Star path). S4/S5/S6
+build on top and can overlap.
+
+## Why this order
+**Time-to-first-success is the whole game** for dev attraction, and it's gated on two things a new dev
+hits in minute one: *can I import the thing I want* (S1) and *can I run a chain to try it* (S2). The
+quickstart (S3) is the single artifact that proves the North Star; examples/showcase/API-ref (S4–S6)
+convert a curious visitor into a builder. None of it touches real value or the audit gate — it's pure
+DX, shippable now by a low-mcap community team.
+
+## Out of scope (deliberately)
+Real-value mainnet, the RFQ market, the counter-leg *production* paths, bridged assets, the audit — all Tier 3/4.
+This sprint is **only** the "make a new dev succeed on regtest in 30 minutes" funnel.

--- a/docs/plans/2026-06-11-tier1-onramp-finish-and-radiant-core-bump-plan.md
+++ b/docs/plans/2026-06-11-tier1-onramp-finish-and-radiant-core-bump-plan.md
@@ -1,0 +1,100 @@
+---
+title: Tier-1 on-ramp — close the three remaining gaps + bump Radiant-Core to the latest release
+type: plan
+date: 2026-06-11
+status: plan (awaiting decision on bump sequencing)
+parent: docs/ROADMAP.md → docs/plans/2026-06-07-sprint-tier1-dev-onramp.md
+---
+
+# Finish Tier 1 + update our Radiant-Core baseline
+
+## Where Tier 1 actually stands (verified 2026-06-11)
+
+PR #185 already shipped S1–S6. The North Star path **works end-to-end** — verified live this
+session: `pyrxd regtest up` → `python examples/regtest_quickstart.py` minted a real Glyph NFT on
+regtest (commit + reveal confirmed) → `pyrxd regtest down`. So Tier 1 is ~80% done. Three gaps remain.
+
+## The discovery that reshapes this work
+
+The dev-facing regtest needs a Docker image, `radiant-core:vX-amd64`. Two grounded facts:
+
+1. **There is no committed Dockerfile.** The current `radiant-core:v2.3.0-amd64` was built ad-hoc
+   outside the repo and never committed. A fresh dev — the whole point of the on-ramp — literally
+   cannot obtain or build it. This is the real funnel leak (gap #1).
+2. **We are three releases behind, across a major bump.** Latest Radiant-Core is **v3.1.1**
+   (2026-06-10); we pin **v2.3.0** (April). Release-note findings (`gh release view`):
+   - v3.0.0 — explicitly **non-consensus** (wallet/security hardening; HF activation: none).
+   - v3.1.0 — introduces a **consensus soft fork** (`SCRIPT_SECURITY_UPGRADE`, incl. a
+     `MAX_SCRIPT_STACK_MEMORY_USAGE` budget enforced as a consensus rule) **and a breaking RPC
+     change** (`-rpcallowhost` now required when reaching RPC by hostname / compose service name).
+   - v3.1.1 — moves `SCRIPT_SECURITY_UPGRADE` to activate **on regtest from genesis**.
+
+   So bumping to v3.1.1 runs our consensus-validated covenant / SPV-differential suite under the
+   **new** script rules. The stack-memory budget *could* reject a covenant that passed on v2.3.0.
+   This is not a string change — it re-opens the regtest consensus validation. **The honest way to
+   settle it is to measure it** (build the image, run the suite), not to assume either way.
+
+   The v3.1.0 RPC break does **not** affect us: devnet reaches RPC via `docker exec radiant-cli`
+   (bound to 127.0.0.1 inside the container), never over the network by hostname
+   (`devnet.py:134-135`). Confirmed.
+
+## Workstreams
+
+### A — Committed, version-parameterized regtest Dockerfile  (foundation; low risk)
+A `docker/regtest.Dockerfile` that fetches an **official Radiant-Core release binary**, verifies its
+SHA256 against the release `SHA256SUMS.txt`, and wraps `radiantd`/`radiant-cli` in a small image.
+- Base `ubuntu:22.04` (satisfies the binaries' Boost 1.74 + GLIBC 2.34 needs — measured via `ldd`/
+  `objdump`; bullseye's glibc 2.31 is too old, bookworm's Boost 1.81 is wrong — 22.04 fits both).
+  Runtime deps: `libboost-{chrono,thread,filesystem,system}1.74.0 libdb5.3++ libevent-2.1-7 libzmq5
+  libminiupnpc17 libsodium23 libssl3`.
+- `--build-arg RADIANT_VERSION=v3.1.1` so the image tracks "the latest release"; the SHA256 check
+  pins integrity per version. We build from the official binary — no redistribution of someone
+  else's binary by us.
+- A `pyrxd regtest setup` (or `build`) verb + quickstart "Step 0" that builds the image, pointing
+  devs to the latest Radiant-Core release. `regtest up`'s missing-image error becomes actionable
+  ("run `pyrxd regtest setup`").
+- Acceptance: a fresh machine with only docker + pip builds the image and `regtest up` succeeds.
+
+### B — Bump the pinned baseline v2.3.0 → v3.1.1  (the "we need to update" part; gated on measurement)
+1. Build the v3.1.1 image via Workstream A.
+2. **Measure** the bump: run the consensus-sensitive suites against it —
+   `test_spv_covenant_differential_deployed.py`, `test_htlc_regtest_e2e.py`,
+   `test_soulbound_covenant_regtest.py`, `test_xchain_swap_regtest_e2e.py`,
+   `test_xchain_eth_swap_regtest_e2e.py` (all `-m integration`). Confirm the `MakerCovenantFlat12x20`
+   covenant still validates under `SCRIPT_SECURITY_UPGRADE` (stack-memory budget) and the nBits /
+   CScriptNum / CSV / OP_OUTPUTBYTECODE semantics are unchanged.
+3. If green → update the pin across `devnet.py` + ~15 test files + docs to `v3.1.1`. If a covenant
+   now fails the stack budget → that is a real finding; stop and report (do not paper over it).
+- Acceptance: the full integration suite is green on v3.1.1, OR a specific consensus-divergence
+  finding is documented.
+
+### C — CI verification of the North Star  (gap #2; depends on A)
+A CI job (`integration`-gated) that builds the image via the Workstream-A Dockerfile, runs
+`pyrxd regtest up` → the quickstart mint → asserts the NFT confirmed, then `down`. Closes the
+sprint's stated DoD ("a CI job runs it green") so the quickstart can't rot. Likely a separate
+workflow (needs docker; the default `test (3.12)` job stays fast and unit-only).
+
+### D — Testnet faucet/guide  (gap #3; independent, low risk)
+`docs/how-to/use-the-public-testnet.md`: point at the public Radiant testnet, the faucet(s), how to
+get the binary from the latest release, and the same mint flow against testnet. Smallest item;
+regtest already covers the core funnel, so this is the "graduate off regtest" step.
+
+## Dependency order
+```
+A (Dockerfile) ─┬─► B (bump, measured) ─► repin everything to v3.1.1
+                └─► C (CI North Star)
+D (testnet guide) — independent, anytime
+```
+
+## The decision to make first (bump sequencing)
+A and the pin interact. Two honest options:
+- **Bump-now (measured):** build v3.1.1, run the consensus suite, and if green pin everything to
+  v3.1.1 in this same effort. Devs + CI + tests all land on the latest, validated release.
+  Risk: if the covenant fails the new stack budget, this effort grows a remediation tail.
+- **Stage it:** ship A + C + D pinned to the **known-good v2.3.0** now (unblocks fresh devs + CI
+  immediately, zero consensus risk), and do the v3.1.1 bump as its own follow-up with the full
+  revalidation. Slower to "latest," but decouples the on-ramp from the consensus-revalidation risk.
+
+Recommendation: **bump-now, but measured** — the suite run turns the risk into a fact within this
+effort, and the user explicitly wants us current. Fall back to staging only if the measurement
+surfaces a real divergence.

--- a/docs/plans/2026-06-11-tier1-onramp-finish-and-radiant-core-bump-plan.md
+++ b/docs/plans/2026-06-11-tier1-onramp-finish-and-radiant-core-bump-plan.md
@@ -2,7 +2,7 @@
 title: Tier-1 on-ramp — close the three remaining gaps + bump Radiant-Core to the latest release
 type: plan
 date: 2026-06-11
-status: plan (awaiting decision on bump sequencing)
+status: DONE — bump-now/measured chosen; v3.1.1 measured GREEN, all workstreams shipped (see Outcome)
 parent: docs/ROADMAP.md → docs/plans/2026-06-07-sprint-tier1-dev-onramp.md
 ---
 
@@ -98,3 +98,26 @@ A and the pin interact. Two honest options:
 Recommendation: **bump-now, but measured** — the suite run turns the risk into a fact within this
 effort, and the user explicitly wants us current. Fall back to staging only if the measurement
 surfaces a real divergence.
+
+## Outcome (2026-06-11) — measured GREEN, all workstreams shipped
+
+The bump risk was settled by measurement, not assumption. Built `radiant-core:v3.1.1-amd64`
+from the committed Dockerfile and ran the consensus-sensitive suites against it:
+
+- `test_spv_covenant_differential_regtest.py` — **21 passed** (nBits exponent ceiling, bin2num
+  significant-bytes, OP_OUTPUTVALUE arity, sentinel direction, 20-level branch): the covenant's
+  consensus semantics are **identical** under v3.1.1's `SCRIPT_SECURITY_UPGRADE`. (The soft fork's
+  per-script stack budget is 64 MB per the v3.1.1 release notes; the covenant uses kilobytes —
+  hence no rejection.)
+- `test_htlc_regtest_e2e.py` + `test_soulbound_covenant_regtest.py` — **6 passed**.
+- BTC↔RXD `test_xchain_swap_regtest_e2e.py` — **10 passed**.
+- ETH↔RXD `test_xchain_eth_swap_regtest_e2e.py` — **7 passed** after fixing an *orthogonal*
+  pre-existing breakage (the test predated #192's MEDIUM-1 guard and never set
+  `accept_estimated_eth_margins=True`; not a bump regression).
+- North Star (`pyrxd regtest up` → `examples/regtest_quickstart.py` → mint) — green on v3.1.1.
+
+So → pinned everything to v3.1.1. Shipped: **A** committed `docker/regtest.Dockerfile` +
+`pyrxd regtest setup` (embedded Dockerfile, drift-guard test); **B** the pin across `devnet.py` +
+the regtest suites + dev-facing docs; **C** the `quickstart` CI job (build image → North Star →
+RXD covenant consensus suites); **D** `docs/how-to/use-the-public-testnet.md` (honest: regtest is
+the reliable path, testnet faucet verified best-effort — testnet faucet 502'd, mainnet faucet 200).

--- a/docs/tutorials/quickstart.md
+++ b/docs/tutorials/quickstart.md
@@ -12,19 +12,33 @@ is that the chain is yours alone and disposable.
 ## What you'll need
 
 - **Docker** — the regtest node runs in a container.
-- **The `radiant-core` regtest image** present locally (the same image the test
-  suite uses, `radiant-core:v2.3.0-amd64`).
 - **pyrxd installed** — `pip install pyrxd`, or `poetry install` from a checkout.
 
-Everything below is regtest-only and reached over `docker exec`; the node binds
-to localhost and is never exposed.
+That's it. The regtest node image is built for you in Step 0 — there's no image
+to find or pull. Everything below is regtest-only and reached over `docker exec`;
+the node binds to localhost and is never exposed.
+
+## Step 0 — build the regtest node image (one time)
+
+```console
+$ pyrxd regtest setup
+building radiant-core:v3.1.1-amd64 from the official Radiant-Core v3.1.1 release…
+(first build pulls ubuntu:22.04 + the release binary; subsequent builds are cached)
+built radiant-core:v3.1.1-amd64
+next: pyrxd regtest up
+```
+
+`setup` fetches the **official** Radiant-Core release daemon, verifies its SHA-256
+against the release checksum file, and wraps it in a small local image. It's a
+one-time step (the build is cached afterwards). To track a newer release later,
+`pyrxd regtest setup --version vX.Y.Z`.
 
 ## Step 1 — stand up a local chain
 
 ```console
 $ pyrxd regtest up
 regtest node up
-  container: pyrxd-devnet  (image radiant-core:v2.3.0-amd64)
+  container: pyrxd-devnet  (image radiant-core:v3.1.1-amd64)
   height:    101
   rpc:       user=pyrxd password=pyrxd wallet=devnet
 

--- a/src/pyrxd/cli/regtest_cmds.py
+++ b/src/pyrxd/cli/regtest_cmds.py
@@ -17,7 +17,7 @@ from __future__ import annotations
 
 import click
 
-from ..devnet import DevnetError, RegtestNode
+from ..devnet import DEFAULT_RADIANT_VERSION, DevnetError, RegtestNode
 from .format import emit
 
 
@@ -28,6 +28,38 @@ def _fail(exc: DevnetError) -> None:
 @click.group(name="regtest")
 def regtest_group() -> None:
     """Manage a local Radiant regtest node for development (docker)."""
+
+
+@regtest_group.command(name="setup")
+@click.option(
+    "--version",
+    "version",
+    default=DEFAULT_RADIANT_VERSION,
+    metavar="TAG",
+    help=f"Radiant-Core release tag to build (default {DEFAULT_RADIANT_VERSION}).",
+)
+@click.option("--no-cache", is_flag=True, help="Rebuild from scratch (ignore docker layer cache).")
+@click.option("--json", "json_output", is_flag=True, help="Machine-readable output.")
+def regtest_setup(version: str, no_cache: bool, json_output: bool) -> None:
+    """Build the regtest node image from the official Radiant-Core release.
+
+    A one-time step before the first `pyrxd regtest up`. Fetches the published
+    radiant-<version>-linux-x64 daemon, verifies its SHA-256 against the release
+    checksum file, and tags the image radiant-core:<version>-amd64.
+    """
+    if not json_output:
+        click.echo(f"building radiant-core:{version}-amd64 from the official Radiant-Core {version} release…")
+        click.echo("(first build pulls ubuntu:22.04 + the release binary; subsequent builds are cached)")
+    node = RegtestNode()
+    try:
+        tag = node.build_image(version, no_cache=no_cache)
+    except DevnetError as exc:
+        _fail(exc)
+    if json_output:
+        click.echo(emit({"image": tag, "version": version}, mode="json"))
+    else:
+        click.echo(f"built {tag}")
+        click.echo("next: pyrxd regtest up")
 
 
 @regtest_group.command(name="up")

--- a/src/pyrxd/devnet.py
+++ b/src/pyrxd/devnet.py
@@ -20,8 +20,87 @@ from __future__ import annotations
 import json
 import shutil
 import subprocess  # nosec B404  # only ever runs a fixed `docker` argv (see call sites)
+import tempfile
 import time
 from dataclasses import dataclass
+from pathlib import Path
+
+# The Radiant-Core release the regtest image is built from. Bump this (and rebuild
+# via `pyrxd regtest setup`) to track the latest release; see docs/ROADMAP.md and
+# the bump plan for the revalidation the version pin carries.
+DEFAULT_RADIANT_VERSION = "v3.1.1"
+
+# Embedded copy of docker/regtest.Dockerfile so `pyrxd regtest setup` works for a
+# `pip install pyrxd` developer who has no repo checkout. A test
+# (tests/test_devnet.py) asserts this stays byte-identical to the committed file.
+_REGTEST_DOCKERFILE = """\
+# Regtest Radiant-Core node for local pyrxd development (`pyrxd regtest`).
+#
+# Wraps an OFFICIAL Radiant-Core release binary — we do not fork, patch, or
+# recompile the node; we fetch the published linux-x64 daemon and verify its
+# SHA-256 against the release's signed checksum file. This is the committed,
+# reproducible replacement for the previously ad-hoc `radiant-core:*-amd64`
+# image that was built outside the repo and that a fresh developer could not
+# obtain.
+#
+# Build (pin to the latest Radiant-Core release):
+#     docker build -f docker/regtest.Dockerfile \\
+#         --build-arg RADIANT_VERSION=v3.1.1 \\
+#         -t radiant-core:v3.1.1-amd64 .
+#
+# `pyrxd regtest setup` builds this for you; `pyrxd regtest up` then runs it.
+# The container is regtest-only, binds RPC to 127.0.0.1, and is reached solely
+# via `docker exec radiant-cli` — never exposed to the network.
+#
+# Base: ubuntu:22.04 is chosen deliberately — the release binary dynamically
+# links Boost 1.74 (22.04's default) and needs GLIBC >= 2.34 (22.04 ships
+# 2.35). Debian bullseye's glibc (2.31) is too old; bookworm's Boost (1.81) is
+# the wrong soname. Measured with `ldd`/`objdump -T` on the v3.1.x daemon.
+
+FROM ubuntu:22.04
+
+ARG RADIANT_VERSION=v3.1.1
+ARG RADIANT_TARBALL=radiant-${RADIANT_VERSION}-linux-x64.tar.gz
+ARG RADIANT_BASEURL=https://github.com/Radiant-Core/Radiant-Core/releases/download/${RADIANT_VERSION}
+
+# Runtime shared libraries the daemon links against (measured via ldd).
+RUN apt-get update && apt-get install -y --no-install-recommends \\
+        ca-certificates \\
+        wget \\
+        libboost-chrono1.74.0 \\
+        libboost-filesystem1.74.0 \\
+        libboost-system1.74.0 \\
+        libboost-thread1.74.0 \\
+        libdb5.3++ \\
+        libevent-2.1-7 \\
+        libevent-pthreads-2.1-7 \\
+        libminiupnpc17 \\
+        libsodium23 \\
+        libssl3 \\
+        libzmq5 \\
+    && rm -rf /var/lib/apt/lists/*
+
+# Fetch the official release daemon + cli, verify integrity against the
+# release checksum file, install only the two binaries the devnet uses.
+RUN set -eux; \\
+    cd /tmp; \\
+    wget -q "${RADIANT_BASEURL}/${RADIANT_TARBALL}"; \\
+    wget -q "${RADIANT_BASEURL}/SHA256SUMS.txt"; \\
+    grep " ${RADIANT_TARBALL}\\$" SHA256SUMS.txt | sha256sum -c -; \\
+    tar xzf "${RADIANT_TARBALL}"; \\
+    install -m0755 "radiant-${RADIANT_VERSION}-linux-x64/radiantd" /usr/local/bin/radiantd; \\
+    install -m0755 "radiant-${RADIANT_VERSION}-linux-x64/radiant-cli" /usr/local/bin/radiant-cli; \\
+    rm -rf /tmp/*
+
+# Smoke-test that the binary actually runs in this base (catches a missing lib
+# at build time rather than at `regtest up`).
+RUN radiantd --version
+
+# The devnet driver overrides the entrypoint and passes -regtest flags
+# (see pyrxd/devnet.py); this default makes the image runnable standalone too.
+ENTRYPOINT ["radiantd"]
+CMD ["-regtest", "-server", "-printtoconsole"]
+"""
 
 
 class DevnetError(RuntimeError):
@@ -47,7 +126,7 @@ class RegtestNode:
     absent.
     """
 
-    IMAGE = "radiant-core:v2.3.0-amd64"
+    IMAGE = f"radiant-core:{DEFAULT_RADIANT_VERSION}-amd64"
     CONTAINER = "pyrxd-devnet"
     RPC_USER = "pyrxd"
     RPC_PASSWORD = "pyrxd"  # nosec B105  # localhost-only regtest sandbox cred (docker exec), not a secret
@@ -60,6 +139,32 @@ class RegtestNode:
     def _require_docker() -> None:
         if shutil.which("docker") is None:
             raise DevnetError("docker is not on PATH — install docker to use `pyrxd regtest`")
+
+    @classmethod
+    def build_image(cls, version: str = DEFAULT_RADIANT_VERSION, *, no_cache: bool = False) -> str:
+        """Build the regtest image from an OFFICIAL Radiant-Core release binary.
+
+        Wraps the published ``radiant-<version>-linux-x64`` daemon (SHA-256-verified
+        against the release checksum file) in a small ubuntu:22.04 image tagged
+        ``radiant-core:<version>-amd64``. Builds from the Dockerfile embedded in this
+        module, so it works for a ``pip install pyrxd`` developer with no repo checkout
+        as well as from a clone. Returns the built image tag.
+
+        This is the dev-facing replacement for the previously ad-hoc image that was
+        built outside the repo; ``pyrxd regtest setup`` calls it.
+        """
+        cls._require_docker()
+        tag = f"radiant-core:{version}-amd64"
+        with tempfile.TemporaryDirectory() as ctx:
+            (Path(ctx) / "Dockerfile").write_text(_REGTEST_DOCKERFILE, encoding="utf-8")
+            cmd = ["docker", "build", "-f", f"{ctx}/Dockerfile", "--build-arg", f"RADIANT_VERSION={version}", "-t", tag]
+            if no_cache:
+                cmd.append("--no-cache")
+            cmd.append(ctx)
+            r = subprocess.run(cmd, capture_output=True, text=True)  # nosec B603 B607  # controlled docker argv
+        if r.returncode != 0:
+            raise DevnetError(f"failed to build {tag}: {r.stderr.strip() or r.stdout.strip()}")
+        return tag
 
     def cli(self, *args: str, wallet: bool = False) -> object:
         """Run ``radiant-cli`` inside the container; parse JSON when possible."""
@@ -142,7 +247,8 @@ class RegtestNode:
             if "No such image" in stderr or "not found" in stderr:
                 raise DevnetError(
                     f"regtest image {self.IMAGE!r} is not present locally — "
-                    "build or pull the radiant-core regtest image first"
+                    "build it with `pyrxd regtest setup` (wraps the official "
+                    f"Radiant-Core {DEFAULT_RADIANT_VERSION} release binary)"
                 )
             raise DevnetError(f"failed to start regtest container: {stderr}")
 

--- a/src/pyrxd/glyph/soulbound_covenant.py
+++ b/src/pyrxd/glyph/soulbound_covenant.py
@@ -1,7 +1,7 @@
 """PROTOTYPE: a *consensus-enforced* soulbound NFT covenant for Radiant Glyphs.
 
 Status: SPIKE — structural guards pass AND the consensus behaviour is CONFIRMED on
-``radiant-core:v2.3.0`` regtest (``tests/test_soulbound_covenant_regtest.py``:
+``radiant-core:v3.1.1`` regtest (``tests/test_soulbound_covenant_regtest.py``:
 recur-to-self ACCEPTED, transfer-to-other REJECTED, burn ACCEPTED), differentially
 alongside the live mainnet deployed design. Still pre-external-audit: do not use
 for real value until audited.

--- a/tests/cli/test_regtest_cmds.py
+++ b/tests/cli/test_regtest_cmds.py
@@ -24,7 +24,7 @@ def _extract_json(output: str) -> dict:
 
 _INFO = {
     "container": "pyrxd-devnet",
-    "image": "radiant-core:v2.3.0-amd64",
+    "image": "radiant-core:v3.1.1-amd64",
     "rpc_user": "pyrxd",
     "rpc_password": "pyrxd",
     "wallet": "devnet",
@@ -66,6 +66,10 @@ class _FakeNode:
         self.calls.append(("fund", address, amount_rxd))
         return "ab" * 32
 
+    def build_image(self, version: str = "v3.1.1", *, no_cache: bool = False) -> str:
+        self.calls.append(("build_image", version, no_cache))
+        return f"radiant-core:{version}-amd64"
+
 
 @pytest.fixture
 def runner() -> CliRunner:
@@ -81,6 +85,37 @@ def patch_node(monkeypatch):
         return node
 
     return _install
+
+
+class TestSetup:
+    def test_setup_builds_default_version(self, runner, patch_node):
+        node = patch_node(_FakeNode())
+        result = runner.invoke(cli, ["regtest", "setup"])
+        assert result.exit_code == 0, result.output
+        assert "built radiant-core:v3.1.1-amd64" in result.output
+        assert ("build_image", "v3.1.1", False) in node.calls
+
+    def test_setup_honours_version_and_no_cache(self, runner, patch_node):
+        node = patch_node(_FakeNode())
+        result = runner.invoke(cli, ["regtest", "setup", "--version", "v3.2.0", "--no-cache"])
+        assert result.exit_code == 0, result.output
+        assert ("build_image", "v3.2.0", True) in node.calls
+
+    def test_setup_json(self, runner, patch_node):
+        patch_node(_FakeNode())
+        result = runner.invoke(cli, ["regtest", "setup", "--json"])
+        assert result.exit_code == 0, result.output
+        assert _extract_json(result.output) == {"image": "radiant-core:v3.1.1-amd64", "version": "v3.1.1"}
+
+    def test_setup_build_failure_is_clean_error(self, runner, monkeypatch):
+        class _BuildFails(_FakeNode):
+            def build_image(self, version: str = "v3.1.1", *, no_cache: bool = False) -> str:
+                raise DevnetError("docker build failed: no space left on device")
+
+        monkeypatch.setattr("pyrxd.cli.regtest_cmds.RegtestNode", lambda: _BuildFails())
+        result = runner.invoke(cli, ["regtest", "setup"])
+        assert result.exit_code != 0
+        assert "no space left on device" in result.output
 
 
 class TestUp:

--- a/tests/test_devnet.py
+++ b/tests/test_devnet.py
@@ -31,6 +31,7 @@ class _Docker:
         self.chain = chain
         self.height = height
         self.run_fails_with = ""  # set to simulate `docker run` failure stderr
+        self.build_fails_with = ""  # set to simulate `docker build` failure stderr
         self.calls: list[list[str]] = []
 
     def _rpc_method(self, argv: list[str]) -> str:
@@ -47,6 +48,10 @@ class _Docker:
         if argv[:2] == ["docker", "rm"]:
             self.running = False
             return _FakeProc(0)
+        if argv[:2] == ["docker", "build"]:
+            if self.build_fails_with:
+                return _FakeProc(1, stderr=self.build_fails_with)
+            return _FakeProc(0, stdout="built\n")
         if argv[:2] == ["docker", "run"]:
             if self.run_fails_with:
                 return _FakeProc(1, stderr=self.run_fails_with)
@@ -241,6 +246,46 @@ def test_cli_filenotfound_maps_to_devnet_error(monkeypatch):
     monkeypatch.setattr("pyrxd.devnet.subprocess.run", _raise)
     with pytest.raises(DevnetError, match="docker is not on PATH"):
         RegtestNode().cli("getblockchaininfo")
+
+
+class TestImageBuild:
+    def test_build_image_constructs_versioned_tag_and_build_arg(self, patch_docker):
+        d = patch_docker(_Docker())
+        tag = RegtestNode.build_image("v3.1.1")
+        assert tag == "radiant-core:v3.1.1-amd64"
+        build = next(c for c in d.calls if c[:2] == ["docker", "build"])
+        assert "--build-arg" in build and "RADIANT_VERSION=v3.1.1" in build
+        assert "-t" in build and "radiant-core:v3.1.1-amd64" in build
+
+    def test_build_image_defaults_to_pinned_version(self, patch_docker):
+        from pyrxd.devnet import DEFAULT_RADIANT_VERSION
+
+        patch_docker(_Docker())
+        assert RegtestNode.build_image() == f"radiant-core:{DEFAULT_RADIANT_VERSION}-amd64"
+
+    def test_build_image_failure_raises(self, patch_docker):
+        d = patch_docker(_Docker())
+        d.build_fails_with = "no space left on device"
+        with pytest.raises(DevnetError, match="no space left on device"):
+            RegtestNode.build_image("v3.1.1")
+
+    def test_image_attr_derives_from_default_version(self):
+        from pyrxd.devnet import DEFAULT_RADIANT_VERSION
+
+        assert f"radiant-core:{DEFAULT_RADIANT_VERSION}-amd64" == RegtestNode.IMAGE
+
+
+def test_committed_dockerfile_matches_embedded_constant():
+    """`pyrxd regtest setup` builds from the embedded _REGTEST_DOCKERFILE; the committed
+    docker/regtest.Dockerfile must stay byte-identical so a clone, CI, and a pip-installed
+    `regtest setup` all build the same image. Regenerate the committed file from the constant
+    if this fails."""
+    from pathlib import Path
+
+    from pyrxd.devnet import _REGTEST_DOCKERFILE
+
+    committed = Path(__file__).resolve().parents[1] / "docker" / "regtest.Dockerfile"
+    assert committed.read_text(encoding="utf-8") == _REGTEST_DOCKERFILE
 
 
 _ = subprocess  # keep the import meaningful for readers; patched via string paths

--- a/tests/test_htlc_regtest_e2e.py
+++ b/tests/test_htlc_regtest_e2e.py
@@ -22,7 +22,7 @@ Gating (matches tests/test_dmint_deploy_integration.py convention):
 * ``@pytest.mark.integration`` — deselected by the default ``-m 'not integration'``
   addopts, so CI stays clean.
 * Opt-in: set ``RADIANT_REGTEST=1`` to run. Skips (not fails) if docker or the
-  ``radiant-core:v2.3.0-amd64`` image is unavailable.
+  ``radiant-core:v3.1.1-amd64`` image is unavailable.
 
 The test manages its OWN isolated regtest container (separate from any mainnet
 node), funds a throwaway wallet, mines its own blocks, and tears the container
@@ -55,7 +55,7 @@ from pyrxd.transaction.transaction_output import TransactionOutput
 
 pytestmark = pytest.mark.integration
 
-_IMAGE = "radiant-core:v2.3.0-amd64"
+_IMAGE = "radiant-core:v3.1.1-amd64"
 _CONTAINER = "gravity-regtest-pytest"
 _RELAY_FEE_SATS = 1_000_000  # 0.01 RXD — >> relayfee (0.01 RXD/kB) for a sub-kB tx
 

--- a/tests/test_soulbound_covenant.py
+++ b/tests/test_soulbound_covenant.py
@@ -6,7 +6,7 @@ the *non-transferability invariant holds at the script level*: any "transfer"
 recur ``OP_EQUALVERIFY``.
 
 The consensus behaviour (does the Radiant VM accept/reject these spends?) is
-validated separately on a real ``radiant-core:v2.3.0`` regtest node in
+validated separately on a real ``radiant-core:v3.1.1`` regtest node in
 ``tests/test_soulbound_covenant_regtest.py`` (recur-to-self ACCEPTED,
 transfer-to-other REJECTED, burn ACCEPTED).
 """
@@ -122,6 +122,6 @@ def test_opcode_stream_walks_cleanly():
 # --------------------------------------------------------------------------- consensus validation
 #
 # The three consensus cases (recur-to-self ACCEPTED, transfer-to-other REJECTED,
-# burn ACCEPTED) are validated on a real radiant-core:v2.3.0 regtest node in
+# burn ACCEPTED) are validated on a real radiant-core:v3.1.1 regtest node in
 # tests/test_soulbound_covenant_regtest.py (run: RADIANT_REGTEST=1 ... -m integration),
 # differentially alongside the live mainnet deployed covenant design.

--- a/tests/test_soulbound_covenant_regtest.py
+++ b/tests/test_soulbound_covenant_regtest.py
@@ -1,6 +1,6 @@
 """Differential consensus validation of soulbound covenants on a real regtest node.
 
-Proves, against ``radiant-core:v2.3.0`` consensus (via ``testmempoolaccept``), that
+Proves, against ``radiant-core:v3.1.1`` consensus (via ``testmempoolaccept``), that
 BOTH soulbound covenant designs enforce the same security property:
 
 * **recur-to-self**  (output[0] is a byte-identical clone)            -> ACCEPTED

--- a/tests/test_spv_covenant_differential_deployed.py
+++ b/tests/test_spv_covenant_differential_deployed.py
@@ -29,7 +29,7 @@ agreement: it is skipped or xfailed with a clear marker. In particular the
 8-byte OP_BIN2NUM >4-byte-element numeric behaviour, the compile-time
 claimDeadline clamp, OP_OUTPUTVALUE arity, and the exact tolerated branch length
 are NOT modelled as accept/reject decisions here. All four are now CONFIRMED on
-live radiant-core:v2.3.0 regtest consensus in
+live radiant-core:v3.1.1 regtest consensus in
 ``tests/test_spv_covenant_differential_regtest.py`` (groups V / S-3 / S-2 / M); see
 ``docs/brainstorms/gravity-ref-spike/REGTEST_COVENANT_SEMANTICS_RESULTS.json``.
 
@@ -581,7 +581,7 @@ def test_header_chain_anchor_differential():
 
 @pytest.mark.skip(
     reason="RESOLVED live in tests/test_spv_covenant_differential_regtest.py::"
-    "test_header_nbits_exponent_ceiling (NB-1..NB-2c): on radiant-core:v2.3.0 regtest "
+    "test_header_nbits_exponent_ceiling (NB-1..NB-2c): on radiant-core:v3.1.1 regtest "
     "the covenant ACCEPTS nBits exponent 0x1e/0x1f/0x20 (which Python's Nbits rejects "
     "as > 0x1d) and REJECTS 0x21 — a confirmed Direction-B accept-band [0x1e..0x20]. "
     "Corroborates F-02 (reject_low_difficulty mandatory for any covenant-less SPV use). "
@@ -729,7 +729,7 @@ def test_coinbase_pos_aliasing_rejected_differential():
 
 @pytest.mark.skip(
     reason="RESOLVED live in tests/test_spv_covenant_differential_regtest.py::"
-    "test_value_bin2num_significant_bytes (V-1..V-5): on radiant-core:v2.3.0 regtest the "
+    "test_value_bin2num_significant_bytes (V-1..V-5): on radiant-core:v3.1.1 regtest the "
     "covenant reads output-0 value as a full 64-bit signed CScriptNum — 5/7/8-significant-"
     "byte values ACCEPT (>= threshold incl. a 7-byte value vs a 7-byte threshold), a "
     "bit-63-set value decodes NEGATIVE and REJECTS, and a 7-byte value just below a 7-byte "

--- a/tests/test_spv_covenant_differential_regtest.py
+++ b/tests/test_spv_covenant_differential_regtest.py
@@ -3,7 +3,7 @@ model leaves skipped.
 
 Resolves every "needs live-regtest" / "NOT modelled" question in
 ``tests/test_spv_covenant_differential_deployed.py`` against REAL Radiant consensus
-via ``testmempoolaccept`` on an isolated ``radiant-core:v2.3.0`` regtest node — the
+via ``testmempoolaccept`` on an isolated ``radiant-core:v3.1.1`` regtest node — the
 only way to pin behaviour that depends on the compiled script interpreter:
 
   * Group V  — value-field ``OP_8 OP_SPLIT OP_DROP OP_BIN2NUM`` on 5..8 significant
@@ -45,7 +45,7 @@ import struct
 import pytest
 
 # Reuse the isolated-regtest harness wholesale (node fixture spins up + tears down
-# a throwaway radiant-core:v2.3.0 container; accepts() == testmempoolaccept).
+# a throwaway radiant-core:v3.1.1 container; accepts() == testmempoolaccept).
 # Bare module names (NOT ``tests.X``): pytest's default prepend import mode puts the
 # ``tests/`` dir on sys.path, and there is no ``tests/__init__.py``, so ``tests`` is not
 # an importable package under ``pytest tests/ -o "addopts="`` (the coverage-overall step).

--- a/tests/test_xchain_eth_glyph_real_rxindexer_e2e.py
+++ b/tests/test_xchain_eth_glyph_real_rxindexer_e2e.py
@@ -19,7 +19,7 @@ pre-running RXinDexer stack indexing the node. It is therefore gated behind its 
 and the explicit node/indexer endpoints. Moves no real value: regtest + local Anvil devnet keys.
 
 Standing up the stack (one time):
-  * rxd-regtest-node  — radiant-core:v2.3.0 regtest, RPC :17443, wallet ``gravity``
+  * rxd-regtest-node  — radiant-core:v3.1.1 regtest, RPC :17443, wallet ``gravity``
   * rxd-indexer       — rxindexer-electrumx:regtest (NET=regtest, DB_ENGINE=rocksdb, GLYPH_INDEX=1),
                         ElectrumX WS on 127.0.0.1:50011
 

--- a/tests/test_xchain_eth_swap_regtest_e2e.py
+++ b/tests/test_xchain_eth_swap_regtest_e2e.py
@@ -73,7 +73,7 @@ from tests.test_xchain_swap_regtest_e2e import (
 
 pytestmark = pytest.mark.integration
 
-_RXD_IMAGE = "radiant-core:v2.3.0-amd64"
+_RXD_IMAGE = "radiant-core:v3.1.1-amd64"
 _RXD_CT = "xchain-eth-rxd-pytest"
 _CHAIN_ID = 31337
 # Anvil's deterministic PUBLIC dev keys (local devnet only — no real value).
@@ -406,7 +406,14 @@ def _build(node, url, *, t_rxd_blocks, asset_variant="rxd"):
         seen_store=_MemSeen(),
         # anvil is treated as value-bearing (it can fork mainnet); accept the in-process seen
         # store for this single-process, single-shot, fresh-H-per-run e2e (the documented hatch).
-        config=CoordinatorConfig(margin_policy=_eth_policy(), accept_nondurable_seen=True),
+        # accept_estimated_eth_margins: this e2e runs the estimated _eth_policy() (is_measured=False)
+        # on a value-bearing (anvil) counter-leg; the MEDIUM-1 guard (#192) refuses that unless the
+        # operator opts in — the same explicit hatch the dust harnesses use. No real value moves.
+        config=CoordinatorConfig(
+            margin_policy=_eth_policy(),
+            accept_nondurable_seen=True,
+            accept_estimated_eth_margins=True,
+        ),
     )
     return coord, cov, p_secret, eth_leg, rpc, ref_utxo
 

--- a/tests/test_xchain_swap_regtest_e2e.py
+++ b/tests/test_xchain_swap_regtest_e2e.py
@@ -74,7 +74,7 @@ from pyrxd.transaction.transaction_output import TransactionOutput
 
 pytestmark = pytest.mark.integration
 
-_RXD_IMAGE = "radiant-core:v2.3.0-amd64"
+_RXD_IMAGE = "radiant-core:v3.1.1-amd64"
 _BTC_IMAGE = "ruimarinho/bitcoin-core:24"
 _RXD_CT = "xchain-rxd-pytest"
 _BTC_CT = "xchain-btc-pytest"


### PR DESCRIPTION
Finishes the **Tier-1 developer on-ramp** and updates our Radiant-Core baseline to the latest release (**v3.1.1**, 2026-06-10). Also lands a sanitized public `docs/ROADMAP.md` + the Tier-1 sprint plan.

## Context
PR #185 already shipped the on-ramp's S1–S6; verifying the North Star this session surfaced the real remaining gaps. The dev regtest needs a `radiant-core:*-amd64` image, but **no Dockerfile was committed** — the old v2.3.0 image was built ad-hoc, so a fresh `pip install` dev couldn't obtain it (the funnel leak). And we were three releases behind, across v3.1.x's `SCRIPT_SECURITY_UPGRADE` soft fork (active on regtest from genesis), which re-opens the covenant's regtest consensus validation.

## What's here

**A — Committed image + one-command setup**
- `docker/regtest.Dockerfile` wraps the **official** Radiant-Core release daemon (SHA-256-verified against the release checksum file) on `ubuntu:22.04` (chosen to satisfy the binary's Boost 1.74 + GLIBC 2.34 needs — measured via `ldd`/`objdump`).
- `pyrxd regtest setup [--version vX.Y.Z] [--no-cache]` builds it from a Dockerfile **embedded in `pyrxd.devnet`**, so a pip-installed dev with no checkout can build it too. A drift-guard test keeps the embedded copy byte-identical to the committed file. The missing-image error now points at `regtest setup`.

**B — Bump to v3.1.1, measured GREEN (not assumed)**
Built `radiant-core:v3.1.1-amd64` and ran the consensus-sensitive suites against it:

| Suite | Result |
|---|---|
| `test_spv_covenant_differential_regtest.py` (nBits ceiling, bin2num sig-bytes, OP_OUTPUTVALUE arity, sentinel, 20-level branch) | **21 passed — identical** under the soft fork |
| `test_htlc_regtest_e2e.py` + `test_soulbound_covenant_regtest.py` | **6 passed** |
| BTC↔RXD `test_xchain_swap_regtest_e2e.py` | **10 passed** |
| ETH↔RXD `test_xchain_eth_swap_regtest_e2e.py` | **7 passed** (after fixing an orthogonal pre-existing breakage — see below) |
| North Star quickstart mint | **green on v3.1.1** |

The soft fork's per-script stack budget is **64 MB** (v3.1.1 release notes); the covenant uses kilobytes — hence no rejection. Pinned v3.1.1 across `devnet.py`, the regtest suites, and dev-facing docs.

> **Orthogonal fix included:** `test_xchain_eth_swap_regtest_e2e.py` predated #192's MEDIUM-1 guard and never set `accept_estimated_eth_margins=True`, so it had been red since #192 (not in default CI, so it slipped). Fixed with the same explicit opt-in #192 applied to the dust harnesses. **Not** a bump regression.

**C — CI North Star gate**
New `quickstart` job in `ci.yml`: builds the image from the committed Dockerfile, runs `pip → regtest up → mint a Glyph → assert confirmed`, then the RXD covenant consensus suites — so the quickstart **and** covenant validation can't silently rot between releases (closes the sprint's "verified in CI" DoD).

**D — Testnet how-to**
`docs/how-to/use-the-public-testnet.md`: when to graduate from regtest to the public testnet, how to run `radiantd -testnet`, point pyrxd at it, and get coins. Honest about reliability — regtest is the dependable path; the community testnet faucet is best-effort (it returned a gateway error when checked 2026-06-11, while the mainnet faucet was up).

Plus: `quickstart.md` gains a "Step 0 — build the image" and drops the manual image prerequisite; `ROADMAP.md` is sanitized for the public repo (private exploration codenames → generic capability categories).

## Verification
`task ci` green: **4132 passed**, 86 skipped; lint / format / typecheck / private-links all clean (verified independently — the local coverage gate is the known fresh-worktree double-count artifact, not a regression; CI runs on a clean checkout). All regtest measurements above ran locally against `radiant-core:v3.1.1-amd64` built from the committed Dockerfile.