### PR TITLE
docs(sdk): covenant building blocks as composable primitives (Tier 2.4)

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -4,10 +4,15 @@ _Written 2026-06-07; committed (sanitized for the public repo) 2026-06-11. Synth
 `docs/plans/`, open issues (#123/#44/#10/#8), the CLI-fuzz PR, and two 2026-06-07 expert-panel reviews
 (bridged-asset feasibility + swap-marketplace demand)._
 
-**Status delta since 2026-06-07:** Tier 0.1 is done (#175 CLI fuzz and the FT↔ETH swap PR both merged);
-3.2 HD multipath recovery shipped (#158); 3.3 dmint subpackage split shipped (#109); watchtower v2
-(dust-capped BTC refund) + alert-only ETH watching shipped (see `src/pyrxd/gravity/watch/README.md`);
-issue #123 is closed. Tier 0.2/0.3 and all of Tier 1 remain open.
+**Status delta (refreshed 2026-06-12):** Tier 0.1 done (#175 + the FT↔ETH swap PR merged); Tier 0.3
+(#44) has per-repo hardening PRs open across the four public repos. **Tier 1 shipped** — the dev
+on-ramp (#185) plus the committed regtest Dockerfile, `pyrxd regtest setup`, the CI North-Star
+`quickstart` job, the testnet how-to, and the Radiant-Core v3.1.1 bump with measured consensus
+revalidation (#195). **Tier 2:** 2.1 cross-chain swap packaged as a library primitive (#196);
+2.2 was already shipped (#123/#177); 2.3 Base as an EVM counter-chain in review (#198); 2.4
+covenant building-block docs land with this change. Tier 3: 3.2/#158 and 3.3/#109 shipped;
+watchtower v2 + alert-only ETH shipped (see `src/pyrxd/gravity/watch/README.md`). Tier 0.2 and
+issue #8 remain open; Tier 4 (audit, real value, bridged assets) stays deliberately deferred.
 
 ## Framing (what this project actually is)
 

--- a/docs/concepts/covenant-building-blocks.md
+++ b/docs/concepts/covenant-building-blocks.md
@@ -1,0 +1,117 @@
+# Covenant building blocks: tokens, covenants, and the REF gate as composable primitives
+
+Radiant's genuinely differentiated capability is that a **UTXO's locking script can
+inspect the transaction spending it** — output scripts, values, and induction-capable
+token references (`refs`) — at consensus level. That lets you build *covenants*: outputs
+that constrain what any future spend must look like, with no trusted server enforcing it.
+
+pyrxd ships four covenant-grade building blocks, each proven against a real
+`radiant-core` node and each usable on its own or composed with the others. This page is
+the map; each section links the import, the contract, and the proof.
+
+> **Pre-audit caveat (applies to all four).** These primitives are consensus-validated on
+> regtest and several are proven on mainnet, but none has had an external security audit.
+> Build and demo on regtest/testnet; do not gate real value on them yet.
+
+## 1. HTLC covenants — lock RXD, an FT, or an NFT behind a hashlock + timelock
+
+```python
+from pyrxd import build_htlc_covenant_rxd, build_htlc_covenant_ft, build_htlc_covenant_nft
+```
+
+`pyrxd.gravity.htlc_covenant` builds the **funded covenant scriptPubKey** — the UTXO a
+maker locks an asset into for an atomic swap. Two spend paths are baked into the script:
+*claim* (present the preimage `p` of the negotiated hashlock; pays the taker's holder
+script) and *refund* (after a consensus-enforced `OP_CHECKSEQUENCEVERIFY` maturity; pays
+the maker). The three variants differ in how the asset binds:
+
+| Variant | Asset binding |
+|---|---|
+| `build_htlc_covenant_rxd` | native RXD — no ref at all |
+| `build_htlc_covenant_ft` | the FT's genesis ref + the FT `codeScriptHashValueSum` epilogue weld (token-amount conservation) |
+| `build_htlc_covenant_nft` | the NFT singleton ref (`d8<ref>`) inside the compiled body |
+
+The covenant pins `hash256(holder script)` for `output[0]`, so a claim/refund can only
+pay the negotiated destination shape. Build-time guards run fail-closed: every push in
+the assembled SPK is re-checked for `MINIMALDATA` minimality (a non-minimal push would
+brick **both** spend branches on-chain — found the hard way, now impossible to ship).
+
+**Proofs:** claim + CSV-refund proven on Radiant **mainnet** for all three variants;
+consensus semantics (CSV maturity, holder-hash pinning, singleton conservation)
+re-validated on the pinned regtest node in `tests/test_htlc_regtest_e2e.py`. These
+covenants are exactly what `RadiantCovenantLeg` funds inside the
+[cross-chain swap](../how-to/build-a-cross-chain-swap.md).
+
+One consensus fact worth internalizing: **"exactly one NFT output" is covenant-enforced,
+not consensus-enforced** — Radiant consensus permits *burning* a singleton (zero
+carrying outputs). Any "the token must go somewhere" property is your covenant's job.
+
+## 2. The soulbound NFT covenant — consensus-enforced non-transferability
+
+```python
+from pyrxd import build_soulbound_nft_covenant   # SoulboundNftCovenant result
+```
+
+`pyrxd.glyph.soulbound_covenant` builds an NFT whose locking script allows exactly two
+futures: **recur into a byte-identical clone of itself** (same ref, same logic, same
+immutable owner — enforced by `OP_INPUTINDEX OP_UTXOBYTECODE` vs `OP_0 OP_OUTPUTBYTECODE`
+full-bytecode equality) **or be burned**. There is no transfer path; a clone with a
+different owner is a different script and fails `OP_EQUALVERIFY` at consensus.
+
+This matters because the ecosystem's existing "soulbound" support is **advisory only** —
+an ordinary transferable NFT plus an off-chain check an honest wallet runs voluntarily.
+A counterparty running its own software can move it freely. The covenant version is the
+chain-side mechanism that makes a soulbound token usable as a *trust anchor* against an
+adversarial counterparty (reputation, compliance, credentials). A covenant of this design
+is live on mainnet; this builder's consensus behaviour (recur accepted / transfer
+rejected / burn accepted) is pinned on the regtest node in
+`tests/test_soulbound_covenant_regtest.py`.
+
+## 3. The REF-authenticity gate — consensus enforces *uniqueness*, not *provenance*
+
+```python
+from pyrxd import verify_ref_authenticity   # async; RefAuthenticityIndexer/ResolvedRef in pyrxd.gravity
+```
+
+The sharpest lesson in the stack (audit finding R1, proven on a live node): a
+consensus-valid singleton ref need **not** be a genuinely minted Glyph. Consensus only
+requires output refs ⊆ input refs — a node will happily mine a covenant whose "NFT" ref
+is a plain wallet outpoint. **A covenant cannot self-verify mint provenance.** Anyone
+buying/swapping "the advertised asset" must resolve the ref off-chain.
+
+`verify_ref_authenticity` makes that defense explicit and fail-closed: five bindings
+against a trusted indexer's resolution — genesis outpoint == advertised ref (a ref is
+the *genesis* outpoint, never the reveal txid), a real `gly` envelope, the agreed payload
+hash, asset identity, and a minimum genesis confirmation depth (a shallow genesis can be
+reorged out after you pay). It is `async` on purpose: a sync wrapper that forgot to await
+the indexer would return a truthy coroutine and fail *open* — the exact catastrophe the
+gate exists to prevent. The `SwapCoordinator` runs it as a hard pre-lock gate for every
+FT/NFT swap.
+
+## 4. Credential-bound swap gating — composing 2 + 3 into the swap
+
+```python
+from pyrxd.glyph.credential_binding import assert_soulbound_credential, verify_credential_binding
+```
+
+The blocks compose: a swap's `NegotiatedTerms.credential_ref` can require the
+counterparty to hold a **soulbound credential** (block 2) whose authenticity is resolved
+through the same indexer discipline as block 3 — giving an HTLC swap (block 1) a
+consensus-anchored "only credentialed counterparties" gate. `tests/test_credential_binding.py`
+pins the binding rules; the swap coordinator consumes it via `CredentialResolver`.
+
+## Where everything lives
+
+| Block | Import | Proof |
+|---|---|---|
+| HTLC covenants | `pyrxd` top level / `pyrxd.gravity.htlc_covenant` | mainnet claims + `test_htlc_regtest_e2e.py` |
+| Soulbound covenant | `pyrxd` top level / `pyrxd.glyph.soulbound_covenant` | `test_soulbound_covenant_regtest.py` |
+| REF gate | `pyrxd` top level / `pyrxd.gravity.ref_authenticity` | live-node R1 reproduction + unit suite |
+| Credential binding | `pyrxd.glyph.credential_binding` | `test_credential_binding.py` |
+
+Token *issuance* (the things these covenants hold) is covered by the tutorials:
+[mint a Glyph FT](../tutorials/mint-a-glyph-ft.md),
+[mint a Glyph NFT](../tutorials/mint-a-glyph-nft.md),
+[dMint](../tutorials/mint-from-a-dmint-contract.md). The
+[5-minute quickstart](../tutorials/quickstart.md) gives you a local chain to try all of
+this on with zero real value.

--- a/docs/concepts/index.md
+++ b/docs/concepts/index.md
@@ -7,6 +7,7 @@ and how Radiant differs from related blockchains.
 :maxdepth: 1
 
 gravity
+covenant-building-blocks
 partial-tx-swaps
 glyph-structures-and-terminology
 radiant-fts-are-on-chain
@@ -15,6 +16,14 @@ external-miner-protocol
 ```
 
 ## Available now
+
+- **[Covenant building blocks](covenant-building-blocks.md)** — Radiant's
+  differentiated tech as composable primitives: the HTLC covenants (RXD/FT/NFT),
+  the consensus-enforced soulbound NFT covenant, the REF-authenticity gate
+  (consensus enforces ref *uniqueness*, not mint *provenance*), and
+  credential-bound swap gating — each with its import path and its on-chain
+  proof. Read this to build *with* covenants rather than only running the
+  shipped swap.
 
 - **[Gravity: cross-chain atomic swaps](gravity.md)** — what the
   Gravity protocol is, what a covenant is, and the difference between

--- a/docs/showcase.md
+++ b/docs/showcase.md
@@ -74,6 +74,11 @@ path works on mainnet.
   independently so claims race in parallel.
   Concept: [`docs/concepts/dmint-v1-deploy.md`](concepts/dmint-v1-deploy.md).
 
+Beyond plain tokens, the covenant layer is where Radiant is genuinely different:
+HTLC covenants, a consensus-enforced **soulbound** NFT, the REF-authenticity gate,
+and credential-bound swap gating — mapped as composable primitives in
+[`docs/concepts/covenant-building-blocks.md`](concepts/covenant-building-blocks.md).
+
 New to all this? The fastest way to mint a real token with zero risk is the
 local-regtest quickstart: [`docs/tutorials/quickstart.md`](tutorials/quickstart.md)
 (stand up a private chain in Docker, mint, tear it down).

--- a/src/pyrxd/__init__.py
+++ b/src/pyrxd/__init__.py
@@ -111,8 +111,18 @@ _LAZY_EXPORTS: dict[str, tuple[str, str]] = {
     "CounterChainLeg": ("pyrxd.gravity.counter_chain_leg", "CounterChainLeg"),
     "RadiantCovenantLeg": ("pyrxd.gravity.radiant_leg", "RadiantCovenantLeg"),
     "EthLeg": ("pyrxd.gravity.eth_leg", "EthLeg"),
+    # Counter-chain registries (per-chain safety knobs; see the cross-chain how-to)
     "EvmChain": ("pyrxd.eth_wallet.chains", "EvmChain"),
     "KNOWN_EVM_CHAINS": ("pyrxd.eth_wallet.chains", "KNOWN_EVM_CHAINS"),
+    # Covenant building blocks (docs/concepts/covenant-building-blocks.md). PRE-AUDIT:
+    # consensus-validated on regtest (several mainnet-proven), not externally audited.
+    "HtlcCovenant": ("pyrxd.gravity.htlc_covenant", "HtlcCovenant"),
+    "build_htlc_covenant_rxd": ("pyrxd.gravity.htlc_covenant", "build_htlc_covenant_rxd"),
+    "build_htlc_covenant_ft": ("pyrxd.gravity.htlc_covenant", "build_htlc_covenant_ft"),
+    "build_htlc_covenant_nft": ("pyrxd.gravity.htlc_covenant", "build_htlc_covenant_nft"),
+    "SoulboundNftCovenant": ("pyrxd.glyph.soulbound_covenant", "SoulboundNftCovenant"),
+    "build_soulbound_nft_covenant": ("pyrxd.glyph.soulbound_covenant", "build_soulbound_nft_covenant"),
+    "verify_ref_authenticity": ("pyrxd.gravity.ref_authenticity", "verify_ref_authenticity"),
     # SPV verification
     "SpvProof": ("pyrxd.spv", "SpvProof"),
     "SpvProofBuilder": ("pyrxd.spv", "SpvProofBuilder"),

--- a/tests/test_sdk_exports.py
+++ b/tests/test_sdk_exports.py
@@ -25,8 +25,17 @@ _CROSS_CHAIN_EXPORTS = [
     "CounterChainLeg",
     "RadiantCovenantLeg",
     "EthLeg",
+    # Counter-chain registries (Tier 2.3)
     "EvmChain",
     "KNOWN_EVM_CHAINS",
+    # Covenant building blocks (Tier 2.4)
+    "HtlcCovenant",
+    "build_htlc_covenant_rxd",
+    "build_htlc_covenant_ft",
+    "build_htlc_covenant_nft",
+    "SoulboundNftCovenant",
+    "build_soulbound_nft_covenant",
+    "verify_ref_authenticity",
 ]
 
 


### PR DESCRIPTION
Closes the last open Tier-2 roadmap item (**2.4**): Radiant's genuinely differentiated tech — covenants on a UTXO chain — documented as **composable building blocks** rather than implementation detail buried in module docstrings, and importable from the top level.

## What's here

**`docs/concepts/covenant-building-blocks.md`** — the map of the four blocks, each with its contract, import path, and on-chain proof:
1. **HTLC covenants** (RXD / FT / NFT funded-SPK builders) — holder-hash pinning, the fail-closed `MINIMALDATA` build guard, mainnet claim/refund proofs + the regtest consensus suite.
2. **The consensus-enforced soulbound NFT covenant** — recur-or-burn via full-bytecode self-equality; why the ecosystem's advisory-only soulbound can't anchor trust against an adversarial counterparty; regtest consensus proof (recur accepted / transfer rejected / burn accepted).
3. **The REF-authenticity gate** — the R1 live-node lesson (consensus enforces ref *uniqueness*, not mint *provenance*; a covenant cannot self-verify provenance), the five fail-closed bindings, and why the gate is `async` on purpose (a sync wrapper would fail *open* on a forgotten await).
4. **Credential-bound swap gating** — composing 2 + 3 into the swap's `NegotiatedTerms.credential_ref`.

Pre-audit caveat is up front, plus the consensus-fact callout that an NFT's "exactly one output" is **covenant**-enforced, not consensus-enforced (consensus permits burning a singleton).

**SDK surface:** `HtlcCovenant`, `build_htlc_covenant_{rxd,ft,nft}`, `SoulboundNftCovenant`, `build_soulbound_nft_covenant`, `verify_ref_authenticity` are now top-level lazy exports, guarded by `tests/test_sdk_exports.py`. Bare `import pyrxd` stays light (subprocess-tested); the glyph-path exports load no network deps — the gravity package's eager init is pre-existing and unchanged (verified by attribution test before shipping).

**Wiring:** indexed in `concepts/index.md`, linked from the showcase's Native-tokens section, and the `ROADMAP.md` status delta refreshed to 2026-06-12 (Tier 1 shipped; Tier 2: 2.1/2.2 shipped, 2.3 in review at #198, 2.4 = this PR).

## Verification
Full unit suite **4150 passed**; lint / format / typecheck / private-links all clean. Docs + exports only — no runtime behavior change; the covenant code itself is untouched and remains pre-audit.