### PR TITLE
docs(readme): lead the front door with 'what you can build'; refresh stale status

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,8 @@ Cryptographic primitives have not been independently audited. See
   small real-value dust runs), against BTC, ETH, and EVM L2s (Base / Optimism / Arbitrum /
   Linea). An external security audit is the hard gate before any real value.
 - dMint **V2** (DAA / ASERT difficulty) — builders ship behind a footgun guard
-  (`allow_v2_deploy=True`) but are not yet consensus-validated (`V2UnvalidatedWarning`).
+  (`allow_v2_deploy=True`) but are not yet consensus-validated (`V2UnvalidatedWarning`);
+  getting V2 mainnet-proven so it can move up is tracked in #219.
 
 ## Upgrading
 

--- a/README.md
+++ b/README.md
@@ -50,11 +50,15 @@ Cryptographic primitives have not been independently audited. See
 
 **Working on mainnet today:**
 
-- RXD send / send-max, balance and UTXO queries
-- Glyph NFT mint (two-phase commit + reveal) and transfer — see `examples/glyph_mint_demo.py`
-- Glyph FT premine deploy via `prepare_ft_deploy_reveal` — entire supply at vout[0]
-- Glyph FT transfer via `FtUtxoSet.build_transfer_tx` (conservation-enforcing)
-- BIP32/BIP39/BIP44 HD wallets with optional encrypted persistence (`HdWallet`)
+- RXD send / send-max, balance and UTXO queries (`pyrxd address` / `balance` / `utxos`)
+- BIP32 / BIP39 / BIP44 HD wallets with optional encrypted persistence (`HdWallet`, `pyrxd wallet`)
+- Glyph **NFT** — mint (two-phase commit + reveal) and transfer (`pyrxd glyph mint-nft` / `transfer-nft`)
+- Glyph **FT** — premine deploy and conservation-enforced transfer (`pyrxd glyph deploy-ft` / `transfer-ft`)
+- **dMint permissionless PoW tokens (V1)** — deploy (byte-equal to the live Glyph-protocol deploy,
+  node-consensus-validated) and mine/claim from live mainnet contracts
+  (`pyrxd glyph deploy-dmint` / `claim-dmint`)
+- List your Glyph tokens (`pyrxd glyph list`)
+- `pyrxd agent` — a per-spend-confirmed signing daemon that keeps the key out of the short-lived CLI process
 - ElectrumX async client with reconnect, balance, UTXOs, history, broadcast
 
 **Experimental (pre-audit — build / demo on regtest / testnet, not for real value):**
@@ -63,9 +67,8 @@ Cryptographic primitives have not been independently audited. See
   Solidity legs driven by a chain-neutral coordinator; proven end-to-end on regtest (plus
   small real-value dust runs), against BTC, ETH, and EVM L2s (Base / Optimism / Arbitrum /
   Linea). An external security audit is the hard gate before any real value.
-- dMint permissionless PoW token mint — deploy + mine/claim ship today via
-  `pyrxd glyph deploy-dmint` / `claim-dmint`, with the V1 PoW mint validated on a real
-  `radiant-core` node (`tests/test_dmint_v1_regtest_e2e.py`). V2 (DAA/ASERT) is unvalidated.
+- dMint **V2** (DAA / ASERT difficulty) — builders ship behind a footgun guard
+  (`allow_v2_deploy=True`) but are not yet consensus-validated (`V2UnvalidatedWarning`).
 
 ## Upgrading
 

--- a/README.md
+++ b/README.md
@@ -6,10 +6,34 @@ Python SDK for the [Radiant (RXD) blockchain](https://radiantcore.org/).
 [![Python](https://img.shields.io/badge/python-3.10%2B-blue.svg)](https://www.python.org/)
 [![Docs](https://github.com/MudwoodLabs/pyrxd/actions/workflows/docs.yml/badge.svg)](https://mudwoodlabs.github.io/pyrxd/)
 
-A typed, async-first SDK for building applications on Radiant. Includes
-transaction construction, HD wallets, the Glyph token protocol (NFT, FT,
-dMint), Gravity cross-chain atomic swaps, SPV verification, and an
-ElectrumX network client.
+A typed, async-first SDK for building on Radiant — a UTXO chain with Bitcoin-style
+script *plus* induction (recursive covenants) and a native, consensus-enforced token
+layer. It ships transaction construction, HD wallets, the Glyph token protocol
+(NFT / FT / dMint), trustless cross-chain atomic swaps, SPV verification, and an
+ElectrumX client.
+
+## What you can build
+
+Things that need a custodian or a bridge elsewhere — on Radiant they're trustless and
+enforced on-chain:
+
+- **On-chain Glyph tokens (NFT / FT).** Supply and transfers enforced by Radiant
+  *consensus*, not an indexer or a sidecar.
+  → [mint an NFT](docs/tutorials/mint-a-glyph-nft.md) · [deploy an FT](docs/tutorials/mint-a-glyph-ft.md)
+- **Permissionless PoW token issuance (dMint).** Deploy a token that *anyone* can mine —
+  distributed issuance, no premine, secured by proof-of-work. Radiant-unique.
+  → [`pyrxd glyph deploy-dmint` / `claim-dmint`](docs/how-to/issue-a-dmint-token.md)
+- **Trustless cross-chain atomic swaps.** Trade a Radiant asset (RXD / FT / NFT) against
+  BTC or ETH — and EVM L2s (Base, Optimism, Arbitrum, Linea) — with **no bridge and no
+  custodian**: a hash-timelock swap driven by a chain-neutral coordinator. *(Pre-audit —
+  regtest / testnet today.)*
+  → [build a cross-chain swap](docs/how-to/build-a-cross-chain-swap.md)
+- **Recursive covenants.** Bitcoin-style script + induction lets a coin constrain the coin
+  that spends it — soulbound NFTs, swap covenants, PoW-mint contracts.
+  → [covenant building blocks](docs/concepts/covenant-building-blocks.md)
+
+**New here?** The [5-minute quickstart](docs/tutorials/quickstart.md) goes from `pip install`
+to a real on-chain token on a local regtest chain — no faucet, nothing at risk.
 
 ## Status
 
@@ -33,13 +57,15 @@ Cryptographic primitives have not been independently audited. See
 - BIP32/BIP39/BIP44 HD wallets with optional encrypted persistence (`HdWallet`)
 - ElectrumX async client with reconnect, balance, UTXOs, history, broadcast
 
-**Experimental:**
+**Experimental (pre-audit — build / demo on regtest / testnet, not for real value):**
 
-- Gravity cross-chain BTC↔RXD atomic swaps (`pyrxd.gravity`) — mainnet-proven
-  for sentinel artifact paths; covenant variants still being hardened.
-- dMint PoW-based distributed FT mint — premine-only deploys ship today; the
-  full PoW mint covenant is documented in `docs/dmint-followup.md` as future
-  work.
+- Cross-chain HTLC atomic swaps (`pyrxd.gravity`) — RXD covenant + BTC Taproot + ETH
+  Solidity legs driven by a chain-neutral coordinator; proven end-to-end on regtest (plus
+  small real-value dust runs), against BTC, ETH, and EVM L2s (Base / Optimism / Arbitrum /
+  Linea). An external security audit is the hard gate before any real value.
+- dMint permissionless PoW token mint — deploy + mine/claim ship today via
+  `pyrxd glyph deploy-dmint` / `claim-dmint`, with the V1 PoW mint validated on a real
+  `radiant-core` node (`tests/test_dmint_v1_regtest_e2e.py`). V2 (DAA/ASERT) is unvalidated.
 
 ## Upgrading
 
@@ -269,7 +295,6 @@ reference + tutorials + how-to guides + concepts).
 Other resources in this repo:
 
 - [`examples/`](examples/) — runnable end-to-end demos
-- [`docs/dmint-followup.md`](docs/dmint-followup.md) — premine vs PoW dMint scope
 - [`docs/dmint-research-photonic.md`](docs/dmint-research-photonic.md) — Photonic Wallet TS reference
 - [`docs/dmint-research-mainnet.md`](docs/dmint-research-mainnet.md) — decoded live dMint contracts
 - [`SECURITY.md`](SECURITY.md) — security policy and disclosure


### PR DESCRIPTION
First increment of the DX / dev-attraction work — the README is the #1 surface a prospective dev hits, and it was underselling.

- **New 'What you can build' value-prop** leading with Radiant's differentiators (on-chain Glyph tokens, permissionless **dMint PoW issuance**, **trustless cross-chain swaps with no bridge/custodian**, recursive covenants), each pointing to a runnable path — instead of a flat feature-list.
- **Refreshed the stale Status:** dMint PoW mint was marked 'future work' but **ships now** (deploy/claim CLI + regtest-consensus-validated this session); the swap line undersold a now full multi-chain HTLC swap (BTC/ETH + Base/Optimism/Arbitrum/Linea). Honest 'pre-audit, not for real value' framing kept.
- Dropped the README pointer to `docs/dmint-followup.md` (that doc self-flags as out-of-date).

Docs-only; link-check + leak-check clean. Positioning is yours to refine — flag any wording you'd say differently.