### PR TITLE
feat(network): endpoint-diversity guard for the BTC funding quorum

### DIFF
--- a/scripts/watchtower_run.py
+++ b/scripts/watchtower_run.py
@@ -61,7 +61,7 @@ from pyrxd.gravity.watch import (
     run_loop,
 )
 from pyrxd.gravity.watch.preflight import preflight_timing
-from pyrxd.network.bitcoin import MempoolSpaceBroadcaster, MempoolSpaceFundingReader, MultiSourceBtcFundingReader
+from pyrxd.network.bitcoin import MempoolSpaceBroadcaster, MultiSourceBtcFundingReader
 from pyrxd.network.electrumx import ElectrumXClient
 
 logger = logging.getLogger("pyrxd.watchtower")
@@ -178,8 +178,10 @@ def _build_funding_reader(network: str, esploras: list[str], quorum: int) -> Mul
     gate stays WATCH (fail-closed, never a wrongful broadcast)."""
     if network == "bc":
         return MultiSourceBtcFundingReader.default_mainnet(quorum=quorum)
-    readers = [MempoolSpaceFundingReader(base_url=u.rstrip("/") + "/api") for u in esploras]
-    return MultiSourceBtcFundingReader(readers, quorum=min(quorum, len(readers)), dust_cap_sats=10_000)
+    # from_endpoints clamps the effective quorum to the number of DISTINCT hosts (not URL count) and warns
+    # — so two same-host esploras can't masquerade as a real 2-of-2 quorum (false corroboration).
+    api_urls = [u.rstrip("/") + "/api" for u in esploras]
+    return MultiSourceBtcFundingReader.from_endpoints(api_urls, quorum=quorum, dust_cap_sats=10_000)
 
 
 #: Default INDEPENDENT public Radiant ElectrumX endpoints (distinct operators), verified live

--- a/src/pyrxd/network/bitcoin.py
+++ b/src/pyrxd/network/bitcoin.py
@@ -26,8 +26,9 @@ import json
 import logging
 from abc import ABC, abstractmethod
 from collections import Counter
+from collections.abc import Sequence
 from typing import Any
-from urllib.parse import quote, urljoin
+from urllib.parse import quote, urljoin, urlparse
 
 import aiohttp
 
@@ -1058,6 +1059,31 @@ class MempoolSpaceFundingReader:
         await self._http.close()
 
 
+def endpoint_host(url: str) -> str | None:
+    """The lowercased hostname of a base URL, for endpoint-diversity checks. ``None`` if unparseable
+    (a token with no host is conservatively treated as its own distinct source by the caller)."""
+    if not isinstance(url, str) or not url.strip():
+        return None
+    parsed = urlparse(url if "://" in url else "//" + url.strip())
+    host = (parsed.hostname or "").lower()
+    return host or None
+
+
+def count_distinct_hosts(urls: Sequence[str]) -> int:
+    """Number of DISTINCT endpoint hosts in *urls*. URLs whose host can't be parsed are counted as one
+    distinct source each (we can't prove they collide). Used to bound a real quorum: a quorum of
+    same-host endpoints is false corroboration — one hostile/buggy host satisfies the whole "quorum"."""
+    hosts: set[str] = set()
+    opaque = 0
+    for u in urls:
+        h = endpoint_host(u)
+        if h is None:
+            opaque += 1
+        else:
+            hosts.add(h)
+    return len(hosts) + opaque
+
+
 class MultiSourceBtcFundingReader:
     """Quorum ``BtcFundingReader`` over N independent Esplora-style providers.
 
@@ -1101,10 +1127,36 @@ class MultiSourceBtcFundingReader:
         self._dust_cap_sats = dust_cap_sats
 
     @classmethod
+    def from_endpoints(
+        cls, urls: Sequence[str], *, quorum: int = 2, dust_cap_sats: int = 10_000
+    ) -> MultiSourceBtcFundingReader:
+        """Build the reader from Esplora base URLs, **clamping the effective quorum to the number of
+        DISTINCT hosts**. A quorum of same-host endpoints is false corroboration (one hostile/buggy host
+        satisfies it), so e.g. two ``mempool.space`` URLs can never form a 2-of-2 quorum. A clamp is
+        logged loudly so the operator sees the real corroboration level."""
+        if not urls:
+            raise ValidationError("from_endpoints requires at least one endpoint URL")
+        distinct = count_distinct_hosts(urls)
+        effective = max(1, min(quorum, distinct))
+        if effective < quorum:
+            logger.warning(
+                "BTC funding quorum: %d endpoint(s) resolve to only %d distinct host(s); clamping quorum "
+                "%d -> %d. A quorum of same-host endpoints is false corroboration — configure >= %d "
+                "INDEPENDENT hosts for genuine %d-of-N safety.",
+                len(urls),
+                distinct,
+                quorum,
+                effective,
+                quorum,
+                quorum,
+            )
+        readers = [MempoolSpaceFundingReader(base_url=u) for u in urls]
+        return cls(readers, quorum=effective, dust_cap_sats=dust_cap_sats)
+
+    @classmethod
     def default_mainnet(cls, *, quorum: int = 2, dust_cap_sats: int = 10_000) -> MultiSourceBtcFundingReader:
         """Wire the three default independent mainnet Esplora endpoints (2-of-3)."""
-        readers = [MempoolSpaceFundingReader(base_url=u) for u in cls.DEFAULT_MAINNET_ENDPOINTS]
-        return cls(readers, quorum=quorum, dust_cap_sats=dust_cap_sats)
+        return cls.from_endpoints(cls.DEFAULT_MAINNET_ENDPOINTS, quorum=quorum, dust_cap_sats=dust_cap_sats)
 
     async def _gather(self, coro_fn) -> list:
         """Run ``coro_fn`` on every reader; return only the successful (non-Exception)

--- a/tests/test_endpoint_diversity.py
+++ b/tests/test_endpoint_diversity.py
@@ -1,0 +1,58 @@
+"""Tests for the BTC quorum endpoint-diversity guard.
+
+A quorum of same-host endpoints is FALSE corroboration — one hostile/buggy host satisfies the whole
+"quorum" — so the effective quorum must be bounded by the number of DISTINCT hosts.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import pytest
+
+from pyrxd.network.bitcoin import MultiSourceBtcFundingReader, count_distinct_hosts, endpoint_host
+from pyrxd.security.errors import ValidationError
+
+
+def test_endpoint_host_parses_hostname():
+    assert endpoint_host("https://mempool.space/api") == "mempool.space"
+    assert endpoint_host("wss://x.example.com:50022") == "x.example.com"
+    assert endpoint_host("HTTPS://Mempool.Space/api") == "mempool.space"
+    assert endpoint_host("") is None
+    assert endpoint_host(None) is None  # type: ignore[arg-type]
+
+
+def test_count_distinct_hosts():
+    # same host, different paths → ONE distinct source
+    assert count_distinct_hosts(["https://mempool.space/api", "https://mempool.space/signet/api"]) == 1
+    # genuinely independent hosts → TWO
+    assert count_distinct_hosts(["https://mempool.space/api", "https://blockstream.info/api"]) == 2
+    # unparseable tokens count as one distinct source each (we can't prove they collide)
+    assert count_distinct_hosts(["", "   "]) == 2
+
+
+def test_default_mainnet_endpoints_are_independent():
+    # Regression guard for the SHIPPED turnkey quorum: it must carry >= the default 2-of-3 in distinct
+    # hosts, so adding a same-host endpoint to DEFAULT_MAINNET_ENDPOINTS fails CI.
+    assert count_distinct_hosts(MultiSourceBtcFundingReader.DEFAULT_MAINNET_ENDPOINTS) >= 2
+
+
+def test_from_endpoints_clamps_same_host_quorum(caplog):
+    with caplog.at_level(logging.WARNING):
+        r = MultiSourceBtcFundingReader.from_endpoints(
+            ["https://mempool.space/api", "https://mempool.space/signet/api"], quorum=2
+        )
+    assert r._quorum == 1  # 2 URLs but only 1 distinct host → clamped
+    assert "false corroboration" in caplog.text
+
+
+def test_from_endpoints_keeps_distinct_host_quorum():
+    r = MultiSourceBtcFundingReader.from_endpoints(
+        ["https://mempool.space/api", "https://blockstream.info/api"], quorum=2
+    )
+    assert r._quorum == 2
+
+
+def test_from_endpoints_rejects_empty():
+    with pytest.raises(ValidationError):
+        MultiSourceBtcFundingReader.from_endpoints([], quorum=2)


### PR DESCRIPTION
A 2-of-3 quorum whose 3 URLs all resolve to the **same host** is really 1-of-1 — false corroboration, since one hostile/buggy host satisfies the whole 'quorum'. The funding reader previously clamped quorum to URL **count**, which doesn't catch this.

- `count_distinct_hosts()` + a `MultiSourceBtcFundingReader.from_endpoints()` factory that **clamps the effective quorum to the number of DISTINCT hosts** and logs the clamp loudly.
- `default_mainnet()` routes through it; the watchtower's non-mainnet path now uses it, so two same-host esploras can't masquerade as 2-of-2.
- A **regression test** pins that the shipped `DEFAULT_MAINNET_ENDPOINTS` carry ≥ the default quorum in distinct hosts — adding a same-host default endpoint fails CI.

6 new tests; 124 existing BTC quorum tests unbroken (fake-reader tests use the direct constructor); lint clean. First item of the ops & reliability track.