### PR TITLE
docs: versioning & deprecation policy (draft for sign-off)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -75,6 +75,12 @@ paperwork process. Most editors and CI systems handle DCO transparently.
   your change pulls in a new third-party package.
 - **Don't bypass tests or linters.** If a check is failing, fix the
   cause; don't add a `# noqa` or skip the test.
+- **Flag breaking-class changes.** "Breaking" for an on-chain SDK is more
+  than a changed Python signature — it includes covenant/script bytecode,
+  wire/serialization formats, and **security-posture / safety-default**
+  changes. If your PR touches any of those, say so in the CHANGELOG and add
+  a deprecation/migration note. See
+  [`docs/versioning-and-deprecation-policy.md`](docs/versioning-and-deprecation-policy.md).
 
 ## Code style
 

--- a/docs/versioning-and-deprecation-policy.md
+++ b/docs/versioning-and-deprecation-policy.md
@@ -1,0 +1,72 @@
+# Versioning & deprecation policy
+
+pyrxd follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html) — but "breaking" for an
+**on-chain SDK** means more than a changed Python signature. This page defines what counts as breaking,
+the pre-1.0 reality, and how deprecations are run, so downstream integrators know what a version bump
+promises (and what it doesn't).
+
+> _Draft for maintainer sign-off. The deprecation windows below are the proposed posture._
+
+## What "breaking" means here
+
+A change is **breaking-class** (a MAJOR bump at 1.0+; a MINOR may carry it pre-1.0, but it must be
+flagged — see below) if it breaks **any** of these contracts, not only the Python API:
+
+| Contract | Breaking change examples |
+|---|---|
+| **Python API** | Removing/renaming a public symbol; changing a signature, return type, or the exception type a caller catches |
+| **On-chain artifact bytecode** | Changing covenant/script bytecode or a dMint contract such that a newly-built artifact's **address/SPK changes**, or it's incompatible with assumptions about existing on-chain state. *(The 0.8.0 `OP_SIZE` preimage-length pin was exactly this — it shifted the HTLC address + covenant SPKs; a protocol bump.)* |
+| **Wire / serialization formats** | The `SwapRecord` JSON schema, the recovery-file format, the RSWP order frame, the Glyph CBOR envelope |
+| **Security posture / safety defaults** | Weakening a fail-closed property or flipping a safety default — **even if the Python signature is unchanged.** *(See "the rule 0.9.0 violated".)* |
+
+## Pre-1.0 reality
+
+pyrxd is **0.x**: the API and on-chain formats are **not yet stable**.
+
+- A **minor** (`0.N → 0.N+1`) **may** carry breaking-class changes. It **must** call them out (see below).
+- A **patch** (`0.N.x → 0.N.x+1`) carries only backward-compatible fixes.
+- Only the **latest published minor** receives security fixes — see [`SECURITY.md`](../SECURITY.md).
+- At **1.0**, MAJOR/MINOR/PATCH take their full SemVer meaning: breaking-class changes require a MAJOR.
+
+## The rule 0.9.0 violated (and the lesson)
+
+0.9.0's CHANGELOG said _"no breaking API changes"_ while it turned `require_audit_cleared` /
+`require_spv_sole_authority_cleared` from fail-closed gates into **advisory no-ops** — a real change to a
+security-relevant default. By the table above that is **breaking-class**, even though no Python signature
+changed. The lesson, now policy:
+
+1. **A change to a safety property or a fail-closed default is breaking-class** and must be the headline
+   of its CHANGELOG entry — never folded under "no breaking changes."
+2. **Where it changes a runtime default, emit a one-time `DeprecationWarning`** (or a startup log for an
+   operational gate) so a downstream that relied on the old behavior sees it in logs/CI, not in
+   production. A silent behavioral reversal of a security gate is the least-surprise violation an SDK
+   must avoid most.
+
+## Deprecation process
+
+To retire a public symbol or behavior:
+
+1. **Keep it working for ≥ 1 minor** with a `DeprecationWarning` (`stacklevel=2`) that names the
+   replacement.
+2. **Document it:** a CHANGELOG **`Deprecated`** entry, plus a migration note in the
+   [migration guides](how-to/migrate-0.4-to-0.5.md) when a caller must change code.
+3. **Remove** no earlier than the next minor (pre-1.0) / the next MAJOR (1.0+).
+4. **On-chain format changes** carry a protocol-version note (which on-chain state they're compatible
+   with) — old artifacts on superseded bytecode are documented, not silently re-pointed
+   (cf. the mainnet LWMA dMint deploy on pre-fix bytecode).
+
+## What SemVer here does NOT promise
+
+So consumers don't over-rely:
+
+- The unaudited cross-chain swap stack's **safety against a hostile counterparty** — that's the external
+  audit gate + the residual register, not a version promise.
+- **Transitive dependency pins** — pyrxd is a library and intentionally does not pin its consumers'
+  transitive graph (`SUPPLY-NOPIN`); pin in your own lockfile.
+- The **exact bytes of an error message** or internal/underscored symbols.
+
+## See also
+
+- [`SECURITY.md`](../SECURITY.md) — supported versions + the safe-harbor / disclosure policy.
+- [`security-audit-scope.md`](security-audit-scope.md) — the residual register breaking changes must keep honest.
+- The [migration guides](how-to/migrate-0.4-to-0.5.md).


### PR DESCRIPTION
Defines what 'breaking' means for an **on-chain SDK** — the CHANGELOG claims SemVer, but signature-SemVer is insufficient: 0.9.0 said 'no breaking API changes' while turning `require_audit_cleared` into an advisory no-op (a real security-default change).

**Breaking-class** now explicitly includes, beyond the Python API: covenant/script **bytecode** (address/SPK shifts — e.g. the 0.8.0 `OP_SIZE` pin), **wire/serialization formats**, and **security posture / safety defaults** even when the signature is unchanged. Encodes the lesson: a safety-property change must headline its CHANGELOG entry and emit a one-time `DeprecationWarning`/startup log. Plus the pre-1.0 reality, the deprecation process, and what SemVer here does *not* promise. Referenced from `CONTRIBUTING.md`.

**⚠️ DRAFT for maintainer sign-off** — the deprecation windows + the breaking-class stance are the proposed posture; not auto-merging. Docs only.