### PR TITLE
feat(btc): Litecoin as a Bitcoin-family counter-chain (Tier 2.3)

### DIFF
--- a/docker/litecoin-regtest.Dockerfile
+++ b/docker/litecoin-regtest.Dockerfile
@@ -1,0 +1,48 @@
+# Regtest Litecoin Core node for the Bitcoin-family counter-leg tests (Tier 2.3).
+#
+# Wraps an OFFICIAL Litecoin Core release binary — we do not fork, patch, or
+# recompile the node. PROVENANCE NOTE (differs from regtest.Dockerfile): the
+# litecoin-project GitHub release carries NO checksum manifest asset, so this
+# Dockerfile pins the SHA-256 measured from the official release download on
+# 2026-06-12 instead of verifying against a signed SHA256SUMS file. A version
+# bump must re-measure and update BOTH args together.
+#
+# Build:
+#     docker build -f docker/litecoin-regtest.Dockerfile \
+#         -t litecoin-core:v0.21.5.5-amd64 .
+#
+# Used by the LTC variants of the BTC-family regtest suites
+# (XCHAIN_BTC_FAMILY=ltc / BTC_REGTEST chain knob). Regtest-only; the harness
+# reaches RPC via `docker exec litecoin-cli` — never exposed to the network.
+#
+# The release binary links only the libc family (measured via ldd), so the bare
+# ubuntu:22.04 base needs no extra runtime packages.
+
+FROM ubuntu:22.04
+
+ARG LITECOIN_VERSION=0.21.5.5
+ARG LITECOIN_SHA256=623410d4f2695a68aa71332ae0672fee19276f41c1c63a531f97e24a50edde14
+ARG LITECOIN_TARBALL=litecoin-${LITECOIN_VERSION}-x86_64-linux-gnu.tar.gz
+ARG LITECOIN_BASEURL=https://github.com/litecoin-project/litecoin/releases/download/v${LITECOIN_VERSION}
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        ca-certificates \
+        wget \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN set -eux; \
+    cd /tmp; \
+    wget -q "${LITECOIN_BASEURL}/${LITECOIN_TARBALL}"; \
+    echo "${LITECOIN_SHA256}  ${LITECOIN_TARBALL}" | sha256sum -c -; \
+    tar xzf "${LITECOIN_TARBALL}"; \
+    install -m0755 "litecoin-${LITECOIN_VERSION}/bin/litecoind" /usr/local/bin/litecoind; \
+    install -m0755 "litecoin-${LITECOIN_VERSION}/bin/litecoin-cli" /usr/local/bin/litecoin-cli; \
+    rm -rf /tmp/*
+
+# Smoke-test the binary runs in this base.
+RUN litecoind --version
+
+# The test harness appends -regtest/-server/... args after the image name,
+# which docker passes as CMD to this entrypoint.
+ENTRYPOINT ["litecoind"]
+CMD ["-regtest", "-server", "-printtoconsole"]

--- a/docs/how-to/build-a-cross-chain-swap.md
+++ b/docs/how-to/build-a-cross-chain-swap.md
@@ -105,7 +105,8 @@ $ XCHAIN_ETH_REGTEST=1 pytest tests/test_xchain_eth_swap_regtest_e2e.py -m integ
 
 ## Adding another counter-chain
 
-There are two very different costs, depending on the chain family.
+Two families are proven; adding a chain within either is a config change, while a new
+family is a deliberate effort.
 
 ### EVM family — Base works today (no new code)
 
@@ -146,13 +147,51 @@ Proofs: `tests/test_eth_leg_anvil_integration.py::test_full_lifecycle_on_base_ch
 Base via `XCHAIN_ETH_CHAIN_ID=84532 XCHAIN_ETH_REGTEST=1 pytest
 tests/test_xchain_eth_swap_regtest_e2e.py -m integration`.
 
-### A new chain family (Litecoin, …) — a deliberate, separate effort
+### Bitcoin family — Litecoin works today (no coordinator change)
+
+The Taproot-HTLC leg machinery is **chain-agnostic across BIP341-activating Bitcoin-family
+chains**: the identical P2TR HTLC, claim/refund builders, preimage scrape, and BIP68 CSV
+semantics were proven byte-for-byte on **Litecoin** regtest consensus (claim accepted,
+wrong-preimage rejected with the same witness-program-mismatch reason, premature refund
+`non-BIP68-final`, matured refund accepted — Litecoin Core 0.21.5.5, taproot active). Swap
+a Radiant asset against LTC by changing three knobs, none of which touch the coordinator:
+
+```python
+from pyrxd import KNOWN_POW_CHAINS, MarginPolicy
+
+ltc = KNOWN_POW_CHAINS["litecoin"]   # network "ltc" / testnet "tltc" / regtest "rltc"
+
+kp = generate_keypair(ltc.regtest_network)            # bech32m, rltc1p… addresses
+htlc = build_htlc(..., network=ltc.regtest_network)   # the SAME taproot builders
+policy = MarginPolicy.estimated(block_interval_s=ltc.block_interval_s)  # 150 s, not 600
+```
+
+The negotiated `counter_chain` stays `"btc"` — it names the *PoW-depth family* — and the
+concrete chain is pinned by the leg/locator `network` tag (the bech32 HRP), exactly as an
+EVM swap pins its chain by chain id. **The one genuinely chain-specific safety knob is the
+block interval** (`pyrxd.btc_wallet.chains`): Litecoin's 2.5-minute target means an N-block
+margin is 4× less wall-clock than on Bitcoin, and the reorg gate's reserve math shifts
+accordingly — pass the registry interval or every timing margin silently shrinks.
+Two more honest caveats: confirmation **depth must be value-scaled per chain** (reorg
+resistance is priced in that chain's hashrate — the registry deliberately ships no depth
+defaults), and the bundled mainnet funding-reader/broadcaster backends are Bitcoin-specific
+(a Litecoin deployment supplies its own; the regtest harness drives the node RPC directly).
+
+Proofs: the BTC-leg consensus suite and the **entire coordinator e2e suite re-run as
+Litecoin** via the chain knobs —
+`BTC_FAMILY_CHAIN=ltc BTC_REGTEST=1 pytest tests/test_btc_htlc_regtest_e2e.py -m integration`
+and `XCHAIN_BTC_FAMILY=ltc XCHAIN_REGTEST=1 pytest tests/test_xchain_swap_regtest_e2e.py -m
+integration` (the node image builds from `docker/litecoin-regtest.Dockerfile`, wrapping the
+official release binary). Mainnet `"ltc"` stays behind the audit gate like every
+value-bearing network.
+
+### A new chain family — the deliberate path
 
 `CounterChainLeg` (`pyrxd.gravity.counter_chain_leg`) is the documented contract a new
 backend implements: `derive_expected_funding` / `fund` / `claim` / `refund` /
 `recover_secret` / `is_final`. The ABC was extracted from two *real* shapes (BTC Taproot +
 ETH Solidity), so it reflects what a third chain actually needs — finality is a per-leg
-concern, not a single RPC read. A non-EVM chain (e.g. Litecoin) means generalizing the
-PoW-depth dispatch and standing up new regtest infrastructure; adopting the ABC in the
-coordinator (the BTC path is still duck-typed) is a deliberate, separately-tested change
-on mainnet-proven code — read the ABC's scope note before starting.
+concern, not a single RPC read. A chain outside both proven families means new consensus
+semantics and new finality modelling; adopting the ABC in the coordinator (the BTC path is
+still duck-typed) is a deliberate, separately-tested change on mainnet-proven code — read
+the ABC's scope note before starting.

--- a/docs/plans/2026-06-12-litecoin-pow-family-counter-leg-plan.md
+++ b/docs/plans/2026-06-12-litecoin-pow-family-counter-leg-plan.md
@@ -1,0 +1,73 @@
+---
+title: Litecoin as a Bitcoin-family (PoW-depth) counter chain
+type: plan
+date: 2026-06-12
+status: DONE — spike GO, shipped with full dual-chain regtest proof (see Outcome)
+parent: docs/ROADMAP.md (Tier 2.3) → docs/plans/2026-06-12-tier2-xchain-swap-library-plan.md
+---
+
+# Litecoin counter-leg — the chain-family effort, de-risked by spike
+
+## The reframe (mirrors the Base decision exactly)
+
+The feared scope was "generalize every `counter_chain == 'btc'` dispatch site." Grounding
+showed that is unnecessary: `counter_chain == "btc"` already names the **PoW-depth
+family** semantics (depth finality, same-clock BLOCKS timelocks), all of which hold for
+Litecoin; the concrete chain is pinned by the leg/locator `network` tag (bech32 HRP) —
+exactly as `counter_chain == "eth"` named the finalized-checkpoint family and Base was
+pinned by chain id. **Zero coordinator dispatch changes.**
+
+## The go/no-go spike (2026-06-12, measured)
+
+Stood up the official Litecoin Core v0.21.5.5 binary on regtest and drove pyrxd's OWN
+taproot builders (`build_htlc` / `build_claim_tx` / `build_refund_tx` / `scrape_secret`)
+against live Litecoin consensus, `network="rltc"`:
+
+- taproot softfork: **active, since: 0** (regtest from genesis); CSV active;
+- P2TR `rltc1p…` address valid (witness v1);
+- correct-preimage claim **accepted**; wrong-preimage **rejected**
+  (`witness program hash mismatch` — the identical Bitcoin reject reason);
+- preimage scraped from the on-chain witness;
+- premature CSV refund rejected `non-BIP68-final`; matured refund **accepted**; both
+  spend paths broadcast and confirmed.
+
+Verdict: **GO** — the Taproot-HTLC leg is chain-agnostic across the family.
+
+## What shipped
+
+- `docker/litecoin-regtest.Dockerfile` — official release binary; PROVENANCE NOTE: the
+  litecoin release publishes no checksum manifest, so the SHA-256 measured from the
+  official download on 2026-06-12 is pinned in the Dockerfile (re-measure on bump).
+- `pyrxd.btc_wallet.chains` — `PowChain` / `KNOWN_POW_CHAINS` (bitcoin 600 s, litecoin
+  150 s) + `pow_chain_by_network` (fail-closed on unvetted tags). Mirrors
+  `eth_wallet.chains`; deliberately ships NO depth defaults (depth must be value-scaled
+  per chain's cost-to-reorg).
+- `AUDIT_CLEARED_NETWORKS` += `rltc`/`tltc` (isolated test chains); `_TESTNET_HRPS` +=
+  same (testnet base58/WIF versions; LTC mainnet stays on the fallback path — bech32m
+  HRP is authoritative for the P2TR flows).
+- Chain knobs on both regtest suites: `BTC_FAMILY_CHAIN=ltc`
+  (`test_btc_htlc_regtest_e2e.py`) and `XCHAIN_BTC_FAMILY=ltc`
+  (`test_xchain_swap_regtest_e2e.py` — image/cli/HRP/`block_interval_s`, with a
+  build-from-Dockerfile fallback for the local-only image).
+- Top-level exports + registry unit tests; how-to gains "Bitcoin family — Litecoin works
+  today" beside the Base section.
+
+## One real finding the LTC run surfaced
+
+`test_reveal_with_closing_window_pages_squeezed` hard-coded a t_rxd window tuned to
+Bitcoin's interval. On Litecoin the gate **correctly** returned WAIT (a 6-block LTC reorg
+depth converts to only 3 RXD blocks of reserve — the window genuinely had room), exposing
+the hidden chain assumption in the TEST, not the gate. The test now derives its squeeze
+window from the same policy math the gate uses, so it forces a squeeze on whichever chain
+the run targets. This is precisely the class of assumption the dual-chain run exists to
+flush out.
+
+## Outcome — dual-chain proof, all green
+
+| Suite | Bitcoin | Litecoin |
+|---|---|---|
+| BTC-leg consensus (`test_btc_htlc_regtest_e2e.py`) | 2 passed | 2 passed |
+| Full coordinator e2e (`test_xchain_swap_regtest_e2e.py`, 10 tests: happy/mutual-refund/maker-stall/watchtower) | 10 passed | 10 passed |
+
+Pre-audit posture unchanged: mainnet `"ltc"` refuses to run without the post-audit
+`audit_cleared=True` opt-in, like every value-bearing network.

--- a/src/pyrxd/__init__.py
+++ b/src/pyrxd/__init__.py
@@ -114,6 +114,8 @@ _LAZY_EXPORTS: dict[str, tuple[str, str]] = {
     # Counter-chain registries (per-chain safety knobs; see the cross-chain how-to)
     "EvmChain": ("pyrxd.eth_wallet.chains", "EvmChain"),
     "KNOWN_EVM_CHAINS": ("pyrxd.eth_wallet.chains", "KNOWN_EVM_CHAINS"),
+    "PowChain": ("pyrxd.btc_wallet.chains", "PowChain"),
+    "KNOWN_POW_CHAINS": ("pyrxd.btc_wallet.chains", "KNOWN_POW_CHAINS"),
     # Covenant building blocks (docs/concepts/covenant-building-blocks.md). PRE-AUDIT:
     # consensus-validated on regtest (several mainnet-proven), not externally audited.
     "HtlcCovenant": ("pyrxd.gravity.htlc_covenant", "HtlcCovenant"),

--- a/src/pyrxd/btc_wallet/chains.py
+++ b/src/pyrxd/btc_wallet/chains.py
@@ -1,0 +1,100 @@
+"""Bitcoin-family (PoW-depth) counter-chain registry — the per-chain safety knobs.
+
+The mirror of :mod:`pyrxd.eth_wallet.chains` for the swap coordinator's *PoW-depth*
+family. The Taproot-HTLC leg machinery (:mod:`pyrxd.btc_wallet.taproot`) is
+chain-agnostic across BIP341-activating Bitcoin-family chains: the same P2TR HTLC,
+claim/refund builders, preimage scrape, and BIP68 CSV semantics were proven byte-for-
+byte on Litecoin 0.21.5.5 regtest consensus (claim accepted, wrong-preimage rejected
+with the identical witness-program-mismatch reason, premature refund ``non-BIP68-final``,
+matured refund accepted) — so adding a Bitcoin-family chain does NOT touch the
+coordinator. ``NegotiatedTerms.counter_chain`` stays ``"btc"`` (it names the PoW-depth
+*family*); the concrete chain is pinned by the leg/locator ``network`` tag (the bech32
+HRP), exactly as an EVM swap pins its chain by EIP-155 chain id.
+
+What IS chain-specific — and safety-critical:
+
+* ``block_interval_s`` — sizes every blocks↔seconds conversion in
+  :class:`~pyrxd.gravity.swap_coordinator.MarginPolicy` (cross-clock margins, the
+  proactive-refund window, reorg-depth reserves). Litecoin's 2.5-minute target means an
+  N-block margin is 4x less wall-clock than the same N on Bitcoin — pass the right
+  interval or every timing safety margin silently shrinks.
+* **Confirmation depth must be value-scaled PER CHAIN.** Depth buys reorg-resistance
+  priced in that chain's hashrate; "6 confirmations" folklore transfers across chains
+  even less than it transfers across values. A real-value run needs a measured
+  ``MarginPolicy.measured(...)`` with depths sized to the target chain's cost-to-reorg —
+  this registry deliberately does NOT ship depth defaults.
+* The mainnet data sources: the bundled funding-reader/broadcaster backends
+  (``network/bitcoin.py``) are Bitcoin-mainnet-specific; a Litecoin deployment supplies
+  its own reader/broadcaster (the regtest harness drives the node RPC directly).
+
+Every mainnet ``network`` tag here is value-bearing and stays behind the leg's
+``audit_cleared`` gate; the regtest/testnet tags are in ``AUDIT_CLEARED_NETWORKS``
+(isolated, no-value chains).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from pyrxd.security.errors import ValidationError
+
+__all__ = ["KNOWN_POW_CHAINS", "PowChain", "pow_chain_by_network"]
+
+
+@dataclass(frozen=True)
+class PowChain:
+    """One Bitcoin-family counter chain the Taproot-HTLC leg can run against.
+
+    ``network`` / ``testnet_network`` / ``regtest_network`` are the bech32 HRPs —
+    the tag the leg, the locator, and the audit gates all key on.
+    ``block_interval_s`` seeds ``MarginPolicy(block_interval_s=...)``.
+    """
+
+    name: str
+    network: str
+    testnet_network: str
+    regtest_network: str
+    block_interval_s: float
+
+    def __post_init__(self) -> None:
+        for label, tag in (
+            ("network", self.network),
+            ("testnet_network", self.testnet_network),
+            ("regtest_network", self.regtest_network),
+        ):
+            if not isinstance(tag, str) or not tag:
+                raise ValidationError(f"PowChain.{label} must be a non-empty str")
+        if (
+            not isinstance(self.block_interval_s, (int, float))
+            or isinstance(self.block_interval_s, bool)
+            or self.block_interval_s <= 0
+        ):
+            raise ValidationError("PowChain.block_interval_s must be a positive number")
+
+
+KNOWN_POW_CHAINS: dict[str, PowChain] = {
+    # Bitcoin — 10-minute target interval.
+    "bitcoin": PowChain(
+        name="bitcoin", network="bc", testnet_network="tb", regtest_network="bcrt", block_interval_s=600.0
+    ),
+    # Litecoin — 2.5-minute target interval. Taproot active since the MWEB upgrade
+    # (Litecoin Core 0.21.x; active from genesis on regtest — measured 2026-06-12 on
+    # the official v0.21.5.5 binary, see docker/litecoin-regtest.Dockerfile).
+    "litecoin": PowChain(
+        name="litecoin", network="ltc", testnet_network="tltc", regtest_network="rltc", block_interval_s=150.0
+    ),
+}
+
+
+def pow_chain_by_network(network: str) -> PowChain:
+    """Look up a known chain by ANY of its network tags (mainnet/testnet/regtest HRP);
+    raises for an unknown tag (fail-closed — an unknown chain has no vetted block
+    interval, so refuse rather than guess)."""
+    for chain in KNOWN_POW_CHAINS.values():
+        if network in (chain.network, chain.testnet_network, chain.regtest_network):
+            return chain
+    raise ValidationError(
+        f"unknown Bitcoin-family network tag {network!r}: no vetted block interval. Add it to "
+        "KNOWN_POW_CHAINS with a sourced block_interval_s, or construct MarginPolicy with an "
+        "explicitly chosen block_interval_s."
+    )

--- a/src/pyrxd/btc_wallet/htlc_leg.py
+++ b/src/pyrxd/btc_wallet/htlc_leg.py
@@ -88,9 +88,11 @@ class FundingPolicy:
 logger = logging.getLogger(__name__)
 
 # Networks that NEVER require the audit opt-in — isolated test chains that cannot
-# move real value. Everything else (mainnet "bc", and any value-bearing network)
-# requires an explicit audit-cleared opt-in.
-AUDIT_CLEARED_NETWORKS: frozenset[str] = frozenset({"bcrt", "regtest", "tb", "signet"})
+# move real value. Everything else (mainnet "bc"/"ltc", and any value-bearing network)
+# requires an explicit audit-cleared opt-in. "rltc"/"tltc" are Litecoin's regtest/
+# testnet HRPs (the Bitcoin-family Taproot-HTLC leg is chain-agnostic; see
+# pyrxd.btc_wallet.chains).
+AUDIT_CLEARED_NETWORKS: frozenset[str] = frozenset({"bcrt", "regtest", "tb", "signet", "rltc", "tltc"})
 
 # Broadcast responses that mean "the node already has this tx" — idempotent
 # success, NOT an error (a crash-recovery retry must not be treated as a failure).

--- a/src/pyrxd/btc_wallet/keys.py
+++ b/src/pyrxd/btc_wallet/keys.py
@@ -57,8 +57,12 @@ _TESTNET_P2PKH = 0x6F
 _TESTNET_P2SH = 0xC4
 _TESTNET_WIF = 0xEF
 
-# Known HRPs for which we use testnet-style base58 version bytes.
-_TESTNET_HRPS = frozenset({"tb", "bcrt"})
+# Known HRPs for which we use testnet-style base58 version bytes. Litecoin's test
+# chains ("tltc" testnet, "rltc" regtest) share Bitcoin's testnet versions
+# (P2PKH 0x6F / WIF 0xEF); Litecoin MAINNET ("ltc") deliberately stays on the
+# fallback path — its base58 versions differ (P2PKH 0x30), but the Taproot-HTLC
+# leg only ever uses bech32m output where the HRP alone is authoritative.
+_TESTNET_HRPS = frozenset({"tb", "bcrt", "tltc", "rltc"})
 
 
 def _version_bytes_for(network: str) -> tuple[int, int, int]:

--- a/tests/test_btc_chains.py
+++ b/tests/test_btc_chains.py
@@ -1,0 +1,57 @@
+"""Unit tests for the Bitcoin-family counter-chain registry (pyrxd.btc_wallet.chains).
+
+The registry is the chain-specific safety knob for the PoW-depth family (Tier 2.3):
+per-chain block intervals that size every blocks↔seconds margin conversion. The live
+consensus proofs are the LTC variants of the regtest suites
+(``BTC_FAMILY_CHAIN=ltc tests/test_btc_htlc_regtest_e2e.py`` and
+``XCHAIN_BTC_FAMILY=ltc tests/test_xchain_swap_regtest_e2e.py``).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from pyrxd.btc_wallet.chains import KNOWN_POW_CHAINS, PowChain, pow_chain_by_network
+from pyrxd.security.errors import ValidationError
+
+
+def test_registry_integrity():
+    tags: list[str] = []
+    for key, chain in KNOWN_POW_CHAINS.items():
+        assert chain.name == key
+        assert chain.block_interval_s > 0
+        tags.extend((chain.network, chain.testnet_network, chain.regtest_network))
+    assert len(tags) == len(set(tags)), "network tags must be globally unique across chains"
+
+
+def test_bitcoin_and_litecoin_entries():
+    btc = KNOWN_POW_CHAINS["bitcoin"]
+    ltc = KNOWN_POW_CHAINS["litecoin"]
+    assert (btc.network, btc.regtest_network, btc.block_interval_s) == ("bc", "bcrt", 600.0)
+    assert (ltc.network, ltc.regtest_network, ltc.block_interval_s) == ("ltc", "rltc", 150.0)
+
+
+def test_lookup_by_any_tag_and_unknown_fails_closed():
+    assert pow_chain_by_network("bc") is KNOWN_POW_CHAINS["bitcoin"]
+    assert pow_chain_by_network("rltc") is KNOWN_POW_CHAINS["litecoin"]
+    assert pow_chain_by_network("tltc") is KNOWN_POW_CHAINS["litecoin"]
+    with pytest.raises(ValidationError, match="unknown Bitcoin-family network"):
+        pow_chain_by_network("doge")
+
+
+def test_powchain_validation():
+    with pytest.raises(ValidationError, match="block_interval_s"):
+        PowChain(name="x", network="x", testnet_network="tx", regtest_network="rx", block_interval_s=0)
+    with pytest.raises(ValidationError, match="network"):
+        PowChain(name="x", network="", testnet_network="tx", regtest_network="rx", block_interval_s=60)
+
+
+def test_test_networks_are_audit_exempt_and_mainnets_are_not():
+    # The regtest/testnet tags must be in AUDIT_CLEARED_NETWORKS (isolated, no value);
+    # the mainnet tags must NOT be (value-bearing → audit gate applies).
+    from pyrxd.btc_wallet.htlc_leg import AUDIT_CLEARED_NETWORKS
+
+    for chain in KNOWN_POW_CHAINS.values():
+        assert chain.regtest_network in AUDIT_CLEARED_NETWORKS, chain.name
+        assert chain.testnet_network in AUDIT_CLEARED_NETWORKS, chain.name
+        assert chain.network not in AUDIT_CLEARED_NETWORKS, chain.name

--- a/tests/test_btc_htlc_regtest_e2e.py
+++ b/tests/test_btc_htlc_regtest_e2e.py
@@ -45,7 +45,18 @@ from pyrxd.btc_wallet import taproot as t
 
 pytestmark = pytest.mark.integration
 
-_IMAGE = "ruimarinho/bitcoin-core:24"
+# Bitcoin-family chain knob (Tier 2.3): BTC_FAMILY_CHAIN=ltc runs this SAME consensus
+# suite against Litecoin Core (taproot active since 0.21.x; regtest HRP "rltc") —
+# proving the Taproot-HTLC leg is chain-agnostic across the family. Default: Bitcoin.
+_CHAIN = os.environ.get("BTC_FAMILY_CHAIN", "btc")
+if _CHAIN == "ltc":
+    _IMAGE = "litecoin-core:v0.21.5.5-amd64"  # built from docker/litecoin-regtest.Dockerfile
+    _CLI = "litecoin-cli"
+    _HRP = "rltc"
+else:
+    _IMAGE = "ruimarinho/bitcoin-core:24"
+    _CLI = "bitcoin-cli"
+    _HRP = "bcrt"
 _CONTAINER = "gravity-btc-regtest-pytest"
 _FEE_SATS = 2_000
 _REFUND_CSV = 3
@@ -64,7 +75,7 @@ class _BtcRegtest:
             "docker",
             "exec",
             _CONTAINER,
-            "bitcoin-cli",
+            _CLI,
             "-regtest",
             f"-rpcuser={self.user}",
             f"-rpcpassword={self.password}",
@@ -73,7 +84,7 @@ class _BtcRegtest:
             base.append("-rpcwallet=btcw")
         r = subprocess.run(base + list(args), capture_output=True, text=True, timeout=60)
         if r.returncode != 0:
-            raise RuntimeError(f"bitcoin-cli {args[0]} failed: {r.stderr.strip()}")
+            raise RuntimeError(f"{_CLI} {args[0]} failed: {r.stderr.strip()}")
         out = r.stdout.strip()
         try:
             return json.loads(out)
@@ -122,9 +133,15 @@ class _BtcRegtest:
         else:
             raise RuntimeError("bitcoind regtest RPC did not become ready")
         assert self.cli("getblockchaininfo")["chain"] == "regtest", "node is NOT regtest — aborting"
-        # Taproot must be active for the P2TR script-path spends.
-        dep = self.cli("getdeploymentinfo")
-        tr = dep["deployments"]["taproot"] if isinstance(dep, dict) and "deployments" in dep else {}
+        # Taproot must be active for the P2TR script-path spends. Bitcoin Core 23+
+        # reports it via getdeploymentinfo; Litecoin Core 0.21 (pre-23 RPC surface)
+        # via getblockchaininfo's softforks map.
+        try:
+            dep = self.cli("getdeploymentinfo")
+            tr = dep["deployments"]["taproot"] if isinstance(dep, dict) and "deployments" in dep else {}
+        except RuntimeError:
+            sf = self.cli("getblockchaininfo").get("softforks", {})
+            tr = sf.get("taproot", {})
         assert tr.get("active") is True, "taproot is not active on this regtest node"
         self.cli("createwallet", "btcw")
         self.mine_addr = str(self.cli("getnewaddress", wallet=True))
@@ -155,12 +172,31 @@ def btc():
         pytest.skip("BTC_REGTEST not set (opt-in for the live bitcoind e2e)")
     if shutil.which("docker") is None:
         pytest.skip("docker not available")
-    # Ensure the image is present (pull if needed); skip if we can't get it.
+    # Ensure the image is present. The bitcoin image pulls from docker hub; the
+    # litecoin image is local-only and builds from the committed Dockerfile.
     have = subprocess.run(["docker", "image", "inspect", _IMAGE], capture_output=True)
     if have.returncode != 0:
-        pull = subprocess.run(["docker", "pull", _IMAGE], capture_output=True, timeout=300)
-        if pull.returncode != 0:
-            pytest.skip(f"could not obtain {_IMAGE}")
+        if _CHAIN == "ltc":
+            repo_root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+            build = subprocess.run(
+                [
+                    "docker",
+                    "build",
+                    "-f",
+                    os.path.join(repo_root, "docker", "litecoin-regtest.Dockerfile"),
+                    "-t",
+                    _IMAGE,
+                    repo_root,
+                ],
+                capture_output=True,
+                timeout=600,
+            )
+            if build.returncode != 0:
+                pytest.skip(f"could not build {_IMAGE}")
+        else:
+            pull = subprocess.run(["docker", "pull", _IMAGE], capture_output=True, timeout=300)
+            if pull.returncode != 0:
+                pytest.skip(f"could not obtain {_IMAGE}")
     n = _BtcRegtest()
     n.start()
     try:
@@ -187,7 +223,7 @@ class TestBtcHtlcOnConsensus:
         h = hashlib.sha256(p).digest()
         timeout = t.Timelock(_REFUND_CSV, t.TimeUnit.BLOCKS)
         htlc = t.build_htlc(
-            hashlock=h, claim_pubkey_xonly=claim_xo, refund_pubkey_xonly=refund_xo, timeout=timeout, network="bcrt"
+            hashlock=h, claim_pubkey_xonly=claim_xo, refund_pubkey_xonly=refund_xo, timeout=timeout, network=_HRP
         )
         locator = btc.fund_htlc(htlc)
         payout = btc.payout_spk()
@@ -212,7 +248,7 @@ class TestBtcHtlcOnConsensus:
             claim_pubkey_xonly=claim_xo,
             refund_pubkey_xonly=refund_xo,
             timeout=timeout,
-            network="bcrt",
+            network=_HRP,
         )
         wrong_loc = wrong_htlc.with_funding(locator.funding_outpoint, locator.amount_sats)
         wrong_claim = t.build_claim_tx(
@@ -243,7 +279,7 @@ class TestBtcHtlcOnConsensus:
         h = hashlib.sha256(p).digest()
         timeout = t.Timelock(_REFUND_CSV, t.TimeUnit.BLOCKS)
         htlc = t.build_htlc(
-            hashlock=h, claim_pubkey_xonly=claim_xo, refund_pubkey_xonly=refund_xo, timeout=timeout, network="bcrt"
+            hashlock=h, claim_pubkey_xonly=claim_xo, refund_pubkey_xonly=refund_xo, timeout=timeout, network=_HRP
         )
         locator = btc.fund_htlc(htlc)
         payout = btc.payout_spk()

--- a/tests/test_sdk_exports.py
+++ b/tests/test_sdk_exports.py
@@ -28,6 +28,8 @@ _CROSS_CHAIN_EXPORTS = [
     # Counter-chain registries (Tier 2.3)
     "EvmChain",
     "KNOWN_EVM_CHAINS",
+    "PowChain",
+    "KNOWN_POW_CHAINS",
     # Covenant building blocks (Tier 2.4)
     "HtlcCovenant",
     "build_htlc_covenant_rxd",

--- a/tests/test_xchain_swap_regtest_e2e.py
+++ b/tests/test_xchain_swap_regtest_e2e.py
@@ -39,6 +39,7 @@ from __future__ import annotations
 
 import hashlib
 import json
+import math
 import os
 import secrets
 import shutil
@@ -75,7 +76,21 @@ from pyrxd.transaction.transaction_output import TransactionOutput
 pytestmark = pytest.mark.integration
 
 _RXD_IMAGE = "radiant-core:v3.1.1-amd64"
-_BTC_IMAGE = "ruimarinho/bitcoin-core:24"
+# Bitcoin-family chain knob (Tier 2.3): XCHAIN_BTC_FAMILY=ltc runs this SAME coordinator
+# e2e with Litecoin Core as the counter chain (the Taproot-HTLC leg is chain-agnostic
+# across the family; counter_chain stays "btc" — the PoW-depth FAMILY — and the network
+# HRP + block interval pin the concrete chain). Default: Bitcoin.
+_BTC_FAMILY = os.environ.get("XCHAIN_BTC_FAMILY", "btc")
+if _BTC_FAMILY == "ltc":
+    _BTC_IMAGE = "litecoin-core:v0.21.5.5-amd64"  # built from docker/litecoin-regtest.Dockerfile
+    _BTC_CLI = "litecoin-cli"
+    _BTC_HRP = "rltc"
+    _BTC_INTERVAL_S = 150.0  # Litecoin 2.5-min target (see pyrxd.btc_wallet.chains)
+else:
+    _BTC_IMAGE = "ruimarinho/bitcoin-core:24"
+    _BTC_CLI = "bitcoin-cli"
+    _BTC_HRP = "bcrt"
+    _BTC_INTERVAL_S = 600.0
 _RXD_CT = "xchain-rxd-pytest"
 _BTC_CT = "xchain-btc-pytest"
 _RXD_RELAY_FEE = 1_000_000  # 0.01 RXD per sub-kB tx
@@ -110,7 +125,7 @@ class _Nodes:
         return self._cli(_RXD_CT, "radiant-cli", "rt_user", self.rpass, wallet, a)
 
     def btc(self, *a, wallet=None):
-        return self._cli(_BTC_CT, "bitcoin-cli", "btc_user", self.bpass, wallet, a)
+        return self._cli(_BTC_CT, _BTC_CLI, "btc_user", self.bpass, wallet, a)
 
     def rxd_mine(self, n=1):
         self.rxd("generatetoaddress", str(n), self.raddr, wallet="gravity")
@@ -210,7 +225,18 @@ def nodes():
         pytest.skip("docker not available")
     for img in (_RXD_IMAGE, _BTC_IMAGE):
         if subprocess.run(["docker", "image", "inspect", img], capture_output=True).returncode != 0:
-            if img == _BTC_IMAGE:
+            if img == _BTC_IMAGE and _BTC_FAMILY == "ltc":
+                # Local-only image; build it from the committed Dockerfile.
+                repo_root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+                dockerfile = os.path.join(repo_root, "docker", "litecoin-regtest.Dockerfile")
+                if (
+                    subprocess.run(
+                        ["docker", "build", "-f", dockerfile, "-t", img, repo_root], capture_output=True, timeout=600
+                    ).returncode
+                    != 0
+                ):
+                    pytest.skip(f"could not build {img}")
+            elif img == _BTC_IMAGE:
                 if subprocess.run(["docker", "pull", img], capture_output=True, timeout=300).returncode != 0:
                     pytest.skip(f"could not obtain {img}")
             else:
@@ -410,7 +436,7 @@ async def _setup_locked_swap(nodes: _Nodes, *, t_rxd_blocks: int = 3) -> _Locked
     t_btc = bt.Timelock(t_rxd_blocks + 40, bt.TimeUnit.BLOCKS)
 
     maker_btc = coincurve.PrivateKey(os.urandom(32))
-    taker_btc_kp = generate_keypair("bcrt")
+    taker_btc_kp = generate_keypair(_BTC_HRP)
     claim_xo = coincurve.PublicKeyXOnly.from_secret(maker_btc.secret).format()
     refund_xo = coincurve.PublicKeyXOnly.from_secret(bytes(taker_btc_kp._privkey.unsafe_raw_bytes())).format()
 
@@ -451,7 +477,7 @@ async def _setup_locked_swap(nodes: _Nodes, *, t_rxd_blocks: int = 3) -> _Locked
         nodes.btc("getaddressinfo", nodes.btc("getnewaddress", wallet="btcw"), wallet="btcw")["scriptPubKey"]
     )
     btc_leg = BitcoinTaprootLeg(
-        network="bcrt",
+        network=_BTC_HRP,
         taker_keypair=taker_btc_kp,
         funding_utxo=funding_utxo,
         maker_claim_pubkey_xonly=claim_xo,
@@ -468,7 +494,7 @@ async def _setup_locked_swap(nodes: _Nodes, *, t_rxd_blocks: int = 3) -> _Locked
     rxd_client = _RadiantCliClient(nodes)
     rxd_client.register_spk(cov.funded_spk)
     rxd_leg = RadiantCovenantLeg(
-        network="bcrt",
+        network=_BTC_HRP,
         taker_pkh=taker_pkh,
         maker_pkh=maker_pkh,
         chain_io=RadiantChainIO(rxd_client),
@@ -482,7 +508,7 @@ async def _setup_locked_swap(nodes: _Nodes, *, t_rxd_blocks: int = 3) -> _Locked
         radiant_leg=rxd_leg,
         indexer=None,
         seen_store=_Seen(),
-        config=CoordinatorConfig(margin_policy=MarginPolicy.estimated()),
+        config=CoordinatorConfig(margin_policy=MarginPolicy.estimated(block_interval_s=_BTC_INTERVAL_S)),
     )
 
     # 1. Taker funds the BTC HTLC.
@@ -878,8 +904,20 @@ class TestWatchtowerIntentSequence:
     async def test_reveal_with_closing_window_pages_squeezed(self, nodes):
         """Tight t_rxd window + a shallow reveal: there is no longer room to wait for a reorg-safe
         burial before the maker's CSV refund opens → the gate SQUEEZES → a decision-required
-        PAGE_SQUEEZED (winner-take-all vs accept loss), never a silent claim or a silent wait."""
-        s = await _setup_locked_swap(nodes, t_rxd_blocks=10)
+        PAGE_SQUEEZED (winner-take-all vs accept loss), never a silent claim or a silent wait.
+
+        The squeeze threshold is CHAIN-SPECIFIC: WAIT needs blocks_left >= counter_reserve +
+        burial, where counter_reserve converts the counter chain's reorg depth into RXD blocks
+        via its block interval (BTC 600 s → reserve 12, threshold 18; LTC 150 s → reserve 3,
+        threshold 9 — a fixed window of 10 genuinely has room to WAIT on Litecoin, which is
+        correct gate behaviour, not slack). Derive the window from the same policy math so the
+        test forces a squeeze on whichever chain this run uses."""
+        policy = MarginPolicy.estimated(block_interval_s=_BTC_INTERVAL_S)
+        counter_reserve = math.ceil(
+            policy.btc_claim_reorg_depth.value * policy.block_interval_s / policy.rxd_block_interval_s
+        )
+        squeeze_window = counter_reserve + policy.rxd_claim_burial.value - 2  # 2 under the WAIT threshold
+        s = await _setup_locked_swap(nodes, t_rxd_blocks=squeeze_window)
         coord = s.coord
         reconciler, channel = _watchtower(nodes, coord)
 
@@ -918,12 +956,12 @@ class TestWatchtowerAutonomousRefundRegtest:
         t_rxd = bt.Timelock(3, bt.TimeUnit.BLOCKS)
         h = hashlib.sha256(os.urandom(32)).digest()
         maker_btc = coincurve.PrivateKey(os.urandom(32))
-        taker_kp = generate_keypair("bcrt")
+        taker_kp = generate_keypair(_BTC_HRP)
         refund_priv = bytes(taker_kp._privkey.unsafe_raw_bytes())
         refund_xo = coincurve.PublicKeyXOnly.from_secret(refund_priv).format()
         claim_xo = coincurve.PublicKeyXOnly.from_secret(maker_btc.secret).format()
         htlc = bt.build_htlc(
-            hashlock=h, claim_pubkey_xonly=claim_xo, refund_pubkey_xonly=refund_xo, timeout=t_btc, network="bcrt"
+            hashlock=h, claim_pubkey_xonly=claim_xo, refund_pubkey_xonly=refund_xo, timeout=t_btc, network=_BTC_HRP
         )
 
         # Fund the HTLC address on bitcoind regtest, find the funding outpoint.
@@ -978,7 +1016,7 @@ class TestWatchtowerAutonomousRefundRegtest:
         ex = RefundExecutor(
             broadcaster=_BtcBroadcaster(nodes),
             blobs_dir=tmp_path,
-            network="bcrt",
+            network=_BTC_HRP,
             cap_sats=btc_sats,
             refund_spk=dest,
             accept_single_source=True,
@@ -1037,7 +1075,7 @@ class TestWatchtowerDustHarnessRegtest:
                     "--swap-id",
                     swap_id,
                     "--network",
-                    "bcrt",
+                    _BTC_HRP,
                     "--btc-sats",
                     str(btc_sats),
                     "--t-btc",
@@ -1104,7 +1142,7 @@ class TestWatchtowerDustHarnessRegtest:
         ex = RefundExecutor(
             broadcaster=_BtcBroadcaster(nodes),
             blobs_dir=records,
-            network="bcrt",
+            network=_BTC_HRP,
             cap_sats=btc_sats,
             refund_spk=dest,
             accept_single_source=True,


### PR DESCRIPTION
Adds **Litecoin** as a PoW-depth counter chain — the mirror of the Base (EVM-family) PR #198 — by the same lowest-risk path. The Taproot-HTLC leg machinery is **chain-agnostic across BIP341-activating Bitcoin-family chains**, so this changes **zero coordinator dispatch code**. `counter_chain` stays `"btc"` (it names the *PoW-depth family*); the concrete chain is pinned by the leg/locator `network` tag (bech32 HRP) + its block interval.

## De-risked by a go/no-go spike *first*
Before writing anything, drove pyrxd's own taproot builders (`build_htlc` / `build_claim_tx` / `build_refund_tx` / `scrape_secret`) against the official **Litecoin Core v0.21.5.5** binary on regtest, `network="rltc"`:
- taproot active from genesis; `rltc1p…` P2TR address valid (witness v1);
- correct-preimage claim **accepted**; wrong-preimage **rejected** with the *identical* `witness program hash mismatch` reason; preimage scraped from the witness;
- premature CSV refund `non-BIP68-final`; matured refund **accepted**. **GO.**

## What's here
- **`docker/litecoin-regtest.Dockerfile`** — wraps the official release binary, SHA-256 pinned. *Provenance note (differs from the radiant Dockerfile):* litecoin ships no checksum manifest, so the hash is measured from the official download (2026-06-12) and must be re-measured on a version bump.
- **`pyrxd.btc_wallet.chains`** — `PowChain` / `KNOWN_POW_CHAINS` (bitcoin 600 s, litecoin 150 s) + `pow_chain_by_network` (fail-closed on unvetted tags). Mirrors `eth_wallet.chains`; deliberately ships **no depth defaults** — confirmation depth must be value-scaled to each chain's cost-to-reorg.
- `AUDIT_CLEARED_NETWORKS` += `rltc`/`tltc`; `_TESTNET_HRPS` += same (LTC mainnet `"ltc"` stays value-bearing behind the audit gate; the bech32m HRP is authoritative for the P2TR flows).
- Chain knobs on both BTC-family regtest suites (`BTC_FAMILY_CHAIN=ltc`, `XCHAIN_BTC_FAMILY=ltc`), with a build-from-Dockerfile fallback for the local-only image. Top-level exports + registry unit tests; the how-to gains a "Bitcoin family — Litecoin works today" section beside Base.

## Proofs (all green, both chains)
| Suite | Bitcoin | Litecoin |
|---|---|---|
| BTC-leg consensus (`test_btc_htlc_regtest_e2e.py`) | 2 passed | 2 passed |
| Full coordinator e2e (`test_xchain_swap_regtest_e2e.py` — happy / mutual-refund / maker-stall / watchtower) | 10 passed | 10 passed |

## One real finding the LTC run flushed out
`test_reveal_with_closing_window_pages_squeezed` hard-coded a Bitcoin-tuned `t_rxd` window. On Litecoin the gate **correctly** returned WAIT — a 6-block LTC reorg depth converts to only 3 RXD blocks of reserve, so the window genuinely had room. The hidden chain assumption was in the **test**, not the gate; it now derives its squeeze window from the same policy math the gate uses, forcing a squeeze on whichever chain the run targets. Exactly the class of assumption a real dual-chain run exists to surface — no coordinator behavior changed.

## Verification
Full unit suite **4150 passed**; lint / format / typecheck / private-links clean. Pre-audit posture unchanged.

> Note: branches off current main, so it carries the born-broken `test_S7` that PR #198 fixes; the other 13 ETH e2e tests pass. Will rebase cleanly once #198 merges.