### PR TITLE
feat(gravity): CappedFeeWalletSource — structural spend ceiling for autonomous RXD fees

### DIFF
--- a/docs/solutions/design-decisions/capped-fee-source-rxd-autonomy-trust-boundary.md
+++ b/docs/solutions/design-decisions/capped-fee-source-rxd-autonomy-trust-boundary.md
@@ -1,0 +1,96 @@
+---
+title: "CappedFeeWalletSource: a structural spend ceiling is the trust boundary for autonomous RXD fee-paying"
+category: design-decisions
+component: gravity / watchtower / fee-source
+tags:
+  - fee-source
+  - trust-boundary
+  - autonomy
+  - watchtower
+  - capped-spend
+  - structural-limit
+  - build-now-arm-never
+  - pre-audit
+date: 2026-06-14
+severity: medium
+symptom: >
+  Every future autonomous RXD action (an autonomous covenant claim/refund fired by the
+  watchtower) needs a key that can pay a miner fee. The only fee source that existed was the
+  UNCAPPED SshTrFeeSource, which carves a fresh fee UTXO from the operator's FULL wallet on
+  every call — so the worst-case spend of an autonomous, possibly-buggy, possibly-compromised
+  process is "the whole wallet". That is the wrong trust boundary to ever wire into a daemon.
+root_cause: >
+  A fee key wired into an autonomous loop is a standing authorisation to spend. The safety
+  question an auditor asks is not "is the spend logic correct?" but "what is the MOST this key
+  can spend if every software check is wrong?". With the uncapped source the answer is unbounded
+  (wallet balance). The fix is to make the ceiling STRUCTURAL — enforced by the chain, not by a
+  software counter a bug could skip.
+---
+
+# CappedFeeWalletSource — the structural ceiling for autonomous RXD fees
+
+## The decision
+
+Autonomous RXD fee-paying goes through **`CappedFeeWalletSource`**
+(`pyrxd.gravity.capped_fee_source`), a `FeeUtxoSource` backed by a **fixed, pre-funded pool**
+of small plain-RXD UTXOs. It can dispense **only the finite inventory it was constructed with**,
+so the most it can ever spend is its funded balance. The uncapped `SshTrFeeSource` is for
+**interactive, operator-confirmed** dust runs only and must **never** be wired into an
+autonomous tower as a stopgap.
+
+## Why the ceiling is *structural*, not just a check
+
+The source holds **only the small pool wallet's key**, never the operator's main wallet. The
+pool wallet has no other coins, so even if every software guard below were bypassed, the source
+cannot spend more than the pool's on-chain balance — the chain enforces it. That is the load
+bearing property: a software-only "stop at N photons" counter is one missed branch away from
+failing open; an empty wallet is not.
+
+Two **defense-in-depth** software guards sit on top:
+
+- **`total_cap_photons`** — a cumulative ceiling, so the operator can authorise spend *below*
+  the funded balance (fund 10 inputs, authorise 6 inputs' worth) and raise it only deliberately.
+- **`max_per_input_photons`** (optional) — refuses construction if any pool UTXO is larger than a
+  single fee should ever be, keeping the "a fee input is small" invariant structural rather than
+  assumed.
+
+## Dispense-once
+
+`next_fee_input()` **commits** each UTXO (advances a cursor); a dispensed input is never handed
+out again, even if the spend that consumed it is later abandoned. A dispensed-but-unused input is
+a conservative loss of one small pool UTXO — strictly better than the alternative failure, which
+is dispensing the same outpoint into two transactions and **double-spending the fee input**. When
+the pool is empty or the cap is reached, it raises `FeePoolExhaustedError` (a `RxdSdkError`
+subclass) and the caller must **fail closed** — page / refuse the autonomous action rather than
+reach for a larger wallet.
+
+## Build-now, arm-never (pre-audit posture)
+
+The primitive is **built and tested now** so the trust boundary exists in code and can be
+reasoned about by an auditor — but **no real pool key is wired into a running tower** until the
+external security audit clears. Until then it is exercised only with throwaway pools in
+`tests/test_capped_fee_source.py`. This mirrors the project rule that every value-bearing
+autonomy item stays dormant-by-construction pre-audit (the v2 watchtower's keyless refund is the
+same posture).
+
+## What an auditor must still verify (residual for the auditor brief)
+
+- The pool wallet is **genuinely isolated** from the operator's main funds (a separate key/seed,
+  no shared change path) — the structural guarantee is only as good as that isolation.
+- **Refill is a manual, audited operation**, never an automatic top-up from the main wallet (an
+  auto-refill would re-introduce the unbounded ceiling the cap exists to remove).
+- The caller (the autonomous spend path) **treats `FeePoolExhaustedError` as fail-closed** and
+  has no fallback to an uncapped source.
+- **The leg's type gate does not enforce "capped".** `RadiantCovenantLeg` accepts any
+  `FeeUtxoSource` (a `runtime_checkable` Protocol that only checks a `next_fee_input` method
+  exists by name), so the uncapped `SshTrFeeSource` passes the *same* gate as this class. "Autonomy
+  uses the capped source" is therefore wiring discipline, not a type guarantee — the future
+  autonomous wiring MUST assert the concrete `CappedFeeWalletSource` type (not just `FeeUtxoSource`)
+  so a wiring mistake or refactor cannot silently restore the unbounded-spend source.
+
+## See also
+
+- `pyrxd.gravity.capped_fee_source.CappedFeeWalletSource` — the implementation + module docstring.
+- `pyrxd.gravity.radiant_leg.FeeUtxoSource` — the `next_fee_input()` contract it satisfies.
+- The watchtower's autonomy notes in `src/pyrxd/gravity/watch/README.md` (each autonomous action
+  needs this fee-key custody seam).

--- a/src/pyrxd/__init__.py
+++ b/src/pyrxd/__init__.py
@@ -110,6 +110,7 @@ _LAZY_EXPORTS: dict[str, tuple[str, str]] = {
     "SwapState": ("pyrxd.gravity.swap_state", "SwapState"),
     "CounterChainLeg": ("pyrxd.gravity.counter_chain_leg", "CounterChainLeg"),
     "RadiantCovenantLeg": ("pyrxd.gravity.radiant_leg", "RadiantCovenantLeg"),
+    "CappedFeeWalletSource": ("pyrxd.gravity.capped_fee_source", "CappedFeeWalletSource"),
     "EthLeg": ("pyrxd.gravity.eth_leg", "EthLeg"),
     # Counter-chain registries (per-chain safety knobs; see the cross-chain how-to)
     "EvmChain": ("pyrxd.eth_wallet.chains", "EvmChain"),

--- a/src/pyrxd/gravity/__init__.py
+++ b/src/pyrxd/gravity/__init__.py
@@ -24,6 +24,7 @@ Public surface
 
 from __future__ import annotations
 
+from .capped_fee_source import CappedFeeWalletSource
 from .codehash import compute_p2sh_code_hash
 from .covenant import (
     CovenantArtifact,
@@ -59,6 +60,7 @@ from .types import (
 
 __all__ = [
     "ActiveOffer",
+    "CappedFeeWalletSource",
     "ClaimResult",
     "ConfirmationStatus",
     "CovenantArtifact",

--- a/src/pyrxd/gravity/capped_fee_source.py
+++ b/src/pyrxd/gravity/capped_fee_source.py
@@ -1,0 +1,212 @@
+"""CappedFeeWalletSource — the structural spend ceiling for autonomous RXD fee-paying.
+
+A :class:`pyrxd.gravity.radiant_leg.FeeUtxoSource` backed by a FIXED, pre-funded pool of
+small plain-RXD UTXOs with a hard total-spend ceiling. It is the trust boundary for every
+future autonomous RXD action: an autonomous covenant claim/refund needs a key that can pay a
+miner fee, and the question an auditor asks is "what is the worst this key can spend if the
+process is buggy or compromised?".
+
+Contrast with :class:`scripts._dust_swap_shared.SshTrFeeSource`, which carves a fresh fee UTXO
+of a fixed size from the operator's **full** wallet on every call — an *unbounded* total spend
+gated only by the wallet balance. Never wire that into an autonomous tower.
+
+This source instead can dispense **only the finite inventory it was constructed with**, so the
+most it can ever spend is its funded balance. That bound is *structural* — but it is only as
+strong as one operator deployment property this class **cannot itself verify**: the pool wallet
+key must be **isolated** from the operator's main funds (a separate key that controls only the
+small pool UTXOs). Given that isolation, the chain enforces the ceiling: the pool wallet holds
+no other coins, so even if every software guard below were bypassed, the source cannot overspend
+the pool. If the isolation assumption is violated (the pool key is the main-wallet key, or it
+later receives more coins) the ceiling is not real — see the design note's residual section.
+
+What this class *does* enforce in code, fail-closed at construction or dispense:
+
+* **plain-RXD, spendable inputs** — every pool input must be a bare P2PKH UTXO whose pkh matches
+  the input's WIF (so the pool key genuinely controls it and the spend builder, which signs a
+  P2PKH fee input, will succeed). This rejects a token UTXO (which would be destroyed if spent as
+  a fee) and a misconfigured (wif, utxo) pair that would strand the fee leg.
+* **dispense-once** — :meth:`next_fee_input` *commits* each UTXO (advances a cursor); a dispensed
+  input is never handed out again, even if the spend that consumed it is later abandoned. A
+  dispensed-but-unused input is a conservative loss of one small pool UTXO — never a double-spend
+  of a fee input across two transactions, which is the far worse failure.
+* **a cumulative cap** — ``total_cap_photons`` lets the operator authorise spend *below* the
+  funded balance (fund 10 inputs, authorise 6 inputs' worth) and raise it only deliberately.
+* **a per-input ceiling** (optional) — ``max_per_input_photons`` refuses construction if any pool
+  UTXO is larger than a single fee should ever be, keeping inputs small by construction.
+
+When the pool is empty or the cap is reached, :meth:`next_fee_input` raises
+:class:`FeePoolExhaustedError` (fail-closed): the caller pages / refuses the autonomous action
+rather than dipping into a larger wallet.
+
+**Build-now, arm-never (pre-audit).** This primitive is built and tested so the trust boundary
+exists in code, but wire NO real pool key into a running tower until the external security audit
+clears. Until then it is exercised only with throwaway pools in tests.
+"""
+
+from __future__ import annotations
+
+import threading
+
+from pyrxd.gravity.htlc_spend import FeeInput
+from pyrxd.keys import PrivateKey
+from pyrxd.security.errors import FeePoolExhaustedError, ValidationError
+from pyrxd.security.types import Hex20
+
+__all__ = ["CappedFeeWalletSource"]
+
+_P2PKH_PREFIX = b"\x76\xa9\x14"  # OP_DUP OP_HASH160 <push-20>
+_P2PKH_SUFFIX = b"\x88\xac"  # OP_EQUALVERIFY OP_CHECKSIG
+
+
+def _p2pkh_pkh(spk: bytes) -> bytes | None:
+    """Return the 20-byte pubkey-hash iff ``spk`` is exactly a bare P2PKH script, else None."""
+    if len(spk) == 25 and spk[:3] == _P2PKH_PREFIX and spk[23:] == _P2PKH_SUFFIX:
+        return spk[3:23]
+    return None
+
+
+class CappedFeeWalletSource:
+    """A capped :class:`~pyrxd.gravity.radiant_leg.FeeUtxoSource` over a fixed pre-funded pool.
+
+    Parameters
+    ----------
+    pool:
+        The pre-funded inventory: small plain-RXD :class:`~pyrxd.gravity.htlc_spend.FeeInput`
+        UTXOs the capped-pool wallet owns. Each must be a bare P2PKH UTXO whose pkh matches its
+        own WIF (validated). Must be non-empty and free of duplicate outpoints (a duplicate would
+        double-spend).
+    total_cap_photons:
+        Hard cumulative ceiling on dispensed value. Dispensing stops once the next input would
+        push the running total over this — *before* handing it out.
+    max_per_input_photons:
+        Optional per-input ceiling. If given, construction fails when any pool UTXO exceeds it,
+        keeping the "a fee input is small" invariant structural rather than assumed.
+    """
+
+    def __init__(
+        self,
+        pool: list[FeeInput] | tuple[FeeInput, ...],
+        *,
+        total_cap_photons: int,
+        max_per_input_photons: int | None = None,
+    ) -> None:
+        pool = tuple(pool)  # immutable inventory — cannot be grown after construction
+        if not pool:
+            raise ValidationError("CappedFeeWalletSource pool must be a non-empty list of FeeInput")
+        if not all(isinstance(x, FeeInput) for x in pool):
+            raise ValidationError("CappedFeeWalletSource pool must contain only FeeInput objects")
+        outpoints = [(x.txid, x.vout) for x in pool]
+        if len(set(outpoints)) != len(outpoints):
+            raise ValidationError(
+                "CappedFeeWalletSource pool contains a duplicate outpoint — the same UTXO "
+                "dispensed twice would double-spend the fee input"
+            )
+        if not isinstance(total_cap_photons, int) or isinstance(total_cap_photons, bool) or total_cap_photons <= 0:
+            raise ValidationError("total_cap_photons must be a positive int")
+        if max_per_input_photons is not None:
+            if (
+                not isinstance(max_per_input_photons, int)
+                or isinstance(max_per_input_photons, bool)
+                or max_per_input_photons <= 0
+            ):
+                raise ValidationError("max_per_input_photons must be a positive int or None")
+            oversized = [x for x in pool if x.value > max_per_input_photons]
+            if oversized:
+                raise ValidationError(
+                    f"{len(oversized)} pool input(s) exceed max_per_input_photons={max_per_input_photons}; "
+                    "the small-balance invariant must hold structurally — re-carve the pool into smaller UTXOs"
+                )
+        # Every input must be a bare P2PKH UTXO the pool key genuinely controls: the spend builder
+        # signs a P2PKH fee input (htlc_spend._fee_input), so a non-P2PKH script (e.g. a token UTXO,
+        # which would be DESTROYED if spent as a fee) or a wif that does not own the script is a
+        # fail-closed construction error, not a spend-time surprise.
+        for x in pool:
+            pkh = _p2pkh_pkh(bytes(x.scriptpubkey))
+            if pkh is None:
+                raise ValidationError(
+                    f"pool input {x.txid}:{x.vout} scriptpubkey is not a bare P2PKH — a capped fee pool "
+                    "must hold only plain-RXD P2PKH UTXOs (a token UTXO would be destroyed if spent as a fee)"
+                )
+            try:
+                owner_pkh = bytes(Hex20(PrivateKey(x.wif).public_key().hash160()))
+            except Exception as exc:  # malformed WIF / key
+                raise ValidationError(f"pool input {x.txid}:{x.vout} has an invalid WIF") from exc
+            if pkh != owner_pkh:
+                raise ValidationError(
+                    f"pool input {x.txid}:{x.vout} WIF does not control its scriptpubkey (pkh mismatch) — "
+                    "the pool key cannot spend this UTXO and the fee leg would be stranded"
+                )
+        self._lock = threading.Lock()
+        # Name-mangled so the dispense-once cursor and the cap counter are not silently reset by a
+        # stray in-process assignment (defense-in-depth; the load-bearing bound is still the chain).
+        self.__pool: tuple[FeeInput, ...] = pool
+        self.__cursor = 0  # index of the next un-dispensed input; dispense-once advances it
+        self.__cap = total_cap_photons
+        self.__dispensed_photons = 0
+        self.__funded_photons = sum(x.value for x in pool)
+
+    # -- introspection (a tower pages when the pool runs low) ------------------------------
+    @property
+    def total_cap_photons(self) -> int:
+        """The configured cumulative software ceiling."""
+        return self.__cap
+
+    @property
+    def funded_photons(self) -> int:
+        """Total value of the pre-funded pool. This is the ceiling **only if** the pool key is
+        isolated from the operator's main wallet (a deployment property this class cannot verify —
+        see the module docstring and the design note's residuals)."""
+        return self.__funded_photons
+
+    @property
+    def dispensed_photons(self) -> int:
+        """Cumulative value handed out so far."""
+        with self._lock:
+            return self.__dispensed_photons
+
+    @property
+    def remaining_inputs(self) -> int:
+        """Count of pool UTXOs not yet dispensed (physical inventory; some may be blocked by the
+        cap — see :attr:`remaining_photons` for the actually-spendable budget)."""
+        with self._lock:
+            return len(self.__pool) - self.__cursor
+
+    @property
+    def remaining_photons(self) -> int:
+        """Photons that :meth:`next_fee_input` will actually dispense from here — the in-order
+        prefix of remaining inputs that fits under the cap. Dispensing is in-order and stops at the
+        first input that would exceed the cap (head-of-line), so this is 0 once the next input no
+        longer fits, giving a tower an honest "page now" signal that matches dispense behaviour."""
+        with self._lock:
+            spendable = 0
+            running = self.__dispensed_photons
+            for x in self.__pool[self.__cursor :]:
+                if running + x.value > self.__cap:
+                    break  # in-order: the head blocks; nothing behind it is reachable either
+                running += x.value
+                spendable += x.value
+            return spendable
+
+    # -- the FeeUtxoSource surface ---------------------------------------------------------
+    def next_fee_input(self) -> FeeInput:
+        """Dispense (commit) the next pool UTXO.
+
+        Raises :class:`FeePoolExhaustedError` — fail-closed — when the pool is empty or the
+        next input would exceed ``total_cap_photons``. Dispense-once: the returned UTXO is
+        never returned again.
+        """
+        with self._lock:
+            if self.__cursor >= len(self.__pool):
+                raise FeePoolExhaustedError(
+                    f"capped fee pool exhausted: all {len(self.__pool)} pre-funded input(s) dispensed "
+                    f"({self.__dispensed_photons} photons). Re-fund the capped pool to continue."
+                )
+            nxt = self.__pool[self.__cursor]
+            if self.__dispensed_photons + nxt.value > self.__cap:
+                raise FeePoolExhaustedError(
+                    f"capped fee cap reached: dispensing {nxt.value} photons would exceed "
+                    f"total_cap_photons={self.__cap} (already dispensed {self.__dispensed_photons}). Fail-closed."
+                )
+            self.__cursor += 1
+            self.__dispensed_photons += nxt.value
+            return nxt

--- a/src/pyrxd/security/errors.py
+++ b/src/pyrxd/security/errors.py
@@ -150,6 +150,17 @@ class PolicyRejection(CovenantError):
     """
 
 
+class FeePoolExhaustedError(RxdSdkError):
+    """Raised by a capped fee source when it refuses to dispense another fee UTXO —
+    the pre-funded pool is empty or the configured total-spend cap would be exceeded.
+
+    Fail-closed: the caller (e.g. an autonomous covenant spend) must surface this and
+    refuse/page rather than fall back to an uncapped wallet. This is the structural
+    spend ceiling for autonomous RXD fee-paying (see
+    ``pyrxd.gravity.capped_fee_source.CappedFeeWalletSource``).
+    """
+
+
 class UnsupportedScriptError(RxdSdkError):
     """Raised when the script engine encounters an opcode or script type it
     does not fully implement.

--- a/tests/test_capped_fee_source.py
+++ b/tests/test_capped_fee_source.py
@@ -1,0 +1,252 @@
+"""Tests for CappedFeeWalletSource — the structural spend ceiling for autonomous RXD fees.
+
+Focus: the ceiling is real (funded bound + software cap), dispense-once never double-spends
+(incl. under concurrency), every pool input is a spendable plain-RXD P2PKH the pool key owns,
+and every refusal fails closed with a typed FeePoolExhaustedError.
+"""
+
+from __future__ import annotations
+
+import os
+import threading
+
+import pytest
+
+from pyrxd.gravity.capped_fee_source import CappedFeeWalletSource
+from pyrxd.gravity.htlc_spend import FeeInput
+from pyrxd.gravity.radiant_leg import FeeUtxoSource
+from pyrxd.keys import PrivateKey
+from pyrxd.security.errors import FeePoolExhaustedError, RxdSdkError, ValidationError
+from pyrxd.security.types import Hex20
+
+# A real (generated) pool key — never hand-write key material. A pool wallet has ONE key that
+# owns many UTXOs, so all inputs share this key's P2PKH script; only the outpoints differ.
+_KEY = PrivateKey(os.urandom(32))
+_WIF = _KEY.wif()
+_SPK = b"\x76\xa9\x14" + bytes(Hex20(_KEY.public_key().hash160())) + b"\x88\xac"
+
+
+def _p2pkh_spk(key: PrivateKey) -> bytes:
+    return b"\x76\xa9\x14" + bytes(Hex20(key.public_key().hash160())) + b"\x88\xac"
+
+
+def _fee(value: int, *, txid: str | None = None, vout: int = 0, wif: str = _WIF, spk: bytes = _SPK) -> FeeInput:
+    return FeeInput(txid=txid or os.urandom(32).hex(), vout=vout, value=value, scriptpubkey=spk, wif=wif)
+
+
+def _pool(*values: int) -> list[FeeInput]:
+    return [_fee(v) for v in values]
+
+
+# --------------------------------------------------------------------------- conformance
+
+
+def test_satisfies_feeutxosource_protocol():
+    src = CappedFeeWalletSource(_pool(1000), total_cap_photons=1000)
+    assert isinstance(src, FeeUtxoSource)  # the RadiantCovenantLeg gate accepts it
+
+
+def test_dispenses_pool_in_order():
+    pool = _pool(1000, 2000, 3000)
+    src = CappedFeeWalletSource(pool, total_cap_photons=10_000)
+    got = [src.next_fee_input() for _ in range(3)]
+    assert [f.value for f in got] == [1000, 2000, 3000]
+    assert [f.txid for f in got] == [f.txid for f in pool]  # same objects, in order
+
+
+# --------------------------------------------------------------------------- exhaustion + dispense-once
+
+
+def test_exhaustion_raises_fail_closed():
+    src = CappedFeeWalletSource(_pool(1000, 1000), total_cap_photons=1_000_000)
+    src.next_fee_input()
+    src.next_fee_input()
+    with pytest.raises(FeePoolExhaustedError, match="exhausted"):
+        src.next_fee_input()
+
+
+def test_dispense_once_never_repeats_an_outpoint():
+    src = CappedFeeWalletSource(_pool(*([1000] * 5)), total_cap_photons=1_000_000)
+    seen = set()
+    for _ in range(5):
+        f = src.next_fee_input()
+        key = (f.txid, f.vout)
+        assert key not in seen, "an outpoint was dispensed twice — would double-spend"
+        seen.add(key)
+
+
+def test_concurrent_dispense_no_double_and_no_premature_exhaustion():
+    # The lock exists to make the check-and-advance atomic so the same outpoint is never dispensed
+    # twice (the "far worse failure"). Exercise it under real concurrency — a refactor that drops
+    # the lock must fail this.
+    n = 50
+    src = CappedFeeWalletSource(_pool(*([1000] * n)), total_cap_photons=1000 * n)
+    got: list[tuple[str, int]] = []
+    errors: list[Exception] = []
+    guard = threading.Lock()
+
+    def worker() -> None:
+        try:
+            f = src.next_fee_input()
+            with guard:
+                got.append((f.txid, f.vout))
+        except Exception as e:
+            with guard:
+                errors.append(e)
+
+    threads = [threading.Thread(target=worker) for _ in range(n)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+    assert not errors, errors  # exactly n inputs, none should have raised
+    assert len(got) == n
+    assert len(set(got)) == n  # no outpoint handed out twice
+
+
+def test_exhaustion_error_is_catchable_as_sdk_error():
+    src = CappedFeeWalletSource(_pool(1000), total_cap_photons=1000)
+    src.next_fee_input()
+    with pytest.raises(RxdSdkError):  # FeePoolExhaustedError subclasses the SDK base
+        src.next_fee_input()
+
+
+# --------------------------------------------------------------------------- the cap binds
+
+
+def test_cap_refuses_before_overspending_even_with_inputs_left():
+    # pool has 30k available, but the cap authorises only 20k.
+    src = CappedFeeWalletSource(_pool(10_000, 10_000, 10_000), total_cap_photons=20_000)
+    src.next_fee_input()  # 10k
+    src.next_fee_input()  # 20k
+    assert src.remaining_inputs == 1  # a pool UTXO is still physically there...
+    with pytest.raises(FeePoolExhaustedError, match="cap reached"):
+        src.next_fee_input()  # ...but the cap fails closed first
+    assert src.dispensed_photons == 20_000  # never over-dispensed
+
+
+def test_cap_at_exact_boundary():
+    src = CappedFeeWalletSource(_pool(10_000, 10_000, 10_000), total_cap_photons=20_000)
+    assert src.next_fee_input().value == 10_000
+    assert src.next_fee_input().value == 10_000
+    with pytest.raises(FeePoolExhaustedError):
+        src.next_fee_input()
+
+
+def test_dispensed_never_exceeds_cap_or_funded():
+    src = CappedFeeWalletSource(_pool(*([1000] * 10)), total_cap_photons=4500)
+    with pytest.raises(FeePoolExhaustedError):
+        for _ in range(10):
+            src.next_fee_input()
+    assert src.dispensed_photons <= 4500
+    assert src.dispensed_photons <= src.funded_photons
+
+
+# --------------------------------------------------------------------------- introspection
+
+
+def test_funded_photons_is_pool_sum():
+    src = CappedFeeWalletSource(_pool(1000, 2000, 3000), total_cap_photons=100_000)
+    assert src.funded_photons == 6000  # arithmetic sum; the *real* ceiling also needs key isolation
+
+
+def test_remaining_photons_is_in_order_dispensable_prefix():
+    # cap 4000 over [1000,2000,3000]: 1000+2000 fit (3000); the 3000 input would exceed -> stops.
+    src = CappedFeeWalletSource(_pool(1000, 2000, 3000), total_cap_photons=4000)
+    assert src.remaining_photons == 3000  # NOT 4000 — the 3rd input is head-of-line blocked
+    assert src.remaining_inputs == 3  # physical inventory unchanged
+    assert src.next_fee_input().value == 1000
+    assert src.remaining_photons == 2000  # [2000] fits, [3000] still blocked
+    assert src.dispensed_photons == 1000
+
+
+def test_remaining_photons_bounded_by_pool_when_cap_is_huge():
+    src = CappedFeeWalletSource(_pool(1000, 2000), total_cap_photons=100_000)
+    assert src.remaining_photons == 3000  # the whole funded pool fits under the huge cap
+
+
+def test_remaining_photons_is_zero_when_next_input_blocked_by_cap():
+    # The paging-footgun fix: cap=4500 over uniform 1000s. After 4 dispenses, dispensed=4000; the
+    # 5th (1000) would hit 5000>4500 and raise. remaining_photons must read 0 (honest "page now"),
+    # not 500 — it tracks what next_fee_input will ACTUALLY dispense, not raw leftover headroom.
+    src = CappedFeeWalletSource(_pool(*([1000] * 10)), total_cap_photons=4500)
+    for _ in range(4):
+        src.next_fee_input()
+    assert src.dispensed_photons == 4000
+    assert src.remaining_photons == 0  # honest: the next input cannot be dispensed
+    assert src.remaining_inputs == 6  # physical inventory remains
+    with pytest.raises(FeePoolExhaustedError):
+        src.next_fee_input()
+
+
+# --------------------------------------------------------------------------- construction validation
+
+
+def test_rejects_empty_pool():
+    with pytest.raises(ValidationError, match="non-empty"):
+        CappedFeeWalletSource([], total_cap_photons=1000)
+
+
+def test_rejects_non_feeinput():
+    with pytest.raises(ValidationError, match="FeeInput"):
+        CappedFeeWalletSource(["not-a-feeinput"], total_cap_photons=1000)
+
+
+def test_rejects_duplicate_outpoint():
+    txid = os.urandom(32).hex()
+    dup = [_fee(1000, txid=txid, vout=0), _fee(1000, txid=txid, vout=0)]
+    with pytest.raises(ValidationError, match="duplicate outpoint"):
+        CappedFeeWalletSource(dup, total_cap_photons=1_000_000)
+
+
+def test_same_txid_different_vout_is_allowed():
+    txid = os.urandom(32).hex()
+    pool = [_fee(1000, txid=txid, vout=0), _fee(1000, txid=txid, vout=1)]
+    src = CappedFeeWalletSource(pool, total_cap_photons=1_000_000)
+    assert src.remaining_inputs == 2
+
+
+def test_rejects_non_p2pkh_input():
+    # a non-bare-P2PKH script (e.g. a token / non-standard UTXO) would be destroyed if spent as a fee.
+    bad = FeeInput(txid=os.urandom(32).hex(), vout=0, value=1000, scriptpubkey=b"\x51\x51", wif=_WIF)
+    with pytest.raises(ValidationError, match="bare P2PKH"):
+        CappedFeeWalletSource([bad], total_cap_photons=1_000_000)
+
+
+def test_rejects_wif_not_controlling_the_utxo():
+    # spk owned by a DIFFERENT key than the wif → the pool key can't spend it (stranded fee leg).
+    other = PrivateKey(os.urandom(32))
+    bad = FeeInput(txid=os.urandom(32).hex(), vout=0, value=1000, scriptpubkey=_p2pkh_spk(other), wif=_WIF)
+    with pytest.raises(ValidationError, match="pkh mismatch"):
+        CappedFeeWalletSource([bad], total_cap_photons=1_000_000)
+
+
+@pytest.mark.parametrize("bad", [0, -1, True, 1.5])
+def test_rejects_nonpositive_or_nonint_cap(bad):
+    with pytest.raises(ValidationError, match="total_cap_photons"):
+        CappedFeeWalletSource(_pool(1000), total_cap_photons=bad)
+
+
+def test_rejects_oversized_input_when_max_set():
+    pool = _pool(1000, 9_999_999)
+    with pytest.raises(ValidationError, match="max_per_input_photons"):
+        CappedFeeWalletSource(pool, total_cap_photons=100_000_000, max_per_input_photons=1_000_000)
+
+
+def test_accepts_when_all_within_max_per_input():
+    src = CappedFeeWalletSource(_pool(1000, 5000), total_cap_photons=100_000, max_per_input_photons=10_000)
+    assert src.remaining_inputs == 2
+
+
+@pytest.mark.parametrize("bad", [0, -5, True])
+def test_rejects_bad_max_per_input(bad):
+    with pytest.raises(ValidationError, match="max_per_input_photons"):
+        CappedFeeWalletSource(_pool(1000), total_cap_photons=1000, max_per_input_photons=bad)
+
+
+def test_cannot_grow_inventory_via_constructor_list_mutation():
+    # the pool is copied to an immutable tuple; mutating the caller's list must not add inventory.
+    caller_list = _pool(1000, 1000)
+    src = CappedFeeWalletSource(caller_list, total_cap_photons=1_000_000)
+    caller_list.append(_fee(1000))
+    assert src.remaining_inputs == 2  # unaffected by the post-construction append


### PR DESCRIPTION
## B4 — the trust boundary for autonomous RXD fee-paying

An autonomous watchtower covenant claim/refund needs a key that can pay a miner fee. The
only existing fee source is the **uncapped** `SshTrFeeSource`, which carves unbounded fee
UTXOs from the operator's **full** wallet — the wrong worst-case to ever wire into a daemon.

**`CappedFeeWalletSource`** (`pyrxd.gravity.capped_fee_source`) is a `FeeUtxoSource` backed
by a **fixed, pre-funded pool** of small plain-RXD UTXOs. It can dispense only the finite
inventory it was constructed with, so — given an **isolated pool key** — the chain enforces
the ceiling (the pool wallet holds no more coins) regardless of any software bug.

On top of that structural bound, enforced in code, fail-closed:

- **plain-RXD P2PKH validation** — every pool input must be a bare P2PKH UTXO whose pkh
  matches its own WIF, so a token UTXO (destroyed if spent as a fee) or a non-controlling
  wif (stranded fee leg) is a construction error, not a spend-time surprise;
- **dispense-once** — each UTXO is committed on hand-out and never re-dispensed;
- **`total_cap_photons`** — a cumulative ceiling to authorise spend below the funded sum;
- **`max_per_input_photons`** (optional) — rejects an oversized pool UTXO at construction.

Exhaustion / cap raises **`FeePoolExhaustedError`** (new, `RxdSdkError` subclass) — the
caller fails closed rather than reaching for a larger wallet.

> **Build-now, arm-never.** Built + tested so the boundary exists in code, but **no real
> pool key is wired into a running tower** until the external audit clears.

## Adversarial review (3 lenses)

Reviewed by a 3-lens adversarial pass (cap-integrity / trust-boundary / claims-vs-tests). It
confirmed **no over-cap, no double-dispense, no WIF leak, no fail-open, sound locking**, and
drove these hardening fixes:

- `remaining_photons` now reports the truly-dispensable **in-order prefix** (was raw
  headroom — a tower could be misled into a spend that then raised);
- pool stored as an **immutable tuple** + guard state **name-mangled** (tamper-resistance);
- the **"structural"** claim is **qualified**: the ceiling holds only under operator key
  isolation, a deployment property this class cannot verify (module docstring + design note);
- added a **concurrency test** (the lock's no-double-dispense branch was untested);
- documented the residual that the leg's `FeeUtxoSource` gate can't distinguish capped from
  uncapped, so future autonomous wiring must assert the concrete type.

## Validation

- **29** unit tests (cap, exhaustion, dispense-once incl. concurrency, P2PKH/wif validation,
  the paging-fix, all construction guards).
- `mypy` (security gate) + `ruff` + `scripts/check-no-private-links.py` clean.
- `import pyrxd` stays lazy (the new module is not eagerly loaded).

Design note: `docs/solutions/design-decisions/capped-fee-source-rxd-autonomy-trust-boundary.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)