### PR TITLE
test(fuzz): persist the Hypothesis counterexample corpus across runs

### DIFF
--- a/tests/.hypothesis-corpus/README.md
+++ b/tests/.hypothesis-corpus/README.md
@@ -1,0 +1,10 @@
+# Committed Hypothesis example corpus
+
+Hypothesis writes shrunk **counterexamples** here (a `DirectoryBasedExampleDatabase`, wired in
+`tests/conftest.py`). Unlike the default gitignored `.hypothesis/`, this directory is **committed** so a
+failure found by any property/fuzz test persists and is **replayed on every future run until fixed** —
+a drift-proof regression corpus.
+
+**Convention:** when a fuzz test surfaces a real bug, the reproducing entry lands here automatically;
+commit it alongside the fix, and add a focused frozen reproducer to the relevant `tests/test_*.py` so
+the case is also named and documented (not only replayed opaquely from the corpus).

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -38,18 +38,31 @@ if _REPO_ROOT not in sys.path:
 #   overnight — extreme: 250_000 examples, no deadline. Hours per file.
 try:
     from hypothesis import HealthCheck, settings
+    from hypothesis.database import DirectoryBasedExampleDatabase
 
-    settings.register_profile("ci")  # no overrides
+    # COMMITTED example database (tests/.hypothesis-corpus/) so a shrunk counterexample found by any
+    # fuzz test PERSISTS and is replayed on every future run until fixed. The default .hypothesis/ dir is
+    # gitignored and ephemeral on CI runners, so found failures were silently discarded (audit follow-up).
+    # A developer who reproduces a failure commits the corpus entry; it then regresses forever. NOT
+    # gitignored (the ignore is `.hypothesis/`, a different name).
+    _corpus = DirectoryBasedExampleDatabase(os.path.join(os.path.dirname(__file__), ".hypothesis-corpus"))
+
+    # ci: keep random exploration but replay the committed corpus first, so a previously-found
+    # counterexample regresses on every run. (Hypothesis makes derandomize and a database mutually
+    # exclusive — derandomize implies database=None — and the persistent corpus is the load-bearing half.)
+    settings.register_profile("ci", database=_corpus)
     settings.register_profile(
         "deep",
         max_examples=25_000,
         deadline=None,
+        database=_corpus,
         suppress_health_check=[HealthCheck.too_slow, HealthCheck.large_base_example],
     )
     settings.register_profile(
         "overnight",
         max_examples=250_000,
         deadline=None,
+        database=_corpus,
         suppress_health_check=[HealthCheck.too_slow, HealthCheck.large_base_example],
     )
     settings.load_profile(os.environ.get("HYPOTHESIS_PROFILE", "ci"))


### PR DESCRIPTION
The 'ci' Hypothesis profile used the default `.hypothesis/` database — gitignored + ephemeral on CI runners — so a shrunk counterexample found by any property/fuzz test was silently **discarded** between runs (audit follow-up).

Wire a **committed** `DirectoryBasedExampleDatabase` (`tests/.hypothesis-corpus/`) into all profiles so a found failure **persists and replays on every future run until fixed** — a drift-proof regression corpus. The corpus README documents the crash→test convention.

(Hypothesis makes `derandomize` and a database mutually exclusive — `derandomize` implies `database=None` — so the persistent corpus, the load-bearing half, wins; CI keeps random exploration + always replays the corpus.)

84 property/fuzz tests green under the new profile; lint clean. **Follow-up (not here):** a weekly scheduled atheris CI lane for the `scripts/fuzz_atheris/` harnesses.