### PR TITLE
feat(eth): add Optimism / Arbitrum / Linea to the EVM registry; exclude Polygon PoS (A6)

### DIFF
--- a/docs/how-to/build-a-cross-chain-swap.md
+++ b/docs/how-to/build-a-cross-chain-swap.md
@@ -124,7 +124,7 @@ $ XCHAIN_ETH_REGTEST=1 pytest tests/test_xchain_eth_swap_regtest_e2e.py -m integ
 Two families are proven; adding a chain within either is a config change, while a new
 family is a deliberate effort.
 
-### EVM family — Base works today (no new code)
+### EVM family — Base, Optimism, Arbitrum, Linea work today (no new code)
 
 The proven `EthLeg` + `EthHtlc.sol` machinery is **chain-id-agnostic**: the same contract
 bytecode, the same `finalized`-checkpoint reads, the same claim/refund/scrape paths run on
@@ -157,6 +157,17 @@ case is the OP-stack **12-hour sequencing window** (a batch may legally land tha
 budget stalls in `CrossClockMargin.eth_finality_stall_tolerance_s`, exactly as for an L1
 finality stall — never by inflating the steady-state window. Provenance is cited in the
 module docstring; `evm_chain_by_id` fails closed on a chain with no vetted window.
+
+**The registry now ships more EVM chains** (mainnet + testnet each, all audit-gated): **Optimism**
+(`optimism`, same OP-stack as Base, 900 s), **Arbitrum One** (`arbitrum-one`, Nitro, 1200 s — ~24 h
+sequencer force-inclusion worst case), and **Linea** (`linea`, a zk/validity rollup, 6000 s ≈ the
+median hard finality, with a documented up-to-16 h tail). Each window is sourced per chain because
+the finality *mechanism* differs (OP-stack batch cadence vs Arbitrum's vs zk proof cadence) even
+though the leg code is identical. **Polygon PoS is deliberately *not* in the registry**: its
+`finalized` tag is Polygon's own validator-set "milestone" finality (~5 s), **not** Ethereum-anchored
+— it's a sidechain, so the Ethereum-finality assumption (and the ≥768 s floor) would misrepresent its
+trust model. A Polygon-PoS swap would need a finality model justified in Polygon's *own* security
+terms; `evm_chain_by_id(137)` fails closed so a sidechain is never silently treated as a rollup.
 
 Proofs: `tests/test_eth_leg_anvil_integration.py::test_full_lifecycle_on_base_chain_id`
 (full leg lifecycle on Base Sepolia's chain id) and the entire coordinator e2e re-run as

--- a/src/pyrxd/eth_wallet/chains.py
+++ b/src/pyrxd/eth_wallet/chains.py
@@ -28,6 +28,31 @@ Window discipline (matches the existing codebase split):
   Sources: Base "Transaction Finality" docs; OP-stack batcher/configurability specs
   (https://docs.base.org/base-chain/network-information/transaction-finality,
   https://specs.optimism.io/protocol/configurability.html).
+* Optimism (OP-stack L2): the SAME stack as Base, identical finalized-tag semantics; 900 s
+  steady-state (observed ~15-20 min), 12 h sequencing-window worst case budgeted separately.
+  Source: https://docs.optimism.io/app-developers/transactions/statuses
+* Arbitrum One (Nitro optimistic rollup): finalized = L2 block whose Sequencer batch sits in a
+  FINALIZED L1 block (Ethereum-anchored hard finality). ~10-20 min steady-state -> 1200 s. WORST
+  CASE: the sequencer force-inclusion delay (``maxTimeVariation``) is ~24 h (vs OP-stack 12 h) — a
+  liveness stall of the finalized tag, budgeted via ``eth_finality_stall_tolerance_s``; NOT the
+  ~6.4 d withdrawal dispute window (irrelevant to reorg safety).
+  Source: https://docs.arbitrum.io/how-arbitrum-works/transaction-lifecycle
+* Linea (zk / validity rollup): finalized = L2 block whose validity PROOF is verified in a
+  finalized L1 block (Ethereum-anchored). Proof-cadence-dominated: official MEDIAN hard finality
+  ~1 h 40 (6000 s), documented to "never exceed 16 h" — that tail goes to the stall budget, not
+  the steady window. Source: https://docs.linea.build (finality).
+
+Deliberately NOT in the registry — **Polygon PoS** (chain_id 137): it does not fit this model.
+Its ``finalized`` tag is Polygon's OWN validator-set "milestone" finality (Heimdall / CometBFT,
+~5 s), NOT Ethereum-anchored — Polygon PoS is a commit-chain/sidechain that checkpoints to
+Ethereum for withdrawal proofs but does not inherit Ethereum finality block-by-block. So the
+768 s floor misrepresents it in BOTH directions: it finalizes far faster than 768 s (via its own
+~5 s consensus), and that finality is secured by Polygon's stake, not Ethereum's. Treating it as
+"just another EVM chain" would silently swap the trust model an atomic-swap operator relies on; a
+Polygon-PoS swap needs an explicit, separately-justified finality model (a reorg depth in
+Polygon's own security terms), not this Ethereum-anchored window. ``evm_chain_by_id(137)`` fails
+closed. (A 2025-09-10 faulty-milestone incident delayed Polygon finality ~15 min-1 h, resolved
+only by an emergency hard fork — a validator-set liveness risk with no Ethereum analogue.)
 
 The ``network`` tag feeds the existing fail-closed gates unchanged: any tag not in
 ``AUDIT_CLEARED_NETWORKS`` (only isolated test chains are) is value-bearing and refuses to
@@ -89,6 +114,28 @@ KNOWN_EVM_CHAINS: dict[str, EvmChain] = {
     # for the 12 h sequencing-window worst case and where to budget it.
     "base": EvmChain(name="base", chain_id=8453, network="base", finalization_window_s=900),
     "base-sepolia": EvmChain(name="base-sepolia", chain_id=84532, network="base-sepolia", finalization_window_s=900),
+    # Optimism (OP-stack L2) — the SAME stack as Base, identical finalized-tag semantics
+    # (finalized = batch in a finalized L1 block). 900 s matches Base's CHOSEN steady-state;
+    # observed steady lag ~15-20 min, the 12 h sequencing-window worst case budgeted separately.
+    "optimism": EvmChain(name="optimism", chain_id=10, network="optimism", finalization_window_s=900),
+    "optimism-sepolia": EvmChain(
+        name="optimism-sepolia", chain_id=11155420, network="optimism-sepolia", finalization_window_s=900
+    ),
+    # Arbitrum One (Nitro optimistic rollup) — finalized = L2 block whose Sequencer batch sits in
+    # a FINALIZED L1 block (Ethereum-anchored "hard finality"). Steady-state ~10-20 min -> 1200 s
+    # (upper end of the cited range); the ~24 h sequencer force-inclusion (maxTimeVariation) worst
+    # case is a liveness stall, budgeted separately. NOT the ~6.4 d withdrawal dispute window.
+    "arbitrum-one": EvmChain(name="arbitrum-one", chain_id=42161, network="arbitrum-one", finalization_window_s=1200),
+    "arbitrum-sepolia": EvmChain(
+        name="arbitrum-sepolia", chain_id=421614, network="arbitrum-sepolia", finalization_window_s=1200
+    ),
+    # Linea (zk / validity rollup) — finalized = L2 block whose validity PROOF is verified in a
+    # finalized L1 block (Ethereum-anchored). Proof-cadence-dominated: 6000 s ~= the official
+    # MEDIAN hard finality (~1 h 40); the documented up-to-16 h tail is budgeted separately.
+    "linea": EvmChain(name="linea", chain_id=59144, network="linea", finalization_window_s=6000),
+    "linea-sepolia": EvmChain(
+        name="linea-sepolia", chain_id=59141, network="linea-sepolia", finalization_window_s=6000
+    ),
 }
 
 

--- a/tests/test_eth_chains.py
+++ b/tests/test_eth_chains.py
@@ -59,6 +59,38 @@ def test_no_registry_network_is_audit_exempt():
         assert chain.network not in AUDIT_CLEARED_NETWORKS, chain.name
 
 
+def test_optimism_arbitrum_linea_entries_present():
+    # The A6 additions: OP-stack (= Base), Arbitrum Nitro, Linea zk — all Ethereum-anchored
+    # rollups, so each (mainnet + testnet) respects the L1 floor with a sourced window.
+    expected = {
+        "optimism": (10, 900),
+        "optimism-sepolia": (11155420, 900),
+        "arbitrum-one": (42161, 1200),
+        "arbitrum-sepolia": (421614, 1200),
+        "linea": (59144, 6000),
+        "linea-sepolia": (59141, 6000),
+    }
+    eth_window = KNOWN_EVM_CHAINS["ethereum"].finalization_window_s
+    for key, (cid, window) in expected.items():
+        c = KNOWN_EVM_CHAINS[key]
+        assert (c.chain_id, c.finalization_window_s) == (cid, window), key
+        assert evm_chain_by_id(cid) is c
+        # an L2 cannot finalize faster than the L1 checkpoint it settles to
+        assert c.finalization_window_s >= eth_window, key
+
+
+def test_polygon_pos_deliberately_excluded():
+    # Polygon PoS (137) / Amoy (80002): a commit-chain/sidechain with its OWN validator-set
+    # milestone finality (Heimdall/CometBFT), NOT Ethereum-anchored — it does NOT fit this
+    # registry's finalized-checkpoint model (see the module docstring). Its absence is
+    # intentional; the lookup must fail closed rather than silently treat a sidechain as a
+    # rollup with an Ethereum-anchored window.
+    assert not any(c.chain_id == 137 for c in KNOWN_EVM_CHAINS.values())
+    for sidechain_id in (137, 80002):
+        with pytest.raises(ValidationError, match="unknown EVM chain id"):
+            evm_chain_by_id(sidechain_id)
+
+
 def test_floor_matches_margin_policy_floor():
     """Audit follow-up: _FLOOR_S re-declares the canonical _MIN_ETH_FINALIZATION_WINDOW_S with a
     'keep in sync' comment — enforce that invariant so a future floor bump in one file can't leave


### PR DESCRIPTION
## A6 — more EVM counter-chains

Adding an EVM chain is a registry entry + a **sourced finalization window** (the `EthLeg` + `EthHtlc.sol` machinery is chain-id-agnostic, so the coordinator is untouched). The real work is the per-chain finality, researched from each chain's **official docs** rather than guessed — and the models genuinely differ.

### Added (mainnet + testnet, all audit-gated)
| Chain | id | Window | Finality model |
|---|---|---|---|
| **Optimism** + OP Sepolia | 10 / 11155420 | **900 s** | OP-stack, identical to Base; `finalized` = batch in a finalized L1 block. 12 h sequencing-window worst case (budgeted separately). |
| **Arbitrum One** + Arb Sepolia | 42161 / 421614 | **1200 s** | Nitro optimistic rollup, Ethereum-anchored. ~10–20 min steady; ~24 h sequencer force-inclusion worst case (a liveness stall, *not* the ~6.4 d withdrawal dispute window). |
| **Linea** + Linea Sepolia | 59144 / 59141 | **6000 s** | zk/validity rollup, Ethereum-anchored (finalized once the proof is verified in a finalized L1 block). ≈ official median hard finality; up-to-16 h tail → stall budget. |

All three are Ethereum-anchored rollups, so the registry's **≥768 s floor** ("an L2 cannot finalize faster than the L1 it settles to") is honest for them. None added to `AUDIT_CLEARED_NETWORKS`.

### Deliberately excluded — Polygon PoS (137 / Amoy 80002)
It was in the requested set, but it **does not fit this model** and I won't add a misleading entry. Polygon PoS's `finalized` tag is Polygon's **own validator-set "milestone" finality** (Heimdall/CometBFT, ~5 s), **not** Ethereum-anchored — a sidechain that checkpoints to Ethereum for withdrawals but doesn't inherit Ethereum finality block-by-block. The 768 s floor misrepresents it **both ways**: it finalizes far faster than 768 s, and that finality is secured by Polygon's stake, not Ethereum's. Treating it as "just another EVM chain" would silently swap the trust model an atomic-swap operator relies on. So `evm_chain_by_id(137)` **fails closed**, a test pins the exclusion, and the module docstring documents why. (A 2025-09-10 faulty-milestone incident stalled Polygon finality ~15 min–1 h, fixed only by an emergency hard fork — a validator-set liveness risk with no Ethereum analogue.)

### Validation
- Per-chain provenance (source URLs) in the module docstring; the how-to's EVM section updated.
- Tests for the new entries + the Polygon-PoS exclusion; `test_registry_integrity` / `test_no_registry_network_is_audit_exempt` already cover the new entries.
- ruff + 30 chains/exports tests + private-link checker clean.