### PR TITLE
docs: fix bare /home/you path in signing-agent how-to

### DIFF
--- a/docs/how-to/use-the-signing-agent.md
+++ b/docs/how-to/use-the-signing-agent.md
@@ -21,7 +21,7 @@ terminal — not the terminal that asked for the signature.
 ```console
 $ pyrxd agent unlock
 Mnemonic (input hidden):
-Signing agent live on /home/you/.pyrxd/agent.sock — Ctrl-C to lock.
+Signing agent live on ~/.pyrxd/agent.sock — Ctrl-C to lock.
 ```
 
 `unlock` prompts for the mnemonic once, then runs in the **foreground**, serving
@@ -76,7 +76,7 @@ to the in-process path and prompts for the mnemonic as normal.
 
 ```console
 $ pyrxd agent status
-Signing agent is live on /home/you/.pyrxd/agent.sock
+Signing agent is live on ~/.pyrxd/agent.sock
 
 $ pyrxd agent lock
 Agent locked and shut down.


### PR DESCRIPTION
The local pre-push gate (`scripts/check-no-private-links.py`) rejects the bare `/home/you/.pyrxd/agent.sock` placeholder in `docs/how-to/use-the-signing-agent.md` (two spots). Rewrite as `~/.pyrxd/agent.sock` — username-agnostic, clone-portable, and it un-breaks the local CI hook for everyone.

Pre-existing issue (on `main`, not introduced by any recent PR); the check is local-only (not in the GitHub CI workflow), which is why `main` stayed green. Docs-only, no code.