### PR TITLE
harden(swap): durable seen-store default in value harnesses + correct shipped-RXD-quorum docs

### DIFF
--- a/scripts/dust_swap_resume.py
+++ b/scripts/dust_swap_resume.py
@@ -32,6 +32,7 @@ from pyrxd.btc_wallet.keys import keypair_from_wif
 from pyrxd.btc_wallet.payment import BtcUtxo
 from pyrxd.gravity.htlc_covenant import build_htlc_covenant_rxd
 from pyrxd.gravity.radiant_leg import RadiantChainIO, RadiantCovenantLeg
+from pyrxd.gravity.seen_store import DurableSeenStore
 from pyrxd.gravity.swap_coordinator import (
     CoordinatorConfig,
     SwapCoordinator,
@@ -50,7 +51,6 @@ from pyrxd.security.types import Hex20, Txid
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 from _dust_swap_shared import (
     CapturingBroadcaster,
-    InMemSeen,
     SshTrFeeSource,
     confirm,
     measured_margin_from_mainnet,
@@ -211,12 +211,12 @@ async def resume(args) -> None:
         btc_leg=btc_leg,
         radiant_leg=rxd_leg,
         indexer=None,
-        seen_store=InMemSeen(),
-        # Single-process, single-shot, fresh-H-per-run: consciously accept the
-        # non-durable in-memory seen-store on this value-bearing network (SEEN-1).
-        # (Resume enters at BTC_LOCKED and never calls taker_funds_btc, so it neither
-        # reserves nor needs H — the guard still fires at construction, hence the opt-in.)
-        config=CoordinatorConfig(margin_policy=policy, accept_nondurable_seen=True),
+        # Durable (SQLite) H-freshness store co-located with the mode-600 recovery file
+        # (shares the run's reservations). Resume enters at BTC_LOCKED and never calls
+        # taker_funds_btc, so it neither reserves nor needs H — but the durable store keeps
+        # the SEEN-1 guard satisfied without the accept_nondurable_seen opt-in.
+        seen_store=DurableSeenStore(str(Path(args.keys_out).expanduser()) + ".seen.sqlite"),
+        config=CoordinatorConfig(margin_policy=policy),
     )
     print(f"  coordinator seeded at {coord.record.state.value}")
 

--- a/scripts/dust_swap_run.py
+++ b/scripts/dust_swap_run.py
@@ -46,6 +46,7 @@ from pyrxd.btc_wallet.keys import generate_keypair
 from pyrxd.btc_wallet.payment import BtcUtxo
 from pyrxd.gravity.htlc_covenant import build_htlc_covenant_rxd
 from pyrxd.gravity.radiant_leg import RadiantChainIO, RadiantCovenantLeg
+from pyrxd.gravity.seen_store import DurableSeenStore
 from pyrxd.gravity.swap_coordinator import (
     CoordinatorConfig,
     SwapCoordinator,
@@ -64,7 +65,6 @@ from pyrxd.security.types import Hex20, Txid
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 from _dust_swap_shared import (
     CapturingBroadcaster,
-    InMemSeen,
     SshTrFeeSource,
     StepReport,
     atomic_write_mode_600,
@@ -84,10 +84,10 @@ _STAGES = {
 _MAINNET_BTC_API = "https://mempool.space/api"
 
 
-# Helpers (CapturingBroadcaster, InMemSeen, SshTrFeeSource, StepReport, confirm,
+# Helpers (CapturingBroadcaster, SshTrFeeSource, StepReport, confirm,
 # atomic_write_mode_600, rxd_blockcount, measured_margin_from_mainnet) live in
 # _dust_swap_shared so the resume runner builds the SAME object graph. Imported at the
-# top of this file.
+# top of this file. (The durable seen-store is pyrxd.gravity.seen_store.DurableSeenStore.)
 
 
 # --------------------------------------------------------------------------- the run
@@ -284,10 +284,11 @@ async def run_dust_swap(args: argparse.Namespace) -> None:
         btc_leg=btc_leg,
         radiant_leg=rxd_leg,
         indexer=None,
-        seen_store=InMemSeen(),
-        # Single-process, single-shot, fresh-H-per-run: consciously accept the
-        # non-durable in-memory seen-store on this value-bearing network (SEEN-1).
-        config=CoordinatorConfig(margin_policy=policy, accept_nondurable_seen=True),
+        # Durable (SQLite) H-freshness store co-located with the mode-600 recovery file,
+        # so the SEEN-1 replay/free-option reservation survives a restart or a second
+        # process (durable-by-default; no accept_nondurable_seen opt-in needed).
+        seen_store=DurableSeenStore(str(Path(args.keys_out).expanduser()) + ".seen.sqlite"),
+        config=CoordinatorConfig(margin_policy=policy),
     )
 
     try:

--- a/scripts/eth_swap_run.py
+++ b/scripts/eth_swap_run.py
@@ -38,9 +38,10 @@ import urllib.request
 from pathlib import Path
 
 # scripts/ siblings (same import style as dust_swap_run.py / dust_swap_resume.py)
+from pyrxd.gravity.seen_store import DurableSeenStore
+
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 from _dust_swap_shared import (
-    InMemSeen,
     SshTrFeeSource,
     StepReport,
     atomic_write_mode_600,
@@ -426,13 +427,17 @@ async def run_sepolia_dust(args: argparse.Namespace) -> None:
     # accept_estimated_eth_margins: this is an operator-gated DUST run that consciously
     # accepts estimated-margin risk (is_measured=False) on negligible value (MEDIUM-1). A
     # real (non-dust) value-bearing ETH swap MUST use MarginPolicy.measured(...) instead.
-    cfg = CoordinatorConfig(margin_policy=policy, accept_nondurable_seen=True, accept_estimated_eth_margins=True)
+    # accept_estimated_eth_margins stays (a separate ETH-margin dust opt-in, MEDIUM-1);
+    # accept_nondurable_seen is dropped — the seen-store below is durable-by-default.
+    cfg = CoordinatorConfig(margin_policy=policy, accept_estimated_eth_margins=True)
     coord = SwapCoordinator(
         record=SwapRecord(state=SwapState.NEGOTIATED, terms=terms),
         counter_leg=eth_leg,
         radiant_leg=rxd_leg,
         indexer=indexer,
-        seen_store=InMemSeen(),
+        # Durable (SQLite) H-freshness store co-located with the mode-600 recovery file,
+        # so the SEEN-1 reservation survives a restart / second process (was InMemSeen).
+        seen_store=DurableSeenStore(str(Path(args.keys_out).expanduser()) + ".seen.sqlite"),
         config=cfg,
     )
 

--- a/src/pyrxd/gravity/watch/README.md
+++ b/src/pyrxd/gravity/watch/README.md
@@ -23,7 +23,7 @@ RecordStore ─┐                                    ┌─ AlertChannel (authe
 
 - **`decide.py`** — pure `decide(record, observations, policy, safety_window_blocks) → Decision`.
 - **`reconciler.py`** — the loop body: list active swaps → observe → decide → route pages. Per-swap-id single-flight; per-swap fail-closed (a failure becomes `PAGE_SQUEEZED`, the loop never crashes). The **daemon shell owns the sleep/poll loop**, so the brain never sleeps.
-- **`quorum.py`** — `ChainObserver` builds `Observations`. BTC depth is quorum-agreed (shell backs `BtcClaimSource.confirmations` with `MultiSourceBtcFundingReader`); RXD is single-source in v1 → every observation is `low_corroboration` (a false RXD read → a false *page*, never a false broadcast).
+- **`quorum.py`** — `ChainObserver` builds `Observations`. BTC depth is quorum-agreed (shell backs `BtcClaimSource.confirmations` with `MultiSourceBtcFundingReader`); RXD depth is now quorum-agreed too (shell backs it with `MultiSourceRxdChainSource` over ≥2 independent Radiant readers, wired by default). A corroborated RXD read clears `low_corroboration`; a single-source fallback stays flagged (a false RXD read → a false *page*, never a false broadcast).
 - **`alerts.py`** — `DedupAlerter` maps a `Decision` → severity + `Page`, deduped by `(swap_id, intent)`; dedup advances only after a successful send (transient channel failures retry).
 
 ## Intent truth table (`decide`)
@@ -50,7 +50,7 @@ the claim race is assessed even if `record.state` is still `BOTH_LOCKED`.
 ```python
 reconciler = Reconciler(
     store=record_store,                      # RecordStore: the operator's in-flight swaps
-    observer=ChainObserver(btc=btc_src, rxd=rxd_src),   # rxd_corroborated=False in v1
+    observer=ChainObserver(btc=btc_src, rxd=rxd_src, rxd_corroborated=True),  # True with a ≥2-source RXD quorum
     alerter=DedupAlerter(channel=alert_channel),
     policy=margin_policy,                    # gravity.swap_coordinator.MarginPolicy
     safety_window_blocks=6,
@@ -71,7 +71,7 @@ while True:                                  # ← the shell's loop, not the bra
 **Remaining (the todo):**
 
 - **Hard gate:** an external security audit **and** a genuine *two-party adversarial* run — every run so far is single-operator (a plumbing proof, not adversarial safety). Blocks all non-dust value.
-- **RXD multi-source quorum** (the recurring hard blocker): RXD is single-source today (one ssh-tr node; `ChainTracker` is BTC-only) so every RXD observation is `low_corroboration`. A 2nd independent source is the prerequisite to broaden autonomy beyond dust. `MultiSourceEthRpc` is the ETH analogue (single-source detection can *delay*, never lose, a page).
+- **RXD multi-source quorum — DONE (#187):** `MultiSourceRxdChainSource` composes ≥2 independent Radiant readers (MAX-aggregated covenant depth, reachability-gated absence, fail-closed below quorum), wired by default in `watchtower_run.py` (2-of-2 public ElectrumX) so a default tower run is `rxd_corroborated`. What remains is operational (run genuinely-independent endpoints) and that broadening autonomy *beyond dust* is still audit-gated. `MultiSourceEthRpc` is the still-open ETH analogue (single-source detection can *delay*, never lose, a page).
 - **Broaden autonomous actions** (each audit-gated; each needs the live capped-fee-key custody seam `RadiantLeg.fee_source`): RXD-covenant refund (not pre-signable), `mutual_refund` (two broadcasts), the autonomous **claim** (`taker_scrape_and_claim_asset` — scrape `p`, fire a reorg-gated Glyph claim before `t_rxd`; highest value, biggest lift), and ETH-leg autonomy (verify the real `EthHtlc.sol` `refund()` guard first).
 - **ETH polish:** wire `FinalityStallTracker` into the live tower (point-in-time finality only today; an across-time stall still SQUEEZES via the RXD deadline math).
 - **Residuals:** below-quorum-inside-window can co-fire claim+refund into a hold-that-loses (accepted residual: hold + CRITICAL operator fallback); dedup/`SeenStore` durability across restarts.

--- a/src/pyrxd/gravity/watch/adapters.py
+++ b/src/pyrxd/gravity/watch/adapters.py
@@ -138,10 +138,12 @@ class MultiSourceRxdChainSource:
     """Quorum ``RxdChainSource`` over N INDEPENDENT Radiant readers (the operator's own
     node + public ElectrumX servers), mirroring :class:`network.bitcoin.MultiSourceBtcFundingReader`.
 
-    RXD reads are single-source in v1, so every observation is flagged low-corroboration
-    (a wrong read → a false page, never a false broadcast). Composing >= ``quorum``
-    independent sources lets a lone lagging/lying/down source NOT drive a decision; wire
-    this and pass ``rxd_corroborated=True`` to the :class:`ChainObserver` to clear the flag.
+    A single RXD source is flagged low-corroboration (a wrong read → a false page, never a
+    false broadcast). Composing >= ``quorum`` independent sources lets a lone lagging/lying/down
+    source NOT drive a decision; wire this and pass ``rxd_corroborated=True`` to the
+    :class:`ChainObserver` to clear the flag. The daemon shell (``scripts/watchtower_run.py``)
+    wires this by default over 2 independent public ElectrumX endpoints, so a default tower run
+    is corroborated; a single-source run is the explicit fallback.
 
     Semantics (conservative; fail-closed toward NOT auto-acting):
 

--- a/src/pyrxd/gravity/watch/quorum.py
+++ b/src/pyrxd/gravity/watch/quorum.py
@@ -5,10 +5,14 @@ safety-critical input — the maker's BTC-claim *depth* — must be quorum-agree
 (conservative ``min`` across independent sources, fail-closed below quorum); the
 shell backs :class:`BtcClaimSource.confirmations` with
 ``network.bitcoin.MultiSourceBtcFundingReader`` (already built: ``min(depth)``,
-2-of-3, fail-closed). The RXD side is **single-source** in v1 (no Radiant
-multi-source primitive exists — Phase-0 finding), so every RXD-derived reading is
-flagged ``low_corroboration`` — a false RXD read causes a false *page*, never a
-false broadcast. Full RXD quorum is a v2 (autonomous) blocker.
+2-of-3, fail-closed). The RXD side is now **multi-source** too:
+:class:`pyrxd.gravity.watch.adapters.MultiSourceRxdChainSource` composes >= 2 independent
+Radiant readers (the operator's node + public ElectrumX), and the daemon shell wires it by
+default (``scripts/watchtower_run.py``, 2-of-2 public ElectrumX) — passing
+``rxd_corroborated=True`` clears the ``low_corroboration`` flag. A single-source RXD config
+is still permitted as a fallback and stays flagged ``low_corroboration`` (a false RXD read
+causes a false *page*, never a false broadcast). Corroboration clears the alert-path flag; it
+does **not** lift the executor's dust cap or the mainnet ``audit_cleared`` gate.
 
 This module defines the ports and the composing :class:`ChainObserver`; the
 concrete transports (mempool.space outspend for claim detection,
@@ -142,8 +146,10 @@ class ChainObserver(Observer):
     a :class:`RxdChainSource` into the :class:`Observations` that :func:`decide` consumes, routing by
     ``record.terms.counter_chain``. The RXD asset-lock derivation is shared across both directions.
 
-    ``rxd_corroborated`` is False in v1 (single RXD source) → every observation is flagged
-    ``low_corroboration``. Pass True only once a real ≥2-source RXD quorum exists (a v2 deliverable).
+    ``rxd_corroborated`` clears the per-observation ``low_corroboration`` flag. Pass True only with a
+    real ≥2-source RXD quorum (:class:`MultiSourceRxdChainSource`, ``corroborated=True``) — the
+    LOW-R2 guard below refuses it over a single source. A single-source RXD config leaves it False and
+    every observation flagged ``low_corroboration`` (a false read → a false page, never a broadcast).
     A swap is observed only if the source for its counter-chain was injected; otherwise ``observe``
     fails closed (the reconciler turns the error into a decision-required page, never a silent miss).
     """


### PR DESCRIPTION
## A4 — two parts (the second corrects a stale-doc premise)

### Part 1 — durable-by-default SEEN-1 in the value harnesses

`scripts/dust_swap_run.py`, `dust_swap_resume.py`, and `eth_swap_run.py` wired the
**non-durable** in-memory seen-store and consciously opted into it
(`accept_nondurable_seen=True`). A non-durable store loses the atomic
pre-broadcast H-reservation across a restart / second process, re-opening the
replay / free-option window (SEEN-1).

This flips all three to **`DurableSeenStore`** (the audited SQLite store,
`durable=True`), co-located with the mode-600 recovery file as
`<keys_out>.seen.sqlite`, and **drops the `accept_nondurable_seen` opt-in**.
Durability now survives a restart by construction — the prerequisite for the
planned two-host run (**B5**).

- `eth_swap_run.py` keeps its separate `accept_estimated_eth_margins` opt-in
  (an unrelated ETH-margin dust gate).
- The **regtest e2e tests keep `InMemSeen`** on purpose (zero value,
  single-process, ephemeral) — out of A4's "value harnesses" scope.

### Part 2 — correct the stale "RXD single-source v1 / v2 blocker" docs

The RXD multi-source quorum **already shipped** (#187:
`MultiSourceRxdChainSource` — MAX-aggregated covenant depth, reachability-gated
absence, fail-closed below quorum) **and is wired by default** in
`scripts/watchtower_run.py` (2-of-2 public ElectrumX, `rxd_corroborated=True`).
But `quorum.py`'s module + `ChainObserver` docstrings, the
`MultiSourceRxdChainSource` docstring, and `watch/README.md` all still claimed
"RXD is single-source in v1 / full quorum is a v2 blocker" — **under-selling a
shipped, audited security capability** and misleading an auditor (**B6** needs
accurate residuals).

Corrected to reflect shipped-and-default-on, keeping the honest residuals:
corroboration clears the **alert-path** flag but does **not** lift the executor's
dust cap or the mainnet `audit_cleared` gate, and broadening autonomy *beyond
dust* stays audit-gated. **No code-logic change** in Part 2 (docstrings/README
only).

## Validation

- `ruff check` + `py_compile` clean on all touched files.
- **95** seen-store / quorum / adapter / watch tests pass.
- `scripts/check-no-private-links.py` passes; no private project names in the diff.