### PR TITLE
harden(swap): value-scaled claim burial — fail-closed, dust opt-out (red-team HIGH)

### DIFF
--- a/docs/how-to/build-a-cross-chain-swap.md
+++ b/docs/how-to/build-a-cross-chain-swap.md
@@ -81,6 +81,15 @@ coordinator = SwapCoordinator(
 - **`MarginPolicy.measured(...)` vs estimated.** A real-value swap MUST use a measured
   margin policy; the coordinator refuses a value-bearing swap on estimated margins unless
   you consciously opt in (`accept_estimated_eth_margins` / the dust-run hatches).
+- **Value-scaled claim burial.** Radiant is low-cap PoW, so a *flat* claim-burial depth
+  bounds reorg probability, not reorg *cost vs. value* — a swap worth more than the marginal
+  cost to reorg a few Radiant blocks is economically reversible. The coordinator therefore
+  refuses a value-bearing Radiant swap unless you give `MarginPolicy` the economic inputs it
+  scales burial from — `rxd_reorg_cost_per_block` (measured, photons/block) and
+  `value_at_risk_photons` (the assessed economic value; for FT/NFT this is *not* the on-chain
+  amount) — **or** set `accept_flat_burial=True` for a deliberate dust run. The reorg gate
+  then requires the taker's claim to bury `max(rxd_claim_burial, ceil(value × factor / cost))`
+  deep before it returns SAFE, so an attacker must out-spend the value to reverse it.
 
 ## Runnable references (start here — these actually execute)
 

--- a/scripts/_dust_swap_shared.py
+++ b/scripts/_dust_swap_shared.py
@@ -242,6 +242,9 @@ async def measured_margin_from_mainnet(args: argparse.Namespace):
         btc_claim_reorg_depth_blocks=args.btc_claim_reorg_depth,
         rxd_claim_burial_blocks=args.rxd_claim_burial,
         rxd_block_interval_s=args.rxd_block_interval_s,
+        # This is a DUST harness (gated on --i-accept-dust-loss): the value is below the Radiant
+        # reorg cost, so opt out of value-scaled burial. A real-value run must NOT use this path.
+        accept_flat_burial=True,
     )
 
 

--- a/scripts/eth_swap_grief_run.py
+++ b/scripts/eth_swap_grief_run.py
@@ -62,6 +62,8 @@ def _policy(args) -> MarginPolicy:
         eth_finalization_window_s=args.eth_finalization_window_s,
         cross_clock_margin=_margin(args),
         max_covenant_confirm_wait_s=args.max_covenant_confirm_wait_s,
+        # Dust grief-test harness: opt out of value-scaled burial (value below the reorg cost).
+        accept_flat_burial=True,
     )
 
 

--- a/scripts/eth_swap_run.py
+++ b/scripts/eth_swap_run.py
@@ -116,6 +116,8 @@ def _policy(args: argparse.Namespace) -> MarginPolicy:
         eth_finalization_window_s=args.eth_finalization_window_s,
         cross_clock_margin=_cross_clock_margin(args),
         max_covenant_confirm_wait_s=args.max_covenant_confirm_wait_s,
+        # Dust harness: value below the Radiant reorg cost → opt out of value-scaled burial.
+        accept_flat_burial=True,
     )
 
 

--- a/src/pyrxd/gravity/swap_coordinator.py
+++ b/src/pyrxd/gravity/swap_coordinator.py
@@ -196,6 +196,32 @@ class MarginPolicy:
     rxd_claim_burial: Timelock = field(
         default_factory=lambda: Timelock(ESTIMATED_RXD_CLAIM_BURIAL_BLOCKS, TimeUnit.BLOCKS)
     )
+    # VALUE-SCALED claim burial (red-team 2026-06-12 HIGH). The flat ``rxd_claim_burial`` above
+    # bounds reorg PROBABILITY, not reorg COST vs. value — a low-cap PoW chain like Radiant can be
+    # shallow-reorged for ~a fixed marginal cost, so a swap whose Radiant-side value exceeds that
+    # cost is economically reversible at a flat burial (Bitcoin's "6 conf" folklore does NOT
+    # transfer to a low-cap chain; cf. THORChain value-scaled confs, Trail-of-Bits 25%-cost
+    # method). When BOTH of the next two are set, the reorg gate raises the required burial to
+    # ``ceil(value_at_risk_photons * burial_safety_factor / rxd_reorg_cost_per_block)`` (floored at
+    # the flat ``rxd_claim_burial``), so an attacker must spend >= the value at stake to reorg the
+    # taker's claim out. The coordinator REFUSES a value-bearing Radiant swap unless these are set
+    # OR ``accept_flat_burial=True`` (the dust opt-out) — fail-closed, mirroring ``require_measured``.
+    #
+    # rxd_reorg_cost_per_block: the MEASURED marginal cost to reorg ONE Radiant block, in PHOTONS
+    # (the honest reward + work an attacker must out-spend per block). Operator-supplied/refreshed
+    # (it tracks hashrate + RXD price); never hardcoded — an estimate masquerading as a measurement
+    # would size the whole defence wrong. None disables value-scaling (then accept_flat_burial gates).
+    rxd_reorg_cost_per_block: int | None = None
+    # value_at_risk_photons: the swap's ECONOMIC value to protect, in PHOTONS. For an RXD swap this
+    # equals ``terms.radiant_amount``; for FT/NFT the on-chain amount (token units / NFT carrier
+    # dust) is NOT the economic value, so the operator MUST assess and supply it explicitly.
+    value_at_risk_photons: int | None = None
+    # burial_safety_factor: required cost-to-reorg >= factor * value. 1.0 = break-even (an attack
+    # costs exactly the value — marginally unprofitable); raise it for margin.
+    burial_safety_factor: float = 1.0
+    # accept_flat_burial: the explicit dust opt-out. True = "this value is below the reorg cost, a
+    # flat burial is fine" — the conscious, logged escape from the fail-closed setup gate.
+    accept_flat_burial: bool = False
     # Finalized-checkpoint (ETH/PoS) counter-leg finalization window, in SECONDS (re-audit §9
     # #3). For a depth-based (BTC/PoW) leg this stays None and the reorg gate uses
     # btc_claim_reorg_depth. For an ETH leg — whose finality is a TIME checkpoint, not a block
@@ -245,6 +271,22 @@ class MarginPolicy:
                 "real-value mode (require_measured=True) requires a MEASURED margin; "
                 "the ESTIMATED default is test-only — supply measured block data + reorg depth"
             )
+        # Value-scaled-burial inputs (red-team 2026-06-12 HIGH): positive when set.
+        for label, val in (
+            ("rxd_reorg_cost_per_block", self.rxd_reorg_cost_per_block),
+            ("value_at_risk_photons", self.value_at_risk_photons),
+        ):
+            if val is not None and (not isinstance(val, int) or isinstance(val, bool) or val <= 0):
+                raise ValidationError(f"MarginPolicy.{label} must be a positive int (photons) or None")
+        if not isinstance(self.burial_safety_factor, (int, float)) or isinstance(self.burial_safety_factor, bool):
+            raise ValidationError("MarginPolicy.burial_safety_factor must be a number")
+        if self.burial_safety_factor < 1.0:
+            raise ValidationError(
+                f"MarginPolicy.burial_safety_factor = {self.burial_safety_factor} < 1.0; a factor below "
+                "break-even lets a reorg cost LESS than the value it reverses (the attack is profitable)"
+            )
+        if not isinstance(self.accept_flat_burial, bool):
+            raise ValidationError("MarginPolicy.accept_flat_burial must be bool")
         if self.eth_finalization_window_s is not None:
             if (
                 not isinstance(self.eth_finalization_window_s, int)
@@ -268,13 +310,20 @@ class MarginPolicy:
             raise ValidationError("MarginPolicy.max_covenant_confirm_wait_s must be a non-negative int or None")
 
     @classmethod
-    def estimated(cls, *, block_interval_s: float = 600.0, require_measured: bool = False) -> MarginPolicy:
-        """The ESTIMATED, test-only policy. Refuses to construct in real-value mode."""
+    def estimated(
+        cls, *, block_interval_s: float = 600.0, require_measured: bool = False, accept_flat_burial: bool = False
+    ) -> MarginPolicy:
+        """The ESTIMATED, test-only policy. Refuses to construct in real-value mode.
+
+        ``accept_flat_burial`` is the dust opt-out from the value-scaled-burial setup gate —
+        set it for a deliberate dust run whose value is below the Radiant reorg cost.
+        """
         return cls(
             margin=Timelock(ESTIMATED_DEFAULT_MARGIN_BLOCKS, TimeUnit.BLOCKS),
             block_interval_s=block_interval_s,
             is_measured=False,
             require_measured=require_measured,
+            accept_flat_burial=accept_flat_burial,
         )
 
     @classmethod
@@ -286,6 +335,10 @@ class MarginPolicy:
         btc_claim_reorg_depth: Timelock | None = None,
         rxd_claim_burial: Timelock | None = None,
         rxd_block_interval_s: float | None = None,
+        rxd_reorg_cost_per_block: int | None = None,
+        value_at_risk_photons: int | None = None,
+        burial_safety_factor: float = 1.0,
+        accept_flat_burial: bool = False,
     ) -> MarginPolicy:
         """A measured policy for real-value mainnet swaps.
 
@@ -293,12 +346,19 @@ class MarginPolicy:
         inputs; if omitted they fall back to the ESTIMATED defaults (acceptable only
         because a measured policy still carries the estimated reorg depths — supply
         measured values for a real mainnet swap).
+
+        ``rxd_reorg_cost_per_block`` (measured, photons/block) + ``value_at_risk_photons``
+        (the assessed economic value) drive the VALUE-SCALED claim burial (red-team HIGH):
+        supply both for a value-bearing Radiant swap, or set ``accept_flat_burial=True`` for
+        a dust run — the coordinator refuses a value-bearing swap that leaves them unset.
         """
         kwargs: dict = {
             "margin": margin,
             "block_interval_s": block_interval_s,
             "is_measured": True,
             "require_measured": True,
+            "burial_safety_factor": burial_safety_factor,
+            "accept_flat_burial": accept_flat_burial,
         }
         if btc_claim_reorg_depth is not None:
             kwargs["btc_claim_reorg_depth"] = btc_claim_reorg_depth
@@ -306,6 +366,10 @@ class MarginPolicy:
             kwargs["rxd_claim_burial"] = rxd_claim_burial
         if rxd_block_interval_s is not None:
             kwargs["rxd_block_interval_s"] = rxd_block_interval_s
+        if rxd_reorg_cost_per_block is not None:
+            kwargs["rxd_reorg_cost_per_block"] = rxd_reorg_cost_per_block
+        if value_at_risk_photons is not None:
+            kwargs["value_at_risk_photons"] = value_at_risk_photons
         return cls(**kwargs)
 
 
@@ -316,6 +380,7 @@ def measure_margin_from_btc_block_times(
     btc_claim_reorg_depth_blocks: int,
     rxd_claim_burial_blocks: int,
     rxd_block_interval_s: float,
+    accept_flat_burial: bool = False,
 ) -> tuple[MarginPolicy, dict]:
     """Build a MEASURED MarginPolicy from real mainnet BTC inter-block data (pure).
 
@@ -375,6 +440,9 @@ def measure_margin_from_btc_block_times(
         btc_claim_reorg_depth=Timelock(btc_claim_reorg_depth_blocks, TimeUnit.BLOCKS),
         rxd_claim_burial=Timelock(rxd_claim_burial_blocks, TimeUnit.BLOCKS),
         rxd_block_interval_s=float(rxd_block_interval_s),  # F-007: stored for the squeeze conversion
+        # Dust runs opt out of value-scaled burial (the value is below the Radiant reorg cost);
+        # a real-value run leaves this False and supplies rxd_reorg_cost_per_block + value_at_risk.
+        accept_flat_burial=accept_flat_burial,
     )
     provenance = {
         "measured": {
@@ -390,6 +458,7 @@ def measure_margin_from_btc_block_times(
             "rxd_claim_burial_blocks": rxd_claim_burial_blocks,
             "rxd_block_interval_s": rxd_block_interval_s,
             "min_reorg_depth_floor_blocks": _MIN_REORG_DEPTH_BLOCKS,
+            "accept_flat_burial": accept_flat_burial,
         },
         "note": (
             "margin + block_interval_s are MEASURED from observed BTC block timestamps; "
@@ -537,6 +606,25 @@ class ClaimFinality(Enum):
     SQUEEZED = "squeezed"
 
 
+def _value_scaled_burial_blocks(policy: MarginPolicy) -> int:
+    """Required claim-burial depth (Radiant blocks) so a reorg of the taker's claim costs at
+    least the value at stake — 0 when value-scaling is not configured (then the flat burial
+    stands). Pure (red-team 2026-06-12 HIGH).
+
+    ``required = ceil(value_at_risk_photons * burial_safety_factor / rxd_reorg_cost_per_block)``:
+    burying ``required`` blocks forces an attacker to out-spend ``required *
+    rxd_reorg_cost_per_block >= value_at_risk_photons * factor`` to reverse the claim. Both
+    economic inputs are operator-supplied (a measured per-block reorg cost + an assessed
+    value); when either is absent there is no basis to scale, so this returns 0 and the
+    coordinator's setup gate is what refused a value-bearing swap that left them unset.
+    """
+    cost = policy.rxd_reorg_cost_per_block
+    value = policy.value_at_risk_photons
+    if cost is None or value is None:
+        return 0
+    return math.ceil(value * policy.burial_safety_factor / cost)
+
+
 def _reserve_to_blocks(reserve: Timelock, block_interval_s: float) -> int:
     """Convert a REQUIREMENT/reserve Timelock to BLOCKS, rounding UP for a seconds-tagged value.
 
@@ -563,7 +651,9 @@ def assess_claim_finality(
       1. the maker's COUNTER-LEG claim must be FINAL (PoW: ``policy.btc_claim_reorg_depth``
          confirmations deep so ``p`` is reorg-safe; PoS: past the ``finalized`` checkpoint),
          supplied as a :class:`CounterClaimFinality` verdict, THEN
-      2. the taker's own Radiant claim must bury ``policy.rxd_claim_burial`` deep,
+      2. the taker's own Radiant claim must bury deep enough — ``max(policy.rxd_claim_burial,
+         value-scaled)``, where the value-scaled depth (red-team HIGH) makes a reorg of the
+         claim cost at least the value at stake (see ``_value_scaled_burial_blocks``) —
       both BEFORE ``t_rxd`` (the maker's CSV refund) opens at
       ``asset_locked_at_height + t_rxd``.
 
@@ -600,7 +690,10 @@ def assess_claim_finality(
         rxd_blocks = t_rxd.normalize_to(TimeUnit.BLOCKS, block_interval_s=policy.block_interval_s).value
         # Reserves round UP when seconds-tagged (flooring under-counts a reserve — unsafe);
         # t_rxd above floors, which is safe for a deadline (only shrinks the window).
-        rxd_burial = _reserve_to_blocks(policy.rxd_claim_burial, policy.block_interval_s)
+        flat_burial = _reserve_to_blocks(policy.rxd_claim_burial, policy.block_interval_s)
+        # VALUE-SCALED burial (red-team HIGH): the taker's claim must bury deep enough that
+        # reorging it costs at least the value at stake; the flat burial is only a FLOOR.
+        rxd_burial = max(flat_burial, _value_scaled_burial_blocks(policy))
         required_depth_blocks = _reserve_to_blocks(policy.btc_claim_reorg_depth, policy.block_interval_s)
     except ValidationError:
         raise
@@ -861,6 +954,29 @@ class SwapCoordinator:
                 "free-option window (SEEN-1). Use a durable SeenStore (durable=True), or pass "
                 "CoordinatorConfig(accept_nondurable_seen=True) to consciously accept "
                 "non-durability for a single-process, single-shot, fresh-H-per-run runbook."
+            )
+        # VALUE-SCALED BURIAL (red-team 2026-06-12 HIGH): the taker's Radiant asset-claim is
+        # deemed reorg-safe at a FLAT burial that is never scaled to value. On a low-cap PoW
+        # chain a swap worth more than the marginal cost to reorg a few Radiant blocks is
+        # economically reversible. Fail-closed at setup, mirroring MEDIUM-1: a value-bearing
+        # RADIANT asset (mainnet) MUST supply the economic inputs the gate value-scales from
+        # (a measured per-block reorg cost + an assessed value-at-risk) OR consciously opt into a
+        # flat burial via MarginPolicy(accept_flat_burial=True) for a dust run.
+        if (
+            _leg_is_value_bearing(radiant_leg)
+            and not config.margin_policy.accept_flat_burial
+            and (
+                config.margin_policy.rxd_reorg_cost_per_block is None
+                or config.margin_policy.value_at_risk_photons is None
+            )
+        ):
+            raise ValidationError(
+                "value-bearing Radiant asset swap without value-scaled claim burial: a flat "
+                "rxd_claim_burial bounds reorg probability, not reorg COST vs. value, so a swap worth "
+                "more than the marginal Radiant reorg cost is economically reversible (red-team HIGH). "
+                "Set MarginPolicy.rxd_reorg_cost_per_block (measured, photons/block) AND "
+                "value_at_risk_photons (the assessed economic value), or pass "
+                "MarginPolicy(accept_flat_burial=True) to consciously accept a flat burial on a dust run."
             )
         # MEDIUM-1 (whole-stack audit): a VALUE-BEARING ETH counter-leg swap on an ESTIMATED
         # policy silently runs in the weak mode of two defenses — the verify->lock 'finalized'

--- a/tests/test_swap_coordinator.py
+++ b/tests/test_swap_coordinator.py
@@ -1453,6 +1453,9 @@ def _eth_finality_policy(*, window_s=768, is_measured=False, rxd_block_interval_
         btc_claim_reorg_depth=t.Timelock(6, t.TimeUnit.BLOCKS),
         rxd_claim_burial=t.Timelock(6, t.TimeUnit.BLOCKS),
         eth_finalization_window_s=window_s,
+        # These tests exercise the MEDIUM-1 ETH / SEEN gates, not the value-scaled-burial gate;
+        # opt out of the latter so a value-bearing radiant leg reaches the gate under test.
+        accept_flat_burial=True,
     )
 
 
@@ -2270,6 +2273,131 @@ def test_value_bearing_btc_estimated_unaffected():
         radiant_leg=_value_bearing_radiant(),
         indexer=FakeIndexer(),
         seen_store=FakeSeenStore(),
+        config=CoordinatorConfig(
+            margin_policy=MarginPolicy.estimated(accept_flat_burial=True), accept_nondurable_seen=True
+        ),
+    )
+    assert coord is not None
+
+
+# --------------------------------------------------------------------------------------------------
+# Value-scaled claim burial (red-team 2026-06-12 HIGH): the taker's claim must bury deep enough
+# that a reorg of it costs at least the value at stake — flat burial is only a floor.
+# --------------------------------------------------------------------------------------------------
+
+
+def _burial_coord(margin_policy):
+    return SwapCoordinator(
+        record=SwapRecord(state=SwapState.NEGOTIATED, terms=_terms()),
+        btc_leg=FakeBtcLeg(),
+        radiant_leg=_value_bearing_radiant(),
+        indexer=FakeIndexer(),
+        seen_store=FakeSeenStore(),
+        config=CoordinatorConfig(margin_policy=margin_policy, accept_nondurable_seen=True),
+    )
+
+
+def test_value_scaled_burial_math_and_floor():
+    from pyrxd.gravity.swap_coordinator import _value_scaled_burial_blocks
+
+    # value 1,000,000 / cost 100,000 / factor 1.0 -> 10 blocks; ceil rounds up.
+    p = MarginPolicy.measured(
+        margin=t.Timelock(36, t.TimeUnit.BLOCKS),
+        block_interval_s=300.0,
+        rxd_reorg_cost_per_block=100_000,
+        value_at_risk_photons=1_050_000,
+    )
+    assert _value_scaled_burial_blocks(p) == 11  # ceil(1,050,000 / 100,000)
+    # factor scales linearly.
+    p2 = MarginPolicy.measured(
+        margin=t.Timelock(36, t.TimeUnit.BLOCKS),
+        block_interval_s=300.0,
+        rxd_reorg_cost_per_block=100_000,
+        value_at_risk_photons=1_000_000,
+        burial_safety_factor=2.0,
+    )
+    assert _value_scaled_burial_blocks(p2) == 20
+    # Unset inputs -> 0 (the flat burial stands).
+    assert _value_scaled_burial_blocks(MarginPolicy.estimated()) == 0
+
+
+def test_high_value_squeezes_where_flat_would_be_safe():
+    # A swap whose value-scaled burial exceeds the t_rxd window is SQUEEZED even with a final
+    # counter-leg claim — the gate refuses to call it SAFE on a shallow burial (the HIGH fix).
+    locked_at, now = 1000, 1001
+    t_rxd = t.Timelock(20, t.TimeUnit.BLOCKS)  # window ~19 blocks left
+    flat_safe = MarginPolicy.measured(
+        margin=t.Timelock(36, t.TimeUnit.BLOCKS),
+        block_interval_s=300.0,
+        rxd_block_interval_s=300.0,
+        rxd_claim_burial=t.Timelock(2, t.TimeUnit.BLOCKS),
+        accept_flat_burial=True,
+    )
+    assert (
+        assess_claim_finality(
+            counter_claim_finality=_final(),
+            now_rxd_height=now,
+            asset_locked_at_height=locked_at,
+            t_rxd=t_rxd,
+            policy=flat_safe,
+        )
+        is ClaimFinality.SAFE
+    )
+    # Same window, but value demands burial 50 (5,000,000 / 100,000) >> 19 left -> SQUEEZED.
+    value_scaled = MarginPolicy.measured(
+        margin=t.Timelock(36, t.TimeUnit.BLOCKS),
+        block_interval_s=300.0,
+        rxd_block_interval_s=300.0,
+        rxd_claim_burial=t.Timelock(2, t.TimeUnit.BLOCKS),
+        rxd_reorg_cost_per_block=100_000,
+        value_at_risk_photons=5_000_000,
+    )
+    assert (
+        assess_claim_finality(
+            counter_claim_finality=_final(),
+            now_rxd_height=now,
+            asset_locked_at_height=locked_at,
+            t_rxd=t_rxd,
+            policy=value_scaled,
+        )
+        is ClaimFinality.SQUEEZED
+    )
+
+
+def test_setup_gate_refuses_value_bearing_radiant_without_value_scaling():
+    with pytest.raises(ValidationError, match="value-scaled claim burial"):
+        _burial_coord(MarginPolicy.estimated())  # value-bearing radiant, no inputs, no opt-out
+
+
+def test_setup_gate_accepts_dust_optout():
+    assert _burial_coord(MarginPolicy.estimated(accept_flat_burial=True)) is not None
+
+
+def test_setup_gate_accepts_value_scaled_inputs():
+    p = MarginPolicy.measured(
+        margin=t.Timelock(36, t.TimeUnit.BLOCKS),
+        block_interval_s=300.0,
+        rxd_reorg_cost_per_block=100_000,
+        value_at_risk_photons=1_000_000,
+    )
+    assert _burial_coord(p) is not None
+
+
+def test_setup_gate_does_not_fire_on_non_value_bearing_radiant():
+    # A regtest/fake (non-mainnet) radiant leg is not value-bearing -> no burial gate, no inputs needed.
+    coord = SwapCoordinator(
+        record=SwapRecord(state=SwapState.NEGOTIATED, terms=_terms()),
+        btc_leg=FakeBtcLeg(),
+        radiant_leg=FakeRadiantLeg(),  # no .network => not value-bearing
+        indexer=FakeIndexer(),
+        seen_store=FakeSeenStore(),
         config=CoordinatorConfig(margin_policy=MarginPolicy.estimated(), accept_nondurable_seen=True),
     )
     assert coord is not None
+
+
+def test_burial_safety_factor_below_one_rejected():
+    with pytest.raises(ValidationError, match="burial_safety_factor"):
+        MarginPolicy.measured(
+            margin=t.Timelock(36, t.TimeUnit.BLOCKS), block_interval_s=300.0, burial_safety_factor=0.9
+        )


### PR DESCRIPTION
Closes the **red-team 2026-06-12 HIGH**: the taker's Radiant asset-claim was deemed reorg-safe at a **flat** burial (2–6 blocks) that is never scaled to the value at stake. On a low-cap PoW chain a flat burial bounds reorg *probability*, not reorg *cost vs. value* — so a swap worth more than the marginal cost to reorg a few Radiant blocks is economically reversible (maker reveals `p`, taker claims, maker rents hashpower to reorg the claim out and mature its CSV refund instead → maker keeps both legs). Bitcoin's "6 conf" folklore does not transfer to a low-cap chain (cf. THORChain value-scaled confs, Trail-of-Bits 25%-cost method).

## Polarity: fail-closed with a dust opt-out (as decided)
Not an "enable to be safe" toggle (that leaves the unsafe behaviour as the default). This mirrors the existing `require_measured` / `accept_estimated_eth_margins` discipline:

- **`MarginPolicy`** gains `rxd_reorg_cost_per_block` (MEASURED, photons/block — operator-supplied, never hardcoded, since it tracks hashrate + RXD price), `value_at_risk_photons` (the ASSESSED economic value — for FT/NFT the on-chain amount is **not** this), `burial_safety_factor` (≥ 1.0, default break-even), and `accept_flat_burial` (the dust opt-out). All validated.
- **The reorg gate** (`assess_claim_finality`) now requires the taker's claim to bury `max(rxd_claim_burial, ceil(value × factor / cost))` deep before it returns SAFE — an attacker must out-spend the value at stake to reverse the claim. Because these live on `MarginPolicy` (already threaded to every gate call site), the **watchtower's `decide()` value-scales identically** — zero caller/signature churn, no coordinator↔watchtower divergence.
- **Setup gate** (`SwapCoordinator.__init__`) fails closed: a value-bearing **Radiant** asset swap must supply both economic inputs **or** set `accept_flat_burial=True`. `measured()` / `estimated()` / `measure_margin_from_btc_block_times()` carry the knobs; the four dust harnesses set `accept_flat_burial=True` (their value is below the reorg cost).

## Tests
Value-scaling math + floor; **a high-value swap SQUEEZES where a flat burial would return SAFE** (the core fix); the setup gate (refuses without inputs / accepts the dust opt-out / accepts value-scaled inputs / does not fire on a non-value-bearing leg); `burial_safety_factor < 1` rejected. The cross-chain how-to documents the knobs.

## Honesty note
`rxd_reorg_cost_per_block` is an explicit **measured** input the operator supplies and refreshes — the code never hardcodes a cost estimate as if it were measured. With no inputs and no opt-out, a value-bearing swap simply won't construct (fail-closed), so the dangerous flat-burial path can't be reached by accident.

## Verification
Full unit suite **4178 passed**; lint / format / typecheck / **bandit (0)** / private-links clean. No behaviour change for dust/regtest paths (non-value-bearing legs skip the gate; dust harnesses opt out explicitly).