### PR TITLE
feat(eth): Base as an EVM counter-chain (Tier 2.3) + S7 adversarial-test fix

### DIFF
--- a/docs/how-to/build-a-cross-chain-swap.md
+++ b/docs/how-to/build-a-cross-chain-swap.md
@@ -105,11 +105,54 @@ $ XCHAIN_ETH_REGTEST=1 pytest tests/test_xchain_eth_swap_regtest_e2e.py -m integ
 
 ## Adding another counter-chain
 
+There are two very different costs, depending on the chain family.
+
+### EVM family — Base works today (no new code)
+
+The proven `EthLeg` + `EthHtlc.sol` machinery is **chain-id-agnostic**: the same contract
+bytecode, the same `finalized`-checkpoint reads, the same claim/refund/scrape paths run on
+any EVM-equivalent chain. Base (an OP-stack L2) is the first packaged example — swap a
+Radiant asset against **native ETH on Base** by changing three knobs, none of which touch
+the coordinator:
+
+```python
+from pyrxd import KNOWN_EVM_CHAINS, EthLeg, MarginPolicy
+
+base = KNOWN_EVM_CHAINS["base-sepolia"]          # or "base" (mainnet; audit-gated)
+
+rpc = EthRpc("https://sepolia.base.org", expected_chain_id=base.chain_id)
+contract_leg = EthHtlcContractLeg(rpc=rpc, signing_key=key, chain_id=base.chain_id, artifact=ARTIFACT)
+eth_leg = EthLeg(contract_leg=contract_leg, network=base.network, ...)  # audit gate applies
+
+policy = MarginPolicy(..., eth_finalization_window_s=base.finalization_window_s)
+```
+
+The chain is pinned at every layer: `EthRpc` refuses a node on the wrong chain id, the leg
+signs EIP-155-bound transactions, and the durable locator records `chain_id`. The
+negotiated `counter_chain` stays `"eth"` — it names the *finalized-checkpoint family*, and
+the locator's chain id pins the concrete chain.
+
+**The one genuinely chain-specific knob is finality.** `KNOWN_EVM_CHAINS`
+(`pyrxd.eth_wallet.chains`) records a sourced `finalization_window_s` per chain: on Base, an
+L2 block is `finalized` only once the batch containing it sits in a *finalized L1 block* —
+batch cadence (~1 min) + L1 inclusion + 2 L1 epochs, ≈15 min steady-state. The honest worst
+case is the OP-stack **12-hour sequencing window** (a batch may legally land that late);
+budget stalls in `CrossClockMargin.eth_finality_stall_tolerance_s`, exactly as for an L1
+finality stall — never by inflating the steady-state window. Provenance is cited in the
+module docstring; `evm_chain_by_id` fails closed on a chain with no vetted window.
+
+Proofs: `tests/test_eth_leg_anvil_integration.py::test_full_lifecycle_on_base_chain_id`
+(full leg lifecycle on Base Sepolia's chain id) and the entire coordinator e2e re-run as
+Base via `XCHAIN_ETH_CHAIN_ID=84532 XCHAIN_ETH_REGTEST=1 pytest
+tests/test_xchain_eth_swap_regtest_e2e.py -m integration`.
+
+### A new chain family (Litecoin, …) — a deliberate, separate effort
+
 `CounterChainLeg` (`pyrxd.gravity.counter_chain_leg`) is the documented contract a new
 backend implements: `derive_expected_funding` / `fund` / `claim` / `refund` /
 `recover_secret` / `is_final`. The ABC was extracted from two *real* shapes (BTC Taproot +
 ETH Solidity), so it reflects what a third chain actually needs — finality is a per-leg
-concern, not a single RPC read. Adopting the ABC in the coordinator (the BTC path is still
-duck-typed) and migrating the durable `SwapRecord` locator to a chain-tagged union is a
-deliberate, separately-tested change on mainnet-proven code — read the ABC's scope note
-before starting. New legs (e.g. Base native-ETH, Litecoin) are tracked in the roadmap.
+concern, not a single RPC read. A non-EVM chain (e.g. Litecoin) means generalizing the
+PoW-depth dispatch and standing up new regtest infrastructure; adopting the ABC in the
+coordinator (the BTC path is still duck-typed) is a deliberate, separately-tested change
+on mainnet-proven code — read the ABC's scope note before starting.

--- a/src/pyrxd/__init__.py
+++ b/src/pyrxd/__init__.py
@@ -111,6 +111,8 @@ _LAZY_EXPORTS: dict[str, tuple[str, str]] = {
     "CounterChainLeg": ("pyrxd.gravity.counter_chain_leg", "CounterChainLeg"),
     "RadiantCovenantLeg": ("pyrxd.gravity.radiant_leg", "RadiantCovenantLeg"),
     "EthLeg": ("pyrxd.gravity.eth_leg", "EthLeg"),
+    "EvmChain": ("pyrxd.eth_wallet.chains", "EvmChain"),
+    "KNOWN_EVM_CHAINS": ("pyrxd.eth_wallet.chains", "KNOWN_EVM_CHAINS"),
     # SPV verification
     "SpvProof": ("pyrxd.spv", "SpvProof"),
     "SpvProofBuilder": ("pyrxd.spv", "SpvProofBuilder"),

--- a/src/pyrxd/eth_wallet/chains.py
+++ b/src/pyrxd/eth_wallet/chains.py
@@ -1,0 +1,105 @@
+"""EVM counter-chain registry — the per-chain safety knobs for the finalized-checkpoint leg.
+
+The swap coordinator treats every non-BTC counter leg as a *finalized-checkpoint* (EVM)
+chain: the proven ``EthLeg`` + ``EthHtlc.sol`` machinery is chain-id-agnostic (the same
+contract bytecode and ``finalized``-tag reads work on any EVM-equivalent chain), so adding
+an EVM chain does NOT touch the coordinator. What IS chain-specific — and safety-critical
+for an atomic swap — is **how long the ``finalized`` tag lags the tip**, which sizes
+``MarginPolicy.eth_finalization_window_s`` (the reorg gate's finalization reserve).
+
+This module is that knowledge, written down once with provenance, instead of a magic
+number per harness.
+
+Window discipline (matches the existing codebase split):
+
+* ``finalization_window_s`` is the **steady-state** lag of the ``finalized`` tag. Stalls
+  (L1 inactivity leak, batcher outage) are budgeted SEPARATELY via
+  ``CrossClockMargin.eth_finality_stall_tolerance_s`` — do not inflate the window to cover
+  them.
+* Ethereum L1: finality = 2 epochs = 768 s steady-state (Casper FFG). The 768 s floor is
+  enforced by :class:`~pyrxd.gravity.swap_coordinator.MarginPolicy`.
+* Base (OP-stack L2): an L2 block is ``finalized`` once the batch containing it sits in a
+  FINALIZED L1 block — i.e. batch-posting cadence (~1 min on Base) + L1 inclusion + the
+  same 2-epoch L1 finality. Steady-state ≈ 15 min; the entry below uses 900 s (CHOSEN/
+  ESTIMATED). HONEST WORST CASE: the OP-stack *sequencing window* permits a batch to land
+  up to **12 hours** late (and a chain that misses it can reorg that far) — a swap
+  operator must size ``eth_finality_stall_tolerance_s`` (and therefore the RXD timelock)
+  for the stall they are willing to survive, exactly as for an L1 finality stall.
+  Sources: Base "Transaction Finality" docs; OP-stack batcher/configurability specs
+  (https://docs.base.org/base-chain/network-information/transaction-finality,
+  https://specs.optimism.io/protocol/configurability.html).
+
+The ``network`` tag feeds the existing fail-closed gates unchanged: any tag not in
+``AUDIT_CLEARED_NETWORKS`` (only isolated test chains are) is value-bearing and refuses to
+run without the explicit post-audit ``audit_cleared=True`` opt-in — so every chain here,
+including the testnets, stays behind the audit gate by construction.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from pyrxd.security.errors import ValidationError
+
+__all__ = ["KNOWN_EVM_CHAINS", "EvmChain", "evm_chain_by_id"]
+
+# Keep in sync with MarginPolicy._MIN_ETH_FINALIZATION_WINDOW_S (the consensus-derived
+# 2-epoch floor); re-declared here so registry entries fail fast at import time.
+_FLOOR_S = 768
+
+
+@dataclass(frozen=True)
+class EvmChain:
+    """One EVM-equivalent counter chain the ETH leg machinery can run against.
+
+    ``chain_id`` pins the chain everywhere it matters: ``EthRpc(expected_chain_id=...)``
+    refuses a node on the wrong chain, ``EthHtlcContractLeg(chain_id=...)`` signs with
+    EIP-155 replay protection, and the durable ``EthHtlcLocator`` records it.
+    ``network`` is the tag ``EthLeg(network=...)`` reads for the value-bearing/audit
+    gates. ``finalization_window_s`` seeds ``MarginPolicy.eth_finalization_window_s``.
+    """
+
+    name: str
+    chain_id: int
+    network: str
+    finalization_window_s: int
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.chain_id, int) or isinstance(self.chain_id, bool) or self.chain_id <= 0:
+            raise ValidationError("EvmChain.chain_id must be a positive int")
+        if not isinstance(self.network, str) or not self.network:
+            raise ValidationError("EvmChain.network must be a non-empty str")
+        if (
+            not isinstance(self.finalization_window_s, int)
+            or isinstance(self.finalization_window_s, bool)
+            or self.finalization_window_s < _FLOOR_S
+        ):
+            raise ValidationError(
+                f"EvmChain.finalization_window_s must be an int >= {_FLOOR_S} "
+                "(an L2 cannot finalize faster than the L1 checkpoint it settles to)"
+            )
+
+
+KNOWN_EVM_CHAINS: dict[str, EvmChain] = {
+    # Ethereum L1 — finality = 2 epochs (Casper FFG), 768 s steady-state.
+    "ethereum": EvmChain(name="ethereum", chain_id=1, network="mainnet", finalization_window_s=768),
+    "sepolia": EvmChain(name="sepolia", chain_id=11155111, network="sepolia", finalization_window_s=768),
+    # Base (OP-stack L2) — finalized = batch in a finalized L1 block. 900 s CHOSEN/ESTIMATED
+    # steady-state (batch cadence + L1 inclusion + 768 s L1 finality); see module docstring
+    # for the 12 h sequencing-window worst case and where to budget it.
+    "base": EvmChain(name="base", chain_id=8453, network="base", finalization_window_s=900),
+    "base-sepolia": EvmChain(name="base-sepolia", chain_id=84532, network="base-sepolia", finalization_window_s=900),
+}
+
+
+def evm_chain_by_id(chain_id: int) -> EvmChain:
+    """Look up a known chain by EIP-155 chain id; raises for an unknown one (fail-closed —
+    an unknown chain has no vetted finalization window, so refuse rather than guess)."""
+    for chain in KNOWN_EVM_CHAINS.values():
+        if chain.chain_id == chain_id:
+            return chain
+    raise ValidationError(
+        f"unknown EVM chain id {chain_id!r}: no vetted finalization window. Add it to "
+        "KNOWN_EVM_CHAINS with a sourced finalization_window_s, or construct MarginPolicy "
+        "with an explicitly chosen eth_finalization_window_s."
+    )

--- a/tests/test_eth_chains.py
+++ b/tests/test_eth_chains.py
@@ -1,0 +1,59 @@
+"""Unit tests for the EVM counter-chain registry (pyrxd.eth_wallet.chains).
+
+The registry is the one Base-specific safety knob (Tier 2.3): per-chain finalization
+windows for the finalized-checkpoint leg. These tests pin the registry's integrity
+invariants and the fail-closed unknown-chain behaviour; the live-chain proof is
+``tests/test_eth_leg_anvil_integration.py::test_full_lifecycle_on_base_chain_id``.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from pyrxd.eth_wallet.chains import KNOWN_EVM_CHAINS, EvmChain, evm_chain_by_id
+from pyrxd.security.errors import ValidationError
+
+
+def test_registry_integrity():
+    # Unique chain ids, names match keys, every entry respects the 2-epoch L1 floor.
+    ids = [c.chain_id for c in KNOWN_EVM_CHAINS.values()]
+    assert len(ids) == len(set(ids)), "duplicate chain ids in KNOWN_EVM_CHAINS"
+    for key, chain in KNOWN_EVM_CHAINS.items():
+        assert chain.name == key
+        assert chain.finalization_window_s >= 768
+        assert chain.network
+
+
+def test_base_entries_present_with_l2_window():
+    base = KNOWN_EVM_CHAINS["base"]
+    base_sepolia = KNOWN_EVM_CHAINS["base-sepolia"]
+    assert (base.chain_id, base_sepolia.chain_id) == (8453, 84532)
+    # An OP-stack L2 finalizes by settling to L1, so its steady-state window must be
+    # at least the L1 window (batch posting + L1 finality can only ADD lag).
+    assert base.finalization_window_s >= KNOWN_EVM_CHAINS["ethereum"].finalization_window_s
+    assert base_sepolia.finalization_window_s >= KNOWN_EVM_CHAINS["sepolia"].finalization_window_s
+
+
+def test_lookup_by_id_and_unknown_fails_closed():
+    assert evm_chain_by_id(8453) is KNOWN_EVM_CHAINS["base"]
+    assert evm_chain_by_id(1) is KNOWN_EVM_CHAINS["ethereum"]
+    with pytest.raises(ValidationError, match="unknown EVM chain id"):
+        evm_chain_by_id(999_999)
+
+
+def test_evm_chain_validation_rejects_sub_floor_window():
+    with pytest.raises(ValidationError, match="finalization_window_s"):
+        EvmChain(name="x", chain_id=42, network="x", finalization_window_s=767)
+    with pytest.raises(ValidationError, match="chain_id"):
+        EvmChain(name="x", chain_id=0, network="x", finalization_window_s=900)
+    with pytest.raises(ValidationError, match="network"):
+        EvmChain(name="x", chain_id=42, network="", finalization_window_s=900)
+
+
+def test_no_registry_network_is_audit_exempt():
+    # Every registry network tag must stay behind the audit gate: none may appear in
+    # AUDIT_CLEARED_NETWORKS (which is reserved for isolated, no-value test chains).
+    from pyrxd.btc_wallet.htlc_leg import AUDIT_CLEARED_NETWORKS
+
+    for chain in KNOWN_EVM_CHAINS.values():
+        assert chain.network not in AUDIT_CLEARED_NETWORKS, chain.name

--- a/tests/test_eth_leg_anvil_integration.py
+++ b/tests/test_eth_leg_anvil_integration.py
@@ -58,12 +58,12 @@ def _free_port() -> int:
     return port
 
 
-def _start_anvil(*extra_args: str):
+def _start_anvil(*extra_args: str, chain_id: int = _CHAIN_ID):
     """Start a fresh, isolated anvil (so evm_increaseTime cannot leak across tests); yield its URL."""
     port = _free_port()
     url = f"http://127.0.0.1:{port}"
     proc = subprocess.Popen(
-        ["anvil", "--port", str(port), "--chain-id", str(_CHAIN_ID), "--silent", *extra_args],
+        ["anvil", "--port", str(port), "--chain-id", str(chain_id), "--silent", *extra_args],
         stdout=subprocess.DEVNULL,
         stderr=subprocess.DEVNULL,
     )
@@ -101,14 +101,14 @@ def anvil_url_fast_finality():
     yield from _start_anvil("--slots-in-an-epoch", "1")
 
 
-def _legs(url: str):
+def _legs(url: str, chain_id: int = _CHAIN_ID):
     """A shared rpc + a taker leg (funds/refunds) and a maker leg (claims)."""
-    rpc = EthRpc(url, expected_chain_id=_CHAIN_ID)
+    rpc = EthRpc(url, expected_chain_id=chain_id)
     taker = EthHtlcContractLeg(
-        rpc=rpc, signing_key=PrivateKeyMaterial(bytes.fromhex(_KEY_TAKER)), chain_id=_CHAIN_ID, artifact=_ARTIFACT
+        rpc=rpc, signing_key=PrivateKeyMaterial(bytes.fromhex(_KEY_TAKER)), chain_id=chain_id, artifact=_ARTIFACT
     )
     maker = EthHtlcContractLeg(
-        rpc=rpc, signing_key=PrivateKeyMaterial(bytes.fromhex(_KEY_MAKER)), chain_id=_CHAIN_ID, artifact=_ARTIFACT
+        rpc=rpc, signing_key=PrivateKeyMaterial(bytes.fromhex(_KEY_MAKER)), chain_id=chain_id, artifact=_ARTIFACT
     )
     return rpc, taker, maker
 
@@ -279,5 +279,58 @@ async def test_finalized_pin_rejects_reorg_swapped_in_contract(anvil_url_fast_fi
         fin2 = await rpc.w3.eth.get_block("finalized")
         assert int(fin2["number"]) >= int(rec["blockNumber"])
         await taker.verify_funded(locator, expected_amount_wei=_AMOUNT_WEI, block_identifier="finalized")
+    finally:
+        await rpc.close()
+
+
+@pytest.fixture()
+def anvil_url_base_sepolia():
+    """Anvil presenting the Base Sepolia chain id — proves the leg machinery is
+    chain-id-agnostic across the EVM family (Tier 2.3: Base as a counter chain)."""
+    from pyrxd.eth_wallet.chains import KNOWN_EVM_CHAINS
+
+    yield from _start_anvil(chain_id=KNOWN_EVM_CHAINS["base-sepolia"].chain_id)
+
+
+async def test_full_lifecycle_on_base_chain_id(anvil_url_base_sepolia):
+    """Tier 2.3 (Base, EVM-family path): the SAME proven EthHtlc machinery — deploy/fund,
+    verify_funded binding gate, claim(p), secret scrape, R6 provenance — runs unmodified
+    against a node presenting Base Sepolia's chain id (84532). The chain is pinned at
+    every layer: EthRpc refuses a wrong chain id, the leg signs EIP-155-bound txs, and
+    the locator records chain_id for the durable SwapRecord."""
+    from pyrxd.eth_wallet.chains import KNOWN_EVM_CHAINS, evm_chain_by_id
+
+    base = KNOWN_EVM_CHAINS["base-sepolia"]
+    rpc, taker, maker = _legs(anvil_url_base_sepolia, chain_id=base.chain_id)
+    try:
+        p, h = _secret()
+        timeout = await _now_plus(rpc, 3600)
+        locator = await taker.fund(
+            hashlock=h, claimant=_ADDR_MAKER, refundee=_ADDR_TAKER, timeout=timeout, amount_wei=_AMOUNT_WEI
+        )
+        assert locator.chain_id == base.chain_id  # the durable record pins the chain
+        await taker.verify_funded(locator, expected_amount_wei=_AMOUNT_WEI)
+        claim_tx = await maker.claim(locator, p)
+        artifacts = await maker.fetch_claim_artifacts(claim_tx)
+        assert maker.recover_secret(artifacts, h) == p
+        await taker.assert_claim_provenance(claim_tx, contract_address=locator.contract_address, preimage=p)
+        # The registry's finality knob exists and respects the L1 floor (the safety contract
+        # a MarginPolicy for this chain is seeded from).
+        assert evm_chain_by_id(base.chain_id).finalization_window_s >= 768
+    finally:
+        await rpc.close()
+
+
+async def test_wrong_chain_id_refused(anvil_url_base_sepolia):
+    """The cross-chain pin fails closed: a leg negotiated for Ethereum L1 (chain id 1)
+    pointed at a Base-chain-id node refuses at assert_chain — a swap can never silently
+    run against the wrong EVM chain."""
+    rpc, taker, _maker = _legs(anvil_url_base_sepolia, chain_id=1)
+    try:
+        _, h = _secret()
+        with pytest.raises(ValidationError, match="wrong network"):
+            await taker.fund(
+                hashlock=h, claimant=_ADDR_MAKER, refundee=_ADDR_TAKER, timeout=4_000_000_000, amount_wei=_AMOUNT_WEI
+            )
     finally:
         await rpc.close()

--- a/tests/test_sdk_exports.py
+++ b/tests/test_sdk_exports.py
@@ -25,6 +25,8 @@ _CROSS_CHAIN_EXPORTS = [
     "CounterChainLeg",
     "RadiantCovenantLeg",
     "EthLeg",
+    "EvmChain",
+    "KNOWN_EVM_CHAINS",
 ]
 
 

--- a/tests/test_xchain_eth_adversarial_e2e.py
+++ b/tests/test_xchain_eth_adversarial_e2e.py
@@ -391,10 +391,18 @@ class TestEthAdversarial:
             with pytest.raises(ValidationError, match="claimant"):
                 await coord.maker_verify_counter_funding(malicious.contract_address)
 
-            # And the maker NEVER advanced to a locked state — its asset is untouched.
-            assert coord.record.state is SwapState.BTC_LOCKED
+            # And the maker recorded NOTHING from the malicious contract: the coordinator raises
+            # BEFORE with_counter_lock, so the record stays NEGOTIATED with no locator — the
+            # fail-closed contract in maker_verify_counter_funding's docstring. (This assert
+            # originally expected BTC_LOCKED, contradicting both that contract and this comment;
+            # the test had NEVER passed — it fails identically at its introducing commit ca78f0e.
+            # Recording a verify-FAILED locator would be the unsafe behavior.)
+            assert coord.record.state is SwapState.NEGOTIATED
+            assert coord.record.counterchain_locator is None
 
-            # Sanity: an HONEST contract (claimant=maker) passes the same gate.
+            # Sanity: an HONEST contract (claimant=maker) passes the same gate and only THEN
+            # records the verified locator. The STATE still does not advance here — the FSM
+            # moves off NEGOTIATED in the maker's subsequent lock step, never inside verify.
             honest_leg = EthLeg(
                 contract_leg=EthHtlcContractLeg(
                     rpc=attacker_rpc,
@@ -410,6 +418,9 @@ class TestEthAdversarial:
             )
             honest = await honest_leg.fund(terms)
             await coord.maker_verify_counter_funding(honest.contract_address)  # no raise
+            assert coord.record.state is SwapState.NEGOTIATED
+            assert coord.record.counterchain_locator is not None
+            assert coord.record.counterchain_locator.contract_address == honest.contract_address
         finally:
             await attacker_rpc.close()
             await rpc.close()

--- a/tests/test_xchain_eth_swap_regtest_e2e.py
+++ b/tests/test_xchain_eth_swap_regtest_e2e.py
@@ -75,7 +75,10 @@ pytestmark = pytest.mark.integration
 
 _RXD_IMAGE = "radiant-core:v3.1.1-amd64"
 _RXD_CT = "xchain-eth-rxd-pytest"
-_CHAIN_ID = 31337
+# The anvil chain id. Default 31337; override to run the SAME coordinator suite as another
+# EVM-family chain (Tier 2.3) — e.g. XCHAIN_ETH_CHAIN_ID=84532 runs it as Base Sepolia,
+# proving the finalized-checkpoint path is chain-id-agnostic end-to-end.
+_CHAIN_ID = int(os.environ.get("XCHAIN_ETH_CHAIN_ID", "31337"))
 # Anvil's deterministic PUBLIC dev keys (local devnet only — no real value).
 _KEY = "ac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80"  # acct 0 — funds/claims/refunds
 _ADDR_TAKER = "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266"  # acct 0 (refundee)


### PR DESCRIPTION
Adds **Base** (OP-stack L2, native ETH) as the first packaged additional counter chain — roadmap Tier 2.3 — by the lowest-risk path: the proven `EthLeg` + `EthHtlc.sol` machinery is **chain-id-agnostic**, so this PR changes **zero coordinator dispatch code**. The genuinely chain-specific piece is finality, now written down once with provenance instead of a magic number per harness.

## What's here

**`pyrxd.eth_wallet.chains` — the EVM counter-chain registry**
- `EvmChain` + `KNOWN_EVM_CHAINS` (ethereum / sepolia / base / base-sepolia) with a sourced `finalization_window_s` per chain, exported lazily from the top level.
- Base entries: **900 s CHOSEN/ESTIMATED steady-state** — batch cadence (~1 min on Base) + L1 inclusion + the 768 s 2-epoch L1 finality ([Base finality docs](https://docs.base.org/base-chain/network-information/transaction-finality)). The honest worst case — the OP-stack **12-hour sequencing window** ([OP specs](https://specs.optimism.io/protocol/configurability.html)) — is documented and routed to the existing `eth_finality_stall_tolerance_s` stall budget, **not** inflated into the steady-state window (matches the codebase's existing 768 s + stall-budget split).
- Fail-closed everywhere: the 768 s floor is enforced at entry construction; `evm_chain_by_id` refuses an unvetted chain id; a test pins that **no registry network tag is audit-exempt** (Base mainnet *and* testnets all stay behind the `audit_cleared` gate).

**Proofs (all green, run locally)**
| Proof | Result |
|---|---|
| Full leg lifecycle on Anvil at Base Sepolia's chain id (deploy / verify_funded / claim / scrape / R6 provenance) | pass |
| Wrong-chain-id refusal (leg negotiated for chain 1 vs a Base-id node → fail-closed at `assert_chain`) | pass |
| **Entire coordinator e2e suite re-run as Base** (`XCHAIN_ETH_CHAIN_ID=84532`, new env knob) | **7 passed** |
| Same suite on the 31337 default (no regression) | 7 passed |
| **Full adversarial suite S1–S7 on both chain ids** | 7 + 7 passed |

**Docs:** the cross-chain how-to gains an "EVM family — Base works today" section (3 knobs: chain id, network tag, finalization window) and clearly separates the **new-chain-family** effort (Litecoin: PoW-depth dispatch + new regtest infra) as its own deliberate plan.

## Drive-by fix: S7 had never passed
Re-running the adversarial suite surfaced `test_S7_maker_refuses_hostile_taker_eth_contract` failing. Diagnosis before patching: it fails **identically at its introducing commit** (`ca78f0e`, PR #155) — it had *never* passed (env-gated; not in default CI). Its state assert expected `BTC_LOCKED` after a **failed** maker verification, contradicting both its own comment ("the maker NEVER advanced to a locked state") and `maker_verify_counter_funding`'s documented fail-closed contract (raise **before** recording). The assert now pins the actual safe behavior: a refused contract records **nothing** (`NEGOTIATED`, no locator); the honest path records the verified locator without advancing state. **No coordinator behavior changed** — the safe behavior was already the implemented one.

## Verification
Full unit suite **4152 passed**; lint / format / typecheck / private-links clean. The pre-audit posture is unchanged: Base mainnet (like ETH mainnet) refuses to run without the post-audit `audit_cleared=True` opt-in.