### PR TITLE
feat(dmint): rewrite the V2 deploy API to mirror V1 (value-1 singletons) (#219)

### DIFF
--- a/src/pyrxd/glyph/builder.py
+++ b/src/pyrxd/glyph/builder.py
@@ -455,61 +455,70 @@ class GlyphBuilder:
         *,
         allow_v2_deploy: bool,
     ) -> DmintV2DeployResult:
-        """Original V2 deploy implementation, gated on ``allow_v2_deploy``."""
+        """Build the V2 deploy commit + placeholder contract scripts.
+
+        Mirrors :meth:`_prepare_dmint_v1_deploy` (commit + reveal that genesises
+        ``num_contracts`` parallel 1-photon V2 contract UTXOs at height 0,
+        ``contractRef[i] = commit:(i+1)`` / ``tokenRef = commit:0``), differing
+        only in the V2 contract bytecode. Gated on ``allow_v2_deploy``.
+        """
+        import warnings
+
+        from .dmint import V2UnvalidatedWarning
+
         if not allow_v2_deploy:
             raise DmintError(
                 "prepare_dmint_deploy with DmintV2DeployParams emits V2 dMint "
                 "contracts; no ecosystem miner (glyph-miner, etc.) targets V2 "
                 "and indexer behavior on V2 deploys is empirically unknown. "
-                "Refusing to build a token nobody can mine. For V1 (the only "
-                "live mainnet format), pass DmintV1DeployParams instead. To "
-                "deploy V2 anyway (e.g. SDK-internal testing), pass "
-                "allow_v2_deploy=True."
+                "Refusing by default. For V1 (the only live mainnet format), pass "
+                "DmintV1DeployParams instead. To deploy V2 anyway (e.g. SDK-internal "
+                "testing or regtest), pass allow_v2_deploy=True."
             )
-        # 1. Encode the token metadata payload.
+        if params.premine_amount is not None:
+            raise ValidationError(
+                "V2 deploy with premine is deferred work (mirrors V1). Set premine_amount=None for now."
+            )
+
+        # 1. Encode the CBOR token body and pin the FT+DMINT protocol shape.
         cbor_bytes, payload_hash = encode_payload(params.metadata)
+        decoded = cbor2.loads(cbor_bytes)
+        if "p" not in decoded or 1 not in decoded["p"] or 4 not in decoded["p"]:
+            raise ValidationError(
+                f"V2 dMint CBOR 'p' field must include both 1 (FT) and 4 (DMINT); got p={decoded.get('p')!r}"
+            )
 
-        # 2. Build commit script (FT shape — dMint tokens are FTs).
-        is_nft = GlyphProtocol.NFT in params.metadata.protocol
-        commit_script = build_commit_locking_script(
-            payload_hash,
-            params.owner_pkh,
-            is_nft=is_nft,
-        )
-        estimated_commit_fee = 276 * MIN_FEE_RATE
-
+        # 2. FT-commit hashlock (same 75-byte commit shape as V1).
+        commit_script = build_commit_locking_script(payload_hash, params.owner_pkh, is_nft=False)
         commit_result = CommitResult(
             commit_script=commit_script,
             cbor_bytes=cbor_bytes,
             payload_hash=payload_hash,
-            estimated_fee=estimated_commit_fee,
+            estimated_fee=276 * MIN_FEE_RATE,
         )
 
-        # 3. Build the reveal scripts (token ref UTXO — 75-byte FT locking script).
-        if params.premine_amount is not None and params.premine_amount < 546:
-            raise ValidationError(f"premine_amount ({params.premine_amount}) is below the dust limit (546).")
-
-        # 4. Build the deploy contract script.
-        deploy_params_template = DmintDeployParams(
-            contract_ref=params.contract_ref_placeholder,
-            token_ref=params.token_ref_placeholder,
-            max_height=params.max_height,
-            reward=params.reward_photons,
-            difficulty=params.difficulty,
-            algo=params.algo,
-            daa_mode=params.daa_mode,
-            target_time=params.target_time,
-            half_life=params.half_life,
-        )
-
-        # Pre-build with placeholder refs so the caller can inspect the script shape.
-        placeholder_contract_script = build_dmint_contract_script(deploy_params_template)
-
-        # 5. Validate reward pool.
-        if params.initial_pool_photons < params.reward_photons:
-            raise ValidationError(
-                f"initial_pool_photons ({params.initial_pool_photons}) must be >= "
-                f"reward_photons ({params.reward_photons}) for at least one mint."
+        # 3. Pre-build placeholder V2 contract scripts (height=0) so the caller can
+        # estimate the reveal fee before the commit txid is known. Each is the full
+        # V2 layout; only the txid component of contractRef/tokenRef changes at reveal.
+        placeholder_txid = "00" * 32
+        placeholder_token_ref = GlyphRef(txid=placeholder_txid, vout=0)
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", V2UnvalidatedWarning)
+            placeholder_contract_scripts = tuple(
+                build_dmint_contract_script(
+                    DmintDeployParams(
+                        contract_ref=GlyphRef(txid=placeholder_txid, vout=i + 1),
+                        token_ref=placeholder_token_ref,
+                        max_height=params.max_height,
+                        reward=params.reward_photons,
+                        difficulty=params.difficulty,
+                        algo=params.algo,
+                        daa_mode=params.daa_mode,
+                        target_time=params.target_time,
+                        half_life=params.half_life,
+                    )
+                )
+                for i in range(params.num_contracts)
             )
 
         return DmintV2DeployResult(
@@ -517,9 +526,16 @@ class GlyphBuilder:
             cbor_bytes=cbor_bytes,
             owner_pkh=params.owner_pkh,
             premine_amount=params.premine_amount,
-            deploy_params_template=deploy_params_template,
-            placeholder_contract_script=placeholder_contract_script,
-            initial_pool_photons=params.initial_pool_photons,
+            num_contracts=params.num_contracts,
+            placeholder_contract_scripts=placeholder_contract_scripts,
+            max_height=params.max_height,
+            reward_photons=params.reward_photons,
+            difficulty=params.difficulty,
+            algo=params.algo,
+            op_return_msg=params.op_return_msg,
+            daa_mode=params.daa_mode,
+            target_time=params.target_time,
+            half_life=params.half_life,
         )
 
     # ------------------------------------------------------------------
@@ -925,55 +941,69 @@ class DmintV1DeployParams:
 
 @dataclass
 class DmintV2DeployParams:
-    """Parameters for a V2 dMint token deploy (commit + reveal + deploy).
+    """Parameters for a V2 dMint token deploy (2-tx: commit + reveal).
 
-    V2 has no live mainnet deploys; only `prepare_dmint_deploy(..., allow_v2_deploy=True)`
-    will accept it. The ecosystem (glyph-miner, RXinDexer) targets V1 only.
+    Mirrors :class:`DmintV1DeployParams`. V2 emits ``num_contracts`` parallel
+    **1-photon singleton** contract UTXOs directly in the reveal —
+    ``contractRef[i] = commit:(i+1)``, ``tokenRef = commit:0`` — exactly like V1.
+    The only consensus differences are the V2 contract bytecode (10-item state +
+    the V2 covenant) and the 8-byte mint nonce; the reward + tx fee for each mint
+    come from a miner-supplied funding input, not a pool.
 
-    :param metadata:                  :class:`GlyphMetadata` for the token
-                                      (must include ``GlyphProtocol.FT`` and
-                                      ``GlyphProtocol.DMINT`` in protocol).
-    :param owner_pkh:                 20-byte PKH of the key that signs commit/reveal.
-    :param max_height:                Maximum number of mints (total supply units).
-    :param reward_photons:            Photons paid to the miner per mint.
-    :param difficulty:                Initial PoW difficulty (1 = easiest).
-    :param initial_pool_photons:      Photons to lock in the contract UTXO as the
-                                      reward pool.  Must be >= ``reward_photons``.
-    :param premine_amount:            Photons to send to ``owner_pkh`` on the
-                                      reveal tx as an optional premine output.
-                                      ``None`` = no premine output.
-    :param contract_ref_placeholder:  Placeholder :class:`GlyphRef` used to
-                                      pre-build the contract script.  The caller
-                                      substitutes the real contract outpoint
-                                      (deploy tx outpoint) before broadcast.
-    :param token_ref_placeholder:     Placeholder :class:`GlyphRef` for the
-                                      token ref.  Substituted with the reveal
-                                      tx outpoint before broadcast.
-    :param algo:                      PoW algorithm (default SHA256d).
-    :param daa_mode:                  Difficulty adjustment algorithm (default FIXED).
-    :param target_time:               Target seconds between mints (DAA only).
-    :param half_life:                 ASERT half-life in seconds (DAA only).
+    Only ``DaaMode.FIXED`` is supported: the covenant's state-transition check
+    forbids advancing ``target``/``last_time``, so ASERT/LWMA contracts can never
+    adjust difficulty and are unmintable (see #219).
+
+    V2 has no live mainnet deploys; only ``prepare_dmint_deploy(..., allow_v2_deploy=True)``
+    accepts it, and construction emits ``V2UnvalidatedWarning``.
+
+    :param metadata:        :class:`GlyphMetadata` (must include ``GlyphProtocol.FT``
+        and ``GlyphProtocol.DMINT``; set ``version=2`` so indexers classify it as V2).
+    :param owner_pkh:       20-byte PKH of the key that signs commit + the
+        ref-seed reveal inputs.
+    :param num_contracts:   Count of parallel V2 contract UTXOs (``[1, 250]``).
+    :param max_height:      Maximum mints per contract.
+    :param reward_photons:  Photons paid per successful mint.
+    :param difficulty:      Initial PoW difficulty (1 = easiest).
+    :param premine_amount:  Deferred (mirrors V1) — must be ``None``.
+    :param op_return_msg:   Optional OP_RETURN data carrier (raw bytes after 0x6a).
+    :param algo:            PoW algorithm (default SHA256d; only SHA256D is mined).
+    :param daa_mode:        Must be ``DaaMode.FIXED`` (the only mintable mode).
+    :param target_time:     Echoed into the state (DAA-only; vestigial for FIXED).
+    :param half_life:       Echoed into the code (DAA-only; vestigial for FIXED).
     """
 
     metadata: GlyphMetadata
     owner_pkh: Hex20
+    num_contracts: int
     max_height: int
     reward_photons: int
     difficulty: int
-    initial_pool_photons: int
     premine_amount: int | None = None
-    contract_ref_placeholder: GlyphRef = None  # type: ignore[assignment]
-    token_ref_placeholder: GlyphRef = None  # type: ignore[assignment]
+    op_return_msg: bytes | None = None
     algo: DmintAlgo = DmintAlgo.SHA256D
     daa_mode: DaaMode = DaaMode.FIXED
     target_time: int = 60
     half_life: int = 3600
 
     def __post_init__(self) -> None:
-        if self.contract_ref_placeholder is None:
-            self.contract_ref_placeholder = GlyphRef(txid="00" * 32, vout=0)
-        if self.token_ref_placeholder is None:
-            self.token_ref_placeholder = GlyphRef(txid="00" * 32, vout=0)
+        if not (1 <= self.num_contracts <= 250):
+            raise ValidationError(
+                f"num_contracts must be in [1, 250], got {self.num_contracts} "
+                f"(250 is the standardness ceiling for the deploy reveal size)"
+            )
+        if self.max_height < 1:
+            raise ValidationError(f"max_height must be >= 1, got {self.max_height}")
+        if self.reward_photons < 1:
+            raise ValidationError(f"reward_photons must be >= 1, got {self.reward_photons}")
+        if self.difficulty < 1:
+            raise ValidationError(f"difficulty must be >= 1, got {self.difficulty}")
+        if self.daa_mode != DaaMode.FIXED:
+            raise ValidationError(
+                f"V2 dMint deploy supports only DaaMode.FIXED (got {self.daa_mode.name}); "
+                "the covenant's state-transition check forbids changing target/last_time, "
+                "so ASERT/LWMA contracts are unmintable. See #219."
+            )
         # V2 quarantine marker — see V2UnvalidatedWarning in pyrxd.glyph.dmint.
         # Subclasses suppress this (DmintFullDeployParams's deprecation warning
         # is the higher-priority signal there).
@@ -1168,88 +1198,94 @@ class DmintV1DeployResult:
 class DmintV2DeployResult:
     """Output of :meth:`GlyphBuilder.prepare_dmint_deploy` for V2 deploys.
 
-    :param commit_result:               :class:`CommitResult` — scripts + fee for the
-                                        commit tx (same as :meth:`prepare_commit` output).
-    :param cbor_bytes:                  Encoded CBOR payload (needed for reveal scriptSig).
-    :param owner_pkh:                   20-byte PKH of the deploy key.
-    :param premine_amount:              Photons for the premine output, or ``None``.
-    :param deploy_params_template:      :class:`DmintDeployParams` with placeholder refs —
-                                        substitute real refs then call
-                                        :func:`build_dmint_contract_script` to get the
-                                        final contract output script.
-    :param placeholder_contract_script: Pre-built contract script with placeholder refs —
-                                        shows the correct byte length for fee estimation.
-    :param initial_pool_photons:        Photons to lock in the deploy output (reward pool).
+    Mirrors :class:`DmintV1DeployResult`: V2 emits ``num_contracts`` parallel
+    1-photon singleton contract UTXOs directly in the reveal (no separate deploy
+    tx, no reward pool). Call :meth:`build_reveal_outputs` once the commit
+    confirms to get the reveal-tx output scripts.
+
+    :param commit_result:                 :class:`CommitResult` — commit-tx script + fee.
+    :param cbor_bytes:                    Encoded CBOR token body.
+    :param owner_pkh:                     20-byte PKH of the deploy key.
+    :param premine_amount:                Deferred — must be ``None`` (mirrors V1).
+    :param num_contracts:                 Count of parallel V2 contracts.
+    :param placeholder_contract_scripts:  Tuple of N V2 contract scripts built with the
+        placeholder commit txid (00…00) — same byte length as the final scripts, for
+        fee estimation before the commit txid is known.
+    :param max_height, reward_photons, difficulty, algo, op_return_msg, daa_mode,
+        target_time, half_life:  Echoed from params for :meth:`build_reveal_outputs`.
     """
 
     commit_result: CommitResult
     cbor_bytes: bytes
     owner_pkh: Hex20
     premine_amount: int | None
-    deploy_params_template: DmintDeployParams
-    placeholder_contract_script: bytes
-    initial_pool_photons: int
+    num_contracts: int
+    placeholder_contract_scripts: tuple[bytes, ...]
+    max_height: int
+    reward_photons: int
+    difficulty: int
+    algo: DmintAlgo
+    op_return_msg: bytes | None
+    daa_mode: DaaMode
+    target_time: int
+    half_life: int
 
-    def build_reveal_scripts(
-        self,
-        commit_txid: str,
-        commit_vout: int,
-        commit_value: int,
-    ) -> FtDeployRevealScripts | RevealScripts:
-        """Build reveal scripts given the confirmed commit outpoint.
+    def build_reveal_outputs(self, commit_txid: str) -> DmintV1RevealScripts:
+        """Build reveal-tx output scripts given the confirmed commit txid.
 
-        :param commit_txid:   txid of the confirmed commit tx.
-        :param commit_vout:   Output index of the commit UTXO.
-        :param commit_value:  Photon value of the commit output.
-        :returns: :class:`FtDeployRevealScripts` if ``premine_amount`` is set,
-                  otherwise :class:`RevealScripts`.
+        Mirrors :meth:`DmintV1DeployResult.build_reveal_outputs`: emits
+        ``num_contracts`` parallel 1-photon V2 contract UTXOs
+        (``contractRef[i] = commit:(i+1)``, ``tokenRef = commit:0``) + the
+        ``gly``/CBOR reveal scriptSig suffix + optional OP_RETURN. The returned
+        :class:`DmintV1RevealScripts` bag has the same shape for V1 and V2.
         """
-        builder = GlyphBuilder()
+        import warnings
+
+        from .dmint import V2UnvalidatedWarning
+
         if self.premine_amount is not None:
-            return builder.prepare_ft_deploy_reveal(
-                commit_txid=commit_txid,
-                commit_vout=commit_vout,
-                commit_value=commit_value,
-                cbor_bytes=self.cbor_bytes,
-                premine_pkh=self.owner_pkh,
-                premine_amount=self.premine_amount,
-            )
-        return builder.prepare_reveal(
-            RevealParams(
-                commit_txid=commit_txid,
-                commit_vout=commit_vout,
-                commit_value=commit_value,
-                cbor_bytes=self.cbor_bytes,
-                owner_pkh=self.owner_pkh,
-                is_nft=False,
-            )
-        )
+            raise NotImplementedError("V2 deploy with premine is deferred work. Set premine_amount=None.")
 
-    def build_contract_script(
-        self,
-        token_ref: GlyphRef,
-        contract_ref: GlyphRef,
-    ) -> bytes:
-        """Build the final contract output script with real outpoint refs.
+        token_ref = GlyphRef(txid=commit_txid, vout=0)
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", V2UnvalidatedWarning)
+            contract_scripts = tuple(
+                build_dmint_contract_script(
+                    DmintDeployParams(
+                        contract_ref=GlyphRef(txid=commit_txid, vout=i + 1),
+                        token_ref=token_ref,
+                        max_height=self.max_height,
+                        reward=self.reward_photons,
+                        difficulty=self.difficulty,
+                        algo=self.algo,
+                        daa_mode=self.daa_mode,
+                        target_time=self.target_time,
+                        half_life=self.half_life,
+                    )
+                )
+                for i in range(self.num_contracts)
+            )
+        scriptsig_suffix = build_reveal_scriptsig_suffix(self.cbor_bytes)
 
-        :param token_ref:    :class:`GlyphRef` of the reveal tx outpoint
-                             (becomes the token ref in the contract state).
-        :param contract_ref: :class:`GlyphRef` of the deploy tx outpoint
-                             (becomes the contract ref in the contract state).
-        :returns: Full dMint contract output script bytes.
-        """
-        real_params = DmintDeployParams(
-            contract_ref=contract_ref,
-            token_ref=token_ref,
-            max_height=self.deploy_params_template.max_height,
-            reward=self.deploy_params_template.reward,
-            difficulty=self.deploy_params_template.difficulty,
-            algo=self.deploy_params_template.algo,
-            daa_mode=self.deploy_params_template.daa_mode,
-            target_time=self.deploy_params_template.target_time,
-            half_life=self.deploy_params_template.half_life,
+        op_return_script: bytes | None = None
+        if self.op_return_msg is not None:
+            msg = self.op_return_msg
+            if len(msg) <= 75:
+                op_return_script = bytes([0x6A, len(msg)]) + msg
+            elif len(msg) <= 255:
+                op_return_script = bytes([0x6A, 0x4C, len(msg)]) + msg
+            else:
+                raise ValidationError(f"op_return_msg too long: {len(msg)} bytes (cap at 255 for now)")
+
+        return DmintV1RevealScripts(
+            contract_scripts=contract_scripts,
+            contract_value=1,
+            cbor_bytes=self.cbor_bytes,
+            scriptsig_suffix=scriptsig_suffix,
+            premine_script=None,
+            premine_amount=None,
+            op_return_script=op_return_script,
         )
-        return build_dmint_contract_script(real_params)
 
 
 class DmintDeployResult(DmintV2DeployResult):

--- a/tests/test_dmint_end_to_end.py
+++ b/tests/test_dmint_end_to_end.py
@@ -408,21 +408,18 @@ class TestPrepareDmintDeploy:
 
     _OWNER_PKH_HEX = None  # lazy init below
 
-    def _make_params(self, premine=None, pool=100_000):
+    def _make_params(self, num_contracts=1):
         from pyrxd.security.types import Hex20
 
-        # Migrated from DmintFullDeployParams (deprecated alias) to
-        # DmintV2DeployParams as part of the V1/V2 sibling-dataclass
-        # refactor. The deprecation warning is exercised separately in
-        # ``TestDmintFullDeployParamsDeprecation`` below.
+        # V2 deploy mirrors V1 (value-1 singletons in the reveal); the deprecation
+        # warning for DmintFullDeployParams is exercised in test_dmint_v1_deploy.py.
         return DmintV2DeployParams(
             metadata=self._META,
             owner_pkh=Hex20(bytes(b"\x11" * 20)),
+            num_contracts=num_contracts,
             max_height=1_000,
             reward_photons=1_000,
             difficulty=10,
-            initial_pool_photons=pool,
-            premine_amount=premine,
         )
 
     def test_returns_dmint_deploy_result(self):
@@ -442,79 +439,47 @@ class TestPrepareDmintDeploy:
         assert d["ticker"] == "TST"
         assert d["name"] == "Test Token"
 
-    def test_placeholder_contract_script_has_state_separator(self):
-        result = GlyphBuilder().prepare_dmint_deploy(self._make_params(), allow_v2_deploy=True)
-        assert b"\xbd" in result.placeholder_contract_script
+    def test_num_contracts_echoed(self):
+        result = GlyphBuilder().prepare_dmint_deploy(self._make_params(num_contracts=3), allow_v2_deploy=True)
+        assert result.num_contracts == 3
+        assert len(result.placeholder_contract_scripts) == 3
 
-    def test_initial_pool_photons_echoed(self):
-        result = GlyphBuilder().prepare_dmint_deploy(self._make_params(pool=500_000), allow_v2_deploy=True)
-        assert result.initial_pool_photons == 500_000
+    def test_placeholder_contract_scripts_have_state_separator(self):
+        result = GlyphBuilder().prepare_dmint_deploy(self._make_params(num_contracts=2), allow_v2_deploy=True)
+        assert all(b"\xbd" in s for s in result.placeholder_contract_scripts)
 
     def test_premine_amount_none_when_not_set(self):
         result = GlyphBuilder().prepare_dmint_deploy(self._make_params(), allow_v2_deploy=True)
         assert result.premine_amount is None
 
-    def test_premine_amount_echoed_when_set(self):
-        result = GlyphBuilder().prepare_dmint_deploy(self._make_params(premine=10_000), allow_v2_deploy=True)
-        assert result.premine_amount == 10_000
+    def test_rejects_premine(self):
+        # V2 deploy with premine is deferred (mirrors V1).
+        from dataclasses import replace
 
-    def test_rejects_premine_below_dust(self):
-        with pytest.raises(ValidationError, match="dust"):
-            GlyphBuilder().prepare_dmint_deploy(self._make_params(premine=100), allow_v2_deploy=True)
+        params = replace(self._make_params(), premine_amount=10_000)
+        with pytest.raises(ValidationError, match="premine"):
+            GlyphBuilder().prepare_dmint_deploy(params, allow_v2_deploy=True)
 
-    def test_rejects_pool_less_than_reward(self):
-        with pytest.raises(ValidationError, match="initial_pool_photons"):
-            GlyphBuilder().prepare_dmint_deploy(self._make_params(pool=500), allow_v2_deploy=True)  # reward=1000
+    def test_build_reveal_outputs_emits_value_1_v2_contracts(self):
+        result = GlyphBuilder().prepare_dmint_deploy(self._make_params(num_contracts=2), allow_v2_deploy=True)
+        rev = result.build_reveal_outputs("ab" * 32)
+        assert len(rev.contract_scripts) == 2
+        assert rev.contract_value == 1  # singleton, like V1
+        for script in rev.contract_scripts:
+            assert b"\xbd" in script  # OP_STATESEPARATOR
+            state = DmintState.from_script(script)
+            assert state.is_v1 is False  # V2 contract
+            assert state.height == 0
 
-    def test_build_reveal_scripts_with_premine(self):
-        result = GlyphBuilder().prepare_dmint_deploy(self._make_params(premine=1_000_000), allow_v2_deploy=True)
-        from pyrxd.glyph.builder import FtDeployRevealScripts
-
-        reveal = result.build_reveal_scripts(
-            commit_txid="ab" * 32,
-            commit_vout=0,
-            commit_value=5_000_000,
-        )
-        assert isinstance(reveal, FtDeployRevealScripts)
-        assert len(reveal.locking_script) == 75
-
-    def test_build_reveal_scripts_without_premine(self):
-        result = GlyphBuilder().prepare_dmint_deploy(self._make_params(), allow_v2_deploy=True)
-        from pyrxd.glyph.builder import RevealScripts
-
-        reveal = result.build_reveal_scripts(
-            commit_txid="ab" * 32,
-            commit_vout=0,
-            commit_value=5_000_000,
-        )
-        assert isinstance(reveal, RevealScripts)
-
-    def test_build_contract_script_with_real_refs(self):
-        result = GlyphBuilder().prepare_dmint_deploy(self._make_params(), allow_v2_deploy=True)
-        real_token_ref = GlyphRef(txid="cc" * 32, vout=0)
-        real_contract_ref = GlyphRef(txid="dd" * 32, vout=0)
-        script = result.build_contract_script(
-            token_ref=real_token_ref,
-            contract_ref=real_contract_ref,
-        )
-        # Should contain both ref bytes and the state separator
-        assert b"\xbd" in script
-        assert real_token_ref.to_bytes() in script
-        assert real_contract_ref.to_bytes() in script
-
-    def test_contract_script_parses_back_with_real_refs(self):
-        result = GlyphBuilder().prepare_dmint_deploy(self._make_params(), allow_v2_deploy=True)
-        real_token_ref = GlyphRef(txid="cc" * 32, vout=0)
-        real_contract_ref = GlyphRef(txid="dd" * 32, vout=0)
-        script = result.build_contract_script(
-            token_ref=real_token_ref,
-            contract_ref=real_contract_ref,
-        )
-        state = DmintState.from_script(script)
-        assert state.token_ref == real_token_ref
-        assert state.contract_ref == real_contract_ref
-        assert state.max_height == 1_000
-        assert state.reward == 1_000
+    def test_build_reveal_outputs_refs_are_commit_outpoints(self):
+        result = GlyphBuilder().prepare_dmint_deploy(self._make_params(num_contracts=2), allow_v2_deploy=True)
+        commit_txid = "cd" * 32
+        rev = result.build_reveal_outputs(commit_txid)
+        for i, script in enumerate(rev.contract_scripts):
+            state = DmintState.from_script(script)
+            # contractRef[i] = commit:(i+1), tokenRef = commit:0 (V1-style)
+            assert state.contract_ref == GlyphRef(txid=commit_txid, vout=i + 1)
+            assert state.token_ref == GlyphRef(txid=commit_txid, vout=0)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_dmint_v1_deploy.py
+++ b/tests/test_dmint_v1_deploy.py
@@ -692,10 +692,10 @@ class TestPrepareDmintDeployDispatch:
                 ticker="TV2",
             ),
             owner_pkh=Hex20(bytes(20)),
+            num_contracts=2,
             max_height=100,
             reward_photons=1_000,
             difficulty=10,
-            initial_pool_photons=100_000,
         )
 
     def test_v1_params_dispatches_to_v1_result(self):
@@ -867,10 +867,10 @@ class TestDeprecationAliases:
                     protocol=[GlyphProtocol.FT, GlyphProtocol.DMINT],
                 ),
                 owner_pkh=Hex20(bytes(20)),
+                num_contracts=1,
                 max_height=10,
                 reward_photons=1,
                 difficulty=1,
-                initial_pool_photons=100,
             )
         # Inheritance — isinstance check works either direction
         assert isinstance(instance, DmintV2DeployParams)
@@ -881,9 +881,8 @@ class TestDeprecationAliases:
             DmintDeployResult,
             DmintV2DeployResult,
         )
-        from pyrxd.glyph.dmint import DaaMode, DmintDeployParams
+        from pyrxd.glyph.dmint import DaaMode
         from pyrxd.glyph.dmint import DmintAlgo as _Algo
-        from pyrxd.glyph.types import GlyphRef
         from pyrxd.security.types import Hex20
 
         commit_result = CommitResult(
@@ -892,26 +891,22 @@ class TestDeprecationAliases:
             payload_hash=b"\x00" * 32,
             estimated_fee=0,
         )
-        params = DmintDeployParams(
-            contract_ref=GlyphRef(txid="00" * 32, vout=0),
-            token_ref=GlyphRef(txid="00" * 32, vout=0),
-            max_height=1,
-            reward=1,
-            difficulty=1,
-            algo=_Algo.SHA256D,
-            daa_mode=DaaMode.FIXED,
-            target_time=60,
-            half_life=3600,
-        )
         with pytest.warns(DeprecationWarning, match="DmintDeployResult"):
             instance = DmintDeployResult(
                 commit_result=commit_result,
                 cbor_bytes=b"",
                 owner_pkh=Hex20(bytes(20)),
                 premine_amount=None,
-                deploy_params_template=params,
-                placeholder_contract_script=b"",
-                initial_pool_photons=100,
+                num_contracts=1,
+                placeholder_contract_scripts=(b"",),
+                max_height=1,
+                reward_photons=1,
+                difficulty=1,
+                algo=_Algo.SHA256D,
+                op_return_msg=None,
+                daa_mode=DaaMode.FIXED,
+                target_time=60,
+                half_life=3600,
             )
         assert isinstance(instance, DmintV2DeployResult)
 

--- a/tests/test_dmint_v1_mint.py
+++ b/tests/test_dmint_v1_mint.py
@@ -1689,12 +1689,10 @@ class TestPrepareDmintDeployV2Refusal:
                 ticker="TST",
             ),
             owner_pkh=Hex20(bytes(20)),
+            num_contracts=1,
             max_height=1000,
             reward_photons=1000,
             difficulty=10,
-            initial_pool_photons=10_000_000,
-            contract_ref_placeholder=_CONTRACT_REF,
-            token_ref_placeholder=_TOKEN_REF,
         )
 
     def test_default_call_raises_dmint_error(self):

--- a/tests/test_dmint_v2_regtest_e2e.py
+++ b/tests/test_dmint_v2_regtest_e2e.py
@@ -19,18 +19,17 @@ This test proves the fixed V2 covenant is accepted by REAL Radiant consensus:
 deploy a FIXED-difficulty V2 contract, PoW-mine an 8-byte-nonce mint, and
 confirm the node accepts it (and rejects a wrong nonce).
 
-The deploy uses direct ref-induction (the HTLC-R1 mechanism: spend two genesis
-outpoints so the contract output's singleton ``contractRef`` + normal
-``tokenRef`` are inducted) rather than ``prepare_dmint_deploy``, because the V2
-deploy/mint *builder* still emits the wrong "pool"/1-input shape — rewriting it
-to the consensus-correct shape proven here is deferred follow-up (see #219). The
-mint is therefore built in the **consensus-correct shape** the covenant
-requires: contract + funding inputs; outputs = recreated contract (value **1**,
-a singleton) at vout[0], 75-byte FT reward at vout[1], OP_RETURN at vout[2],
-change at vout[3]; the recreated contract's state equals the current state with
-**only** ``height`` incremented (the covenant forbids changing any other state
-field — which is also why DAA/ASERT/LWMA cannot work with this covenant; FIXED
-only).
+Two paths are proven: ``test_v2_fixed_mint_...`` deploys by direct ref-induction
+(spend two genesis outpoints so the singleton ``contractRef`` + normal
+``tokenRef`` are inducted) as a focused covenant proof, and
+``test_v2_deploy_via_api_then_mint`` exercises the full library API
+(``prepare_dmint_deploy(DmintV2DeployParams)`` -> commit -> reveal ->
+``build_reveal_outputs``). Both feed ``build_dmint_mint_tx``, which emits the
+consensus-correct V1-shaped mint: contract + funding inputs; outputs = recreated
+contract (value **1**, a singleton) at vout[0], FT reward at vout[1], OP_RETURN
+at vout[2], change. The recreated state equals the current state with **only**
+``height`` incremented — which is also why DAA/ASERT/LWMA cannot work with this
+covenant (FIXED only).
 
 Gating / safety: opt-in via ``@pytest.mark.integration`` + ``RADIANT_REGTEST=1``;
 reuses the isolated throwaway-container harness from ``test_htlc_regtest_e2e``
@@ -58,6 +57,7 @@ from test_htlc_regtest_e2e import (  # noqa: F401  (node = fixture)
     node,
 )
 
+from pyrxd.glyph.builder import DmintV2DeployParams, GlyphBuilder
 from pyrxd.glyph.dmint import (
     DaaMode,
     DmintAlgo,
@@ -72,10 +72,10 @@ from pyrxd.glyph.dmint import (
     build_mint_scriptsig,
     mine_solution_dispatch,
 )
-from pyrxd.glyph.types import GlyphRef
+from pyrxd.glyph.types import GlyphMetadata, GlyphProtocol, GlyphRef
 from pyrxd.keys import PrivateKey
 from pyrxd.script.script import Script
-from pyrxd.script.type import encode_pushdata
+from pyrxd.script.type import encode_pushdata, to_unlock_script_template
 from pyrxd.security.types import Hex20
 from pyrxd.transaction.transaction import Transaction
 from pyrxd.transaction.transaction_input import TransactionInput
@@ -226,6 +226,120 @@ def _build_signed_v2_mint(node: _RegtestNode, contract: DmintContractUtxo) -> tu
     return tx, nonce
 
 
+# --------------------------------------------------------------------------- deploy via the real API
+
+
+def _p2pkh(pkh) -> bytes:
+    return b"\x76\xa9\x14" + bytes(pkh) + b"\x88\xac"
+
+
+def _commit_reveal_unlock(key: PrivateKey, suffix: bytes):
+    """Unlock template for the reveal's FT-commit hashlock input:
+    ``<sig> <pubkey> <gly> <CBOR>`` (the ``<gly><CBOR>`` part is ``suffix``)."""
+    pub = key.public_key().serialize()
+
+    def _u(tx, idx):
+        inp = tx.inputs[idx]
+        sig = key.sign(tx.preimage(idx))
+        return Script(encode_pushdata(sig + inp.sighash.to_bytes(1, "little")) + encode_pushdata(pub) + suffix)
+
+    return to_unlock_script_template(_u, lambda: 110 + len(suffix))
+
+
+def _deploy_v2_via_api(node: _RegtestNode, owner: PrivateKey) -> DmintContractUtxo:
+    """Deploy a 1-contract V2 dMint via the real API (prepare_dmint_deploy +
+    commit -> reveal + build_reveal_outputs) and return the live value-1 singleton
+    contract UTXO. Mirrors the V1 deploy; asserts the reveal is accepted by
+    consensus before the caller spends minutes mining.
+    """
+    owner_pkh = Hex20(owner.public_key().hash160())
+    owner_spk = _p2pkh(owner_pkh)
+    meta = GlyphMetadata.for_dmint_ft(
+        ticker="TV2",
+        name="V2 dMint regtest",
+        decimals=0,
+        protocol=[int(GlyphProtocol.FT), int(GlyphProtocol.DMINT)],
+    )
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", V2UnvalidatedWarning)
+        deploy = GlyphBuilder().prepare_dmint_deploy(
+            DmintV2DeployParams(
+                metadata=meta,
+                owner_pkh=owner_pkh,
+                num_contracts=1,
+                max_height=1000,
+                reward_photons=1000,
+                difficulty=1,
+            ),
+            allow_v2_deploy=True,
+        )
+    commit_script = deploy.commit_result.commit_script
+
+    # commit tx: FT-commit (vout0) | ref-seed -> contractRef genesis (vout1) | change
+    seed_txid = _pay_to_spk(node, owner_spk, 10_000_000)
+    c0, c1 = 2_000_000, 1_000_000
+    cin = TransactionInput(
+        source_transaction=_src(seed_txid, 0, owner_spk, 10_000_000),
+        source_txid=seed_txid,
+        source_output_index=0,
+        unlocking_script_template=_p2pkh_unlock(owner),
+    )
+    cin.satoshis = 10_000_000
+    cin.locking_script = Script(owner_spk)
+    commit_change = 10_000_000 - c0 - c1 - _RELAY_FEE_SATS
+    commit_tx = Transaction(
+        tx_inputs=[cin],
+        tx_outputs=[
+            TransactionOutput(Script(commit_script), c0),
+            TransactionOutput(Script(owner_spk), c1),
+            TransactionOutput(Script(owner_spk), commit_change),
+        ],
+    )
+    commit_tx.sign()
+    commit_txid = node.cli("sendrawtransaction", commit_tx.serialize().hex())
+    assert isinstance(commit_txid, str), commit_txid
+    node.mine(1)
+
+    # reveal tx: spend commit:0 (FT-commit + CBOR) AND commit:1 (contractRef genesis)
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", V2UnvalidatedWarning)
+        rev = deploy.build_reveal_outputs(commit_txid)
+    contract_script = rev.contract_scripts[0]
+    rin0 = TransactionInput(
+        source_transaction=_src(commit_txid, 0, commit_script, c0),
+        source_txid=commit_txid,
+        source_output_index=0,
+        unlocking_script_template=_commit_reveal_unlock(owner, rev.scriptsig_suffix),
+    )
+    rin0.satoshis = c0
+    rin0.locking_script = Script(commit_script)
+    rin1 = TransactionInput(
+        source_transaction=_src(commit_txid, 1, owner_spk, c1),
+        source_txid=commit_txid,
+        source_output_index=1,
+        unlocking_script_template=_p2pkh_unlock(owner),
+    )
+    rin1.satoshis = c1
+    rin1.locking_script = Script(owner_spk)
+    reveal_change = c0 + c1 - _CONTRACT_VALUE - _RELAY_FEE_SATS
+    reveal_tx = Transaction(
+        tx_inputs=[rin0, rin1],
+        tx_outputs=[
+            TransactionOutput(Script(contract_script), rev.contract_value),  # value 1 (singleton)
+            TransactionOutput(Script(owner_spk), reveal_change),
+        ],
+    )
+    reveal_tx.sign()
+    res = node.accepts(reveal_tx.serialize().hex())
+    assert res.get("allowed") is True, f"V2 deploy reveal REJECTED by consensus: {res}"
+    reveal_txid = node.cli("sendrawtransaction", reveal_tx.serialize().hex())
+    assert isinstance(reveal_txid, str), reveal_txid
+    node.mine(1)
+    state = DmintState.from_script(contract_script)
+    assert state.is_v1 is False and state.height == 0
+    return DmintContractUtxo(txid=reveal_txid, vout=0, value=rev.contract_value, script=contract_script, state=state)
+
+
 class TestRadiantDmintV2OnConsensus:
     def test_v2_fixed_mint_accepted_and_wrong_nonce_rejected(self, node):
         contract = _deploy_v2_contract(node, max_height=10, reward=1000)
@@ -257,3 +371,14 @@ class TestRadiantDmintV2OnConsensus:
         assert recreated_out and round(recreated_out["value"] * 1e8) == _CONTRACT_VALUE, "recreated V2 contract wrong"
         reward_out = node.cli("gettxout", mtxid, "1")
         assert reward_out and round(reward_out["value"] * 1e8) == 1000, "V2 FT reward output (vout 1) wrong"
+
+    def test_v2_deploy_via_api_then_mint(self, node):
+        """The real deploy API (prepare_dmint_deploy(DmintV2DeployParams) ->
+        commit -> reveal -> build_reveal_outputs) produces a value-1 V2 singleton
+        that the real mint builder can spend and consensus accepts."""
+        owner = PrivateKey(secrets.token_bytes(32))
+        contract = _deploy_v2_via_api(node, owner)
+        assert contract.value == 1 and contract.state.is_v1 is False
+        tx, _nonce = _build_signed_v2_mint(node, contract)
+        res = node.accepts(tx.serialize().hex())
+        assert res["allowed"] is True, f"mint of API-deployed V2 contract rejected: {res}"


### PR DESCRIPTION
**Stacked on #230** (the V2 mint-builder rewrite it depends on). Base retargets to `main` once #230 merges. Together, #228 (covenant) + #230 (mint) + this (deploy) make dMint V2 fully usable via the library on FIXED difficulty.

## What

The V2 deploy API was bespoke and **never validated** — it modeled a separate "deploy tx" with a reward pool (`initial_pool_photons`) and a self-referential `contractRef`, none of which the covenant accepts (the contract is a 1-photon singleton, exactly like V1). This replaces it with V1's **proven** commit→reveal:

- `DmintV2DeployParams` mirrors `DmintV1DeployParams`: adds `num_contracts`; drops `initial_pool_photons` / `contract_ref_placeholder` / `token_ref_placeholder`; **FIXED-only** (ASERT/LWMA rejected — unmintable).
- `_prepare_dmint_v2_deploy` builds the FT-commit + N placeholder V2 contract scripts, mirroring the V1 prepare.
- `DmintV2DeployResult.build_reveal_outputs` emits `num_contracts` parallel **1-photon V2 singletons** (`contractRef[i] = commit:(i+1)`, `tokenRef = commit:0`), reusing `DmintV1RevealScripts`. The bespoke `build_reveal_scripts` / `build_contract_script` are removed.

## Validation

- `tests/test_dmint_v2_regtest_e2e.py::test_v2_deploy_via_api_then_mint` — deploy via the **real API** (commit → reveal **ACCEPTED** by `radiant-core:v2.3.0` regtest) → mint via `build_dmint_mint_tx` → **ACCEPTED**. ✅
- Updated the offline deploy tests + the `DmintFullDeployParams`/`DmintDeployResult` deprecation-alias tests for the new field shape.
- Full non-integration suite green (4219 passed).

## API break

`DmintV2DeployParams`/`DmintV2DeployResult` change shape — acceptable since V2 deploy is gated behind `allow_v2_deploy=True` + `V2UnvalidatedWarning` (no real users).

Refs #219. `V2UnvalidatedWarning` stays (no mainnet V2 contract yet).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
