### PR TITLE
fix(dmint): make dMint V1 + FIXED V2 validate on real Radiant consensus (#219)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -172,6 +172,9 @@ ignore = [
 "tests/test_dmint_v1_regtest_e2e.py" = [
     "F811",   # same: reuses the shared `node` regtest fixture from test_htlc_regtest_e2e
 ]
+"tests/test_dmint_v2_regtest_e2e.py" = [
+    "F811",   # same: reuses the shared `node` regtest fixture from test_htlc_regtest_e2e
+]
 "examples/**" = [
     "S",      # examples use test keys / hardcoded WIFs intentionally
     "E402",   # examples may reorder imports for narrative clarity

--- a/src/pyrxd/glyph/dmint/builders.py
+++ b/src/pyrxd/glyph/dmint/builders.py
@@ -101,9 +101,21 @@ def _push_4bytes_le(n: int) -> bytes:
 # contractRefPickIndex = 10 - 1 = 9  → pushMinimal(9) = 0x59 (OP_9)
 # inputOutputPickIndex = 10 + 3 = 13 → pushMinimal(13) = 0x5d (OP_13)
 # nonceRollIndex       = 10 + 4 = 14 → pushMinimal(14) = 0x5e (OP_14)
+#
+# OP_INPUTINDEX (0xc0) is REQUIRED before OP_OUTPOINTTXHASH (0xc8): the latter
+# is a unary introspection op that pops an input index off the stack. Without
+# the OP_INPUTINDEX push, OP_OUTPOINTTXHASH consumes the top state item
+# (``target``, a huge number) as the index → consensus rejects every mint with
+# "input index out of range". V1's prologue has the same ``c0 c8`` pair; the
+# pick indices above (9/13/14 = stateItemCount ± offset, mirroring V1's 5/9/10)
+# are already calibrated for the stack WITH OP_INPUTINDEX present. Upstream
+# Photonic (script.ts) dropped the 0xc0 — that omission is the bug pyrxd copied;
+# restoring it is validated against radiant-core regtest (see
+# tests/test_dmint_v2_regtest_e2e.py). Refs #219.
 _PART_A = bytes.fromhex(
     "51"  # OP_1
     "75"  # OP_DROP
+    "c0"  # OP_INPUTINDEX  (pushes current input index for OP_OUTPOINTTXHASH)
     "c8"  # OP_OUTPOINTTXHASH
     "59"  # pushMinimal(9) = OP_9
     "79"  # OP_PICK

--- a/src/pyrxd/glyph/dmint/types.py
+++ b/src/pyrxd/glyph/dmint/types.py
@@ -130,9 +130,20 @@ _PART_B2 = bytes.fromhex("51797ca269")
 # Part B.4: drop 5 V2 extras (new_target, lastTime, targetTime, daaMode, algoId)
 _PART_B4 = bytes.fromhex("7575757575")
 
-# Part C: output validation (identical to V1 — code script continuity + token reward + height checks)
+# Part C: output validation (code-script continuity + token reward + height checks).
+#
+# This is V1's epilogue tail starting at OP_7 OP_ROLL. The earlier version began
+# with an extra ``a269`` (OP_GREATERTHANOREQUAL OP_VERIFY) — V1's PoW
+# target-compare. But V2 already performs that compare in ``_PART_B2``
+# (``OP_1 OP_PICK OP_SWAP`` so ``target`` survives for the ``_PART_B4`` drop), so
+# the duplicate ran AFTER B4 popped the extras: with the stack reduced to
+# ``[.., maxHeight, reward]`` it executed ``maxHeight >= reward`` (e.g. 10 >= 1000)
+# → consensus rejects the mint with "Script failed an OP_VERIFY operation". From
+# OP_7 OP_ROLL onward this block is byte-identical to V1's tail and operates on
+# the same normalized stack. Dropping the leading ``a269`` is validated against
+# radiant-core regtest (tests/test_dmint_v2_regtest_e2e.py). Refs #219.
 _PART_C = bytes.fromhex(
-    "a269577ae500a069567ae600a06901d053797e0c"
+    "577ae500a069567ae600a06901d053797e0c"
     "dec0e9aa76e378e4a269e69d7eaa76e47b9d547a"
     "818b76537a9c537ade789181547ae6939d635279"
     "cd01d853797e016a7e886778de519d547854807e"

--- a/src/pyrxd/transaction/transaction_preimage.py
+++ b/src/pyrxd/transaction/transaction_preimage.py
@@ -22,10 +22,19 @@ def _get_push_refs(script_bytes: bytes) -> list:
     each is followed by exactly 36 bytes of ref data. All other opcodes are
     skipped using their standard encoding (data-push length or single byte).
 
-    The sort + dedup behavior is **consensus-required**, not a bug:
-    radiantjs ``GetHashOutputHashes`` (lib/transaction/sighash.js) produces
-    the same encoding, and pyrxd's vectors are pinned against a confirmed
-    mainnet reveal tx (see ``tests/test_preimage.py``).
+    The sort + dedup behavior is **consensus-required**, not a bug. Radiant
+    consensus collects an output's refs into a ``std::set<uint288>`` and
+    hashes them in iteration order — i.e. ascending by the *uint288 numeric
+    value* of each 36-byte ref, which is **little-endian** (byte[35] is the
+    most-significant). See Radiant-Core ``src/primitives/transaction.h``
+    (``getRefHashDataSummary`` / ``writeOutputDataSummaryVector`` /
+    ``GetHashOutputHashes``). We therefore sort by ``ref[::-1]`` (the
+    fully-reversed bytes), NOT by the raw byte order (which would be
+    big-endian / lexicographic and diverges for any output with 2+ refs —
+    the bug that made dMint contract-output signing fail ~50% of the time on
+    a real node; single-ref outputs are unaffected since order is moot).
+    Validated end-to-end against radiant-core regtest by
+    ``tests/test_dmint_v1_regtest_e2e.py`` (2-ref contract output).
 
     Raises ``ValidationError`` if a pushref opcode is followed by fewer
     than 36 bytes (truncated script). Earlier versions silently produced
@@ -60,7 +69,9 @@ def _get_push_refs(script_bytes: bytes) -> list:
             n = int.from_bytes(script_bytes[i : i + 4], "little")
             i += 4 + n
         # else: single-byte opcode, already advanced by 1
-    return [refs[k] for k in sorted(refs.keys())]
+    # Sort by uint288 numeric value (little-endian: byte[35] most-significant),
+    # matching Radiant's std::set<uint288> iteration order — NOT raw lexicographic.
+    return sorted(refs.values(), key=lambda r: r[::-1])
 
 
 def _compute_hash_output_hashes(outputs: list[TransactionOutput], index: int = None) -> bytes:

--- a/tests/test_dmint_v2_regtest_e2e.py
+++ b/tests/test_dmint_v2_regtest_e2e.py
@@ -1,0 +1,289 @@
+"""dMint **V2** (FIXED difficulty) end-to-end consensus proof on a real
+radiant-core regtest node — the V2 analog of ``test_dmint_v1_regtest_e2e.py``
+(issue #219).
+
+V2 dMint had never been validated against on-chain bytes (hence
+``V2UnvalidatedWarning``) and was in fact broken at the covenant-bytecode level
+— it has never worked on any chain (consistent with "no V2 contract in the
+wild"). Two transcription bugs (inherited from Photonic's ``script.ts``) made
+every V2 mint consensus-invalid, and are fixed in ``pyrxd.glyph.dmint``:
+
+1. ``_PART_A`` was missing ``OP_INPUTINDEX`` (0xc0) before ``OP_OUTPOINTTXHASH``,
+   so the latter popped the ``target`` state value as the input index →
+   "input index out of range".
+2. ``_PART_C`` began with a duplicate ``a269`` (the PoW target-compare
+   ``_PART_B2`` already performs), which after ``_PART_B4`` ran ``maxHeight >=
+   reward`` → "Script failed an OP_VERIFY operation".
+
+This test proves the fixed V2 covenant is accepted by REAL Radiant consensus:
+deploy a FIXED-difficulty V2 contract, PoW-mine an 8-byte-nonce mint, and
+confirm the node accepts it (and rejects a wrong nonce).
+
+The deploy uses direct ref-induction (the HTLC-R1 mechanism: spend two genesis
+outpoints so the contract output's singleton ``contractRef`` + normal
+``tokenRef`` are inducted) rather than ``prepare_dmint_deploy``, because the V2
+deploy/mint *builder* still emits the wrong "pool"/1-input shape — rewriting it
+to the consensus-correct shape proven here is deferred follow-up (see #219). The
+mint is therefore built in the **consensus-correct shape** the covenant
+requires: contract + funding inputs; outputs = recreated contract (value **1**,
+a singleton) at vout[0], 75-byte FT reward at vout[1], OP_RETURN at vout[2],
+change at vout[3]; the recreated contract's state equals the current state with
+**only** ``height`` incremented (the covenant forbids changing any other state
+field — which is also why DAA/ASERT/LWMA cannot work with this covenant; FIXED
+only).
+
+Gating / safety: opt-in via ``@pytest.mark.integration`` + ``RADIANT_REGTEST=1``;
+reuses the isolated throwaway-container harness from ``test_htlc_regtest_e2e``
+(same pattern as the V1 test). Never touches mainnet, moves no real value.
+
+Run: ``RADIANT_REGTEST=1 pytest tests/test_dmint_v2_regtest_e2e.py -m integration -s``
+"""
+
+from __future__ import annotations
+
+import secrets
+import sys
+import warnings
+
+import pytest
+
+# Reuse the isolated-regtest harness wholesale (same pattern as the V1 test):
+# the ``node`` fixture spins up + tears down a throwaway radiant-core container.
+from test_htlc_regtest_e2e import (  # noqa: F401  (node = fixture)
+    _RELAY_FEE_SATS,
+    _p2pkh_unlock,
+    _pay_to_spk,
+    _RegtestNode,
+    _src,
+    node,
+)
+
+from pyrxd.glyph.dmint import (
+    DaaMode,
+    DmintAlgo,
+    DmintContractUtxo,
+    DmintDeployParams,
+    DmintState,
+    V2UnvalidatedWarning,
+    build_dmint_contract_script,
+    build_dmint_v1_ft_output_script,
+    build_mint_scriptsig,
+    build_pow_preimage,
+    mine_solution_dispatch,
+)
+from pyrxd.glyph.types import GlyphRef
+from pyrxd.keys import PrivateKey
+from pyrxd.script.script import Script
+from pyrxd.script.type import encode_pushdata
+from pyrxd.security.types import Hex20
+from pyrxd.transaction.transaction import Transaction
+from pyrxd.transaction.transaction_input import TransactionInput
+from pyrxd.transaction.transaction_output import TransactionOutput
+
+pytestmark = pytest.mark.integration
+
+_MINER_ARGV = [sys.executable, "-m", "pyrxd.contrib.miner"]
+_CONTRACT_VALUE = 1  # V2 contract is a value-1 singleton (covenant: OP_OUTPUTVALUE OP_1 OP_NUMEQUALVERIFY)
+
+
+def _p2pkh_spk(key: PrivateKey) -> bytes:
+    return b"\x76\xa9\x14" + bytes(Hex20(key.public_key().hash160())) + b"\x88\xac"
+
+
+class _Coin:
+    def __init__(self, txid: str, spk: bytes, val: int, key: PrivateKey) -> None:
+        self.txid, self.vout, self.spk, self.val, self.key = txid, 0, spk, val, key
+
+
+def _carve(node: _RegtestNode, value: int) -> _Coin:
+    """Carve a fresh plain-P2PKH UTXO worth ``value`` under a brand-new key
+    (genesis outpoint for ref induction, or the miner's funding coin)."""
+    key = PrivateKey(secrets.token_bytes(32))
+    spk = _p2pkh_spk(key)
+    txid = _pay_to_spk(node, spk, value)
+    return _Coin(txid, spk, value, key)
+
+
+def _spend(coin: _Coin) -> TransactionInput:
+    tin = TransactionInput(
+        source_transaction=_src(coin.txid, coin.vout, coin.spk, coin.val),
+        source_txid=coin.txid,
+        source_output_index=coin.vout,
+        unlocking_script_template=_p2pkh_unlock(coin.key),
+    )
+    tin.satoshis = coin.val
+    tin.locking_script = Script(coin.spk)
+    return tin
+
+
+def _sign_funding_input(tx: Transaction, idx: int, key: PrivateKey) -> None:
+    """Manually sign a P2PKH input whose unlocking_script is a placeholder."""
+    inp = tx.inputs[idx]
+    sig = key.sign(tx.preimage(idx))
+    inp.unlocking_script = Script(
+        encode_pushdata(sig + inp.sighash.to_bytes(1, "little")) + encode_pushdata(key.public_key().serialize())
+    )
+
+
+def _v2_params(*, max_height, reward, height, last_time, contract_ref, token_ref):
+    return DmintDeployParams(
+        contract_ref=contract_ref,
+        token_ref=token_ref,
+        max_height=max_height,
+        reward=reward,
+        difficulty=1,  # FIXED, easiest target — only the 4-zero-byte PoW floor applies
+        algo=DmintAlgo.SHA256D,
+        daa_mode=DaaMode.FIXED,
+        target_time=60,
+        half_life=3600,
+        height=height,
+        last_time=last_time,
+    )
+
+
+def _deploy_v2_contract(node: _RegtestNode, *, max_height: int, reward: int) -> DmintContractUtxo:
+    """Create a FIXED-difficulty V2 dMint contract UTXO (value-1 singleton) by
+    inducting the singleton ``contractRef`` + normal ``tokenRef`` from two spent
+    genesis outpoints, with the V2 contract script at vout 0.
+    """
+    g_tok = _carve(node, 200_000_000)
+    g_con = _carve(node, 200_000_000)
+    token_ref = GlyphRef(txid=g_tok.txid, vout=0)
+    contract_ref = GlyphRef(txid=g_con.txid, vout=0)
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", V2UnvalidatedWarning)
+        params = _v2_params(
+            max_height=max_height,
+            reward=reward,
+            height=0,
+            last_time=0,
+            contract_ref=contract_ref,
+            token_ref=token_ref,
+        )
+        contract_script = build_dmint_contract_script(params)
+        state = DmintState.from_script(contract_script)
+    assert state.is_v1 is False, "deployed script did not parse as V2"
+
+    change_key = PrivateKey(secrets.token_bytes(32))
+    change_val = g_tok.val + g_con.val - _CONTRACT_VALUE - _RELAY_FEE_SATS
+    deploy = Transaction(
+        tx_inputs=[_spend(g_tok), _spend(g_con)],
+        tx_outputs=[
+            TransactionOutput(Script(contract_script), _CONTRACT_VALUE),
+            TransactionOutput(Script(_p2pkh_spk(change_key)), change_val),
+        ],
+    )
+    deploy.sign()
+    res = node.accepts(deploy.serialize().hex())
+    assert res["allowed"] is True, f"V2 deploy not accepted by consensus: {res}"
+    dtxid = node.cli("sendrawtransaction", deploy.serialize().hex())
+    assert isinstance(dtxid, str), dtxid
+    node.mine(1)
+    assert node.cli("gettxout", dtxid, "0"), "deployed V2 contract UTXO missing"
+    return DmintContractUtxo(txid=dtxid, vout=0, value=_CONTRACT_VALUE, script=contract_script, state=state)
+
+
+def _build_signed_v2_mint(node: _RegtestNode, contract: DmintContractUtxo) -> tuple[Transaction, bytes]:
+    """Build, mine, and sign a consensus-correct (V1-shaped) FIXED V2 mint.
+
+    Returns ``(tx, nonce)``. The recreated contract carries the next state
+    (current state with only ``height`` incremented) at value 1; the FT reward +
+    fee come from a plain funding input; the OP_RETURN at vout[2] is the
+    preimage's bound output. An 8-byte nonce reliably solves in a single ~2**32
+    sweep (no message-rolling, unlike V1's 4-byte nonce).
+    """
+    state = contract.state
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", V2UnvalidatedWarning)
+        recreated = build_dmint_contract_script(
+            _v2_params(
+                max_height=state.max_height,
+                reward=state.reward,
+                height=state.height + 1,
+                last_time=state.last_time,
+                contract_ref=state.contract_ref,
+                token_ref=state.token_ref,
+            )
+        )
+    miner_pkh = bytes(Hex20(PrivateKey(secrets.token_bytes(32)).public_key().hash160()))
+    reward_script = build_dmint_v1_ft_output_script(miner_pkh, state.token_ref)
+    msg = b"pyrxd-v2-regtest"
+    op_return = b"\x6a\x03msg" + bytes([len(msg)]) + msg
+
+    funding = _carve(node, 50_000_000)
+    change_key = PrivateKey(secrets.token_bytes(32))
+
+    placeholder = b"\xff" * 32
+    # Contract input: a covenant UTXO (raw scriptSig), not a P2PKH — build directly.
+    contract_in = TransactionInput(
+        source_transaction=_src(contract.txid, contract.vout, contract.script, contract.value),
+        source_txid=contract.txid,
+        source_output_index=contract.vout,
+        unlocking_script_template=None,
+    )
+    contract_in.satoshis = contract.value
+    contract_in.locking_script = Script(contract.script)
+    contract_in.unlocking_script = Script(build_mint_scriptsig(b"\x00" * 8, placeholder, placeholder, nonce_width=8))
+    funding_in = _spend(funding)
+    funding_in.unlocking_script_template = None
+    funding_in.unlocking_script = Script(b"\x00" * 108)
+
+    outs = [
+        TransactionOutput(Script(recreated), _CONTRACT_VALUE),
+        TransactionOutput(Script(reward_script), state.reward),
+        TransactionOutput(Script(op_return), 0),
+        TransactionOutput(Script(_p2pkh_spk(change_key)), 0),
+    ]
+    tx = Transaction(tx_inputs=[contract_in, funding_in], tx_outputs=outs)
+    fee = len(tx.serialize()) * 10_000
+    change_val = funding.val - state.reward - fee
+    assert change_val > 546, f"funding too small: change {change_val}"
+    outs[3].satoshis = change_val
+
+    pre = build_pow_preimage(
+        txid_le=bytes.fromhex(contract.txid)[::-1],
+        contract_ref_bytes=state.contract_ref.to_bytes(),
+        input_script=funding.spk,
+        output_script=op_return,
+    )
+    mined = mine_solution_dispatch(
+        preimage=pre.preimage, target=state.target, nonce_width=8, miner_argv=_MINER_ARGV, timeout_s=900.0
+    )
+    nonce = mined.nonce
+    contract_in.unlocking_script = Script(build_mint_scriptsig(nonce, pre.input_hash, pre.output_hash, nonce_width=8))
+    _sign_funding_input(tx, 1, funding.key)
+    return tx, nonce
+
+
+class TestRadiantDmintV2OnConsensus:
+    def test_v2_fixed_mint_accepted_and_wrong_nonce_rejected(self, node):
+        contract = _deploy_v2_contract(node, max_height=10, reward=1000)
+        tx, nonce = _build_signed_v2_mint(node, contract)
+
+        raw_good = tx.serialize().hex()
+        res = node.accepts(raw_good)
+        assert res["allowed"] is True, f"valid FIXED V2 mint rejected by consensus: {res}"
+
+        # Wrong nonce: flip the first nonce byte → PoW four-zero-bytes check fails.
+        good_ss = tx.inputs[0].unlocking_script.script
+        # V2 scriptsig: <0x08><nonce8><0x20><ih32><0x20><oh32><0x00>
+        ih = good_ss[10:42]
+        oh = good_ss[43:75]
+        bad_nonce = bytes([nonce[0] ^ 0xFF]) + nonce[1:]
+        tx.inputs[0].unlocking_script = Script(build_mint_scriptsig(bad_nonce, ih, oh, nonce_width=8))
+        raw_wrong = tx.serialize().hex()
+        tx.inputs[0].unlocking_script = Script(good_ss)
+        assert raw_wrong != raw_good
+        res = node.accepts(raw_wrong)
+        assert res["allowed"] is False, f"wrong-nonce V2 mint was accepted: {res}"
+
+        # The valid mint spends the contract + recreates it at height+1 with the FT reward.
+        mtxid = node.cli("sendrawtransaction", raw_good)
+        assert isinstance(mtxid, str), mtxid
+        node.mine(1)
+        assert node.cli("gettxout", contract.txid, "0") in (None, ""), "V2 contract UTXO should be spent after mint"
+        recreated_out = node.cli("gettxout", mtxid, "0")
+        assert recreated_out and round(recreated_out["value"] * 1e8) == _CONTRACT_VALUE, "recreated V2 contract wrong"
+        reward_out = node.cli("gettxout", mtxid, "1")
+        assert reward_out and round(reward_out["value"] * 1e8) == 1000, "V2 FT reward output (vout 1) wrong"

--- a/tests/test_preimage.py
+++ b/tests/test_preimage.py
@@ -64,8 +64,23 @@ class TestGetPushRefs:
         script = bytes([0xD8]) + ref_a + bytes([0xD8]) + ref_b
         refs = _get_push_refs(script)
         assert len(refs) == 2
-        assert refs[0] == ref_b  # 00... sorts before ff...
+        assert refs[0] == ref_b  # 00... sorts before ff... (LE and BE agree here)
         assert refs[1] == ref_a
+
+    def test_multiple_refs_sorted_little_endian(self):
+        # Radiant collects refs into a std::set<uint288> sorted by NUMERIC
+        # (little-endian) value: byte[35] is most-significant, byte[0] least.
+        # This case distinguishes LE from raw-lexicographic (big-endian):
+        #   ref_lo differs only in its FIRST byte (0xff) -> uint288 is tiny
+        #   ref_hi differs only in its LAST byte (0x01)  -> uint288 is large
+        # Lexicographic (the old bug) would put ref_lo (0xff..) LAST; the
+        # uint288 order (consensus-correct) puts ref_hi (..0x01) last. Proven
+        # against radiant-core regtest by the dMint 2-ref contract-output e2e.
+        ref_lo = b"\xff" + bytes(35)  # MSB = byte[35] = 0x00 -> small
+        ref_hi = bytes(35) + b"\x01"  # MSB = byte[35] = 0x01 -> large
+        script = bytes([0xD0]) + ref_hi + bytes([0xD0]) + ref_lo
+        refs = _get_push_refs(script)
+        assert refs == [ref_lo, ref_hi], "refs must sort by uint288 (little-endian) value, not lexicographic"
 
     def test_skips_data_pushes_correctly(self):
         # OP_PUSH3 'gly' then OP_PUSHINPUTREFSINGLETON + ref


### PR DESCRIPTION
First node-consensus validation of dMint (V1 and V2) against a real `radiant-core:v2.3.0` regtest node, fixing the two consensus bugs it surfaced. Issue #219 assumed a V1 consensus test already existed (`test_dmint_v1_regtest_e2e.py`) — it never did; there was **no** dMint consensus test, V1 or V2.

## 1. Multi-ref output sighash ordering (commit 1)

pyrxd's BIP143 `hashOutputHashes` sorted an output's `OP_PUSHINPUTREF`/`SINGLETON` refs **lexicographically** (`ref.hex()`, big-endian). Radiant consensus collects them into a `std::set<uint288>` and hashes them in ascending **numeric** order — **little-endian** (byte[35] most-significant). See Radiant-Core `src/primitives/transaction.h` (`getRefHashDataSummary`/`GetHashOutputHashes`).

The orderings diverge for any output with **2+ refs**, producing a wrong sighash → invalid signature ~50% of the time. Every shipped mainnet tx (HTLC, gravity, FT/NFT commit+reveal) carries a *single* ref, so it stayed hidden; the dMint contract's 2 refs (contractRef + tokenRef) are the first to expose it.

**Fix:** sort by `ref[::-1]` (uint288 numeric order). Pinned single-ref radiantjs vectors unaffected; added an order-distinguishing 2-ref unit test.

## 2. V2 covenant bytecode (commit 2)

V2 dMint had **never worked on any chain** — broken by two transcription bugs inherited from Photonic's `script.ts`:

- `_PART_A` was missing `OP_INPUTINDEX` (`0xc0`) before `OP_OUTPOINTTXHASH`, so the latter popped the `target` state value as the input index → *"input index out of range."*
- `_PART_C` began with a duplicate `a269` (the PoW target-compare `_PART_B2` already performs while preserving `target`), which after `_PART_B4` ran `maxHeight >= reward` → *"Script failed an OP_VERIFY operation."*

**Fix:** add `c0` to `_PART_A`; strip the leading `a269` from `_PART_C` (byte-identical to V1's tail from `OP_7 OP_ROLL` onward).

## Validation

- Both fixes confirmed against the Radiant-Core C++ consensus source.
- New opt-in regtest e2e tests (`RADIANT_REGTEST=1`, skip cleanly without docker/image):
  - `test_dmint_v1_regtest_e2e.py` — V1 deploy + real PoW mint accepted, wrong nonce rejected.
  - `test_dmint_v2_regtest_e2e.py` — FIXED V2 deploy + 8-byte-nonce mint accepted, wrong nonce rejected, contract recreated at height+1.
- Full non-integration suite green (4186 passed).

## Known limitations (deferred, see #219)

- The consensus-correct V2 mint shape (value-1 singleton, funding input, 4 outputs, height-only state change) is built in the test; `build_dmint_mint_tx`'s V2 path still emits the old pool/1-input shape and needs the matching rewrite.
- **DAA (ASERT/LWMA) cannot work** with this covenant — the state-transition check forbids changing any state field but `height`. FIXED is the only functional mode.
- `V2UnvalidatedWarning` is retained: V2 is now regtest-validated but has no mainnet contract yet.

Upstream note: Photonic `script.ts` carries both V2 bugs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
