### PR TITLE
docs(swap): runnable HTLC swap example + deprecate the SPV-oracle demos

### DIFF
--- a/docs/how-to/build-a-cross-chain-swap.md
+++ b/docs/how-to/build-a-cross-chain-swap.md
@@ -12,6 +12,13 @@ end-to-end on regtest and on small real-value mainnet/Sepolia runs.
 > property is what an audit certifies. See the swap coordinator's module docstring for
 > the current residual-risk notes.
 
+> **This is the HTLC swap — not the SPV-oracle one.** An earlier SPV-oracle swap covenant
+> is **deprecated and superseded** by this HTLC construction (it was a non-atomic, weaker
+> swap with known won't-fix parser findings). Build on the coordinator below; the
+> `examples/gravity_*` scripts are SPV-oracle reference-only. See
+> [the design decision](../solutions/design-decisions/spv-swap-deprecated-primitive-retained.md)
+> for why, and `examples/htlc_swap_demo.py` for a runnable on-ramp to *this* path.
+
 ## The mental model
 
 Two parties, two chains, one secret:

--- a/examples/README.md
+++ b/examples/README.md
@@ -105,31 +105,37 @@ it runs with **no node and no network** — it exercises the real swap API
 
 ---
 
-## Cross-chain / Gravity swaps (pre-audit)
+## Cross-chain swaps (pre-audit)
 
-The Gravity BTC↔RXD swap covenant is **pre-audit** — it has not cleared an
-external security review. Treat all three scripts as reference material; do not
-use them with real mainnet value.
+pyrxd's cross-chain atomic swap is a **hash-timelock (HTLC) swap** driven by the
+chain-neutral `pyrxd.SwapCoordinator` — trade RXD / a Glyph FT / a Glyph NFT
+against BTC or ETH with no custodian. It is **pre-audit**: build and demo on
+regtest/testnet, but do not move real value until the audit gate clears.
 
-### `gravity_swap_demo.py` — testnet, `DRY_RUN=1` by default — pre-audit
-The safe entry point for Gravity. Walks every step of a BTC↔RXD swap against
-**testnet** (Radiant + Bitcoin). `DRY_RUN=1` (default) builds and prints every
-tx but broadcasts nothing; `DRY_RUN=0` broadcasts to live testnets (no mainnet
-value).
+### `htlc_swap_demo.py` — no network — the current swap, START HERE
+Builds the **Radiant asset leg of the current HTLC swap** end to end: the NFT
+HTLC covenant, the taker's hashlock claim spend (reveals the secret), and the
+maker's CSV refund spend — with the production builders, structurally validated,
+no network. The on-ramp to the swap you should actually build.
+→ [`../docs/how-to/build-a-cross-chain-swap.md`](../docs/how-to/build-a-cross-chain-swap.md)
+For the full two-chain flow on a live regtest node, see
+`tests/test_xchain_swap_regtest_e2e.py` (BTC↔RXD) and
+`tests/test_xchain_eth_swap_regtest_e2e.py` (ETH↔RXD).
 
-### `gravity_live_test.py` — RXD mainnet reads + BTC testnet, `DRY_RUN=1` by default — pre-audit
-Integration test driving the Gravity SDK against **live** networks: reads from
-RXD **mainnet** ElectrumX and BTC **testnet**, building txs from real covenant
-bytecode and running the SPV verifier on real BTC data. `DRY_RUN=0` broadcasts
-the maker-offer tx on **RXD mainnet** (real photons); the BTC side never
-broadcasts.
+### Deprecated — the `gravity_*` SPV-oracle swap demos
 
-### `gravity_full_trade.py` — RXD mainnet (+ BTC mainnet default) — NO dry-run — pre-audit
-The full offer → claim → finalize / forfeit / cancel state machine. **This
-script has no `DRY_RUN` mode** — it broadcasts real transactions. The BTC side
-defaults to **mainnet** (`BTC_NETWORK=bc`). As a guard, on mainnet it refuses to
-run unless you set `I_UNDERSTAND_THIS_IS_REAL=yes`, acknowledging irreversible
-value movement. Prefer `gravity_swap_demo.py` for a safe walkthrough.
+> **Deprecated. Do not build on these.** The three `gravity_*` scripts demo the
+> **retired SPV-oracle swap** construction, which is superseded by the HTLC swap
+> above. Their any-wallet covenant parser has known, won't-fix security findings,
+> and `gravity_full_trade.py` broadcasts real RXD mainnet value. They are kept
+> only as reference for the **retained SPV verification primitive** (one-way
+> bridge-in / oracle — which the HTLC swap structurally cannot replace). Why:
+> [`../docs/solutions/design-decisions/spv-swap-deprecated-primitive-retained.md`](../docs/solutions/design-decisions/spv-swap-deprecated-primitive-retained.md).
+
+- `gravity_swap_demo.py` — testnet, `DRY_RUN=1` by default — the safe SPV walkthrough.
+- `gravity_live_test.py` — RXD mainnet reads + BTC testnet, `DRY_RUN=1` by default.
+- `gravity_full_trade.py` — RXD mainnet, **no dry-run** (broadcasts real value;
+  guarded by `I_UNDERSTAND_THIS_IS_REAL=yes`).
 
 ---
 

--- a/examples/gravity_full_trade.py
+++ b/examples/gravity_full_trade.py
@@ -1,6 +1,19 @@
 #!/usr/bin/env python3
 """Gravity full trade flow — broadcast MakerOffer, then claim via SPV.
 
+    !! DEPRECATED — SPV-ORACLE SWAP, superseded by the HTLC swap. !!
+    This script demos the RETIRED SPV-oracle swap construction, not the current
+    atomic swap, and it broadcasts REAL value on RXD mainnet. Its any-wallet
+    covenant parser has KNOWN, won't-fix security findings
+    (forged-payment-in-scriptsig); it is dominated by the HTLC swap
+    (pyrxd.SwapCoordinator) and is kept only as reference for the RETAINED SPV
+    verification PRIMITIVE (one-way bridge-in / oracle). Do NOT build a new swap
+    on this path.
+
+      Current swap example : examples/htlc_swap_demo.py
+      Guide                : docs/how-to/build-a-cross-chain-swap.md
+      Why deprecated       : docs/solutions/design-decisions/spv-swap-deprecated-primitive-retained.md
+
 Four modes selected by GRAVITY_MODE env var:
 
   GRAVITY_MODE=offer  (default)

--- a/examples/gravity_live_test.py
+++ b/examples/gravity_live_test.py
@@ -1,6 +1,18 @@
 #!/usr/bin/env python3
 """Gravity live integration test — real ElectrumX + real BTC testnet APIs.
 
+    !! DEPRECATED — SPV-ORACLE SWAP, superseded by the HTLC swap. !!
+    This script exercises the RETIRED SPV-oracle swap construction, not the
+    current atomic swap. Its any-wallet covenant parser has KNOWN, won't-fix
+    security findings (forged-payment-in-scriptsig); it is dominated by the HTLC
+    swap (pyrxd.SwapCoordinator) and is kept only as reference for the RETAINED
+    SPV verification PRIMITIVE (one-way bridge-in / oracle). Do NOT build a new
+    swap on this path.
+
+      Current swap example : examples/htlc_swap_demo.py
+      Guide                : docs/how-to/build-a-cross-chain-swap.md
+      Why deprecated       : docs/solutions/design-decisions/spv-swap-deprecated-primitive-retained.md
+
 Exercises the Gravity SDK against LIVE networks (RXD mainnet ElectrumX +
 BTC testnet/signet blockstream.info). Every fact this script reports is derived
 from a live network call, a cryptographic operation, or the SDK's own validators.

--- a/examples/gravity_swap_demo.py
+++ b/examples/gravity_swap_demo.py
@@ -1,6 +1,18 @@
 #!/usr/bin/env python3
 """Gravity BTC↔RXD swap — end-to-end testnet demo.
 
+    !! DEPRECATED — SPV-ORACLE SWAP, superseded by the HTLC swap. !!
+    This script demos the RETIRED SPV-oracle swap construction, not the current
+    atomic swap. Its any-wallet covenant parser has KNOWN, won't-fix security
+    findings (forged-payment-in-scriptsig); it is dominated by the HTLC swap
+    (pyrxd.SwapCoordinator) and is kept only as reference for the RETAINED SPV
+    verification PRIMITIVE (one-way bridge-in / oracle). Do NOT build a new swap
+    on this path.
+
+      Current swap example : examples/htlc_swap_demo.py
+      Guide                : docs/how-to/build-a-cross-chain-swap.md
+      Why deprecated       : docs/solutions/design-decisions/spv-swap-deprecated-primitive-retained.md
+
 Walks through every step of the Gravity protocol against live testnets:
 
     Step 1  Generate / load keypairs (Maker RXD, Taker RXD, Taker BTC)

--- a/examples/htlc_swap_demo.py
+++ b/examples/htlc_swap_demo.py
@@ -1,0 +1,174 @@
+#!/usr/bin/env python3
+"""HTLC cross-chain swap — the Radiant asset leg, built end to end (no network).
+
+This is the **current** atomic-swap construction in pyrxd: a hash-timelock (HTLC)
+swap driven by the chain-neutral :class:`pyrxd.SwapCoordinator`. It SUPERSEDES the
+deprecated SPV-oracle swap demoed by the ``gravity_*`` scripts in this directory
+(see ``docs/solutions/design-decisions/spv-swap-deprecated-primitive-retained.md``).
+Build new swaps on this path, not on the SPV-oracle one.
+
+The script walks the **Radiant side** of a BTC/ETH <-> Glyph-NFT swap: the on-chain
+HTLC covenant that holds the NFT, the TAKER's hashlock *claim* spend (which reveals
+the secret ``p``), and the MAKER's CSV *refund* spend (after the relative timelock).
+It builds the real covenant + spend transactions with the production builders
+(:mod:`pyrxd.gravity.htlc_covenant`, :mod:`pyrxd.gravity.htlc_spend`) and
+structurally validates them — but it never connects out (synthetic funding UTXOs,
+exactly like ``partial_swap_demo.py``). Run it anywhere:
+
+    python examples/htlc_swap_demo.py
+
+What this does NOT do: drive the full two-chain state machine (that is
+:class:`pyrxd.SwapCoordinator`, which orchestrates BOTH legs, the reorg-finality
+gate, and the durable swap record) or broadcast to any chain. For the live-chain
+proof — happy path, mutual-refund, maker-stall, reorg-gate, all on a real regtest
+node — see the maintained harnesses:
+
+    RADIANT_REGTEST=1 pytest tests/test_htlc_regtest_e2e.py -m integration
+    XCHAIN_REGTEST=1  pytest tests/test_xchain_swap_regtest_e2e.py -m integration
+
+and the how-to: ``docs/how-to/build-a-cross-chain-swap.md``.
+
+> PRE-AUDIT. The swap covenant has not had an external security audit. This script
+> moves no value and needs no network, but do not move real value with the swap
+> until the audit gate clears — an atomic swap's whole job is to be safe against a
+> hostile counterparty, and that is what an audit certifies.
+"""
+
+from __future__ import annotations
+
+import os
+
+from pyrxd import build_htlc_covenant_nft, generate_secret
+from pyrxd.gravity.htlc_spend import FeeInput, build_htlc_claim_tx, build_htlc_refund_tx
+from pyrxd.keys import PrivateKey
+from pyrxd.security.types import Hex20
+
+
+def _hr(title: str) -> None:
+    print(f"\n{'-' * 72}\n{title}\n{'-' * 72}")
+
+
+def _ok(msg: str) -> None:
+    print(f"  [ok] {msg}")
+
+
+def _info(msg: str) -> None:
+    print(f"       {msg}")
+
+
+def _pkh(key: PrivateKey) -> bytes:
+    return bytes(Hex20(key.public_key().hash160()))
+
+
+def _synthetic_fee_input(owner: PrivateKey) -> FeeInput:
+    """A throwaway plain-P2PKH fee UTXO.
+
+    NO network — the outpoint is synthetic. The single covenant output carries the
+    asset and cannot also pay the miner fee, so every HTLC spend joins a fee input
+    the spender owns; in a real spend this is a confirmed RXD UTXO you control.
+    """
+    pkh = _pkh(owner)
+    spk = b"\x76\xa9\x14" + pkh + b"\x88\xac"  # OP_DUP OP_HASH160 <20> OP_EQUALVERIFY OP_CHECKSIG
+    return FeeInput(txid=os.urandom(32).hex(), vout=0, value=5_000_000, scriptpubkey=spk, wif=owner.wif())
+
+
+def main() -> None:
+    # -- Roles + the shared secret --------------------------------------------
+    # MAKER holds the Radiant NFT and wants BTC/ETH. TAKER holds BTC/ETH and wants
+    # the NFT. The maker generates the secret; both legs lock to H = SHA256(p).
+    _hr("1. The maker's secret (p, H)")
+    p, hashlock = generate_secret()  # p is SecretBytes — unpicklable, never persisted
+    _ok(f"H = SHA256(p) = {hashlock.hex()}")
+    _info("p is wrapped in SecretBytes so it can never be serialised to the durable")
+    _info("record; only at claim time is it exposed via p.unsafe_raw_bytes().")
+
+    maker = PrivateKey(os.urandom(32))
+    taker = PrivateKey(os.urandom(32))
+    _ok(f"maker pkh {_pkh(maker).hex()}")
+    _ok(f"taker pkh {_pkh(taker).hex()}")
+
+    # -- The safety invariant -------------------------------------------------
+    _hr("2. The ordering + timelock invariant (read before wiring anything)")
+    _info("1) maker publishes H        2) taker locks BTC/ETH  FIRST")
+    _info("3) maker locks the NFT covenant  SECOND")
+    _info("4) maker claims BTC/ETH FIRST, revealing p   5) taker scrapes p, claims the NFT")
+    _info("")
+    _info("Timelocks MUST satisfy   t_counterchain > t_rxd + margin .  The leg claimed")
+    _info("SECOND (Radiant) carries the SHORTER refund window, so the taker has time to")
+    _info("scrape p and claim before its own refund opens. SwapCoordinator enforces this")
+    _info("fail-closed (assert_timelock_margin) — never route around it.")
+
+    # -- The NFT HTLC covenant (the asset leg) --------------------------------
+    _hr("3. Build the NFT HTLC covenant (the asset the maker locks SECOND)")
+    # In a real swap the genesis outpoint is the NFT's actual mint ref, resolved and
+    # authenticity-checked via verify_ref_authenticity: consensus enforces ref
+    # UNIQUENESS, not mint PROVENANCE, so a fake-singleton covenant is accepted by
+    # consensus (the R1 case) — verify_ref_authenticity is the only defence.
+    genesis_txid = os.urandom(32).hex()
+    genesis_vout = 0
+    carrier = 1000  # the NFT's carrier photons (a singleton, NOT a fungible "amount")
+    refund_csv = 20  # the maker's relative-timelock refund window, in blocks
+
+    cov = build_htlc_covenant_nft(
+        genesis_txid=genesis_txid,
+        genesis_vout=genesis_vout,
+        nft_carrier_value=carrier,
+        taker_pkh=_pkh(taker),
+        maker_pkh=_pkh(maker),
+        hashlock=hashlock,
+        refund_csv=refund_csv,
+    )
+    _ok(f"covenant funded_spk ({len(cov.funded_spk)} bytes): {cov.funded_spk.hex()[:56]}...")
+    _info("It pins both spend paths: TAKER claims on hashlock(H)  |  MAKER refunds after")
+    _info(f"CSV({refund_csv}). The NFT singleton ref d8<{genesis_txid[:16]}...:{genesis_vout}> rides in the body.")
+
+    # The maker funds the NFT into this SPK; that funding outpoint is what the
+    # spends below consume (synthetic here — no broadcast).
+    cov_outpoint = f"{os.urandom(32).hex()}:0"
+
+    # -- The TAKER's claim spend (reveal p) -----------------------------------
+    _hr("4. TAKER claim spend — reveal p, take the NFT (hashlock branch)")
+    claim = build_htlc_claim_tx(
+        covenant=cov,
+        covenant_outpoint=cov_outpoint,
+        carrier_value=carrier,
+        preimage=p.unsafe_raw_bytes(),  # raw 32 bytes — only exposed at claim time
+        fee=_synthetic_fee_input(taker),
+    )
+    raw_claim = claim.serialize().hex()
+    assert p.unsafe_raw_bytes().hex() in raw_claim, "the claim scriptSig must embed the preimage"
+    _ok(
+        f"claim tx built + serialised ({len(claim.inputs)} inputs, {len(claim.outputs)} output, {len(raw_claim) // 2} bytes)"
+    )
+    _info("covenant scriptSig = <preimage push> <OP_0>; the single output pays the TAKER.")
+    _info("A WRONG preimage is rejected by REAL consensus (hashlock OP_EQUALVERIFY) —")
+    _info("proven in test_htlc_regtest_e2e.py::test_claim_accepted_wrong_preimage_rejected.")
+
+    # -- The MAKER's refund spend (CSV) ---------------------------------------
+    _hr("5. MAKER refund spend — reclaim the NFT after the timelock (CSV branch)")
+    refund = build_htlc_refund_tx(
+        covenant=cov,
+        covenant_outpoint=cov_outpoint,
+        carrier_value=carrier,
+        fee=_synthetic_fee_input(maker),
+    )
+    cov_in = refund.inputs[0]  # tx_inputs = [covenant_input, fee_input]
+    assert refund.version == 2, "BIP68 relative timelocks require tx version 2"
+    assert cov_in.sequence == refund_csv, "covenant input nSequence must equal refund_csv"
+    _ok(f"refund tx built; version={refund.version}, covenant nSequence={cov_in.sequence}")
+    _info("covenant scriptSig = <OP_1> ONLY (no preimage, no sig — gated by the CSV).")
+    _info("A PREMATURE refund is rejected (BIP68 non-final); a MATURED one is accepted —")
+    _info("test_htlc_regtest_e2e.py::test_premature_refund_rejected_matured_accepted.")
+
+    # -- Where to go next -----------------------------------------------------
+    _hr("Next: the full two-chain swap")
+    _info("This was the Radiant ASSET leg only. The full cross-chain swap is driven by")
+    _info("pyrxd.SwapCoordinator (both legs + the reorg-finality gate + a durable record):")
+    _info("  - docs/how-to/build-a-cross-chain-swap.md            (the guide)")
+    _info("  - tests/test_xchain_swap_regtest_e2e.py              (BTC <-> RXD, live regtest)")
+    _info("  - tests/test_xchain_eth_swap_regtest_e2e.py          (ETH <-> RXD, Anvil + regtest)")
+    print()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## What & why

The cross-chain atomic swap is already regtest-verified (incl. NFT —
`test_htlc_regtest_e2e.py`, mainnet claim `8333e80b`) and documented. But the
only **runnable** swap examples were the three `gravity_*` scripts, and **all
three demo the deprecated SPV-oracle swap**, not the current HTLC swap:

- `gravity_full_trade.py` broadcasts **real RXD mainnet value** on the retired
  SPV-oracle path (the one with known, won't-fix any-wallet-parser findings).
- The current HTLC `SwapCoordinator` path had **no example at all**.

A contributor copying `examples/` would build the wrong, weaker, non-atomic
construction. This PR surfaces the current path and warns off the deprecated one.

## Changes

- **`examples/htlc_swap_demo.py` (new)** — a **no-network** walkthrough of the
  current HTLC swap's Radiant asset leg: builds a real NFT HTLC covenant + the
  taker's hashlock claim spend + the maker's CSV refund spend with the production
  builders (`pyrxd.gravity.htlc_covenant` / `htlc_spend`), prints the maker/taker
  secret roles and the `t_counterchain > t_rxd + margin` invariant, and
  structurally validates the txs. Points to `SwapCoordinator` + the e2e harnesses
  for the full two-chain flow. Runs anywhere (synthetic UTXOs, like
  `partial_swap_demo.py`).
- **`examples/gravity_{swap_demo,full_trade,live_test}.py`** — clear `DEPRECATED`
  banners pointing to the HTLC example, the how-to, and the design-decision note.
- **`examples/README.md`** — the cross-chain section now **leads with the HTLC
  example**; the SPV demos are demoted to a marked *Deprecated* subsection.
- **`docs/how-to/build-a-cross-chain-swap.md`** — links the deprecated-design
  note so a reader of the guide is steered off the SPV-oracle path.

## Validation

- `examples/htlc_swap_demo.py` runs green — real 305-byte claim tx with the
  preimage embedded; v2 refund tx with covenant `nSequence=20`; all structural
  asserts pass.
- `ruff check` + `ruff format --check` clean on all touched examples.
- `scripts/check-no-private-links.py` passes; all doc/test link targets exist.
- Docs build unaffected (`sphinx-build`, no `-W`; the `solutions/` cross-ref
  pattern is already used by other how-tos).

No source (`src/pyrxd/`) changes — examples + docs only.