### PR TITLE
feat(sdk): expose the cross-chain HTLC swap as a library primitive (Tier 2.1)

### DIFF
--- a/docs/how-to/build-a-cross-chain-swap.md
+++ b/docs/how-to/build-a-cross-chain-swap.md
@@ -1,0 +1,115 @@
+# Build a cross-chain atomic swap (BTC/ETH ↔ RXD)
+
+pyrxd ships a **trustless cross-chain atomic swap**: trade a Radiant asset (RXD, a
+Glyph FT, or a Glyph NFT) against BTC or ETH with no custodian and no trusted third
+party. It's a hash-timelock (HTLC) swap driven by a chain-neutral coordinator, proven
+end-to-end on regtest and on small real-value mainnet/Sepolia runs.
+
+> **PRE-AUDIT — regtest / testnet only.** This primitive has **not** had an external
+> security audit. It's the right tool to build and demo cross-chain swaps on
+> regtest/testnet, but **do not move real value** with it until the audit gate clears.
+> An atomic swap's entire job is to be safe against a hostile counterparty; that
+> property is what an audit certifies. See the swap coordinator's module docstring for
+> the current residual-risk notes.
+
+## The mental model
+
+Two parties, two chains, one secret:
+
+- The **maker** holds the Radiant asset and wants BTC/ETH. The **taker** holds BTC/ETH
+  and wants the asset.
+- The maker generates a 32-byte secret `p` and publishes `H = SHA256(p)`. The same `H`
+  locks both legs; revealing `p` to claim one leg lets the counterparty claim the other.
+- The coordinator drives a chain-neutral state machine over **two legs**: the **Radiant
+  covenant leg** (the asset side) and a **counter-chain leg** (the BTC or ETH value side).
+
+### The one safety invariant you must respect
+
+```python
+from pyrxd import SwapCoordinator
+print(SwapCoordinator.__module__)  # the role invariant lives in swap_coordinator
+```
+
+`MAKER_SECRET_TAKER_LOCKS_BTC_FIRST` (a documented constant in
+`pyrxd.gravity.swap_coordinator`) is the safety hinge — read it before you wire anything:
+
+1. The **maker** generates `p`, publishes `H`.
+2. The **taker** locks the counter-chain (BTC/ETH HTLC) **first**.
+3. The **maker** locks the Radiant covenant **second**.
+4. The **maker** claims the counter-chain **first**, revealing `p`.
+5. The **taker** scrapes `p` and claims the Radiant asset **before its refund opens**.
+
+The timelocks must satisfy **`t_counterchain > t_rxd + margin`**: the leg claimed
+*second* (Radiant) carries the *shorter* refund window. The taker's client MUST verify
+`t_counterchain − t_rxd ≥ margin` before funding, or refuse. The coordinator enforces
+this fail-closed (`assert_timelock_margin`) — don't route around it.
+
+## The pieces (all importable from the top level)
+
+```python
+from pyrxd import (
+    SwapCoordinator,    # the chain-neutral orchestrator / FSM
+    CoordinatorConfig,  # margins, durability + value-bearing opt-ins
+    MarginPolicy,       # timelock margins; MarginPolicy.measured(...) for real value
+    NegotiatedTerms,    # H, amounts, timeouts, destinations — the public envelope
+    SwapRecord, SwapState,  # the durable swap record + its FSM states
+    generate_secret,    # the maker's (p, H)
+    RadiantCovenantLeg, # the asset (RXD/FT/NFT) leg
+    EthLeg,             # the ETH counter-chain leg (Solidity HTLC)
+    CounterChainLeg,    # the ABC every counter-chain backend implements
+)
+```
+
+The coordinator is constructed with both legs plus its collaborators:
+
+```python
+coordinator = SwapCoordinator(
+    record=SwapRecord(state=SwapState.NEGOTIATED, terms=terms),
+    counter_leg=eth_leg,      # or btc_leg=... for the BTC Taproot-HTLC path
+    radiant_leg=rxd_leg,
+    indexer=indexer,          # resolves Glyph refs / reads RXD chain state
+    seen_store=seen_store,    # dedup / replay durability across restarts
+    config=CoordinatorConfig(margin_policy=MarginPolicy.measured(...)),
+)
+```
+
+- **BTC counter-leg.** The proven BTC path consumes the Taproot-HTLC functions in
+  `pyrxd.btc_wallet.taproot` through a duck-typed surface (there is no `BitcoinTaprootLeg`
+  class yet — see `CounterChainLeg`'s scope note). Pass it as `btc_leg=`.
+- **ETH counter-leg.** `EthLeg` wraps the Solidity `EthHtlc` contract via web3 (an optional
+  dependency: `pip install pyrxd[eth]` or add `web3`).
+- **`MarginPolicy.measured(...)` vs estimated.** A real-value swap MUST use a measured
+  margin policy; the coordinator refuses a value-bearing swap on estimated margins unless
+  you consciously opt in (`accept_estimated_eth_margins` / the dust-run hatches).
+
+## Runnable references (start here — these actually execute)
+
+Rather than a toy snippet that wouldn't run against real chains, embed from the proven,
+maintained harnesses:
+
+| What | Where |
+|---|---|
+| BTC ↔ RXD full swap on regtest (happy / mutual-refund / maker-stall / reorg-gate) | `tests/test_xchain_swap_regtest_e2e.py` |
+| ETH ↔ RXD full swap on Anvil + regtest | `tests/test_xchain_eth_swap_regtest_e2e.py` |
+| Two-party adversarial scenarios (hostile maker/taker, races) | `tests/test_xchain_eth_adversarial_e2e.py` |
+| Operational driver (Sepolia + RXD, at-keyboard, dust) | `scripts/eth_swap_run.py` |
+
+Run the regtest suites with a local node — see the
+[quickstart](../tutorials/quickstart.md) for `pyrxd regtest setup` / `up`, plus an Anvil
+binary (ETH) or a `bitcoin-core` regtest image (BTC):
+
+```console
+$ RADIANT_REGTEST=1 XCHAIN_REGTEST=1 pytest tests/test_xchain_swap_regtest_e2e.py -m integration
+$ XCHAIN_ETH_REGTEST=1 pytest tests/test_xchain_eth_swap_regtest_e2e.py -m integration
+```
+
+## Adding another counter-chain
+
+`CounterChainLeg` (`pyrxd.gravity.counter_chain_leg`) is the documented contract a new
+backend implements: `derive_expected_funding` / `fund` / `claim` / `refund` /
+`recover_secret` / `is_final`. The ABC was extracted from two *real* shapes (BTC Taproot +
+ETH Solidity), so it reflects what a third chain actually needs — finality is a per-leg
+concern, not a single RPC read. Adopting the ABC in the coordinator (the BTC path is still
+duck-typed) and migrating the durable `SwapRecord` locator to a chain-tagged union is a
+deliberate, separately-tested change on mainnet-proven code — read the ABC's scope note
+before starting. New legs (e.g. Base native-ETH, Litecoin) are tracked in the roadmap.

--- a/docs/how-to/index.md
+++ b/docs/how-to/index.md
@@ -9,6 +9,7 @@ you already know the basics and want a focused answer to "how do I X."
 broadcast-a-transaction
 recover-funds-across-wallet-paths
 use-the-public-testnet
+build-a-cross-chain-swap
 migrate-0.4-to-0.5
 verify-an-spv-proof
 spv-verification-pitfalls
@@ -30,6 +31,10 @@ spv-verification-pitfalls
   graduate from the local regtest quickstart to the shared public testnet, how to
   run `radiantd -testnet`, point pyrxd at it, and get testnet coins from the
   (best-effort, community-run) faucet. For most work, stay on regtest.
+- **[Build a cross-chain atomic swap](build-a-cross-chain-swap.md)** — embed the
+  trustless BTC/ETH ↔ RXD HTLC swap: the role/timelock safety invariant, the
+  `SwapCoordinator` + legs surface, and the proven regtest/Anvil harnesses to copy
+  from. Pre-audit — regtest/testnet only, no real value.
 - **[Migrate from pyrxd 0.4.x to 0.5.0](migrate-0.4-to-0.5.md)** — three
   breaking signature changes on the V1 dMint mint path, with
   before/after snippets. Read this first if you upgraded from a 0.4.x

--- a/docs/plans/2026-06-12-tier2-xchain-swap-library-plan.md
+++ b/docs/plans/2026-06-12-tier2-xchain-swap-library-plan.md
@@ -1,0 +1,56 @@
+---
+title: Tier-2 — package the Radiant-unique primitives as a clean, testnet-ready library
+type: plan
+date: 2026-06-12
+status: 2.1 shipped this change; 2.3/2.4 scoped as follow-ups
+parent: docs/ROADMAP.md
+---
+
+# Tier 2 — package the cross-chain swap (and friends) as library primitives
+
+Roadmap Tier 2 packages Radiant's differentiated capabilities as **library + regtest/
+testnet** features (no real value, no audit gate). Grounded state of each item:
+
+## 2.1 — Cross-chain atomic swap as a clean library primitive  ✅ this change
+**Gap (verified):** the proven HTLC `SwapCoordinator` + legs were exported from *neither*
+the top-level SDK *nor* the `pyrxd.gravity` package `__all__`, and appeared in **zero**
+examples — the existing `gravity_*.py` examples are the older *SPV-swap* session, not the
+HTLC primitive. A dev could not discover or embed the headline capability.
+
+**Shipped:**
+- Top-level lazy exports (`from pyrxd import SwapCoordinator, CoordinatorConfig,
+  MarginPolicy, NegotiatedTerms, SwapRecord, SwapState, generate_secret,
+  RadiantCovenantLeg, EthLeg, CounterChainLeg`). Lazy (PEP 562) so `import pyrxd` stays
+  web3-free; guarded by `tests/test_sdk_exports.py`.
+- `docs/how-to/build-a-cross-chain-swap.md`: the role/timelock safety invariant
+  (`MAKER_SECRET_TAKER_LOCKS_BTC_FIRST`, `t_counterchain > t_rxd + margin`), the
+  construction shape, and the **proven** regtest/Anvil e2e harnesses as the runnable
+  reference (rather than a toy snippet that wouldn't execute). PRE-AUDIT caveat is
+  prominent — regtest/testnet only.
+- Linked from the showcase ("Build it").
+
+## 2.2 — Same-chain swap API  ✅ already shipped (#123/#177)
+`pyrxd.swap` (SIGHASH_SINGLE|ANYONECANPAY partial-tx offers) is in the SDK surface
+(`create_offer`/`accept_offer`/`SwapOffer`/…). Done; no work here.
+
+## 2.3 — Base + Bitcoin-family counter-legs  ⏭ deferred (separate, careful effort)
+**Why not now:** new counter-chains (Base native-ETH, Litecoin, then USDC/DOGE/BCH) are
+gated behind adopting the `CounterChainLeg` ABC in the coordinator. The ABC's own scope
+note is explicit: the BTC path is still duck-typed module functions, and rewiring the
+mainnet-proven coordinator + migrating the durable `SwapRecord` locator to a chain-tagged
+union is "the larger, riskier half… it must not be done casually on mainnet-proven code."
+That warrants its own plan + dedicated tests, not a parallel one-turn change.
+
+**Sequence when picked up:** (1) adopt `CounterChainLeg` in the coordinator behind the
+existing BTC/ETH legs with no behaviour change (pure refactor, regtest-proven); (2) add a
+`BitcoinTaprootLeg` class wrapping the duck-typed `btc_wallet.taproot` surface; (3) then a
+new leg (Litecoin is cheapest/closest to BTC — reuses the Taproot/CSV machinery) against a
+litecoin regtest node; (4) Base native-ETH reuses `EthLeg` with a different chain id/RPC.
+
+## 2.4 — Token + covenant building-block docs  ⏭ follow-up (pure docs, low risk)
+Document the FT/NFT/dMint standards, the covenant builders, and the REF gate as composable
+primitives. Independent of 2.1/2.3; a good next docs pass.
+
+## Net
+2.1 (the headline) is the highest-leverage, audit-free, grounded slice and ships here. 2.3
+is real chain work behind a deliberate coordinator refactor — tracked, not rushed.

--- a/docs/showcase.md
+++ b/docs/showcase.md
@@ -45,8 +45,11 @@ mainnet.**
 > real value with someone you don't trust. Treat the cross-chain swap code as
 > pre-audit.
 
-### Run it
+### Build it
 
+- **[How-to: build a cross-chain atomic swap](how-to/build-a-cross-chain-swap.md)** —
+  the `SwapCoordinator` + legs surface (`from pyrxd import SwapCoordinator, …`), the
+  role/timelock safety invariant, and the proven regtest/Anvil harnesses to copy from.
 - [`examples/gravity_swap_demo.py`](../examples/gravity_swap_demo.py) — the full
   Gravity swap flow (offer → claim → payment → finalize). Defaults to a safe
   dry-run that builds every transaction but broadcasts nothing.

--- a/src/pyrxd/__init__.py
+++ b/src/pyrxd/__init__.py
@@ -98,6 +98,19 @@ _LAZY_EXPORTS: dict[str, tuple[str, str]] = {
     "SwapTerms": ("pyrxd.swap", "SwapTerms"),
     "accept_offer": ("pyrxd.swap", "accept_offer"),
     "create_offer": ("pyrxd.swap", "create_offer"),
+    # Cross-chain atomic swap — pyrxd.gravity HTLC primitive (BTC/ETH↔RXD). PRE-AUDIT:
+    # proven on regtest + dust mainnet, but NOT externally audited — regtest/testnet only,
+    # no real value, until the audit gate clears. See docs/how-to/build-a-cross-chain-swap.md.
+    "SwapCoordinator": ("pyrxd.gravity.swap_coordinator", "SwapCoordinator"),
+    "CoordinatorConfig": ("pyrxd.gravity.swap_coordinator", "CoordinatorConfig"),
+    "MarginPolicy": ("pyrxd.gravity.swap_coordinator", "MarginPolicy"),
+    "generate_secret": ("pyrxd.gravity.swap_coordinator", "generate_secret"),
+    "NegotiatedTerms": ("pyrxd.gravity.swap_state", "NegotiatedTerms"),
+    "SwapRecord": ("pyrxd.gravity.swap_state", "SwapRecord"),
+    "SwapState": ("pyrxd.gravity.swap_state", "SwapState"),
+    "CounterChainLeg": ("pyrxd.gravity.counter_chain_leg", "CounterChainLeg"),
+    "RadiantCovenantLeg": ("pyrxd.gravity.radiant_leg", "RadiantCovenantLeg"),
+    "EthLeg": ("pyrxd.gravity.eth_leg", "EthLeg"),
     # SPV verification
     "SpvProof": ("pyrxd.spv", "SpvProof"),
     "SpvProofBuilder": ("pyrxd.spv", "SpvProofBuilder"),

--- a/tests/test_sdk_exports.py
+++ b/tests/test_sdk_exports.py
@@ -1,0 +1,46 @@
+"""Guards the top-level ``pyrxd`` SDK surface for the cross-chain swap primitive.
+
+The Tier-2 packaging goal (docs/ROADMAP.md): the proven HTLC cross-chain swap is
+embeddable from a clean top-level import. These tests pin that the names resolve via
+the PEP 562 lazy ``__getattr__`` and that the headline import doesn't eagerly pull the
+optional ``web3`` dependency (the same import-graph discipline the package docstring
+documents for the browser inspect tool).
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+
+import pytest
+
+_CROSS_CHAIN_EXPORTS = [
+    "SwapCoordinator",
+    "CoordinatorConfig",
+    "MarginPolicy",
+    "generate_secret",
+    "NegotiatedTerms",
+    "SwapRecord",
+    "SwapState",
+    "CounterChainLeg",
+    "RadiantCovenantLeg",
+    "EthLeg",
+]
+
+
+@pytest.mark.parametrize("name", _CROSS_CHAIN_EXPORTS)
+def test_cross_chain_primitive_is_importable_from_top_level(name):
+    import pyrxd
+
+    assert name in pyrxd.__all__, f"{name} missing from pyrxd.__all__"
+    assert getattr(pyrxd, name) is not None
+
+
+def test_importing_pyrxd_does_not_eagerly_load_web3():
+    # `import pyrxd` must stay light: web3 is an optional dep and only the ETH leg needs
+    # it. Lazy exports must not drag it in at package-import time. Checked in a clean
+    # subprocess so we never mutate this interpreter's sys.modules (popping web3 here
+    # would contaminate other suites that mock it).
+    code = "import sys; import pyrxd; sys.exit(1 if 'web3' in sys.modules else 0)"
+    result = subprocess.run([sys.executable, "-c", code], capture_output=True, text=True)
+    assert result.returncode == 0, f"importing pyrxd eagerly loaded web3 (should be lazy)\n{result.stderr}"


### PR DESCRIPTION
Packages the **cross-chain atomic swap** — the project's headline differentiator — as a clean, embeddable library primitive. Roadmap Tier 2.1.

## The gap (verified)
The proven BTC/ETH↔RXD HTLC `SwapCoordinator` + legs were exported from **neither** the top-level SDK **nor** the `pyrxd.gravity` package `__all__`, and appeared in **zero** examples — the existing `gravity_*.py` examples are the *older SPV-swap* session, not the HTLC primitive. A developer literally could not discover or embed the capability the showcase advertises.

## What's here
- **Top-level lazy exports:** `from pyrxd import SwapCoordinator, CoordinatorConfig, MarginPolicy, NegotiatedTerms, SwapRecord, SwapState, generate_secret, RadiantCovenantLeg, EthLeg, CounterChainLeg`. Lazy (PEP 562) so `import pyrxd` stays **web3-free** — the optional ETH dependency loads only when `EthLeg` is actually accessed (the same import-graph discipline the package docstring documents for the browser inspect tool).
- **`docs/how-to/build-a-cross-chain-swap.md`:** the role/timelock **safety invariant** (`MAKER_SECRET_TAKER_LOCKS_BTC_FIRST`; `t_counterchain > t_rxd + margin`), the construction shape, and the **proven regtest/Anvil e2e harnesses** as the runnable reference — rather than a toy snippet that wouldn't execute against real chains. The **pre-audit** caveat is prominent (regtest/testnet only, no real value).
- **`tests/test_sdk_exports.py`** guards the surface: every name resolves + is in `__all__`, and a clean-subprocess check that bare `import pyrxd` doesn't eagerly load `web3`.
- Linked from the showcase ("Build it") and the how-to index.

## Scope (the rest of Tier 2 — `docs/plans/2026-06-12-…`)
- **2.2** same-chain swap API — already shipped (#123/#177).
- **2.3** new counter-legs (Base, Litecoin, …) — **deferred** behind a deliberate `CounterChainLeg` coordinator refactor that the ABC's own scope note flags as *"not to be done casually on mainnet-proven code."* Tracked with a sequence, not rushed into a parallel change.
- **2.4** token/covenant building-block docs — a follow-up docs pass.

## Verification
Full suite green: **4134 passed**, 86 skipped; lint/format/typecheck/private-links clean. (The one test-isolation bug I introduced — a `sys.modules` mutation in the new test — was caught by the full suite and fixed by moving the check into a clean subprocess.)

No runtime behaviour change: this is a packaging/exports + docs change. The cross-chain swap code itself is untouched and remains pre-audit.