### PR TITLE
fix(deps): pin regtest base image to ubuntu:22.04 digest

### DIFF
--- a/docker/regtest.Dockerfile
+++ b/docker/regtest.Dockerfile
@@ -21,7 +21,7 @@
 # 2.35). Debian bullseye's glibc (2.31) is too old; bookworm's Boost (1.81) is
 # the wrong soname. Measured with `ldd`/`objdump -T` on the v3.1.x daemon.
 
-FROM ubuntu:22.04
+FROM ubuntu:22.04@sha256:4f838adc7181d9039ac795a7d0aba05a9bd9ecd480d294483169c5def983b64d
 
 ARG RADIANT_VERSION=v3.1.1
 ARG RADIANT_TARBALL=radiant-${RADIANT_VERSION}-linux-x64.tar.gz

--- a/src/pyrxd/devnet.py
+++ b/src/pyrxd/devnet.py
@@ -57,7 +57,7 @@ _REGTEST_DOCKERFILE = """\
 # 2.35). Debian bullseye's glibc (2.31) is too old; bookworm's Boost (1.81) is
 # the wrong soname. Measured with `ldd`/`objdump -T` on the v3.1.x daemon.
 
-FROM ubuntu:22.04
+FROM ubuntu:22.04@sha256:4f838adc7181d9039ac795a7d0aba05a9bd9ecd480d294483169c5def983b64d
 
 ARG RADIANT_VERSION=v3.1.1
 ARG RADIANT_TARBALL=radiant-${RADIANT_VERSION}-linux-x64.tar.gz


### PR DESCRIPTION
## Summary

- Pins `docker/regtest.Dockerfile` base image from `ubuntu:22.04` (floating tag) to `ubuntu:22.04@sha256:4f838adc7181d9039ac795a7d0aba05a9bd9ecd480d294483169c5def983b64d` (SHA256 digest)
- Resolves Scorecard alert #316 (Pinned-Dependencies, severity Medium)
- No behavioural change — same Ubuntu 22.04 image, now immutable at build time

Dependabot will keep the digest current going forward.

## Test plan

- [x] Pre-push `task ci` passed (no source changes; Dockerfile is only built by `pyrxd regtest setup`)