### PR TITLE
docs(api): add agent / eth_wallet / cli reference pages (+ fix 3 surfaced docstring errors)

### DIFF
--- a/docs/api/agent.rst
+++ b/docs/api/agent.rst
@@ -1,0 +1,11 @@
+pyrxd.agent — sign-on-behalf signing daemon
+===========================================
+
+The optional ``pyrxd agent`` daemon holds an unlocked wallet for a bounded window and signs
+transactions on request — with a per-spend confirmation on its own controlling terminal and
+prevout-authenticity checks — so the key is removed from the short-lived CLI process and a
+same-uid caller can only *request* a signature, never take the key.
+
+.. automodule:: pyrxd.agent
+   :members:
+   :show-inheritance:

--- a/docs/api/cli.rst
+++ b/docs/api/cli.rst
@@ -1,0 +1,29 @@
+pyrxd — command-line interface
+==============================
+
+Run ``pyrxd --help`` (and ``pyrxd <group> --help``) for the authoritative, version-accurate
+usage. The command groups:
+
+Wallet & queries
+----------------
+
+- ``pyrxd wallet`` — create / manage an encrypted HD wallet.
+- ``pyrxd address`` / ``balance`` / ``utxos`` — query an address via ElectrumX.
+- ``pyrxd agent`` — the sign-on-behalf signing daemon (see :doc:`agent`).
+
+Glyph tokens
+------------
+
+- ``pyrxd glyph init-metadata`` — scaffold a metadata template.
+- ``pyrxd glyph mint-nft`` / ``transfer-nft`` — mint and transfer a Glyph NFT.
+- ``pyrxd glyph deploy-ft`` / ``transfer-ft`` — deploy (premine) and transfer a Glyph FT.
+- ``pyrxd glyph deploy-dmint`` / ``claim-dmint`` — deploy a dMint contract and mine/claim from one.
+- ``pyrxd glyph list`` — list the Glyph tokens a wallet holds.
+
+Local dev chain
+---------------
+
+- ``pyrxd regtest setup`` / ``up`` / ``down`` — build + run a throwaway radiant-core regtest node.
+- ``pyrxd setup`` — first-run environment setup.
+
+For guided walkthroughs, see the :doc:`../tutorials/index` and :doc:`../how-to/index`.

--- a/docs/api/eth_wallet.rst
+++ b/docs/api/eth_wallet.rst
@@ -1,0 +1,27 @@
+pyrxd.eth_wallet — Ethereum counter-leg
+=======================================
+
+The ETH side of a cross-chain swap. The chain-neutral coordinator and the ``EthLeg``
+orchestrator live in :doc:`gravity`; the durable ``EthHtlcLocator`` and ``recover_secret`` are
+re-exported on the package and documented under :doc:`pyrxd`.
+
+EVM chain registry
+------------------
+
+.. automodule:: pyrxd.eth_wallet.chains
+   :members:
+   :show-inheritance:
+
+JSON-RPC client
+---------------
+
+.. automodule:: pyrxd.eth_wallet.rpc
+   :members:
+   :show-inheritance:
+
+HTLC contract leg
+-----------------
+
+.. automodule:: pyrxd.eth_wallet.htlc_leg
+   :members:
+   :show-inheritance:

--- a/docs/api/index.rst
+++ b/docs/api/index.rst
@@ -10,10 +10,12 @@ functions, and exceptions.
    pyrxd
    glyph
    gravity
+   eth_wallet
    swap
    hd
    network
    security
+   agent
    spv
    transaction
    script
@@ -22,3 +24,4 @@ functions, and exceptions.
    fee_models
    btc_wallet
    devnet
+   cli

--- a/src/pyrxd/eth_wallet/htlc_leg.py
+++ b/src/pyrxd/eth_wallet/htlc_leg.py
@@ -194,17 +194,18 @@ class EthHtlcContractLeg:
 
         Fail-closed checks (any mismatch raises; the taker does NOT tell the maker to
         lock RXD):
-          1. chain id matches;
-          2. deployed runtime logic == the committed artifact's (immutable slots masked —
-             no attacker contract / no modified logic);
-          3. the contract IMMUTABLES (hashlock/claimant/refundee/timeout) read back via
-             the getters == the negotiated terms in the locator (the meaningful binding
-             check — proves the contract releases on the right secret to the right party
-             at the right time);
-          4. claimant and refundee are EOAs (empty code) — a contract recipient that
-             reverts on ``receive`` would brick claim/refund via the contract's
-             ``require(ok)``;
-          5. funded balance == expected amount (no underfunded contract).
+
+        1. chain id matches;
+        2. deployed runtime logic == the committed artifact's (immutable slots masked —
+           no attacker contract / no modified logic);
+        3. the contract IMMUTABLES (hashlock/claimant/refundee/timeout) read back via
+           the getters == the negotiated terms in the locator (the meaningful binding
+           check — proves the contract releases on the right secret to the right party
+           at the right time);
+        4. claimant and refundee are EOAs (empty code) — a contract recipient that
+           reverts on ``receive`` would brick claim/refund via the contract's
+           ``require(ok)``;
+        5. funded balance == expected amount (no underfunded contract).
 
         ``block_identifier`` (red-team HIGH TOCTOU): pin EVERY read to one block. The taker's
         fund-time self-verify reads 'latest' (None). The MAKER's pre-lock re-verify passes

--- a/src/pyrxd/glyph/dmint/miner.py
+++ b/src/pyrxd/glyph/dmint/miner.py
@@ -202,11 +202,12 @@ def compute_next_target_asert(
 ) -> int:
     """Compute next ASERT-lite target (mirrors on-chain OP_LSHIFT/OP_RSHIFT logic).
 
-    drift = (current_time - last_time - target_time) // half_life
-    drift is clamped to [-4, +4].
-    drift > 0 → target <<= drift (easier)
-    drift < 0 → target >>= |drift| (harder)
-    Minimum target is 1.
+    The V2-only retarget, as pseudo-code::
+
+        drift = (current_time - last_time - target_time) // half_life   # clamped to [-4, +4]
+        drift > 0  ->  target <<= drift          # easier
+        drift < 0  ->  target >>= abs(drift)     # harder
+        minimum target is 1
 
     .. warning::
        V2-only DAA. V1 has no DAA (fixed difficulty). Emits
@@ -461,13 +462,13 @@ def mine_solution_external(
 
     The miner is expected to:
 
-    1. Read one JSON object from stdin: ``{"preimage_hex", "target_hex", "nonce_width"}``
-    2. Search for a valid nonce
-    3. Write one JSON object to stdout:
-       - On hit (exit 0): ``{"nonce_hex", "attempts", "elapsed_s"}``
-       - On nonce-space exhaustion (exit 2, added in 0.5.1): ``{"exhausted": true}``
-         — pyrxd raises :class:`MaxAttemptsError` immediately rather than
-         waiting for the parent timeout to fire.
+    1. Read one JSON object from stdin: ``{"preimage_hex", "target_hex", "nonce_width"}``.
+    2. Search for a valid nonce.
+    3. Write one JSON object to stdout — on a hit (exit 0):
+       ``{"nonce_hex", "attempts", "elapsed_s"}``; on nonce-space exhaustion
+       (exit 2, added in 0.5.1): ``{"exhausted": true}`` (pyrxd then raises
+       :class:`MaxAttemptsError` immediately rather than waiting for the parent
+       timeout to fire).
 
     A bundled reference implementation ships at :mod:`pyrxd.contrib.miner`
     (added in 0.5.1) — see :doc:`/concepts/parallel-mining` for the full


### PR DESCRIPTION
DX increment #1 of the remaining set — fills the named API-reference gaps. The docs already autodoc most subpackages; **agent**, **eth_wallet**, and **cli** had none.

- **`agent.rst`** — the sign-on-behalf signing daemon (`pyrxd.agent`), autodoc (51 members).
- **`eth_wallet.rst`** — the ETH counter-leg's useful API: the EVM chain registry, the JSON-RPC client, and the HTLC contract leg (`chains`/`rpc`/`htlc_leg`, 33 members). `EthHtlcLocator`/`recover_secret` are package re-exports and stay documented via the top-level `pyrxd` page (avoids a duplicate).
- **`cli.rst`** — a curated command-group reference (autodoc of click commands adds little); points to `pyrxd --help` + the tutorials/how-tos.
- dMint already surfaces via `glyph.rst` (the `pyrxd.glyph` package re-exports it), so no separate page — which also avoids the lazy-export duplicate-object warnings.

**Bonus:** fixes **3 latent docstring-rst rendering errors** the new autodoc surfaced (no behavior change) — `compute_next_target_asert` (a `|drift|` parsed as an rst substitution), `mine_solution_external` (mis-indented nested list), and `verify_funded` (numbered list needing a blank line + de-indent).

Verified: `sphinx-build` clean on the new pages (**0 errors, 0 new warnings**); ruff + private-link clean.