### PR TITLE
ci: restore the 3.10/3.11/3.12 test matrix (deterministic async tests)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,12 +23,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # CI currently only verifies 3.12. The lib supports 3.10+ in metadata but
-        # a few async tests in tests/network/test_electrumx.py are timing-sensitive
-        # on slower runners and fail on 3.10/3.11. To re-enable, fix the
-        # TestResponseCorrelation tests to be timing-robust, then add the
-        # versions back to this matrix.
-        python-version: ["3.12"]
+        # pyrxd advertises 3.10+ (classifiers + requires-python) and has a real 3.10-only
+        # code path (the tomli backport in cli/config.py), so CI verifies the whole range.
+        # The TestResponseCorrelation async tests that previously raced on slower 3.10/3.11
+        # runners now wait on a deterministic condition (_drain_until) instead of a fixed
+        # number of sleep(0) yields.
+        python-version: ["3.10", "3.11", "3.12"]
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6

--- a/tests/network/test_electrumx.py
+++ b/tests/network/test_electrumx.py
@@ -405,6 +405,18 @@ class TestBroadcastMalformedResponse:
 # behavior: each _call() future is resolved by the matching id.
 
 
+async def _drain_until(predicate, *, max_yields: int = 10_000) -> None:
+    """Yield the event loop until ``predicate()`` is true (bounded). A deterministic, slow-runner-robust
+    replacement for a fixed number of ``await asyncio.sleep(0)`` — the fixed-yield form raced and failed
+    on 3.10/3.11 CI runners (the awaited tasks hadn't reached their send yet). Bounded so a never-true
+    predicate fails fast instead of hanging."""
+    for _ in range(max_yields):
+        if predicate():
+            return
+        await asyncio.sleep(0)
+    raise AssertionError("condition not reached within the yield bound")
+
+
 class TestResponseCorrelation:
     """Concurrent _call() invocations must each receive the response whose
     JSON-RPC id matches the request they sent — never another caller's.
@@ -474,8 +486,7 @@ class TestResponseCorrelation:
         task_a = asyncio.create_task(client._call("blockchain.transaction.get", ["a" * 64, False]))
         task_b = asyncio.create_task(client._call("blockchain.transaction.get", ["b" * 64, False]))
         # Let both register and send.
-        await asyncio.sleep(0)
-        await asyncio.sleep(0)
+        await _drain_until(lambda: len(send_log) == 2)
 
         # Both sends should have happened.
         assert len(send_log) == 2
@@ -527,7 +538,7 @@ class TestResponseCorrelation:
 
         # Now make a real call.
         task = asyncio.create_task(client.broadcast(_VALID_RAW_TX))
-        await asyncio.sleep(0)
+        await _drain_until(lambda: len(send_log) == 1)
         assert len(send_log) == 1
         good = "a" * 64
         await outbox.put(json.dumps({"id": send_log[0]["id"], "result": good}))
@@ -564,8 +575,7 @@ class TestResponseCorrelation:
 
         # Fire a call that will never receive a response.
         task = asyncio.create_task(client.get_tip_height())
-        await asyncio.sleep(0)
-        await asyncio.sleep(0)
+        await _drain_until(lambda: len(client._pending) >= 1)
 
         # Close while the call is pending.
         await client.close()
@@ -602,8 +612,7 @@ class TestResponseCorrelation:
 
         task_a = asyncio.create_task(client.get_tip_height())  # will time out
         task_b = asyncio.create_task(client.broadcast(_VALID_RAW_TX))
-        await asyncio.sleep(0)
-        await asyncio.sleep(0)
+        await _drain_until(lambda: len(send_log) == 2)
         assert len(send_log) == 2
         id_b = send_log[1]["id"]
 
@@ -658,9 +667,8 @@ class TestResponseCorrelation:
         client._ws = ws
 
         tasks = [asyncio.create_task(client.get_tip_height()) for _ in range(5)]
-        # Give them a chance to all send.
-        for _ in range(10):
-            await asyncio.sleep(0)
+        # Wait until all five have funneled through the send lock.
+        await _drain_until(lambda: len(send_log) == 5)
 
         assert max_concurrent_sends == 1, f"send_lock should serialize sends; max concurrent was {max_concurrent_sends}"
 
@@ -697,7 +705,7 @@ class TestResponseCorrelation:
         client._ws = ws
 
         task = asyncio.create_task(client.get_tip_height())
-        await asyncio.sleep(0)
+        await _drain_until(lambda: len(send_log) >= 1)
 
         # Push two malformed messages (no id, then string id), then the real one.
         await outbox.put(json.dumps({"method": "blockchain.headers.subscribe", "params": [{"height": 999}]}))


### PR DESCRIPTION
CI verified only 3.12, while pyrxd advertises 3.10+ (classifiers + `requires-python`) and has a **real 3.10-only path** (the `tomli` backport in `cli/config.py`) — so a 3.10/3.11 break on the wallet/glyph/swap surface would never be caught (the decision-audit flagged this).

**Root cause of the flakiness:** the `TestResponseCorrelation` async tests fired concurrent `_call()`s then did a *fixed* number of `await asyncio.sleep(0)` before asserting a precondition (sends logged / call pending) — not guaranteed to be enough yields on slower 3.10/3.11 runners.

**Fix:** a bounded `_drain_until(predicate)` that waits on the actual observable condition (deterministic on any runner). The other `sleep(0)` uses in the file are intentional latency simulations (assertions follow the awaited result) — left as-is. Restore `python-version: ['3.10','3.11','3.12']`.

Stable across 3 local 3.12 runs; **this PR's own CI run is the 3.10/3.11 verification.** Tests-only + CI config.