### PR TITLE
chore(audit-readiness): SBOM, incident-response runbook, single-source assumption

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -30,6 +30,11 @@ jobs:
   build:
     name: Build sdist + wheel
     runs-on: ubuntu-latest
+    permissions:
+      # contents: write attaches the CycloneDX SBOM to the GitHub Release.
+      # The release event is a trusted "publish now" gesture, so granting it
+      # to this build job is acceptable.
+      contents: write
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6
@@ -54,6 +59,25 @@ jobs:
           echo "Version OK: $pkg_version"
       - name: Build distributions
         run: poetry build
+      - name: Generate CycloneDX SBOM
+        # Declared dependency tree from pyproject + a freshly-resolved lock
+        # (poetry.lock is intentionally gitignored — a published library pins
+        # nothing for its consumers). Written OUTSIDE dist/ so PyPI never sees
+        # it (gh-action-pypi-publish uploads everything in dist/).
+        # continue-on-error: the SBOM is supplementary — never block the PyPI
+        # publish on it.
+        continue-on-error: true
+        run: |
+          pkg_version=$(poetry version --short)
+          poetry lock --no-interaction
+          pip install cyclonedx-bom
+          mkdir -p sbom
+          cyclonedx-py poetry . --output-format JSON --output-file "sbom/pyrxd-${pkg_version}.cdx.json"
+      - name: Attach SBOM to the GitHub Release
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: gh release upload "${GITHUB_REF_NAME}" sbom/pyrxd-*.cdx.json --clobber
       - name: Upload distributions as workflow artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
@@ -86,8 +110,11 @@ jobs:
           path: dist/
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b  # v1.14.0
-        # No `with:` block: defaults publish to PyPI from ./dist using
-        # Trusted Publishing OIDC. Print the upload URL so the workflow
-        # log links straight to the new release page.
+        # Publishes to PyPI from ./dist using Trusted Publishing OIDC. With
+        # id-token: write present, this action defaults `attestations: true`,
+        # so each artifact ships a PEP 740 / Sigstore digital attestation
+        # (verifiable on the PyPI project page and via `pip download
+        # --require-hashes`). Verify they appear after the first publish at
+        # https://pypi.org/project/pyrxd/#files (the "Provenance" badge).
         with:
           print-hash: true

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -24,6 +24,10 @@ We aim to:
 We will publicly credit reporters in the changelog and security
 advisories unless you request otherwise.
 
+Our internal handling steps — triage, private fix, coordinated disclosure,
+and release — are documented in
+[`docs/runbooks/incident-response.md`](docs/runbooks/incident-response.md).
+
 ## Scope
 
 Security reports are welcome on:

--- a/docs/runbooks/incident-response.md
+++ b/docs/runbooks/incident-response.md
@@ -1,0 +1,92 @@
+# Security incident-response runbook
+
+The internal procedure for handling a vulnerability reported to
+**security@mudwoodlabs.com**. The public-facing policy (where to report,
+what to include, the response SLA) lives in
+[`SECURITY.md`](../../SECURITY.md); this runbook is the maintainer's
+checklist for what happens *after* a report lands.
+
+## Why this exists
+
+pyrxd is a single-maintainer project handling cryptographic and
+value-bearing code. Without a written procedure, response to a report is
+ad-hoc and the SLA in `SECURITY.md` (acknowledge within 2 business days,
+assess within 7, coordinate disclosure within ~90) is easy to miss under
+pressure. This runbook makes the steps mechanical so the right things
+happen in the right order, even for the first real report.
+
+## Severity guide
+
+Use this to set urgency and the disclosure clock. When in doubt, round up.
+
+| Severity | Examples | Target fix window |
+|---|---|---|
+| **Critical** | Key/seed exfiltration; a forged SPV proof or REF that drains a Maker; signing the wrong tx; a covenant bypass that steals an in-flight swap | Days; consider an out-of-band advisory |
+| **High** | Fee/value miscalculation that loses funds; a broadcast-path crash that strands a confirmed commit; auth/confirmation-gate bypass | ~2 weeks |
+| **Medium** | Information leak (key bytes in a traceback/log); a fail-*open* default where a control must be explicitly enabled | Next scheduled release |
+| **Low / Info** | Hardening gaps, missing warnings, defense-in-depth | Backlog |
+
+The trust boundaries and current accepted residuals are in
+[`docs/threat-model.md`](../threat-model.md) — read the relevant scenario
+(S1–S20) before assessing impact.
+
+## The flow
+
+### 1. Acknowledge (≤ 2 business days)
+
+Reply to the reporter from `security@mudwoodlabs.com`: confirm receipt,
+give a tracking handle, and ask for anything missing (repro steps,
+affected versions). Do **not** discuss the issue in a public channel,
+issue, or PR.
+
+### 2. Triage + reproduce (≤ 7 business days for the initial assessment)
+
+- Reproduce it. If you can't, say so to the reporter and ask for more.
+- Set severity (table above) and the affected version range.
+- Open a **private** GitHub Security Advisory (Security tab →
+  "Report a vulnerability" → draft): `gh api
+  repos/MudwoodLabs/pyrxd/security-advisories -f summary=… -f severity=…`.
+  The advisory is the private workspace; it can request a CVE and spin a
+  private fork for the fix when ready.
+
+### 3. Fix privately
+
+- Branch from the advisory's private fork (or a local branch you do **not**
+  push to a public branch). Conventional-commit scope `fix(security):` —
+  but keep the message non-specific until disclosure.
+- **Write a regression test that fails before the fix** (the project rule;
+  for a value/assembly bug, a build→fee→sign or consensus-path test).
+- Run `task ci` locally. Patch the lowest still-supported affected version
+  if a backport is warranted (see `SECURITY.md` → Supported Versions).
+
+### 4. Coordinate disclosure
+
+- Agree a disclosure date with the reporter (default ≤ 90 days, sooner for
+  Critical). If the bug is being actively exploited, shorten it.
+- Request the CVE via the advisory if the issue warrants a public
+  identifier (most Critical/High do).
+
+### 5. Release the fix
+
+- Bump `pyproject.toml`, update `CHANGELOG.md` (crediting the reporter
+  unless they opted out).
+- Cut a GitHub Release → this triggers
+  [`.github/workflows/publish.yml`](../../.github/workflows/publish.yml)
+  (OIDC Trusted Publishing + PEP 740 attestations + the CycloneDX SBOM).
+- Verify the new version is on PyPI with its provenance attestation.
+
+### 6. Publish + notify
+
+- Publish the GitHub Security Advisory (this is the public disclosure).
+- Confirm to the reporter that it's out; thank them.
+- If a config/usage change is needed by users, note it in the advisory and
+  the release notes.
+- Update [`docs/threat-model.md`](../threat-model.md): close the gap or add
+  the new scenario, and record any newly-accepted residual.
+
+## After-action
+
+For anything Critical/High, write a short
+[`docs/solutions/`](../solutions/) note: the root cause, why existing tests
+missed it, and the test class that now guards it — so the same class of
+bug can't recur silently.

--- a/docs/threat-model.md
+++ b/docs/threat-model.md
@@ -375,7 +375,7 @@ Honest list. These are not vulnerabilities; they're places where pyrxd's defense
 
 ### Network
 
-6. **Single ElectrumX endpoint by default.** TA5 has unmitigated reach for plain RXD operations. Multi-source ElectrumX is not implemented; only Bitcoin data sources have quorum.
+6. **Single-source RXD reads (accepted assumption, stated for the auditor).** Three RXD-side reads trust a single source by design: (a) the default single **ElectrumX** endpoint for plain-RXD wallet ops (TA5 has unmitigated reach here — multi-source ElectrumX is not implemented; only the Bitcoin data sources have quorum); (b) the single **RXinDexer** that resolves Glyph reads and backs the Gravity REF-authenticity gate (`verify_ref_authenticity`); (c) single-source RXD funding depth (a SPOF accepted only for dust). This is an **accepted assumption, not a missing control**: a *self-consistent* lie is byte-identical from every source, so adding a 2nd source — which only detects *disagreement* — has bounded value while the operating cost is real. The load-bearing defenses are the on-chain covenant pins (nBits / `expectedNBits`, the REF-uniqueness consensus rule), not read-side quorum. Standing up a 2nd independent RXD source is the right hardening **at first non-dust real value**; it is documented here so the audit reviews a stated single-source boundary up front rather than discovering it.
 7. **No certificate pinning for ElectrumX TLS.** A CA compromise enables TA4. We rely on system trust store.
 8. **The SPV primitive is not a self-sufficient sole authority.** It enforces the committed nBits pin and per-header PoW but does **not** do most-cumulative-work selection or independent network-difficulty oracling (audit F-01). It is safe only behind an on-chain covenant pinning nBits; any covenant-less use (bridge-in/oracle/gate) fails closed via `require_spv_sole_authority_cleared` pending external audit. See [`docs/how-to/spv-verification-pitfalls.md`](how-to/spv-verification-pitfalls.md).
 
@@ -393,15 +393,15 @@ Honest list. These are not vulnerabilities; they're places where pyrxd's defense
 
 ### Supply chain
 
-14. **No pinned transitive dependency hashes.** A compromised release of `coincurve`, `Cryptodome`, etc. would propagate. `pip-audit` catches known CVEs but not zero-days.
-15. **No SBOM generation.** A signed software bill of materials would help downstream users verify what they got.
-16. **Release signing not yet set up.** PyPI 2FA is on; release artifact signing (sigstore, gpg) is not.
+14. **No pinned transitive dependency hashes.** A compromised release of `coincurve`, `Cryptodome`, etc. would propagate. `pip-audit` catches known CVEs but not zero-days. (Deliberate for a *library* — pinning transitive hashes over-constrains downstreams.)
+15. **SBOM now generated.** Each GitHub Release attaches a CycloneDX SBOM (`pyrxd-<version>.cdx.json`) built from the resolved dependency tree by the publish workflow (`.github/workflows/publish.yml`).
+16. **Release artifacts now carry PEP 740 attestations.** PyPI 2FA + OIDC Trusted Publishing are on, and the publish action emits per-artifact Sigstore digital attestations (verifiable on the PyPI project page). A gpg-signed git tag / GitHub Release signature is still optional and not set up.
 
 ### Process
 
-17. **No formal incident response plan.** If a vulnerability is reported via `security@mudwoodlabs.com`, response is ad-hoc.
-18. **No coordinated-disclosure SLA.** Researchers don't know what response time to expect.
-19. **No external eyes.** Solo developer; nothing has been reviewed by anyone else.
+17. **Incident-response runbook now exists.** [`docs/runbooks/incident-response.md`](runbooks/incident-response.md) documents the triage → fix-branch → GitHub Security Advisory / CVE → release → notify flow for a report to `security@mudwoodlabs.com`.
+18. ~~No coordinated-disclosure SLA.~~ **Resolved:** [`SECURITY.md`](../SECURITY.md) states the SLA — acknowledge within 2 business days, initial assessment within 7, coordinated disclosure typically within 90 (Project Zero norms).
+19. **No external eyes.** Solo developer; nothing has been reviewed by anyone else. The standing hard gate before any real-value mainnet use.
 
 ## Out of scope (explicit non-coverage)
 


### PR DESCRIPTION
Three small audit-readiness items toward the eventual external-audit gate. No code changes — docs + the release workflow.

## B3 — supply chain (SBOM + attestations)
- `publish.yml` now generates a **CycloneDX SBOM** (`pyrxd-<version>.cdx.json`, from the resolved dependency tree) and attaches it to each GitHub Release. It's written outside `dist/` (so PyPI never sees it) and is **`continue-on-error`** so it can never block the actual PyPI publish.
- Documented (in the workflow + threat-model) that the publish action **already emits PEP 740 / Sigstore attestations** by default (OIDC Trusted Publishing + `id-token: write`) — with a note to verify the provenance badge appears after the first publish. threat-model gaps 15 & 16 updated.

## B2 — incident response
- New **`docs/runbooks/incident-response.md`**: the internal triage → private fix (with a failing-first regression test) → coordinated disclosure (GitHub Security Advisory / CVE) → release → notify flow for a report to `security@mudwoodlabs.com`, with a severity guide. Linked from `SECURITY.md`.
- threat-model gaps 17 & 18 updated — **18 was stale** (the disclosure SLA is already in `SECURITY.md`).

## B1 — single-source assumption (the cheap arm)
- threat-model gap 6 now states the **accepted single-source RXD/REF read boundary** up front for the auditor: the single ElectrumX endpoint (plain RXD), the single RXinDexer (Glyph reads + the `verify_ref_authenticity` REF gate), and single-source funding depth. Framed honestly as an *accepted assumption, not a missing control* — a self-consistent lie is byte-identical from every source, so read-side quorum has bounded value; the load-bearing defenses are the on-chain covenant pins. The trigger to add a 2nd source is "first non-dust real value."
- The deeper hardening (actually standing up a 2nd RXD source) stays deferred — documented as the accepted residual rather than built.

## Checks
- `publish.yml` is valid YAML; SBOM tooling (`cyclonedx-bom` 7.3.0) verified locally.
- Private-link checker passes; Sphinx builds (the runbook follows the existing `docs/runbooks/` + threat-model convention of not being in the nav toctree).