### PR TITLE
harden(agent): re-derive account xprv transiently — no long-lived key residency (#8/H1)

### DIFF
--- a/docs/threat-model.md
+++ b/docs/threat-model.md
@@ -343,7 +343,7 @@ Cross-reference of controls and the threats they address:
 | Agent `ALL\|FORKID`-only sighash + fully-owned-only | S19 | `src/pyrxd/agent/signer.py` |
 | Agent never returns key material (conformance-tested) | S18 | `src/pyrxd/agent/signer.py`, `tests/test_agent_signer.py` |
 | Agent socket: `0700` dir + `0600` socket + `SO_PEERCRED` uid==owner; per-conn recv timeout (anti-slow-loris) | TA1 (other-uid) | `src/pyrxd/agent/daemon.py:_bind/_read_peer_uid/_serve_conn` |
-| Agent lock scrubs the seed AND drops the signing-key reference; idle auto-lock + on-demand `lock` + SIGTERM/SIGHUP/atexit | A11 window | `src/pyrxd/agent/daemon.py:lock`, `hd/wallet.py:zeroize`, `cli/agent_cmds.py` |
+| Agent lock scrubs the seed (the only long-lived secret — the account xprv is re-derived transiently, never stored, #8/H1) and fails the derivation seam closed; idle auto-lock + on-demand `lock` + SIGTERM/SIGHUP/atexit | A11 window | `src/pyrxd/agent/daemon.py:lock`, `hd/wallet.py:zeroize`/`_xprv`, `cli/agent_cmds.py` |
 | Agent process hygiene (mlock, PR_SET_DUMPABLE 0, no core dumps; best-effort) | A11 residency | `src/pyrxd/agent/hygiene.py` |
 | CodeQL on every push | static analysis | `.github/workflows/codeql.yml` |
 | Bandit on every push | security smells | `.github/workflows/ci.yml` |
@@ -363,7 +363,7 @@ Honest list. These are not vulnerabilities; they're places where pyrxd's defense
 2. **No formal verification of BIP32/39/44 vectors** beyond unit tests. Test vectors come from the BIP specs themselves.
 3. **No fuzz testing of the CLI surface.** [Issue #10.](https://github.com/MudwoodLabs/pyrxd/issues/10)
 4. **No timing-attack analysis** of pyrxd-internal comparisons beyond known-good `hmac.compare_digest` use.
-5. **Memory zeroization is best-effort** — CPython does not guarantee secure memory. Specifically, the signing agent's seed (a `SecretBytes`) IS `memset` on lock, but the account xprv's private bytes are immutable `bytes` and partly held in libsecp256k1's C memory; `HdWallet.zeroize()` drops the reference (GC-eligible) but cannot overwrite those copies in place. Residency past lock is bounded by the agent's best-effort process hygiene (`mlock`/`PR_SET_DUMPABLE 0`/no core dumps), not a guaranteed erase. A future hardening would re-derive the xprv transiently from the seed per signing op so the only resident long-lived secret is the scrubbable seed.
+5. **Memory zeroization is best-effort** — CPython does not guarantee secure memory. The signing agent's only resident **long-lived** secret is the seed (a `SecretBytes`), which IS `memset` on lock. The account xprv is **no longer stored long-lived** (hardening #8/H1): `HdWallet._xprv` is now a property that re-derives the account key from the seed per operation, so on lock the seed is scrubbed and the property fails closed — there is no persistent xprv copy to leak across the unlock window. The residual is now only the **transient** per-operation copy: while a signature is actively being produced, an account xprv / libsecp256k1 key necessarily exists in memory for that moment (you cannot sign without the key), and CPython cannot overwrite those immutable/C copies in place before GC. Their residency until the pages are reused is bounded by the agent's best-effort process hygiene (`mlock`/`PR_SET_DUMPABLE 0`/no core dumps), not a guaranteed erase — do not over-state it as "erased". This is the irreducible floor (the key must be usable to sign), not a design gap.
 
 ### Network
 

--- a/src/pyrxd/hd/wallet.py
+++ b/src/pyrxd/hd/wallet.py
@@ -53,7 +53,7 @@ from typing import TYPE_CHECKING
 
 from Cryptodome.Cipher import AES
 
-from ..hd.bip32 import Xprv, Xpub, bip32_derive_xprv_from_mnemonic
+from ..hd.bip32 import Xprv, Xpub, ckd, master_xprv_from_seed
 from ..hd.bip39 import seed_from_mnemonic
 from ..keys import PrivateKey
 from ..network.electrumx import UtxoRecord, script_hash_for_address
@@ -225,7 +225,6 @@ class HdWallet:
         ``{path_key: AddressRecord}`` where path_key is ``f"{change}/{index}"``.
     """
 
-    _xprv: Xprv = field(repr=False)
     _seed: SecretBytes = field(repr=False)
     account: int = 0
     _coin_type: int = field(default_factory=lambda: _COIN_TYPE)
@@ -288,6 +287,35 @@ class HdWallet:
         """
         return self._coin_type
 
+    @property
+    def _xprv(self) -> Xprv:
+        """The account-level extended private key, **re-derived transiently** from the
+        seed on every access — it is NEVER stored as a long-lived field (hardening #8 /
+        threat-model gap #5, H1).
+
+        Why a property and not a stored field: the BIP39 seed lives in a scrubbable
+        :class:`SecretBytes` (``zeroize`` memsets it), but an ``Xprv``'s private bytes are
+        immutable ``bytes`` plus copies inside libsecp256k1's C memory, which CPython
+        cannot overwrite in place. Holding the account xprv for the whole unlock window
+        therefore left a non-erasable long-lived secret. Re-deriving it per operation
+        (``master_xprv_from_seed`` → hardened ``m/44'/coin'/account'``) means the only
+        resident long-lived secret is the scrubbable seed; each derived xprv is a local
+        that is GC-eligible the moment the caller is done. The re-derivation is
+        byte-for-byte identical to the previously-stored xprv (proved in
+        ``tests/test_hd_wallet.py``), so callers are unaffected.
+
+        Cost: one HMAC-SHA512 + the hardened path walk per access — microseconds, fine for
+        a CLI wallet; if a future hot path needs many derivations it can cache the result
+        for the duration of a single operation (never beyond it).
+        """
+        if getattr(self, "_zeroized", False):
+            raise ValidationError("wallet is locked/zeroized; re-create it from the mnemonic to sign")
+        # The path is ALWAYS the canonical m/44'/<coin>'/<account>' — _parse_radiant_path
+        # normalises any configured path to that shape, so reconstructing it here matches
+        # what from_mnemonic/load derived (the env override only ever changes the coin int).
+        master = master_xprv_from_seed(self._seed.unsafe_raw_bytes())
+        return ckd(master, f"m/44'/{self._coin_type}'/{self.account}'")
+
     # ------------------------------------------------------------------
     # Construction
 
@@ -313,12 +341,11 @@ class HdWallet:
         The chosen coin type is recorded on the wallet and persisted in
         the wallet file; subsequent :meth:`load` calls validate it.
         """
-        radiant_path, resolved_coin_type = _resolve_coin_type(coin_type)
+        _radiant_path, resolved_coin_type = _resolve_coin_type(coin_type)
         seed = seed_from_mnemonic(mnemonic, passphrase=passphrase)
-        path = f"{radiant_path}/{account}'"
-        xprv = bip32_derive_xprv_from_mnemonic(mnemonic, passphrase=passphrase, path=path)
+        # The account xprv is NOT stored — the _xprv property re-derives it from this seed
+        # on demand (hardening #8/H1). _coin_type + account fully determine the path.
         return cls(
-            _xprv=xprv,
             _seed=SecretBytes(seed),
             account=account,
             _coin_type=resolved_coin_type,
@@ -479,14 +506,11 @@ class HdWallet:
                     f"coin_type={coin_type}. Pass coin_type={persisted_coin_type} to load "
                     f"this wallet, or use a different file."
                 )
-            # Derive at the persisted path, not the module default — this is
-            # what prevents a default change from silently watching the wrong
-            # addresses for already-saved wallets.
-            account_xprv = bip32_derive_xprv_from_mnemonic(
-                mnemonic, passphrase=passphrase, path=f"m/44'/{persisted_coin_type}'/{account}'"
-            )
+            # The persisted coin_type pins the path; the _xprv property re-derives the
+            # account xprv from the seed at m/44'/<persisted_coin_type>'/<account>' on
+            # demand (hardening #8/H1) — this is what prevents a module-default change from
+            # silently watching the wrong addresses for already-saved wallets.
             wallet = cls(
-                _xprv=account_xprv,
                 _seed=SecretBytes(seed),
                 account=account,
                 _coin_type=persisted_coin_type,
@@ -758,20 +782,22 @@ class HdWallet:
         return self._derive_address(change, index)
 
     def zeroize(self) -> None:
-        """Scrub the seed and drop the account-xprv reference; the wallet cannot sign after.
+        """Scrub the seed and mark the wallet dead; it cannot derive or sign after.
 
-        The 64-byte seed lives in a :class:`SecretBytes` and IS memset here. The
-        account xprv's private bytes, however, are immutable ``bytes``
-        (:class:`~pyrxd.hd.bip32.Xkey`) and partly held inside libsecp256k1's C
-        memory (coincurve) — CPython cannot overwrite either in place, so we drop
-        the reference (making them GC-eligible) rather than pretend to erase them.
-        Residency of those copies until the pages are reused is bounded by the
-        signing agent's best-effort process hygiene (``mlock`` / ``PR_SET_DUMPABLE 0``
-        / no core dumps), NOT a guaranteed erase. This matches the threat model's
-        documented best-effort memory limit; do not over-state it as "erased".
+        Hardening #8/H1: the account xprv is NO LONGER stored long-lived — the ``_xprv``
+        property re-derives it transiently from the seed per operation — so the ONLY
+        resident long-lived secret is this 64-byte seed, which lives in a
+        :class:`SecretBytes` and IS memset here. Setting ``_zeroized`` makes the ``_xprv``
+        property fail closed (rather than silently re-deriving a garbage key from the
+        now-zeroed seed). Any account-xprv copies that existed only during an in-flight
+        derivation are short-lived locals (GC-eligible immediately, never held across the
+        unlock window); their residency until the pages are reused is bounded by the
+        agent's best-effort process hygiene (``mlock`` / ``PR_SET_DUMPABLE 0`` / no core
+        dumps), NOT a guaranteed erase — do not over-state it as "erased".
         """
         self._seed.zeroize()
-        self._xprv = None  # type: ignore[assignment]  # wallet is intentionally dead after zeroize
+        # Bypass the __setattr__ guard (it only blocks _coin_type, but be explicit).
+        object.__setattr__(self, "_zeroized", True)
 
     def _next_change_index(self) -> int:
         """Return the next unused internal-chain index for change outputs.

--- a/tests/test_hd_wallet.py
+++ b/tests/test_hd_wallet.py
@@ -646,19 +646,15 @@ class TestDirectConstructionValidatesCoinType:
 
     def _make_wallet_kwargs(self, *, coin_type: object) -> dict:
         # Build the minimum set of constructor kwargs needed to land
-        # in __post_init__ with a malicious _coin_type. The xprv/seed
-        # are real (so the test is realistic), but they're rooted at
-        # the *valid* default path — the test isn't about whether
-        # _xprv matches _coin_type, it's about whether the validator
-        # runs at all.
-        from pyrxd.hd.bip32 import bip32_derive_xprv_from_mnemonic
+        # in __post_init__ with a malicious _coin_type. The seed is real
+        # (so the test is realistic); the account xprv is no longer a
+        # stored field (the _xprv property re-derives it from the seed,
+        # hardening #8/H1), so it isn't passed here.
         from pyrxd.hd.bip39 import seed_from_mnemonic
         from pyrxd.security.secrets import SecretBytes
 
         seed = seed_from_mnemonic(MNEMONIC, passphrase="")
-        xprv = bip32_derive_xprv_from_mnemonic(MNEMONIC, passphrase="", path="m/44'/512'/0'")
         return {
-            "_xprv": xprv,
             "_seed": SecretBytes(seed),
             "account": 0,
             "_coin_type": coin_type,
@@ -686,6 +682,53 @@ class TestDirectConstructionValidatesCoinType:
         kwargs = self._make_wallet_kwargs(coin_type=0)
         w = HdWallet(**kwargs)
         assert w.coin_type == 0
+
+
+class TestTransientAccountXprv:
+    """Hardening #8/H1: the account xprv is re-derived from the seed per access and NEVER
+    stored long-lived, so the only resident long-lived secret is the scrubbable seed."""
+
+    def test_no_long_lived_xprv_is_stored_on_the_instance(self):
+        from pyrxd.hd.bip32 import Xprv
+
+        w = HdWallet.from_mnemonic(MNEMONIC, coin_type=512)
+        # The instance dict holds the seed + metadata but NO Xprv object.
+        assert not any(isinstance(v, Xprv) for v in vars(w).values()), (
+            f"a long-lived Xprv is stored on the wallet: {vars(w)}"
+        )
+
+    def test_property_rederivation_is_byte_identical_to_the_canonical_path(self):
+        # The security contract: re-deriving from the seed must equal the old stored xprv
+        # exactly, for every supported coin type — else addresses would silently shift.
+        from pyrxd.hd.bip32 import bip32_derive_xprv_from_mnemonic
+
+        for coin_type in (512, 0, 236):
+            w = HdWallet.from_mnemonic(MNEMONIC, coin_type=coin_type)
+            canonical = bip32_derive_xprv_from_mnemonic(MNEMONIC, path=f"m/44'/{coin_type}'/0'")
+            assert w._xprv == canonical, f"xprv != canonical for coin_type={coin_type}"
+            assert w._xprv.serialize() == canonical.serialize()
+
+    def test_rederivation_is_stable_across_accesses(self):
+        w = HdWallet.from_mnemonic(MNEMONIC, coin_type=512)
+        assert w._xprv == w._xprv  # two independent derivations agree
+        assert w.derive_address(0, 0) == w.derive_address(0, 0)
+        assert w.privkey_for(0, 3).public_key().hash160() == w.privkey_for(0, 3).public_key().hash160()
+
+    def test_account_index_is_honoured_in_rederivation(self):
+        from pyrxd.hd.bip32 import bip32_derive_xprv_from_mnemonic
+
+        w = HdWallet.from_mnemonic(MNEMONIC, account=7, coin_type=512)
+        assert w._xprv == bip32_derive_xprv_from_mnemonic(MNEMONIC, path="m/44'/512'/7'")
+
+    def test_xprv_fails_closed_after_zeroize(self):
+        w = HdWallet.from_mnemonic(MNEMONIC, coin_type=512)
+        _ = w._xprv  # works before
+        w.zeroize()
+        with pytest.raises(ValidationError, match="locked/zeroized"):
+            _ = w._xprv
+        # And the derivation seam is dead too (no silent garbage-key derivation).
+        with pytest.raises(ValidationError, match="locked/zeroized"):
+            w.privkey_for(0, 0)
 
 
 class TestUnderscoreMutationBlocked:


### PR DESCRIPTION
Closes the one residual the #8 signing-agent security panel left open (**H1 / threat-model gap #5**) — surfaced again when I re-assessed the agent's security posture.

## The gap
`HdWallet` stored the account **xprv** long-lived. An `Xprv`'s private bytes are immutable `bytes` plus copies inside libsecp256k1's C memory, which CPython cannot overwrite in place — so `zeroize()` could only *drop the reference*, leaving a non-erasable secret resident for the entire unlock window. The seed was scrubbable; the xprv wasn't.

## The fix
`HdWallet._xprv` is now a **property that re-derives the account key from the seed per access** (`master_xprv_from_seed` → hardened `m/44'/coin'/account'`) and is **never stored**. So:
- The only resident **long-lived** secret is the BIP39 seed, which lives in a scrubbable `SecretBytes`.
- On `zeroize()` the seed is `memset` and a `_zeroized` flag makes the property **fail closed** — a locked wallet can't silently re-derive a garbage key from the now-zeroed seed.

## Why it's safe (funds-critical correctness)
`_parse_radiant_path` always normalises any configured path to the canonical `m/44'/<coin>'` shape, so the property's reconstructed path is **byte-for-byte** what `from_mnemonic`/`load` derived. A regression test proves:
- `_xprv == canonical` (and `.serialize()` equal) for coin types **512 / 0 / 236**, and per-account;
- **no `Xprv` object is stored on the instance** (only the seed + metadata);
- re-derivation is stable across accesses;
- the derivation seam **fails closed** after `zeroize`.

Every existing reader (`wallet._xprv`, the signer's `privkey_for`, the watch-only `account_xpub`, `wallet_cmds.py`) is unchanged — `_xprv` stayed the access name; only its *storage* changed. Cost is one HMAC-SHA512 + the hardened path walk per access (microseconds; fine for a CLI).

## Residual (now the irreducible floor, documented honestly)
A transient account xprv / libsecp256k1 key necessarily exists in memory for the *instant* a signature is produced — you cannot sign without the key. That's bounded by the agent's best-effort process hygiene (`mlock` / `PR_SET_DUMPABLE 0` / no core dumps), not a guaranteed erase. The threat model is updated to say exactly this (no overclaim). The standing external-audit gate is unchanged.

## Verification
Full suite **4171 passed**; agent / signer / watch-only / wallet suites green; lint / format / typecheck / **bandit (0 issues)** / private-links clean.