### PR TITLE
feat(watch): boot-time timing-safety preflight for the watchtower

### DIFF
--- a/scripts/watchtower_run.py
+++ b/scripts/watchtower_run.py
@@ -60,6 +60,7 @@ from pyrxd.gravity.watch import (
     mempool_space_outspend,
     run_loop,
 )
+from pyrxd.gravity.watch.preflight import preflight_timing
 from pyrxd.network.bitcoin import MempoolSpaceBroadcaster, MempoolSpaceFundingReader, MultiSourceBtcFundingReader
 from pyrxd.network.electrumx import ElectrumXClient
 
@@ -326,6 +327,13 @@ def _parse_args(argv=None) -> argparse.Namespace:
         "blocking past the dead-man's-switch window (defaults to 4x poll interval)",
     )
     p.add_argument("--poll-interval-s", type=float, default=30.0)
+    p.add_argument(
+        "--deadman-max-silence-s",
+        type=float,
+        default=180.0,
+        help="the dead-man's-switch --max-silence-s you run watchtower_deadman.py with; used only for a "
+        "boot-time timing cross-check (the watchdog is a separate process). Set to match it.",
+    )
     p.add_argument("--safety-window-blocks", type=int, default=6)
     p.add_argument("--quorum", type=int, default=2, help="BTC funding-reader quorum (of 3 Esplora sources)")
     p.add_argument("--block-interval-s", type=float, default=600.0)
@@ -448,6 +456,24 @@ async def _amain(argv=None) -> int:
             "(the dead-man's-switch is DISABLED — a crash/wedge will NOT be detected). Configure at least "
             "one before relying on this tower."
         )
+
+    # Boot-time timing-safety preflight (config-only, no chain reads). Fail fast on a footgun config
+    # rather than false-paging (or paging too late) in production — see docs/runbooks/watchtower-operations.md.
+    effective_tick_timeout = (
+        args.tick_timeout_s if args.tick_timeout_s is not None else max(4.0 * args.poll_interval_s, 30.0)
+    )
+    timing_problems = preflight_timing(
+        poll_interval_s=args.poll_interval_s,
+        tick_timeout_s=effective_tick_timeout,
+        safety_window_blocks=args.safety_window_blocks,
+        rxd_block_interval_s=args.rxd_block_interval_s,
+        deadman_max_silence_s=args.deadman_max_silence_s,
+    )
+    for problem in timing_problems:
+        (logger.error if problem.severity == "error" else logger.warning)("timing preflight: %s", problem.message)
+    if any(p.severity == "error" for p in timing_problems):
+        logger.error("refusing to start on a timing-unsafe config (fix the errors above)")
+        return 2
 
     reader = _build_funding_reader(args.network, esploras, args.quorum)
     async with contextlib.AsyncExitStack() as stack:

--- a/src/pyrxd/gravity/watch/preflight.py
+++ b/src/pyrxd/gravity/watch/preflight.py
@@ -1,0 +1,84 @@
+"""Boot-time timing-safety checks for the watchtower — pure, no chain reads.
+
+The tower's correctness rests on a few timing relationships configured across two separate processes
+(the tower and the dead-man's-switch) with no built-in cross-check. :func:`preflight_timing` recomputes
+those relationships from the loaded config and returns the problems, so the operational entrypoint can
+**fail fast** on a footgun config instead of false-paging (or paging too late) in production.
+
+See ``docs/runbooks/watchtower-operations.md`` for the operational context of each check.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class TimingProblem:
+    """One config-timing problem. ``severity`` is ``"error"`` (refuse to start) or ``"warning"``."""
+
+    severity: str
+    message: str
+
+
+def preflight_timing(
+    *,
+    poll_interval_s: float,
+    tick_timeout_s: float,
+    safety_window_blocks: int,
+    rxd_block_interval_s: float,
+    deadman_max_silence_s: float | None = None,
+) -> list[TimingProblem]:
+    """Return the timing-safety problems in this watchtower config (empty == clean).
+
+    Checks (all config-only — no chain reads):
+
+    * ``poll_interval_s`` / ``tick_timeout_s`` are positive.
+    * **Heartbeat-vs-watchdog (footgun #1).** The tower refreshes the heartbeat once per poll; if the
+      poll interval is at or beyond the dead-man's-switch window, the heartbeat is stale by the time the
+      watchdog looks and it false-pages CRITICAL every cycle. ``error`` at ``>=``; ``warning`` past half.
+    * **Tick-vs-safety-window (footgun #2).** A tick that can run as long as the safety window pages
+      *after* the window it was meant to protect. ``warning`` when ``tick_timeout_s`` reaches that window.
+
+    The caller refuses to start on any ``error`` and logs each ``warning``.
+    """
+    problems: list[TimingProblem] = []
+
+    if poll_interval_s <= 0:
+        problems.append(TimingProblem("error", f"poll-interval-s must be > 0 (got {poll_interval_s})"))
+    if tick_timeout_s <= 0:
+        problems.append(TimingProblem("error", f"tick-timeout-s must be > 0 (got {tick_timeout_s})"))
+
+    if deadman_max_silence_s is not None:
+        if poll_interval_s >= deadman_max_silence_s:
+            problems.append(
+                TimingProblem(
+                    "error",
+                    f"poll-interval-s ({poll_interval_s}s) >= dead-man's-switch max-silence-s "
+                    f"({deadman_max_silence_s}s): the watchdog will false-page CRITICAL every cycle "
+                    "(the heartbeat is stale before it is checked). Lower the poll interval or widen "
+                    "max-silence.",
+                )
+            )
+        elif poll_interval_s * 2 >= deadman_max_silence_s:
+            problems.append(
+                TimingProblem(
+                    "warning",
+                    f"poll-interval-s ({poll_interval_s}s) is more than half the dead-man's-switch "
+                    f"max-silence-s ({deadman_max_silence_s}s): a single missed/slow tick can false-page. "
+                    "Widen the margin (e.g. poll 30s, max-silence 180s).",
+                )
+            )
+
+    window_s = safety_window_blocks * rxd_block_interval_s
+    if window_s > 0 and tick_timeout_s >= window_s:
+        problems.append(
+            TimingProblem(
+                "warning",
+                f"tick-timeout-s ({tick_timeout_s}s) >= the safety window ({safety_window_blocks} blk x "
+                f"{rxd_block_interval_s}s = {window_s}s): a slow tick can page AFTER the window it is "
+                "meant to protect. Lower the tick budget or widen --safety-window-blocks.",
+            )
+        )
+
+    return problems

--- a/tests/test_watch_preflight.py
+++ b/tests/test_watch_preflight.py
@@ -1,0 +1,82 @@
+"""Tests for the watchtower boot-time timing-safety preflight (pure, no chain reads)."""
+
+from __future__ import annotations
+
+from pyrxd.gravity.watch.preflight import TimingProblem, preflight_timing
+
+
+def _sev(problems: list[TimingProblem]) -> set[str]:
+    return {p.severity for p in problems}
+
+
+def test_clean_config_has_no_problems():
+    # poll 30s, deadman 180s (6x margin), tick 120s, window 6*300=1800s.
+    assert (
+        preflight_timing(
+            poll_interval_s=30.0,
+            tick_timeout_s=120.0,
+            safety_window_blocks=6,
+            rxd_block_interval_s=300.0,
+            deadman_max_silence_s=180.0,
+        )
+        == []
+    )
+
+
+def test_poll_at_or_above_max_silence_is_an_error():
+    problems = preflight_timing(
+        poll_interval_s=200.0,
+        tick_timeout_s=120.0,
+        safety_window_blocks=6,
+        rxd_block_interval_s=300.0,
+        deadman_max_silence_s=180.0,
+    )
+    assert "error" in _sev(problems)
+    assert any("false-page CRITICAL every cycle" in p.message for p in problems)
+
+
+def test_poll_past_half_max_silence_is_a_warning_not_error():
+    problems = preflight_timing(
+        poll_interval_s=100.0,  # > 90 (half of 180), < 180
+        tick_timeout_s=120.0,
+        safety_window_blocks=6,
+        rxd_block_interval_s=300.0,
+        deadman_max_silence_s=180.0,
+    )
+    assert _sev(problems) == {"warning"}
+    assert any("more than half" in p.message for p in problems)
+
+
+def test_nonpositive_poll_is_an_error():
+    problems = preflight_timing(
+        poll_interval_s=0.0,
+        tick_timeout_s=120.0,
+        safety_window_blocks=6,
+        rxd_block_interval_s=300.0,
+    )
+    assert any(p.severity == "error" and "poll-interval-s must be > 0" in p.message for p in problems)
+
+
+def test_tick_budget_exceeding_safety_window_is_a_warning():
+    # tick 2000s vs window 6*300=1800s.
+    problems = preflight_timing(
+        poll_interval_s=30.0,
+        tick_timeout_s=2000.0,
+        safety_window_blocks=6,
+        rxd_block_interval_s=300.0,
+        deadman_max_silence_s=180.0,
+    )
+    assert _sev(problems) == {"warning"}
+    assert any("page AFTER the window" in p.message for p in problems)
+
+
+def test_deadman_none_skips_the_heartbeat_checks():
+    # No deadman cross-check supplied → the poll-vs-max-silence checks don't fire.
+    problems = preflight_timing(
+        poll_interval_s=999.0,
+        tick_timeout_s=120.0,
+        safety_window_blocks=6,
+        rxd_block_interval_s=300.0,
+        deadman_max_silence_s=None,
+    )
+    assert all("max-silence" not in p.message for p in problems)


### PR DESCRIPTION
The tower's correctness rests on timing relationships configured across **two separate processes** (tower + dead-man's-switch) with no cross-check. Two footguns went unvalidated:

- **poll-interval ≥ deadman max-silence** → the watchdog false-pages CRITICAL every cycle (the heartbeat is stale before it's checked).
- **tick budget ≥ safety window** → a slow tick pages *after* the window it was meant to protect.

Add a pure, unit-tested `preflight_timing()` (`src/pyrxd/gravity/watch/preflight.py`) that recomputes those relationships and returns errors/warnings, wired into `watchtower_run.py`: **fail fast (exit 2) on an error**, log warnings, at startup. New `--deadman-max-silence-s` arg lets the tower cross-check against the watchdog's window. Pairs with the ops runbook (#247).

Tests: clean config, poll≥max-silence (error), poll>half (warning), non-positive poll (error), tick≥window (warning), deadman None (skips). 6 green; lint/format clean.