### PR TITLE
docs: fill newcomer gaps + repair stale indexes and source links

### DIFF
--- a/docs/concepts/dmint-v1-deploy.md
+++ b/docs/concepts/dmint-v1-deploy.md
@@ -110,7 +110,7 @@ The epilogue is the same 145 bytes across every V1 mainnet deploy
 except for one byte: the algo selector (`0xaa` for sha256d on every
 live deploy seen to date). pyrxd's parser fingerprints on the
 epilogue prefix + algo byte + epilogue suffix
-([`_match_v1_epilogue`](../../src/pyrxd/glyph/dmint.py)).
+([`_match_v1_epilogue`](../../src/pyrxd/glyph/dmint/__init__.py)).
 
 ---
 

--- a/docs/concepts/external-miner-protocol.md
+++ b/docs/concepts/external-miner-protocol.md
@@ -1,7 +1,7 @@
 # External miner protocol: JSON-over-stdio subprocess contract
 
 **Why this page exists:** pyrxd ships a pure-Python reference miner
-([`mine_solution`](../../src/pyrxd/glyph/dmint.py)) so the library is
+([`mine_solution`](../../src/pyrxd/glyph/dmint/__init__.py)) so the library is
 self-contained and the verifier path is the same as the mining path —
 no silent divergence between "what the miner accepts" and "what
 on-chain validation enforces." That correctness comes at a cost: a
@@ -10,7 +10,7 @@ Mh/s per core, so a real mainnet contract takes minutes to over an
 hour on a single CPU. Anyone wanting to mine V1 dMint contracts in
 production wants a faster miner — a parallel Python worker pool, a C
 binary, a WebGPU shader. The shim that bridges pyrxd to those is
-[`mine_solution_external`](../../src/pyrxd/glyph/dmint.py): it spawns
+[`mine_solution_external`](../../src/pyrxd/glyph/dmint/__init__.py): it spawns
 a caller-supplied binary, hands it the search problem over JSON, and
 **re-verifies the returned nonce locally** before letting it touch a
 transaction. This page documents that wire protocol so you can wire
@@ -23,7 +23,7 @@ in your own miner.
 Two entry points:
 
 1. **Direct API.** Pass an `argv` list to
-   [`mine_solution_external`](../../src/pyrxd/glyph/dmint.py):
+   [`mine_solution_external`](../../src/pyrxd/glyph/dmint/__init__.py):
 
    ```python
    from pyrxd.glyph.dmint import mine_solution_external, build_pow_preimage
@@ -49,7 +49,7 @@ Two entry points:
      reference miner.
    - `EXTERNAL_MINER_TIMEOUT_S` — hard timeout in seconds (default
      `600.0`, defined as `EXTERNAL_MINER_TIMEOUT_S` at
-     [`src/pyrxd/glyph/dmint.py:877`](../../src/pyrxd/glyph/dmint.py)).
+     [`src/pyrxd/glyph/dmint.py:877`](../../src/pyrxd/glyph/dmint/__init__.py)).
      On timeout the subprocess is killed and `MaxAttemptsError` is
      raised.
 
@@ -81,7 +81,7 @@ exits.
 | `nonce_width`  | int    | yes      | `4` for V1 contracts, `8` for V2                   |
 
 The exact request shape lives in
-[`src/pyrxd/glyph/dmint.py:951-957`](../../src/pyrxd/glyph/dmint.py):
+[`src/pyrxd/glyph/dmint.py:951-957`](../../src/pyrxd/glyph/dmint/__init__.py):
 
 ```python
 request = json.dumps({
@@ -109,7 +109,7 @@ pyrxd then checks:
   `nonce_width` bytes long.
 
 If any of those fail, pyrxd raises `ValidationError`. See
-[`src/pyrxd/glyph/dmint.py:988-1016`](../../src/pyrxd/glyph/dmint.py)
+[`src/pyrxd/glyph/dmint.py:988-1016`](../../src/pyrxd/glyph/dmint/__init__.py)
 for the exact decoding path.
 
 ### Exit codes
@@ -131,7 +131,7 @@ parent timeout fires, or exit non-zero (which surfaces as
 
 Discarded. pyrxd attaches `stderr=subprocess.DEVNULL` so a misbehaving
 miner cannot OOM the parent by flooding stderr (see the comment at
-[`src/pyrxd/glyph/dmint.py:967-971`](../../src/pyrxd/glyph/dmint.py)).
+[`src/pyrxd/glyph/dmint.py:967-971`](../../src/pyrxd/glyph/dmint/__init__.py)).
 Loss of debug output is the price; if you need to see what your miner
 is doing, run it standalone with the same JSON request and watch
 stderr there.
@@ -142,7 +142,7 @@ stderr there.
 
 The 64 bytes pyrxd hands the miner are the **canonical V1 mint
 preimage** built by
-[`build_pow_preimage`](../../src/pyrxd/glyph/dmint.py): a fixed-layout
+[`build_pow_preimage`](../../src/pyrxd/glyph/dmint/__init__.py): a fixed-layout
 concatenation of the contract's previous txid, the contract ref, the
 miner's input script hash, and the miner's output script hash. The
 exact byte layout is pinned in
@@ -159,7 +159,7 @@ full[0:4] == b'\x00\x00\x00\x00'  AND  int.from_bytes(full[4:12], 'big') < targe
 ```
 
 This is the exact check `verify_sha256d_solution` performs at
-[`src/pyrxd/glyph/dmint.py:711`](../../src/pyrxd/glyph/dmint.py),
+[`src/pyrxd/glyph/dmint.py:711`](../../src/pyrxd/glyph/dmint/__init__.py),
 which `mine_solution_external` calls against every returned nonce
 before declaring success. A nonce that fails this check raises
 `ValidationError` regardless of what the miner claims, which is the
@@ -288,5 +288,5 @@ contract documented above will continue to work without change.
    network. Mitigations: invoke with an absolute path, verify
    checksums against the upstream release, run in a controlled
    environment. See the supply-chain warning in the
-   [`mine_solution_external` docstring](../../src/pyrxd/glyph/dmint.py)
+   [`mine_solution_external` docstring](../../src/pyrxd/glyph/dmint/__init__.py)
    for the full discussion.

--- a/docs/concepts/index.md
+++ b/docs/concepts/index.md
@@ -11,9 +11,12 @@ gravity
 covenant-building-blocks
 partial-tx-swaps
 glyph-structures-and-terminology
+glyph-inspect-tool
 radiant-fts-are-on-chain
 dmint-v1-deploy
+v1-mint-mechanics
 external-miner-protocol
+parallel-mining
 ```
 
 ## Available now
@@ -48,6 +51,12 @@ external-miner-protocol
   the inspect tool. Read this first if you've ever been confused by
   why pasting a "contract id" shows you the *deploy* transaction
   instead of your *transfer*.
+- **[The Glyph inspect tool: structural match, not semantic correctness](glyph-inspect-tool.md)** —
+  what a green check from `glyph inspect` (CLI and browser) actually
+  means: it classifies which on-chain *shape* a script or transaction
+  matches, offline — it does **not** assert the FT will spend or the
+  contract will mint. Read this to understand the trust boundary before
+  trusting an inspect result.
 - **[Radiant FTs are on-chain (not metadata-on-P2PKH)](radiant-fts-are-on-chain.md)** —
   the most common confusion when porting from Atomicals / Runes / SPL
   is to assume Radiant FTs are plain UTXOs with off-chain meaning. This
@@ -58,6 +67,11 @@ external-miner-protocol
   to Radiant Glyph Protocol), why pyrxd refuses to emit V2 by default,
   and the five Photonic divergences pyrxd ships with. Read this before
   using `prepare_dmint_deploy` with `DmintV1DeployParams`.
+- **[V1 dMint mint mechanics: claiming a contract UTXO](v1-mint-mechanics.md)** —
+  the *claim* side of a V1 dMint contract: the canonical 4-output mint
+  transaction, the 72-byte scriptSig push convention, the 64-byte PoW
+  preimage layout, and the FT-conservation covenant check the script
+  enforces on the reward output. The companion to the *deploy* page above.
 - **[External miner protocol: JSON-over-stdio subprocess contract](external-miner-protocol.md)** —
   the wire protocol `mine_solution_external` uses to drive a fast
   external miner binary as a child process. Documents the request /
@@ -65,6 +79,11 @@ external-miner-protocol
   `EXTERNAL_MINER_TIMEOUT_S` env vars used by the dMint claim demo,
   what the library re-verifies before trusting a returned nonce, and
   a 20-line reference miner that fits the contract.
+- **[Parallel mining and the bundled miner](parallel-mining.md)** — the two
+  miners pyrxd ships (the slow-but-correct in-process `mine_solution` and the
+  fast subprocess `mine_solution_external`), the bundled `pyrxd.contrib.miner`
+  added in 0.5.1 so you don't have to supply your own, and how parallel workers
+  divide the nonce space. Read this to mine a dMint claim at a useful rate.
 
 ## Adjacent reading (not yet promoted to concept docs)
 

--- a/docs/concepts/v1-mint-mechanics.md
+++ b/docs/concepts/v1-mint-mechanics.md
@@ -75,7 +75,7 @@ The contract input value is **preserved across mints**. V1 contracts
 are singletons (the on-chain reference deploys all use 1-photon
 contract outputs), not a value pool — the reward photons come from
 the funding input, not from the contract UTXO. See
-[`_build_dmint_v1_mint_tx`](../../src/pyrxd/glyph/dmint.py) for the
+[`_build_dmint_v1_mint_tx`](../../src/pyrxd/glyph/dmint/__init__.py) for the
 builder's output assembly.
 
 The 241-byte recreated contract layout (state + epilogue) is the same
@@ -88,7 +88,7 @@ changes between mints.
 
 pyrxd's V1 mint builder will produce a 3-output transaction (no
 OP_RETURN) if `op_return_msg` is `None`. But the V1 preimage helper
-[`build_dmint_v1_mint_preimage`](../../src/pyrxd/glyph/dmint.py)
+[`build_dmint_v1_mint_preimage`](../../src/pyrxd/glyph/dmint/__init__.py)
 **requires** `unsigned_tx.outputs[2]` to exist and to be an OP_RETURN
 script (starts with `0x6a`). The covenant binds `outputHash` to that
 specific position; building a 3-output mint produces a preimage with
@@ -108,7 +108,7 @@ public helpers.
 The contract input's scriptSig is a fixed byte layout. The 4-byte
 nonce variant (V1) totals 72 bytes; the 8-byte variant (V2) totals
 76. Layout from
-[`build_mint_scriptsig`](../../src/pyrxd/glyph/dmint.py):
+[`build_mint_scriptsig`](../../src/pyrxd/glyph/dmint/__init__.py):
 
 ```
 ┌── V1 mint scriptSig (72 bytes) ────────────────────────────────────┐
@@ -132,7 +132,7 @@ where:
 The V2 form is identical except the first byte is `0x08` and the
 nonce is 8 bytes (76 bytes total). The single-byte switch
 between layouts is why
-[`build_mint_scriptsig`](../../src/pyrxd/glyph/dmint.py) takes a
+[`build_mint_scriptsig`](../../src/pyrxd/glyph/dmint/__init__.py) takes a
 keyword-only `nonce_width: Literal[4, 8]` argument — a stray
 positional `4` is a type error rather than a silent V1/V2 confusion.
 
@@ -151,7 +151,7 @@ scriptsig = build_mint_scriptsig(
 ```
 
 The scriptSig's `inputHash` / `outputHash` are
-[`PowPreimageResult.input_hash`](../../src/pyrxd/glyph/dmint.py) and
+[`PowPreimageResult.input_hash`](../../src/pyrxd/glyph/dmint/__init__.py) and
 `.output_hash` from the same call that produced the preimage the
 miner solved. Splitting the sources (recomputing the hashes
 separately in two helpers) is exactly the silent-rejection failure
@@ -191,8 +191,8 @@ where:
   the scriptSig also pushes (see previous section).
 
 This is the exact layout
-[`build_pow_preimage`](../../src/pyrxd/glyph/dmint.py) returns inside
-[`PowPreimageResult`](../../src/pyrxd/glyph/dmint.py). The miner
+[`build_pow_preimage`](../../src/pyrxd/glyph/dmint/__init__.py) returns inside
+[`PowPreimageResult`](../../src/pyrxd/glyph/dmint/__init__.py). The miner
 appends the nonce, double-SHA256's the 68 bytes (64 preimage + 4
 nonce for V1), and accepts the nonce when the little-endian integer
 of the result is less than `target`.
@@ -250,7 +250,7 @@ with:
 - The output value (`satoshis` field) exactly equal to
   `state.reward` photons — `1 photon = 1 FT unit` for Radiant FTs.
 
-[`build_dmint_v1_ft_output_script`](../../src/pyrxd/glyph/dmint.py)
+[`build_dmint_v1_ft_output_script`](../../src/pyrxd/glyph/dmint/__init__.py)
 builds this exact shape. A plain 25-byte P2PKH at `vout[1]` fails
 the covenant: the FT-CSH fingerprint isn't there to match, and the
 conservation sum collapses to zero on the output side while the
@@ -273,7 +273,7 @@ producing a covenant-rejected broadcast:
 
 1. **scriptSig pushes derived independently from the preimage.**
    `build_pow_preimage` returns a frozen
-   [`PowPreimageResult`](../../src/pyrxd/glyph/dmint.py) carrying
+   [`PowPreimageResult`](../../src/pyrxd/glyph/dmint/__init__.py) carrying
    the preimage plus `.input_hash` / `.output_hash`. The scriptSig
    builder takes those same hashes — there is no public path that
    splits the preimage halves and the scriptSig pushes into two
@@ -290,7 +290,7 @@ producing a covenant-rejected broadcast:
    addresses with matching payload bytes.
 
 3. **Missing OP_RETURN at vout[2].**
-   [`build_dmint_v1_mint_preimage`](../../src/pyrxd/glyph/dmint.py)
+   [`build_dmint_v1_mint_preimage`](../../src/pyrxd/glyph/dmint/__init__.py)
    refuses to compute a preimage when `unsigned_tx.outputs[2]` is
    absent or doesn't start with `0x6a`. The covenant binds
    `outputHash` to that exact position; producing a preimage from a

--- a/docs/how-to/index.md
+++ b/docs/how-to/index.md
@@ -6,33 +6,58 @@ you already know the basics and want a focused answer to "how do I X."
 ```{toctree}
 :maxdepth: 1
 
-broadcast-a-transaction
+receive-and-check-balance
+transfer-a-glyph-token
+use-the-signing-agent
 recover-funds-across-wallet-paths
+broadcast-a-transaction
 use-the-public-testnet
+scan-address-for-glyphs
 issue-a-dmint-token
 build-a-cross-chain-swap
 run-a-two-host-swap-dry-run
-migrate-0.4-to-0.5
 verify-an-spv-proof
 spv-verification-pitfalls
+handle-radiant-bip143-quirks
+migrate-0.4-to-0.5
 ```
 
 ## Available now
 
+- **[Receive funds and check your balance](receive-and-check-balance.md)** — the
+  read-only wallet basics: `pyrxd address` for a receive address, `pyrxd balance
+  --refresh` to confirm money arrived, `pyrxd utxos` to see exactly what you
+  hold, and `wallet export-xpub` for watch-only receiving. No signing, no
+  mnemonic.
+- **[Transfer a Glyph token after you mint it](transfer-a-glyph-token.md)** — the
+  canonical second task: send an FT or NFT to someone with `glyph transfer-ft
+  REF AMOUNT --to ADDR` / `glyph transfer-nft REF --to ADDR`. Explains that `REF`
+  is the token's genesis ref (not the UTXO), FT conservation + change, and why an
+  NFT transfer needs a little plain RXD for the fee.
+- **[Use the local signing agent](use-the-signing-agent.md)** — unlock the wallet
+  once into a foreground agent (`pyrxd agent unlock`); the seed lives in one
+  process, `wallet send` signs against it with no mnemonic re-entry, and you
+  approve each spend in the agent's terminal. Covers `--idle-timeout`,
+  `--auto-confirm-under`, and `agent status` / `lock`.
+- **[Recover funds across wallet paths](recover-funds-across-wallet-paths.md)** —
+  when a restored seed shows a zero balance but the explorer shows funds, scan
+  the BIP44 coin-type/account paths (Photonic, Chainbow, Electron, Tangem) to
+  find which derivation actually holds the money, then `pyrxd wallet sweep` it to
+  a reachable address. Read-only scan; `pyrxd wallet recover --scan` or the
+  `pyrxd.hd.discover` API.
 - **[Broadcast a transaction](broadcast-a-transaction.md)** — push a
   signed tx through `ElectrumXClient.broadcast(...)`, recognise the
   four common rejection symptoms (`bad-txns-inputs-missingorspent`,
   `txn-mempool-conflict`, `min relay fee not met`,
   `mandatory-script-verify-flag-failed`), and poll for confirmation.
-- **[Recover funds across wallet paths](recover-funds-across-wallet-paths.md)** —
-  when a restored seed shows a zero balance but the explorer shows funds, scan
-  the BIP44 coin-type/account paths (Photonic, Chainbow, Electron, Tangem) to
-  find which derivation actually holds the money. Read-only; `pyrxd wallet
-  recover --scan` or the `pyrxd.hd.discover` API.
 - **[Use the public Radiant testnet](use-the-public-testnet.md)** — when to
   graduate from the local regtest quickstart to the shared public testnet, how to
   run `radiantd -testnet`, point pyrxd at it, and get testnet coins from the
   (best-effort, community-run) faucet. For most work, stay on regtest.
+- **[Scan an address for Glyphs](scan-address-for-glyphs.md)** — given any
+  Radiant address, list the Glyph tokens (NFTs and FTs) held at it. An async
+  ElectrumX recipe returning typed objects you can filter in-process — the
+  library counterpart to `pyrxd glyph list`.
 - **[Issue and mine your own dMint token](issue-a-dmint-token.md)** — launch a
   permissionless, PoW-mined fungible token (no premine, no central issuer) and
   mine the first claim, end to end from the CLI: `glyph init-metadata --type
@@ -47,11 +72,6 @@ spv-verification-pitfalls
   their own keys and exchanging only the public negotiation envelope out-of-band: the
   first real exercise of untrusted-counterparty verification. The prep for a genuine
   two-party adversarial run. Pre-audit — regtest/testnet only, no real value.
-- **[Migrate from pyrxd 0.4.x to 0.5.0](migrate-0.4-to-0.5.md)** — three
-  breaking signature changes on the V1 dMint mint path, with
-  before/after snippets. Read this first if you upgraded from a 0.4.x
-  pin and your build is now raising `TypeError` or `ValidationError`
-  from `pyrxd.glyph.dmint`.
 - **[Verify an SPV proof](verify-an-spv-proof.md)** — given a txid, a
   Merkle path, and a block header, confirm the tx is in the block.
   Covers the raise-on-failure `verify_tx_in_block` recipe, fetching a
@@ -63,6 +83,17 @@ spv-verification-pitfalls
   depth from a reported height, the 64-byte node and coinbase-position
   forgeries, quorum-is-not-a-forgery-defense, and what to differential-test.
   Implementation-agnostic; the companion *why* to the *how* above.
+- **[Handle Radiant's BIP143 sighash quirks](handle-radiant-bip143-quirks.md)** —
+  for porting a sighash implementation from Bitcoin/BCH/BSV: the extra
+  `hashOutputHashes` field and ref-aware preimage Radiant adds. You only need
+  this if you build preimages by hand — `Transaction.sign(...)` handles it for
+  you.
+- **[Breaking changes since pyrxd 0.4.x](migrate-0.4-to-0.5.md)** — the only
+  public-API break since 0.4.x is the three V1-dMint mint-path signature changes
+  in 0.5.0 (`build_pow_preimage` and friends), with before/after snippets. Every
+  release since (0.5.x → current) is additive and drop-in. Read this only if
+  you're upgrading from a 0.4.x pin and hitting `TypeError` / `ValidationError`
+  from `pyrxd.glyph.dmint`.
 
 ## Coming soon
 
@@ -74,7 +105,5 @@ meantime.
 Suggested guides on the roadmap (open an
 [issue](https://github.com/MudwoodLabs/pyrxd/issues) to influence priority):
 
-- How to broadcast a transaction
 - How to build a custom locking script
-- How to scan an address for Glyphs
-- How to handle Radiant's BIP143 quirks (`hashOutputHashes`, ref-aware sighash)
+- How to run a same-chain partial-transaction swap (`pyrxd.swap`)

--- a/docs/how-to/migrate-0.4-to-0.5.md
+++ b/docs/how-to/migrate-0.4-to-0.5.md
@@ -1,10 +1,16 @@
-# How to migrate from pyrxd 0.4.x to 0.5.0
+# Breaking changes since pyrxd 0.4.x
 
-**Who this page is for:** anyone who imports `build_pow_preimage`,
-`build_mint_scriptsig`, or `build_dmint_v1_mint_preimage` from
-`pyrxd.glyph.dmint`. If you only use the CLI, the higher-level
-`GlyphBuilder` API, or the inspect tool, 0.5.0 is a drop-in upgrade and
-you can stop reading here.
+**Scope:** the only break to the stable public API since 0.4.x landed in
+**0.5.0** — three signature changes on the V1 dMint mint path, documented below.
+Every release since (0.5.x through the current version) is **additive and
+drop-in**: existing import paths and CLI commands are unchanged. If you're on
+0.5.0 or later, there is nothing to migrate.
+
+**Who this page is for:** anyone upgrading from a **0.4.x** pin who imports
+`build_pow_preimage`, `build_mint_scriptsig`, or `build_dmint_v1_mint_preimage`
+from `pyrxd.glyph.dmint`. If you only use the CLI, the higher-level
+`GlyphBuilder` API, or the inspect tool, 0.5.0 is a drop-in upgrade and you can
+stop reading here.
 
 0.5.0 makes three signature changes to the V1 dMint mint path. They
 are deliberately **hard breaks with loud errors** — no deprecation

--- a/docs/how-to/receive-and-check-balance.md
+++ b/docs/how-to/receive-and-check-balance.md
@@ -1,0 +1,99 @@
+# How to receive funds and check your balance
+
+**Who this page is for:** you have a wallet (`pyrxd wallet new` or
+`pyrxd wallet recover`) and you want a receive address, then to confirm money
+arrived. Everything on this page is **read-only** — no signing, no broadcast, no
+mnemonic required for the balance and UTXO views.
+
+```
+pyrxd address   →  give it to the sender
+pyrxd balance   →  did it arrive?
+pyrxd utxos     →  what exactly do I hold?
+```
+
+---
+
+## Get a receive address
+
+```console
+$ pyrxd address
+1Abc…yourReceiveAddress
+```
+
+With no flags, `address` prints the **next unused external receive address** —
+the right default for "where do I get paid." For deterministic lookups:
+
+```console
+$ pyrxd address --index 5            # external address at index 5
+$ pyrxd address --index 5 --change   # the change-chain address at index 5
+```
+
+Hand the printed address to whoever is paying you. It's a public receive address
+— safe to share.
+
+---
+
+## Check your balance
+
+```console
+$ pyrxd balance
+Confirmed:    1.23456789 RXD
+Unconfirmed:  0.00000000 RXD
+```
+
+`balance` sums confirmed and unconfirmed photons across the addresses the wallet
+already knows about. If you just received to a **fresh** address the wallet
+hasn't seen used yet, run a gap-limit scan first so it gets discovered:
+
+```console
+$ pyrxd balance --refresh
+```
+
+Use `--refresh` after receiving to a new address, or any time the balance looks
+lower than the explorer shows. (If `--refresh` *still* shows zero while an
+explorer shows funds, your coins are likely on a different derivation path —
+see [Recover funds across wallet paths](recover-funds-across-wallet-paths.md).)
+
+---
+
+## See exactly what you hold
+
+```console
+$ pyrxd utxos
+```
+
+`utxos` is a read-only diagnostic listing every spendable output across your
+used addresses. Two filters:
+
+```console
+$ pyrxd utxos --min-photons 10000   # hide dust below 10,000 photons
+$ pyrxd utxos --addr 1Abc…           # only this address
+```
+
+This is the view to reach for when a send picks unexpected inputs, or when you
+want to confirm a specific payment landed at a specific address.
+
+---
+
+## Receive without exposing the wallet: watch-only xpub
+
+To let an external tool or service generate receive addresses for you **without
+ever touching the seed**, export the account-level xpub:
+
+```console
+$ pyrxd wallet export-xpub
+xpub6C…
+```
+
+The xpub at `m/44'/<coin_type>'/<account>'` derives receive addresses but
+**carries no private keys** — safe to hand to a watch-only wallet or a merchant
+integration. Anyone with it can watch and derive addresses; they cannot spend.
+
+---
+
+## See also
+
+- [Your first Radiant transaction](../tutorials/your-first-radiant-transaction.md)
+  — receive, check, then build and sign a send.
+- [Recover funds across wallet paths](recover-funds-across-wallet-paths.md) —
+  when the balance is zero but the explorer shows funds.

--- a/docs/how-to/recover-funds-across-wallet-paths.md
+++ b/docs/how-to/recover-funds-across-wallet-paths.md
@@ -110,8 +110,33 @@ report = await discover(client, mnemonic, coin_types=(0, 512, 236), accounts=ran
 - Restore the seed in a wallet configured for the reported `coin_type`
   (for Photonic ≥ v3.0.1, the Recover screen auto-detects coin type 0 vs 512;
   tick "Use legacy derivation path" if it shows empty), **or**
-- Sweep with pyrxd's own spend path once your wallet is built at that coin
-  type (`HdWallet.from_mnemonic(mnemonic, coin_type=…)` then `send_max`).
+- Sweep the path with pyrxd directly — the next section.
+
+### Sweep a derived path with `pyrxd wallet sweep`
+
+When the funds sit at a path no GUI wallet can reach (a non-zero account, or a
+coin type your wallet won't derive), `wallet sweep` moves **everything** under
+that path to an address you control:
+
+```console
+$ pyrxd wallet sweep --coin-type 0 --to 1YourSafeAddress
+```
+
+Pass the `--coin-type` (and `--account`, if non-zero) that `wallet recover
+--scan` reported. The command sweeps every spendable UTXO under
+`m/44'/<coin-type>'/<account>'` to `--to`, minus the fee. It is a **real signed
+broadcast**, so it shows you the amount, fee, and destination and asks you to
+confirm before anything goes out.
+
+| Option | Default | Notes |
+|---|---|---|
+| `--coin-type` | *(required)* | The SLIP-0044 coin type the funds are on (e.g. `0` or `512`). |
+| `--account` | `0` | The BIP44 account index the funds are on. |
+| `--to` | *(required)* | Destination address you control. |
+| `--fee-rate` | `10000` | Photons per kB. |
+
+Send `--to` an address from a wallet you can actually use day-to-day — the point
+of the sweep is to get the coins onto a reachable path.
 
 ---
 

--- a/docs/how-to/transfer-a-glyph-token.md
+++ b/docs/how-to/transfer-a-glyph-token.md
@@ -1,0 +1,138 @@
+# How to transfer a Glyph token after you mint it
+
+**Who this page is for:** you minted a Glyph FT or NFT (see
+[Mint a Glyph FT](../tutorials/mint-a-glyph-ft.md) /
+[Mint a Glyph NFT](../tutorials/mint-a-glyph-nft.md)) and now want to send some
+of it to someone else. Two CLI verbs cover both cases:
+
+| You hold | Command | What moves |
+|---|---|---|
+| A fungible token (FT) | `pyrxd glyph transfer-ft` | `AMOUNT` units to one recipient, change back to you |
+| A non-fungible token (NFT) | `pyrxd glyph transfer-nft` | the whole singleton to one recipient |
+
+Both **sign and broadcast a real transaction** and ask you to confirm the
+amount, recipient, and network first. A confirmed transfer is irreversible.
+
+---
+
+## The `REF` is the token, not the UTXO
+
+The one thing that trips people up: `REF` is the token's **genesis ref** — the
+`txid:vout` that identifies the token *class*, embedded in every output that
+carries it. It is **not** the outpoint of the specific UTXO you happen to hold
+right now. You pass the genesis ref once; pyrxd scans your wallet and finds
+whichever UTXO(s) currently hold that token for you.
+
+For an FT, the ref is the **commit outpoint from the deploy**, not the reveal
+txid (a common mix-up — see
+[Glyph structures and terminology](../concepts/glyph-structures-and-terminology.md)).
+If you're not sure what your ref is, list your holdings:
+
+```console
+$ pyrxd glyph list --type ft
+$ pyrxd glyph list --type nft
+```
+
+or decode any output you hold with the inspect tool — `ref_outpoint` in the
+output is the value to pass:
+
+```console
+$ pyrxd glyph inspect <txid:vout> --resolve
+```
+
+---
+
+## Transfer fungible tokens (FT)
+
+```console
+$ pyrxd glyph transfer-ft <REF> <AMOUNT> --to <ADDRESS>
+```
+
+- `REF` — the token's genesis ref as `txid:vout`.
+- `AMOUNT` — units to send (must be > 0). One photon carries one FT unit.
+- `--to` — the recipient's Radiant address (required).
+
+pyrxd scans your used addresses for UTXOs of `REF`, greedily selects enough to
+cover `AMOUNT`, and builds a **conservation-enforcing** transfer: the recipient
+gets a new FT output for `AMOUNT`, and any remainder comes back to you as a
+change FT output. The Radiant FT consensus rule (token in == token out) is
+preserved by construction — you cannot accidentally create or destroy units.
+
+```console
+$ pyrxd glyph transfer-ft 9d3f…a1:1 250 --to 1Qq…recipient
+
+  FT transfer
+    ref:          9d3f…a1:1
+    amount:       250 units
+    recipient:    1Qq…recipient
+    network:      mainnet
+
+Broadcast this transfer? [y/N]: y
+
+FT transfer broadcast: 4b1c…e7
+```
+
+> **One-address restriction (current).** The FT transfer signs all selected
+> inputs with a single key. If your units are spread across multiple wallet
+> addresses, the command stops with *"FT transfer across multiple wallet
+> addresses isn't supported"* and asks you to consolidate first. Send the
+> scattered pieces to one of your own addresses, then retry.
+
+---
+
+## Transfer a non-fungible token (NFT)
+
+```console
+$ pyrxd glyph transfer-nft <REF> --to <ADDRESS>
+```
+
+There's no amount — an NFT is a singleton, so the whole thing moves. pyrxd
+finds the one UTXO holding `REF`, re-locks it to the recipient, and broadcasts.
+
+```console
+$ pyrxd glyph transfer-nft 7a0c…42:0 --to 1Rr…recipient
+
+  NFT transfer
+    ref:          7a0c…42:0
+    recipient:    1Rr…recipient
+    network:      mainnet
+
+Broadcast this transfer? [y/N]: y
+
+NFT transfer broadcast: c88a…91
+```
+
+> **You need a little plain RXD to pay the fee.** An NFT singleton carries only
+> dust, so the transfer pulls the network fee from a separate plain-RXD UTXO in
+> the same wallet. If the wallet has no spendable RXD, the command stops with
+> *"no plain-RXD UTXO to fund the NFT transfer fee"* — fund the wallet with a
+> small amount of RXD and retry. The fee change returns to you.
+
+---
+
+## Failure modes
+
+- **`no FT holdings for <ref>` / `<NFT> is not held by this wallet`.** The
+  wallet doesn't see the token at any used address. Run `pyrxd balance
+  --refresh` to rescan, then retry. If it's still missing, the token is owned by
+  a different wallet/address.
+- **`insufficient FT balance: need N, have M`.** You're trying to send more
+  units than you hold. Check with `pyrxd glyph list --type ft`.
+- **`FT transfer across multiple wallet addresses isn't supported`.**
+  Consolidate the units onto one address first (see the note above).
+- **`no plain-RXD UTXO to fund the NFT transfer fee`.** Add a little RXD to the
+  wallet — the NFT itself can't pay its own fee.
+- **Couldn't reach ElectrumX.** The transfer needs the network to fetch source
+  outputs and broadcast. Point at a reachable server with `--electrumx URL`.
+
+---
+
+## See also
+
+- [Mint a Glyph FT](../tutorials/mint-a-glyph-ft.md) /
+  [Mint a Glyph NFT](../tutorials/mint-a-glyph-nft.md) — where your `REF` comes
+  from.
+- [Radiant FTs are on-chain](../concepts/radiant-fts-are-on-chain.md) — why FT
+  conservation is a consensus rule, not a wallet convention.
+- [Broadcast a transaction](broadcast-a-transaction.md) — what the rejection
+  messages mean if a broadcast fails.

--- a/docs/how-to/use-the-signing-agent.md
+++ b/docs/how-to/use-the-signing-agent.md
@@ -1,0 +1,111 @@
+# How to use the local signing agent
+
+**Who this page is for:** you're running several wallet commands in a session
+and don't want to retype your mnemonic for each one — and you'd rather the seed
+live in exactly one place you can see, not get re-entered at every prompt. The
+`pyrxd agent` group unlocks the wallet **once** into a small foreground process;
+the key never leaves it, and signing requests are served over a local socket.
+
+```
+unlock once  →  agent holds the seed  →  pyrxd wallet send … (signed by the agent)  →  lock
+```
+
+The seed is held in one process, is zeroized when you lock it (or on idle
+timeout, or Ctrl-C), and every non-trivial spend is approved in the agent's own
+terminal — not the terminal that asked for the signature.
+
+---
+
+## Start the agent
+
+```console
+$ pyrxd agent unlock
+Mnemonic (input hidden):
+Signing agent live on /home/you/.pyrxd/agent.sock — Ctrl-C to lock.
+```
+
+`unlock` prompts for the mnemonic once, then runs in the **foreground**, serving
+signing requests on `<wallet dir>/agent.sock` (the socket sits next to the
+wallet file, so `--wallet PATH` co-locates it). Leave this terminal open — spend
+confirmations appear **here**, where you can see them. Press Ctrl-C to lock.
+
+Two options worth knowing:
+
+| Option | Default | What it does |
+|---|---|---|
+| `--idle-timeout SECONDS` | `900` | Auto-lock (zeroize the seed) after this many seconds with no activity. |
+| `--auto-confirm-under PHOTONS` | `0` | Skip the keypress for spends whose total to external payees is **at or below** this. `0` = always confirm. Spends above the threshold **always** require a keypress. |
+
+So `pyrxd agent unlock --auto-confirm-under 100000` waves through small payments
+(≤ 100,000 photons) but still stops and asks before anything larger.
+
+---
+
+## Use it from another terminal
+
+With the agent live, run wallet commands as usual in a **second** terminal —
+they detect the agent automatically (no flag, no env var). Today this is wired
+into `wallet send`:
+
+```console
+$ pyrxd wallet send --to 1Qq…recipient --amount 50000
+
+  Send:
+    to address:  1Qq…recipient
+    amount:      0.0005 RXD
+    network fee: …
+    inputs:      1 UTXO(s)
+    signed by:   agent
+
+  Approve the spend in the agent's terminal to broadcast.
+```
+
+When the agent is live, `wallet send` builds the transaction **watch-only** from
+the account xpub (no mnemonic prompt), hands it to the agent to sign, and the
+**agent's terminal** shows the authoritative confirmation prompt. Approve it
+there and the send broadcasts. If no agent is running, `wallet send` falls back
+to the in-process path and prompts for the mnemonic as normal.
+
+> **Scope, honestly:** the agent currently signs for `wallet send`. Other
+> signing commands (token transfers, deploys) still prompt for the mnemonic
+> in-process — the agent-backed path is being extended outward from `send`.
+
+---
+
+## Check and stop the agent
+
+```console
+$ pyrxd agent status
+Signing agent is live on /home/you/.pyrxd/agent.sock
+
+$ pyrxd agent lock
+Agent locked and shut down.
+```
+
+`status` reports whether an agent is live on this wallet's socket; `lock` tells
+a running agent to zeroize the seed and shut down. The seed is also zeroized
+automatically on the idle timeout and on Ctrl-C in the agent's terminal.
+
+---
+
+## What the agent does and doesn't protect
+
+- **The seed lives in one process.** Other commands talk to it over a local Unix
+  socket and never receive key material — they get *signatures*, not the seed.
+- **You approve spends where the key is.** The confirmation prompt is on the
+  agent's terminal, so a command in another terminal (or a script) can't approve
+  its own spend — a human at the agent has to. `--auto-confirm-under` is the one
+  deliberate exception, bounded to small external payments.
+- **It is not a hardware wallet or an HSM.** The key is in your machine's
+  memory while unlocked. The agent reduces *re-entry* and *exposure surface*
+  (one process, zeroized on lock/idle); it does not move the key off the host.
+  Lock it when you're done.
+
+---
+
+## See also
+
+- [Your first Radiant transaction](../tutorials/your-first-radiant-transaction.md)
+  — the in-process `wallet send` flow the agent replaces.
+- [Receive funds and check your balance](receive-and-check-balance.md) — the
+  read-only commands need no agent and no mnemonic.

--- a/docs/tutorials/index.md
+++ b/docs/tutorials/index.md
@@ -60,13 +60,14 @@ cross-chain-swap
   negotiated → completed for native RXD, a Glyph NFT, *and* a Glyph FT. Pre-audit —
   local/testnet only, no real value at risk.
 
-## Planned tutorials
+## More walkthroughs
 
-Tutorials are being written as the v0.5.x line stabilises. In the
-meantime, the runnable end-to-end demos in
-[`examples/`](https://github.com/MudwoodLabs/pyrxd/tree/main/examples) are
-the closest thing — they exercise the same flows that the future tutorials
-will explain step-by-step.
+Once you've worked through the tutorials, the task-focused
+[How-to guides](../how-to/index.md) cover the next steps — transferring a token
+after you mint it, running the signing agent, recovering funds, and building a
+cross-chain swap. The runnable end-to-end demos in
+[`examples/`](https://github.com/MudwoodLabs/pyrxd/tree/main/examples) exercise
+the same flows in code.
 
 If you have a use case that would make a useful tutorial, please open an
 [issue](https://github.com/MudwoodLabs/pyrxd/issues) describing it.

--- a/docs/tutorials/mint-from-a-dmint-contract.md
+++ b/docs/tutorials/mint-from-a-dmint-contract.md
@@ -184,7 +184,7 @@ small JSON-over-stdio protocol.
 Install [`glyph-miner`](https://github.com/RadiantBlockchain-Community/glyph-miner)
 (or any miner that speaks the same protocol — the wire shape is
 documented in the docstring of
-[`pyrxd.glyph.dmint.mine_solution_external`](https://github.com/MudwoodLabs/pyrxd/blob/main/src/pyrxd/glyph/dmint.py)).
+[`pyrxd.glyph.dmint.mine_solution_external`](https://github.com/MudwoodLabs/pyrxd/blob/main/src/pyrxd/glyph/dmint/__init__.py)).
 
 Then export the variable. The value is the full command line pyrxd
 should spawn, space-separated:

--- a/src/pyrxd/cli/main.py
+++ b/src/pyrxd/cli/main.py
@@ -112,7 +112,7 @@ def cli(
     """pyrxd — wallet, Glyph token, and Gravity-swap CLI for Radiant.
 
     Use `pyrxd <command> --help` for command-specific options. See the
-    repository docs (docs/how-to/cli.md) for the full reference.
+    repository docs (docs/api/cli.rst) for the full reference.
     """
     if json_output and quiet:
         click.echo("error: --json and --quiet are mutually exclusive", err=True)


### PR DESCRIPTION
## What

A documentation **completeness audit** (run ahead of the 0.9.0 community announcement) found two genuine first-hour gaps and a set of stale/orphaned navigation entries. This PR closes them.

### New how-to guides
- **`transfer-a-glyph-token`** — send an FT/NFT *after* minting (`glyph transfer-ft` / `transfer-nft`). The canonical second task ("I minted a token, how do I send it?") had **zero** coverage. Explains that `REF` is the token's genesis ref (not the UTXO), FT conservation + change, and why an NFT transfer needs a little plain RXD for the fee.
- **`use-the-signing-agent`** — unlock once into a foreground agent; the seed lives in one process and `wallet send` signs against it with no mnemonic re-entry. Covers `agent unlock/status/lock`, `--idle-timeout`, `--auto-confirm-under`. Scoped honestly to `wallet send` (the only path currently wired to the agent).
- **`receive-and-check-balance`** — the read-only basics: `address` / `balance --refresh` / `utxos`, plus `wallet export-xpub` for watch-only receiving.

### Index + content fixes
- Wire **5 orphaned pages** into their toctrees: `scan-address-for-glyphs`, `handle-radiant-bip143-quirks`, `glyph-inspect-tool`, `parallel-mining`, `v1-mint-mechanics` (all existed on disk, unreachable from nav).
- Prune "Coming soon" roadmap bullets that **already exist**; refresh the stale `v0.5.x` tutorials-index wording.
- Reframe the `0.4→0.5` migration guide as **"Breaking changes since 0.4.x"** — the only public-API break since 0.4.x; every release since is additive/drop-in (filename kept so inbound links stay valid).
- Document **`wallet sweep`** + **`export-xpub`** in the recover-funds guide.
- Fix the `pyrxd --help` pointer: `docs/how-to/cli.md` (never existed) → `docs/api/cli.rst`.
- Repair `dmint.py` → `dmint/__init__.py` source links left by the dMint subpackage split (concepts + dMint tutorial).

## Verification
- ✅ Sphinx build clean for **every** changed file — no new warnings, no orphans, no missing toctree refs.
- ✅ Private-link checker passes.
- ✅ `ruff` passes on the one source file touched (`cli/main.py` docstring).
- ✅ All cross-links resolve to existing files; the repaired `dmint/__init__.py` links re-export every referenced symbol.

Docs-only + a one-line CLI docstring. No behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)