### PR TITLE
docs(api): add dmint subpackage reference page

### DIFF
--- a/docs/api/dmint.rst
+++ b/docs/api/dmint.rst
@@ -1,0 +1,37 @@
+pyrxd.glyph.dmint — dMint permissionless PoW issuance
+=====================================================
+
+.. automodule:: pyrxd.glyph.dmint
+
+The subpackage layers as ``types ← builders ← chain ← miner`` (a one-way
+dependency graph). Every public symbol is re-exported at the
+``pyrxd.glyph.dmint`` path via PEP 562 lazy ``__getattr__``; the reference
+below documents each symbol at its defining submodule.
+
+Types & parameters
+------------------
+
+.. automodule:: pyrxd.glyph.dmint.types
+   :members:
+   :show-inheritance:
+
+Covenant & transaction builders
+-------------------------------
+
+.. automodule:: pyrxd.glyph.dmint.builders
+   :members:
+   :show-inheritance:
+
+Contract & chain state
+----------------------
+
+.. automodule:: pyrxd.glyph.dmint.chain
+   :members:
+   :show-inheritance:
+
+Proof-of-work miner
+-------------------
+
+.. automodule:: pyrxd.glyph.dmint.miner
+   :members:
+   :show-inheritance:

--- a/docs/api/index.rst
+++ b/docs/api/index.rst
@@ -9,6 +9,7 @@ functions, and exceptions.
 
    pyrxd
    glyph
+   dmint
    gravity
    eth_wallet
    swap

--- a/docs/tutorials/mint-from-a-dmint-contract.md
+++ b/docs/tutorials/mint-from-a-dmint-contract.md
@@ -31,7 +31,10 @@ contract.
 
 For the theory behind what a V1 dMint contract is and the byte-by-byte
 shape of the mint transaction, see the
-[V1 dMint deploys concept page](../concepts/dmint-v1-deploy.md). This
+[V1 dMint deploys concept page](../concepts/dmint-v1-deploy.md). The
+Python API used throughout — `find_dmint_contract_utxos`,
+`build_dmint_mint_tx`, the miner — is documented in
+[`pyrxd.glyph.dmint`](../api/dmint.rst). This
 tutorial is hands-on; it assumes you have already skimmed that page or
 are willing to follow along without it.
 
@@ -184,7 +187,7 @@ small JSON-over-stdio protocol.
 Install [`glyph-miner`](https://github.com/RadiantBlockchain-Community/glyph-miner)
 (or any miner that speaks the same protocol — the wire shape is
 documented in the docstring of
-[`pyrxd.glyph.dmint.mine_solution_external`](https://github.com/MudwoodLabs/pyrxd/blob/main/src/pyrxd/glyph/dmint/__init__.py)).
+[`pyrxd.glyph.dmint.mine_solution_external`](../api/dmint.rst)).
 
 Then export the variable. The value is the full command line pyrxd
 should spawn, space-separated:
@@ -360,7 +363,9 @@ mainnet:
   the supply-chain caveats are.
 
 For the protocol-level detail behind any of the above, see the
-[V1 dMint deploys concept page](../concepts/dmint-v1-deploy.md). For
+[V1 dMint deploys concept page](../concepts/dmint-v1-deploy.md); for the
+full signature of every function above, see the
+[`pyrxd.glyph.dmint` API reference](../api/dmint.rst). For
 the runnable reference,
 [`examples/dmint_claim_demo.py`](https://github.com/MudwoodLabs/pyrxd/tree/main/examples/dmint_claim_demo.py)
 is the canonical script — every snippet on this page is a transcription


### PR DESCRIPTION
## What

Adds `docs/api/dmint.rst` and wires it into the API `toctree` — the dMint subpackage was the one distinct subpackage without a dedicated API-reference page (closes roadmap item **A5**'s dMint gap).

## Why the submodule approach

`pyrxd.glyph.dmint` re-exports its public surface via PEP 562 lazy `__getattr__`. A package-level `.. automodule:: pyrxd.glyph.dmint :members:` renders **empty**, because every symbol's `__module__` resolves to a submodule and `imported-members` is off in `autodoc_default_options`. So the page documents the four submodules directly — matching the one-way layering `types ← builders ← chain ← miner` — which renders the real surface: deploy params, the 5 DAA modes, the covenant/mint builders, and the PoW miner.

## Verification

- `sphinx-build -b html docs` exits 0; the built `api/dmint.html` renders actual members (DmintDeployParams, DmintAlgo, DaaMode, `build_dmint_mint_tx`, the miner).
- One `DmintState` duplicate-object warning — consistent with the 32 pre-existing ones the build already emits for the same package-reexport + dedicated-page pattern (gravity/hd/btc_wallet).

Docs-only; no source or test changes.