### PR TITLE
chore(deps): combined Dependabot updates (#221, #222, #224, #225)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -103,7 +103,7 @@ pre-commit = "4.6.0"
 pytest-cov = "7.1.0"
 pytest-mock = "<3.10.1"
 pytest-runner = "*"
-pytest = ">=9.0.3"
+pytest = ">=9.1.0"
 pytest-github-actions-annotate-failures = "*"
 shellcheck-py = "0.11.0.1"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -78,7 +78,7 @@ pycryptodomex = "^3.23.0"
 # Required for X25519 ECDH + HKDF-SHA256 used by Glyph TIMELOCK / ENCRYPTED
 # (pyrxd.crypto.kem). OpenSSL-backed, well-audited, typically already a
 # transitive dep in most environments.
-cryptography = ">=42.0"
+cryptography = ">=49.0.0"
 websockets = ">=15.0.1,<17.0.0"
 cbor2 = "^6.1"
 click = "^8.4"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -89,7 +89,7 @@ tomli = {version = "^2.4", python = "<3.11"}
 [tool.poetry.group.dev.dependencies]
 taskipy = "^1.14.1"
 bandit = {version = "^1.9.4", extras = ["toml"]}
-pip-audit = "^2.10.0"
+pip-audit = "^2.10.1"
 detect-secrets = "^1.5.0"
 mypy = "^2.1.0"
 ruff = "^0.15.16"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -92,7 +92,7 @@ bandit = {version = "^1.9.4", extras = ["toml"]}
 pip-audit = "^2.10.0"
 detect-secrets = "^1.5.0"
 mypy = "^2.1.0"
-ruff = "^0.15.16"
+ruff = "^0.15.17"
 hypothesis = "^6.155.2"
 pytest-asyncio = ">=1.4.0"
 


### PR DESCRIPTION
Combines four green Dependabot PRs into one, so the batch costs a single CI run + a single merge instead of one (plus a strict-mode rebase) per PR. Built by the Combine-PRs workflow (which then couldn't open the PR itself — GitHub Actions is not permitted to create PRs without the `COMBINE_PRS_TOKEN` PAT — so opened here by a real user, which also gets CI to run).

Folded in:
- #221 — ruff 0.15.15 → 0.15.17 (python-minor-and-patch group)
- #222 — pip-audit ^2.10.0 → ^2.10.1
- #224 — cryptography 48.0.0 → 49.0.0
- #225 — pytest >=9.0.3 → >=9.1.0

**Skipped — handle separately:**
- #223 — websockets >=15.0.1 → >=16.0 (merge conflict against this batch; resolve on its own)

Close the four superseded PRs above once this merges.