### PR TITLE
feat(watch): wire FinalityStallTracker into the live ETH alert path (A8)

### DIFF
--- a/src/pyrxd/eth_wallet/rpc.py
+++ b/src/pyrxd/eth_wallet/rpc.py
@@ -189,6 +189,15 @@ class EthRpc:
             raise NetworkError(f"incoherent finalized={fin} > latest head={head}; refusing (fail-closed)")
         return fin
 
+    async def block_number(self) -> int:
+        """The current ``latest`` head block number (``eth_blockNumber``). Used alongside
+        :meth:`finalized_block_number` to feed the across-time PoS finality-stall tracker the
+        ``(head, finalized)`` pair (a frozen ``finalized`` while the head climbs = a stall)."""
+        try:
+            return int(await self._w3.eth.block_number)
+        except Exception as exc:
+            raise NetworkError(f"eth_blockNumber failed: {exc}") from exc
+
     async def canonical_block_hash(self, block_number: int) -> bytes:
         """The canonical block hash at ``block_number`` (eth_getBlockByNumber). Used to bind a
         receipt's claimed blockNumber to the canonical chain (red-team HIGH: receipt blockNumber on

--- a/src/pyrxd/gravity/finality.py
+++ b/src/pyrxd/gravity/finality.py
@@ -90,14 +90,15 @@ class CounterClaimFinality:
 class FinalityStallTracker:
     """RF-06 across-time stall detector for a finalized-checkpoint (PoS) counter leg.
 
-    ⚠️ NOT WIRED INTO THE LIVE SWAP PATH (Phase-3 deferred — red-team). This class is built and
-    unit-tested (tests/test_finality_verdict.py) but the production ``SwapCoordinator`` does NOT
-    yet feed it samples: the running ETH↔RXD swap relies on the point-in-time
-    ``claim_finality_verdict`` only, so a sustained PoS finality stall ("finalized" frozen while
-    the head advances) is NOT currently auto-detected end-to-end. Do not assume across-time
-    stall protection is active. Wiring = a poll-loop that calls ``observe(...)`` each sample and
-    routes ``COUNTER_CHAIN_NOT_FINALIZING`` into the coordinator's SQUEEZE path; tracked as a
-    Phase-4 follow-up, NOT part of the current merge. Keep this banner until it is wired.
+    WIRED INTO THE LIVE WATCHTOWER ALERT PATH (A8): the watchtower's ``ChainObserver`` holds one
+    tracker per ``swap_id`` and feeds it the current ``(head, finalized)`` each tick (via the ETH
+    source's ``finality_checkpoint()`` capability), so a sustained PoS finality stall ("finalized"
+    frozen while the head advances) upgrades ``NOT_YET_FINAL_LIVE`` → ``COUNTER_CHAIN_NOT_FINALIZING``,
+    which ``decide()`` routes to an earlier SQUEEZE page. This is ALERT-ONLY — it sharpens/advances a
+    page; the tower broadcasts nothing and there is NO autonomy change. (The production
+    ``SwapCoordinator``'s own one-shot claim path still consults only the point-in-time
+    ``claim_finality_verdict``; the across-time judgment lives in the polling tower, which is where
+    samples accrue across time.)
 
     ``claim_finality_verdict`` is deliberately a single POINT-IN-TIME observation and never
     emits ``COUNTER_CHAIN_NOT_FINALIZING`` (a single non-advance of ``finalized`` is normal —

--- a/src/pyrxd/gravity/watch/eth_adapters.py
+++ b/src/pyrxd/gravity/watch/eth_adapters.py
@@ -114,6 +114,27 @@ class RpcEthChainSource:
             raise NetworkError("a log from the HTLC contract is missing transactionHash; cannot identify the claim")
         return EthClaimStatus(claimed=True, claim_tx_hash=_to_0x_hash(tx_hash))
 
+    async def finality_checkpoint(self) -> tuple[int, int]:
+        """The current ``(head_block, finalized_block)`` checkpoint — the across-time stall input.
+
+        The point-in-time :meth:`claim_finality_verdict` only sees one ``finalized`` reading; a
+        genuine PoS finality STALL (``finalized`` frozen while the head climbs) can only be judged
+        across ticks. The watchtower observer feeds this pair to a per-swap
+        :class:`~pyrxd.gravity.finality.FinalityStallTracker` so a sustained stall upgrades
+        ``NOT_YET_FINAL_LIVE`` → ``COUNTER_CHAIN_NOT_FINALIZING`` (the gate then SQUEEZES). This is an
+        OPTIONAL capability (duck-typed; the observer probes for it) so a minimal source without it
+        keeps the point-in-time fast path unchanged — a missing checkpoint never INVENTS a stall.
+
+        ``finalized_block_number`` already rejects an incoherent ``finalized > head`` over-report
+        (fail-closed) and returns the same head it bounded against, so ``finalized <= head`` holds for
+        the tracker by construction."""
+        finalized = await self._rpc.finalized_block_number()  # rejects finalized > head (fail-closed)
+        head = await self._rpc.block_number()
+        # Defend the tracker's finalized <= head precondition against a head that regressed between the
+        # two reads (a reorg/lagging-replica race): clamp head up to finalized rather than feed an
+        # incoherent pair. A frozen finalized with head==finalized is simply "no stall" (gap 0).
+        return max(head, finalized), finalized
+
     async def claim_finality_verdict(self, claim_tx_hash: str) -> CounterClaimFinality:
         # VERDICT LOGIC identical to EthHtlcContractLeg.claim_finality_verdict (htlc_leg.py:438-460),
         # pinned by test_finality_verdict_parity_with_audited_leg. The ONE deliberate difference: a

--- a/src/pyrxd/gravity/watch/quorum.py
+++ b/src/pyrxd/gravity/watch/quorum.py
@@ -26,7 +26,7 @@ from dataclasses import dataclass
 from typing import Protocol, runtime_checkable
 
 from pyrxd.eth_wallet.locator import EthHtlcLocator
-from pyrxd.gravity.finality import CounterClaimFinality, CounterClaimState
+from pyrxd.gravity.finality import CounterClaimFinality, CounterClaimState, FinalityStallTracker
 from pyrxd.gravity.swap_state import SwapRecord, SwapState
 from pyrxd.gravity.watch.decide import Observations
 from pyrxd.gravity.watch.reconciler import Observer
@@ -124,6 +124,15 @@ class EthChainSource(Protocol):
         """The point-in-time finalized-checkpoint verdict for the maker's ETH claim tx."""
         ...
 
+    # OPTIONAL across-time capability (duck-typed; the observer probes for it via ``hasattr``, like
+    # the RXD source's ``corroborated`` attribute): a source MAY expose ``finality_checkpoint()`` ->
+    # ``(head_block, finalized_block)`` so the observer can feed a per-swap FinalityStallTracker and
+    # upgrade ``NOT_YET_FINAL_LIVE`` -> ``COUNTER_CHAIN_NOT_FINALIZING`` on a sustained PoS stall (the
+    # point-in-time verdict alone never can — a single non-advance of ``finalized`` is normal). A
+    # source WITHOUT it keeps the point-in-time fast path unchanged; a missing checkpoint never
+    # INVENTS a stall. ``RpcEthChainSource`` provides it; it is intentionally NOT a required Protocol
+    # method so a minimal point-in-time-only source stays a valid EthChainSource.
+
 
 @runtime_checkable
 class RxdChainSource(Protocol):
@@ -152,6 +161,16 @@ class ChainObserver(Observer):
     every observation flagged ``low_corroboration`` (a false read → a false page, never a broadcast).
     A swap is observed only if the source for its counter-chain was injected; otherwise ``observe``
     fails closed (the reconciler turns the error into a decision-required page, never a silent miss).
+
+    STATEFUL across ticks for ETH only: it holds ONE :class:`FinalityStallTracker` per ``swap_id``
+    (A8 / RF-06). The point-in-time ``claim_finality_verdict`` cannot see a *sustained* PoS finality
+    stall (``finalized`` frozen while the head climbs) because a single non-advance of ``finalized`` is
+    normal epoch lag; the tracker judges it across observations and upgrades a ``NOT_YET_FINAL_LIVE``
+    verdict to ``COUNTER_CHAIN_NOT_FINALIZING`` once the stall is sustained (``decide()`` then routes
+    that to an earlier SQUEEZE page). Per-swap-id isolation: one swap's stall run never bleeds into
+    another's. ALERT-ONLY — the only effect is a sharper/earlier page; no broadcast, no autonomy. The
+    upgrade requires the ETH source to expose the optional ``finality_checkpoint()`` capability; a
+    source without it keeps the unchanged point-in-time fast path.
     """
 
     def __init__(
@@ -183,6 +202,10 @@ class ChainObserver(Observer):
         self._eth = eth
         self._rxd = rxd
         self._rxd_corroborated = rxd_corroborated
+        # Per-swap-id RF-06 finality-stall trackers (ETH only), created lazily on first observation of
+        # each swap. STATEFUL across ticks; isolated per swap_id so one stall run cannot bleed into
+        # another. Only consulted when the ETH source exposes finality_checkpoint() (see below).
+        self._eth_stall_trackers: dict[str, FinalityStallTracker] = {}
 
     async def observe(self, swap_id: str, record: SwapRecord) -> Observations:
         tip = await self._rxd.tip_height()
@@ -199,7 +222,7 @@ class ChainObserver(Observer):
         low_corr = not self._rxd_corroborated
 
         if record.terms.counter_chain == "eth":
-            eth_detected, eth_finality = await self._observe_eth_claim(record)
+            eth_detected, eth_finality = await self._observe_eth_claim(swap_id, record)
             return Observations(
                 maker_has_claimed_btc=False,
                 now_rxd_height=tip,
@@ -235,11 +258,18 @@ class ChainObserver(Observer):
             low_corroboration=low_corr,
         )
 
-    async def _observe_eth_claim(self, record: SwapRecord) -> tuple[bool, CounterClaimState | None]:
+    async def _observe_eth_claim(self, swap_id: str, record: SwapRecord) -> tuple[bool, CounterClaimState | None]:
         """Detect the maker's ETH claim + its finalized-checkpoint verdict STATE. Returns
         ``(detected, finality_state)``. ``(False, None)`` when no ETH locator is present yet
         (pre-fund) or the contract is unclaimed; fails closed (raises) if no ETH source was injected
-        — the reconciler turns that into a decision-required page rather than a silent all-clear."""
+        — the reconciler turns that into a decision-required page rather than a silent all-clear.
+
+        A8 / RF-06 across-time stall: the point-in-time ``verdict`` is the fast path and unchanged;
+        when the source exposes the optional ``finality_checkpoint()`` capability, the per-``swap_id``
+        :class:`FinalityStallTracker` may UPGRADE a ``NOT_YET_FINAL_LIVE`` to
+        ``COUNTER_CHAIN_NOT_FINALIZING`` once a sustained stall is judged across ticks (a ``FINAL``
+        verdict is never touched; a single non-advance never trips). Alert-only — the only effect is
+        that ``decide()`` SQUEEZES earlier; nothing is broadcast."""
         if self._eth is None:
             raise ValidationError("ChainObserver has no EthChainSource for an ETH swap")
         locator = record.counterchain_locator
@@ -249,4 +279,25 @@ class ChainObserver(Observer):
         if not status.claimed or status.claim_tx_hash is None:
             return False, None
         verdict = await self._eth.claim_finality_verdict(status.claim_tx_hash)
+        verdict = await self._upgrade_eth_stall(swap_id, verdict)
         return True, verdict.state
+
+    async def _upgrade_eth_stall(self, swap_id: str, verdict: CounterClaimFinality) -> CounterClaimFinality:
+        """Feed the per-``swap_id`` :class:`FinalityStallTracker` this tick's ``(head, finalized)`` and
+        return the (possibly upgraded) verdict. A ``FINAL`` verdict short-circuits BEFORE any chain
+        read — a final claim is final regardless of a counter-chain stall. The upgrade is skipped (the
+        point-in-time verdict returned unchanged) when the ETH source does not expose the optional
+        ``finality_checkpoint()`` capability, so a minimal source keeps the unchanged fast path and a
+        missing checkpoint never INVENTS a stall. The tracker itself only ever upgrades
+        ``NOT_YET_FINAL_LIVE`` and resets on a fresh ``finalized`` (live again)."""
+        if verdict.state is CounterClaimState.FINAL:
+            return verdict
+        checkpoint = getattr(self._eth, "finality_checkpoint", None)
+        if checkpoint is None:
+            return verdict  # point-in-time-only source: no across-time judgment available
+        head_block, finalized_block = await checkpoint()
+        tracker = self._eth_stall_trackers.get(swap_id)
+        if tracker is None:
+            tracker = FinalityStallTracker()
+            self._eth_stall_trackers[swap_id] = tracker
+        return tracker.verdict(verdict, head_block=head_block, finalized_block=finalized_block)

--- a/tests/test_watch_eth_adapter.py
+++ b/tests/test_watch_eth_adapter.py
@@ -63,6 +63,7 @@ class _FakeEthRpc:
         finalized: int = 120,
         block_hash: bytes | None = b"\x11" * 32,
         canonical: bytes | None = b"\x11" * 32,
+        head: int | None = None,
     ) -> None:
         self._deploy_block = deploy_block
         self._logs = logs if logs is not None else []
@@ -70,6 +71,9 @@ class _FakeEthRpc:
         self._finalized_error = finalized_error
         self._status, self._block, self._finalized = status, block, finalized
         self._bh, self._canonical = block_hash, canonical
+        # `head` drives finality_checkpoint()'s latest-head read (eth_blockNumber). Defaults to
+        # finalized + 200 so a frozen finalized with a climbing head is the natural stall scenario.
+        self._head = head if head is not None else finalized + 200
         self.get_logs_calls: list[dict] = []
 
     async def get_transaction(self, tx_hash):
@@ -104,6 +108,9 @@ class _FakeEthRpc:
         if self._finalized_error is not None:
             raise self._finalized_error
         return self._finalized
+
+    async def block_number(self):  # eth_blockNumber — the latest head for finality_checkpoint()
+        return self._head
 
 
 class _FakeEthNs:
@@ -397,3 +404,40 @@ async def test_real_adapter_unclaimed_through_chain_observer():
     obs = await ChainObserver(eth=RpcEthChainSource(fake), rxd=FakeRxd(tip=200, cov_confs=101)).observe("s", rec)
     assert obs.eth_claim_detected is False
     assert obs.eth_claim_finality is None
+
+
+# ─────────────────────────────── A8: finality_checkpoint() + across-time stall via real adapter ──
+
+
+async def test_finality_checkpoint_returns_head_and_finalized():
+    # finality_checkpoint() surfaces (head, finalized) for the stall tracker; finalized <= head holds.
+    fake = _FakeEthRpc(deploy_block=10, finalized=900, head=1100)
+    head, finalized = await RpcEthChainSource(fake).finality_checkpoint()
+    assert (head, finalized) == (1100, 900)
+
+
+async def test_finality_checkpoint_clamps_a_head_that_regressed_below_finalized():
+    # A reorg/lagging-replica race where the head read comes back BELOW finalized must not yield an
+    # incoherent pair the tracker would reject — head is clamped up to finalized (gap 0 = no stall).
+    fake = _FakeEthRpc(deploy_block=10, finalized=1000, head=990)
+    head, finalized = await RpcEthChainSource(fake).finality_checkpoint()
+    assert finalized == 1000 and head == 1000  # clamped, finalized <= head holds
+
+
+async def test_real_adapter_sustained_stall_upgrades_to_not_finalizing_across_ticks():
+    # End-to-end through the REAL adapter: finalized frozen while the head climbs past the tracker's
+    # patience window upgrades NOT_YET_FINAL_LIVE -> COUNTER_CHAIN_NOT_FINALIZING, and decide() SQUEEZES.
+    # The point-in-time branch returns FINAL only when the claim tx_block <= finalized; here the claim
+    # is at block 100 while finalized is frozen at 50, so the point-in-time verdict stays
+    # NOT_YET_FINAL_LIVE every tick and only the across-time stall can upgrade it.
+    fake = _FakeEthRpc(deploy_block=10, logs=[_log(CLAIMED_TOPIC0, _CLAIM_HASH)], block=100, finalized=50, head=60)
+    observer = ChainObserver(eth=RpcEthChainSource(fake), rxd=FakeRxd(tip=150, cov_confs=51))
+    rec = _eth_record(state=SwapState.SECRET_REVEALED)
+
+    obs = await observer.observe("s", rec)  # establish the frozen-finalized run (gap 10, head 60)
+    assert obs.eth_claim_finality is CounterClaimState.NOT_YET_FINAL_LIVE
+    fake._head = 60 + 130  # head climbs +130 past patience while finalized(50) stays frozen; gap now 140
+    obs = await observer.observe("s", rec)
+    assert obs.eth_claim_finality is CounterClaimState.COUNTER_CHAIN_NOT_FINALIZING
+    d = decide(record=rec, observations=obs, policy=_eth_policy(), safety_window_blocks=6)
+    assert d.intent is Intent.PAGE_SQUEEZED

--- a/tests/test_watch_quorum.py
+++ b/tests/test_watch_quorum.py
@@ -357,3 +357,120 @@ def test_eth_claim_status_claimed_requires_hash():
     # The dead-branch invariant the observer relies on: a claimed status MUST carry the tx hash.
     with pytest.raises(ValidationError):
         EthClaimStatus(claimed=True)
+
+
+# --- A8 / RF-06: across-time finality-stall wiring into the ETH observer path ----------------------
+
+
+class FakeStallEth:
+    """An ETH source whose point-in-time verdict is always NOT_YET_FINAL_LIVE and that exposes the
+    optional ``finality_checkpoint()`` capability so the observer's per-swap FinalityStallTracker can
+    judge a stall across ticks. The test drives ``(head, finalized)`` between observations to simulate
+    a frozen ``finalized`` (a stall) or a healthy one (advancing)."""
+
+    def __init__(self) -> None:
+        self.head = 5_000
+        self.finalized = 4_900  # initial gap 100 (> 96 normal-lag), well under FINAL
+        self.checkpoint_calls = 0
+
+    async def claim_status(self, contract_address, deploy_tx_hash):
+        return EthClaimStatus(claimed=True, claim_tx_hash="0x" + "12" * 32)
+
+    async def claim_finality_verdict(self, claim_tx_hash):
+        # Point-in-time always "live, not yet final" — the stall is an ACROSS-TIME judgment only.
+        return CounterClaimFinality(state=CounterClaimState.NOT_YET_FINAL_LIVE)
+
+    async def finality_checkpoint(self):
+        self.checkpoint_calls += 1
+        return self.head, self.finalized
+
+
+async def test_eth_sustained_finality_stall_upgrades_to_not_finalizing_and_squeezes():
+    # A SUSTAINED stall (finalized frozen while the head climbs past the tracker's patience window
+    # with a wide gap) must upgrade NOT_YET_FINAL_LIVE -> COUNTER_CHAIN_NOT_FINALIZING across ticks,
+    # which decide() then SQUEEZES even with an ample t_rxd window (RF-06). One observer instance is
+    # reused across ticks (the per-swap tracker is its state).
+    eth = FakeStallEth()
+    observer = ChainObserver(eth=eth, rxd=FakeRxd(tip=150, cov_confs=51))
+    rec = _eth_record(state=SwapState.SECRET_REVEALED)
+
+    # Tick 1: establishes the frozen-finalized run; not yet a stall.
+    obs = await observer.observe("swap-A", rec)
+    assert obs.eth_claim_finality is CounterClaimState.NOT_YET_FINAL_LIVE
+    assert decide(record=rec, observations=obs, policy=_eth_policy(), safety_window_blocks=6).intent is Intent.WATCH
+
+    # The head climbs PAST the patience window (>128 slots) while finalized stays frozen → stall.
+    eth.head = 5_000 + 130  # gap now 230 (> 96) AND head progress 130 (>= 128)
+    obs = await observer.observe("swap-A", rec)
+    assert obs.eth_claim_finality is CounterClaimState.COUNTER_CHAIN_NOT_FINALIZING
+    d = decide(record=rec, observations=obs, policy=_eth_policy(), safety_window_blocks=6)
+    assert d.intent is Intent.PAGE_SQUEEZED  # earlier/sharper page, never WAITed out
+
+
+async def test_eth_single_non_advance_does_not_trip_the_stall():
+    # A single tick's non-advance of finalized is NORMAL epoch lag — it must NOT upgrade the verdict.
+    eth = FakeStallEth()
+    observer = ChainObserver(eth=eth, rxd=FakeRxd(tip=150, cov_confs=51))
+    rec = _eth_record(state=SwapState.SECRET_REVEALED)
+
+    obs = await observer.observe("swap-A", rec)  # establish the run
+    assert obs.eth_claim_finality is CounterClaimState.NOT_YET_FINAL_LIVE
+    eth.head = 5_000 + 50  # only 50 slots of head progress (< 128 patience) → no stall yet
+    obs = await observer.observe("swap-A", rec)
+    assert obs.eth_claim_finality is CounterClaimState.NOT_YET_FINAL_LIVE
+    assert decide(record=rec, observations=obs, policy=_eth_policy(), safety_window_blocks=6).intent is Intent.WATCH
+
+
+async def test_eth_stall_tracker_is_per_swap_id_isolated():
+    # Two swaps share one observer; a sustained stall on swap-A must NOT contaminate swap-B, whose own
+    # finalized is advancing healthily. Per-swap-id tracker state is the isolation boundary.
+    eth = FakeStallEth()
+    observer = ChainObserver(eth=eth, rxd=FakeRxd(tip=150, cov_confs=51))
+    rec = _eth_record(state=SwapState.SECRET_REVEALED)
+
+    # swap-A: drive it into a sustained stall (two ticks, finalized frozen, head past patience).
+    await observer.observe("swap-A", rec)
+    eth.head = 5_000 + 130
+    obs_a = await observer.observe("swap-A", rec)
+    assert obs_a.eth_claim_finality is CounterClaimState.COUNTER_CHAIN_NOT_FINALIZING
+
+    # swap-B is observed for the FIRST time at the SAME stalled checkpoint reading. Because its tracker
+    # is fresh, this is just the run-establishing sample → NOT a stall (no cross-contamination from A).
+    obs_b = await observer.observe("swap-B", rec)
+    assert obs_b.eth_claim_finality is CounterClaimState.NOT_YET_FINAL_LIVE
+
+    # And swap-B with a healthy ADVANCING finalized never trips, even as the head keeps climbing.
+    eth.finalized = 5_000  # finalized jumped forward → live again for B's next sample
+    eth.head = 5_000 + 200
+    obs_b = await observer.observe("swap-B", rec)
+    assert obs_b.eth_claim_finality is CounterClaimState.NOT_YET_FINAL_LIVE
+
+
+async def test_eth_final_verdict_unaffected_by_stall_and_skips_checkpoint_read():
+    # A FINAL point-in-time verdict is final regardless of any counter-chain stall — the observer must
+    # return it unchanged AND short-circuit before reading the checkpoint (a final claim needs none).
+    class FinalThenCheckpoint(FakeStallEth):
+        async def claim_finality_verdict(self, claim_tx_hash):
+            return CounterClaimFinality(state=CounterClaimState.FINAL)
+
+    eth = FinalThenCheckpoint()
+    observer = ChainObserver(eth=eth, rxd=FakeRxd(tip=150, cov_confs=51))
+    rec = _eth_record(state=SwapState.SECRET_REVEALED)
+    obs = await observer.observe("swap-A", rec)
+    assert obs.eth_claim_finality is CounterClaimState.FINAL
+    assert eth.checkpoint_calls == 0  # FINAL short-circuits before the checkpoint read
+
+
+async def test_eth_point_in_time_only_source_without_checkpoint_keeps_fast_path():
+    # A minimal EthChainSource WITHOUT the optional finality_checkpoint() capability is still valid:
+    # the observer keeps the unchanged point-in-time verdict (a missing checkpoint never invents a
+    # stall). FakeEth (above) has no finality_checkpoint method.
+    eth = FakeEth(
+        EthClaimStatus(claimed=True, claim_tx_hash="0x" + "12" * 32), finality=CounterClaimState.NOT_YET_FINAL_LIVE
+    )
+    assert not hasattr(eth, "finality_checkpoint")  # capability genuinely absent
+    observer = ChainObserver(eth=eth, rxd=FakeRxd(tip=150, cov_confs=51))
+    rec = _eth_record(state=SwapState.SECRET_REVEALED)
+    for _ in range(5):  # many ticks, still no stall judgment available → stays the point-in-time state
+        obs = await observer.observe("swap-A", rec)
+        assert obs.eth_claim_finality is CounterClaimState.NOT_YET_FINAL_LIVE


### PR DESCRIPTION
## A8 — across-time ETH finality-stall detection in the live tower

Residual `WATCH-STALLTRACKER` (low; alert-only). The watchtower's ETH path used only the **point-in-time** `finalized`-checkpoint verdict, which structurally **cannot** see a *sustained* PoS finality stall (`finalized` frozen while the head climbs) — a single non-advance of `finalized` is normal epoch lag. `FinalityStallTracker` existed and was unit-tested but carried a "⚠️ NOT WIRED INTO THE LIVE SWAP PATH" banner; `decide()` was already ready to route `COUNTER_CHAIN_NOT_FINALIZING → PAGE_SQUEEZED`. This wires the two together.

### What changed
- **`watch/quorum.py`** — `ChainObserver` now holds one `FinalityStallTracker` **per `swap_id`** (lazy, isolated). After the point-in-time read, `_upgrade_eth_stall()` feeds the tracker this tick's `(head, finalized)` and may upgrade `NOT_YET_FINAL_LIVE → COUNTER_CHAIN_NOT_FINALIZING` once a stall is *sustained*.
- **`watch/eth_adapters.py`** — `RpcEthChainSource.finality_checkpoint() → (head, finalized)` (clamps a regressed head so the tracker's `finalized ≤ head` precondition holds).
- **`eth_wallet/rpc.py`** — `EthRpc.block_number()` (the head read).
- **`gravity/finality.py`** — replaced the stale "NOT WIRED" banner with an accurate "wired (A8)" note (kept honest: the coordinator's own one-shot path still uses point-in-time only; the across-time judgment lives in the polling tower).

### Safe by construction
- The tracker only ever makes the verdict **more pessimistic** (→ earlier squeeze) — never less safe.
- `FINAL` short-circuits before any chain read.
- A source without the **optional, duck-typed** `finality_checkpoint()` keeps the unchanged fast path — a missing checkpoint never invents a stall.
- **Alert-only**: no `executor.py` / broadcast path touched. The only effect is a sharper/earlier page.

### Threshold (unchanged from the tested tracker)
`patience_slots=128` (4 epochs) + `max_normal_lag_slots=96` (3 epochs): a stall is declared only when `finalized` is frozen across ≥128 slots of head progress **and** the live gap >96. A single non-advance never trips; a fresh `finalized` resets the run.

### Tests (8 new, none skipped)
Sustained stall → `COUNTER_CHAIN_NOT_FINALIZING` → `decide()` SQUEEZES; single non-advance does **not** trip; **per-swap-id isolation** (swap A's stall doesn't contaminate swap B); `FINAL` unaffected + skips the checkpoint read; point-in-time-only source keeps the fast path; adapter checkpoint + head-clamp + end-to-end stall→SQUEEZE. Validation: ruff clean; watch subset **324 passed / 13 skipped** (pre-existing web3-gated skips); broader eth/rpc/watch **499 passed**.

### Two items flagged for review (not blockers)
1. **`_eth_stall_trackers` is not pruned on terminal swaps.** The reconciler observes only active swaps, so it grows by distinct in-flight `swap_id`s (tiny entries; bounded in practice; mirrors the alerter's dedup-state lifecycle). A hard cap / prune-on-terminal is a clean follow-up if wanted.
2. **Optional capability is duck-typed** (`hasattr finality_checkpoint`), not a required `Protocol` method — chosen so minimal/point-in-time-only sources (and `FakeEth`) stay valid `EthChainSource`s. Can be promoted to a required protocol method if preferred.