### PR TITLE
feat(gravity): RSWP on-chain swap-order decoder + commit the wire spec

### DIFF
--- a/docs/swap-order-wire-format.md
+++ b/docs/swap-order-wire-format.md
@@ -1,0 +1,113 @@
+# Radiant on-chain swap order ("RSWP") wire format
+
+**Date:** 2026-05-22. **Status:** confirmed from canonical source (Radiant-Core node parser + Photonic-Wallet producer + RXinDexer indexer), cross-checked against a Radiant-Core functional-test vector. Informs a future pyrxd swap-offer builder.
+
+## Why this exists
+
+Third-party RXD wallets that post to the on-chain swap orderbook (e.g. Orbital, Photonic) must sign their offered UTXO with `SIGHASH_SINGLE | ANYONECANPAY | FORKID`. Because `SINGLE` binds the signature to the one paired output *including its exact value*, the offered side must be a single UTXO of an exact amount — which is why those wallets do a "self-send" to mint a clean exact-amount UTXO before posting an offer. pyrxd's signing stack already supports `0xC3` (`SIGHASH.SINGLE_ANYONECANPAY_FORKID`, `src/pyrxd/constants.py:38`), so building/parsing these orders is a serializer job, not a crypto gap. This doc pins the byte format so a builder can be implemented without re-deriving it.
+
+## Source authority
+
+| Concern | Authoritative source |
+|---|---|
+| On-chain OP_RETURN layout & detection | Radiant-Core `src/index/swapindex.cpp:558-695` (the consensus-node parser — *defines* the format) |
+| RPC field names/types (`getopenorders`) | Radiant-Core `src/rpc/swap.cpp:20-43, 608-618` |
+| `price_terms` inner structure | Photonic-Wallet `packages/app/src/swapBroadcast.ts:300-403` (the actual on-chain producer) |
+| `signature` content & sighash flags | Photonic-Wallet `packages/app/src/pages/Swap.tsx`, `packages/lib/src/transfer.tsx:208-228`, `tx.ts:44-70` |
+| Sighash constants | Radiant-Core `src/script/sighashtype.h:14-18` |
+| Test vector | Radiant-Core `test/functional/feature_swap.py:80-178` |
+
+## Detection mechanism
+
+A swap order is advertised by an **`OP_RETURN` output** whose first push is the 4 ASCII bytes `RSWP` (`52 53 57 50`). It is **not** a special script template, and the advertising transaction is otherwise an ordinary tx (it may be funded from any UTXO). "Open vs filled" is derived separately by the node tracking whether the offered UTXO is still unspent.
+
+## v2 frame (current — Photonic emits only v2)
+
+Pushes after `OP_RETURN`, in order (Radiant-Core `swapindex.cpp:594-659`):
+
+| # | Field | Size / encoding | Notes |
+|---|---|---|---|
+| 1 | `"RSWP"` | 4 bytes ASCII | magic |
+| 2 | `version` | 1 byte | `0x02` |
+| 3 | `flags` | 1 byte | only `FLAG_HAS_WANT = 0x01` defined |
+| 4 | `offeredType` | 1 byte | Photonic `ContractType` int; node stores verbatim |
+| 5 | `termsType` | 1 byte | Photonic always emits `0x01` |
+| 6 | `tokenID` | 32 bytes | see asset encoding below |
+| 7 | `wantTokenID` | 32 bytes | **present iff `flags & 0x01`** |
+| 8 | `offeredUTXOHash` | 32 bytes | reversed (little-endian internal) txid of offered UTXO |
+| 9 | `offeredUTXOIndex` | minimal `CScriptNum` (≤4 bytes; `OP_0..OP_16` ok) | vout |
+| 10..N-1 | `priceTerms` | one or more pushes, **concatenated** | see below |
+| N | `signature` | final push | full scriptSig, see below |
+
+Reassembly rule (`swapindex.cpp:642-659`): collect all remaining pushes into `tail`; require `len(tail) >= 2`; `price_terms = concat(tail[:-1])`, `signature = tail[-1]`.
+
+(v1/legacy `version=0x01` has no flags/offeredType/termsType/wantTokenID and single-push price_terms+signature. Build against v2.)
+
+## `price_terms` byte layout (Photonic `MultiTxOutV1`)
+
+The node treats `price_terms` as **opaque bytes** (`HexStr(priceTerms)`). The real structure is imposed by the producer (Photonic) — a serialized list of the outputs the maker wants to receive:
+
+```
+price_terms := CompactSize(outputCount)
+               || [ value(8 bytes LE) || CompactSize(scriptLen) || script ] * outputCount
+```
+
+- `value`: 8-byte **little-endian** uint64 (satoshis/photons).
+- `scriptLen`: Bitcoin CompactSize/varint.
+- `script`: raw scriptPubKey of the desired output (e.g. an FT/NFT/P2PKH script to the maker).
+- Photonic currently always writes a single output.
+- Reader fallback (`swapBroadcast.ts:359-371`): if MultiTxOutV1 parse fails, treat the blob as bare `value(8 LE) || script(rest)`.
+
+## `signature` format & sighash
+
+The `signature` push is **the entire unlocking scriptSig of input[0] of a partially-signed tx** (Photonic `Swap.tsx:655`), not a bare ECDSA sig:
+
+```
+signature := PUSH( DER_ECDSA_sig || sighashByte ) || PUSH( compressed_pubkey )
+```
+
+- **sighashByte = `0xC3` = `SIGHASH_SINGLE(0x03) | SIGHASH_FORKID(0x40) | SIGHASH_ANYONECANPAY(0x80)`.**
+- `ANYONECANPAY` → signs only the maker's one offered input (taker adds their inputs).
+- `SINGLE` → signs only the output at the same index as that input — the maker's single demanded output. **The demanded output value is bound into the signature, so it is exact by construction** (root cause of the self-send requirement).
+- `FORKID` → Radiant/BCH-style (BIP143-style preimage with prevout value).
+- With `SINGLE`, in the completion tx the maker's input index must equal the index of the maker's demanded output. Photonic builds the partial with offered-input and demand-output both at index 0.
+
+## Field meanings
+
+- `version`: `0x01` legacy, `0x02` current.
+- `flags`: bit 0 `FLAG_HAS_WANT = 0x01` (presence of `wantTokenID`). No other bits defined.
+- `offeredType`: Photonic `ContractType` enum int (verify mapping in Photonic `packages/app/src/types.ts` before assuming RXD=0/FT=1/NFT=2). Node assigns no meaning.
+- `termsType`: selects `price_terms` interpretation; Photonic always `0x01` + MultiTxOutV1.
+
+## Asset encoding (RXD-native vs Glyph token)
+
+Frame is identical for both; asset identity lives in the 32-byte `tokenID`/`wantTokenID` and the embedded `price_terms` script (`assetToSwapTokenId`, `swapBroadcast.ts:405-416`):
+
+- **RXD-native side:** `tokenID` = 32 zero bytes. When the *want* side is RXD, omit `wantTokenID` and clear `flags` bit 0.
+- **Glyph-token side:** `tokenID` = `sha256( Outpoint.fromString(glyphRef).ref() )`, pushed **byte-reversed**.
+- RPC `tokenid` is big-endian display hex; the on-chain push is little-endian internal bytes.
+
+## ⚠️ Conflicts / pitfalls (read before implementing)
+
+1. **`price_terms`: Photonic and RXinDexer DISAGREE.** RXinDexer (`electrumx/server/swap_index.py:462-517`) decodes `price_terms` as small price/amount integers keyed by `terms_type` — this is RXinDexer-local invention and produces **garbage against real Photonic-produced orders**. Follow **Photonic's MultiTxOutV1**; it is what is actually on chain and what the node round-trips. This is the one place the usual "Photonic is canonical" default and RXinDexer happen to be incompatible — and Photonic wins because it is the on-chain producer.
+2. **`signature` is the full scriptSig**, not a bare signature, despite RPC help labeling it "Partial signature."
+3. **`tokenID` derivation differs** between the node's functional test (bare reversed txid) and Photonic (`sha256(ref)` reversed). Node accepts either (opaque 32 bytes); use Photonic's `sha256(ref)` for orderbook interop.
+4. **No `swap.get_orders` RPC exists.** Photonic queries the **node** (`getopenorders`, …). RXinDexer's ElectrumX methods are differently named (`swap.get_open_orders`, `swap.get_orderbook`, …) and a plain ElectrumX server returns `unknown method`.
+5. `offeredUTXOIndex` uses minimal `CScriptNum` encoding.
+
+## Verified test vector (Radiant-Core `feature_swap.py:80-178`)
+
+An order with two price-term pushes `0102030405` + `060708090a` and signature `04050607` round-trips through `getopenorders` as `price_terms="0102030405060708090a"`, `signature="04050607"` — proving (a) price_terms = concatenation of middle pushes, (b) signature = final push, (c) on-chain pushes are little-endian/reversed while RPC reports big-endian display hex.
+
+## Minimal build recipe for pyrxd (v2)
+
+1. `tokenID` (offered): `sha256(genesis_ref_bytes)` for a Glyph token else 32×`0x00`; push reversed.
+2. `wantTokenID`: same rule; omit + clear `flags` bit 0 if want side is RXD.
+3. `flags = 0x01` iff `wantTokenID` present else `0x00`.
+4. `offeredType` = ContractType int; `termsType = 0x01`.
+5. `offeredUTXOHash` = reversed offered txid; `offeredUTXOIndex` = minimal CScriptNum.
+6. `price_terms` = `CompactSize(1) || value(8 LE) || CompactSize(len(script)) || script` for the single demanded output.
+7. Sign the offered UTXO with sighash `0xC3` (FORKID/BIP143 preimage); `signature` push = full P2PKH scriptSig `PUSH(der||0xC3) PUSH(pubkey)`.
+8. Emit `OP_RETURN "RSWP" 0x02 flags offeredType termsType tokenID [wantTokenID] offeredUTXOHash offeredUTXOIndex priceTerms signature` as a value-0 output in any funded tx.
+
+pyrxd already has the preimage + signing for `0xC3` (`src/pyrxd/transaction/transaction_preimage.py:190-235`, `src/pyrxd/script/type.py:78-85`, `src/pyrxd/constants.py:38`). Remaining work is the OP_RETURN/`MultiTxOutV1` serializer + a per-input sighash-aware offer builder.

--- a/src/pyrxd/gravity/swap_order.py
+++ b/src/pyrxd/gravity/swap_order.py
@@ -1,0 +1,195 @@
+"""Decoder for the Radiant on-chain swap-order ("RSWP") OP_RETURN wire format — the READ side.
+
+Decodes a **v2** RSWP order advertised in an ``OP_RETURN`` output into structured fields, including the
+Photonic ``MultiTxOutV1`` ``price_terms`` (the outputs the maker demands). This is the **canonical**
+decode: it follows the on-chain producer (Photonic-Wallet) and the consensus-node parser
+(Radiant-Core ``swapindex.cpp``), **not** RXinDexer — which mis-decodes ``price_terms`` as small price
+integers and produces garbage against real on-chain orders (see ``docs/swap-order-wire-format.md``
+§Conflicts). Read-only: this builds and signs nothing.
+
+The frame (pushes after ``OP_RETURN``): ``"RSWP" version flags offeredType termsType tokenID
+[wantTokenID] offeredUTXOHash offeredUTXOIndex priceTerms… signature``. The tail rule (node
+``swapindex.cpp:642-659``): of the remaining pushes, ``price_terms = concat(tail[:-1])`` and
+``signature = tail[-1]`` (require ``len(tail) >= 2``).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from ..constants import OpCode
+from ..script import Script
+from ..security.errors import ValidationError
+from ..utils import Reader
+
+_RSWP_MAGIC = b"RSWP"
+_FLAG_HAS_WANT = 0x01
+_RXD_TOKEN_ID = b"\x00" * 32
+
+
+@dataclass(frozen=True)
+class DemandedOutput:
+    """One output the maker demands (a parsed ``MultiTxOutV1`` entry)."""
+
+    value: int  # satoshis/photons (8-byte LE)
+    script: bytes  # raw scriptPubKey the maker wants paid
+
+
+@dataclass(frozen=True)
+class RswpOrder:
+    """A decoded v2 RSWP swap order. ``price_terms`` is the raw opaque blob; ``demanded_outputs`` is the
+    parsed ``MultiTxOutV1`` view (``None`` if the blob isn't valid MultiTxOutV1 — use ``price_terms``)."""
+
+    version: int
+    flags: int
+    offered_type: int
+    terms_type: int
+    token_id: bytes  # 32 bytes; all-zero == RXD-native offered side
+    want_token_id: bytes | None  # 32 bytes iff flags & FLAG_HAS_WANT
+    offered_utxo_hash: bytes  # 32 bytes, internal (little-endian) txid of the offered UTXO
+    offered_utxo_index: int  # vout
+    price_terms: bytes  # opaque concat of the middle pushes
+    demanded_outputs: list[DemandedOutput] | None  # parsed MultiTxOutV1, or None
+    signature: bytes  # the full scriptSig: PUSH(DER||0xC3) PUSH(pubkey)
+
+    @property
+    def offered_txid(self) -> str:
+        """Display (big-endian) txid of the offered UTXO."""
+        return self.offered_utxo_hash[::-1].hex()
+
+    @property
+    def offered_is_rxd(self) -> bool:
+        """True iff the offered side is native RXD (token_id all-zero)."""
+        return self.token_id == _RXD_TOKEN_ID
+
+
+def _items(op_return_script: bytes) -> list:
+    """Post-``OP_RETURN`` pushes as a list of ``bytes`` (data push) or ``int`` (OP_0 / OP_1..OP_16)."""
+    chunks = Script(op_return_script).chunks
+    if not chunks or chunks[0].op != bytes(OpCode.OP_RETURN):
+        raise ValidationError("not an OP_RETURN script")
+    out: list = []
+    for c in chunks[1:]:
+        if c.data is not None:
+            out.append(c.data)
+        elif c.op == b"\x00":  # OP_0
+            out.append(0)
+        elif b"\x51" <= c.op <= b"\x60":  # OP_1..OP_16
+            out.append(c.op[0] - 0x50)
+        else:
+            raise ValidationError(f"unexpected opcode 0x{c.op.hex()} in RSWP frame")
+    return out
+
+
+def _decode_scriptnum(data: bytes) -> int:
+    """Decode a minimal ``CScriptNum`` (little-endian, sign bit in the MSB)."""
+    if not data:
+        return 0
+    n = int.from_bytes(data, "little")
+    if data[-1] & 0x80:  # negative
+        n &= ~(0x80 << (8 * (len(data) - 1)))
+        return -n
+    return n
+
+
+def parse_price_terms(blob: bytes) -> list[DemandedOutput] | None:
+    """Parse a ``MultiTxOutV1`` ``price_terms`` blob into demanded outputs, or ``None`` if it is not
+    clean MultiTxOutV1. (Photonic's reader has a bare ``value(8 LE) || script(rest)`` fallback — see
+    :func:`parse_price_terms_lenient`.)"""
+    r = Reader(blob)
+    count = r.read_var_int_num()
+    if count is None or count <= 0 or count > 10_000:
+        return None
+    outs: list[DemandedOutput] = []
+    for _ in range(count):
+        vb = r.read_bytes(8)
+        if vb is None or len(vb) != 8:
+            return None
+        slen = r.read_var_int_num()
+        if slen is None or slen < 0:
+            return None
+        script = r.read_bytes(slen) if slen else b""
+        if script is None or len(script) != slen:
+            return None
+        outs.append(DemandedOutput(value=int.from_bytes(vb, "little"), script=script))
+    if not r.eof():  # trailing bytes => not clean MultiTxOutV1
+        return None
+    return outs
+
+
+def parse_price_terms_lenient(blob: bytes) -> list[DemandedOutput] | None:
+    """MultiTxOutV1, else Photonic's bare ``value(8 LE) || script(rest)`` fallback, else ``None``."""
+    strict = parse_price_terms(blob)
+    if strict is not None:
+        return strict
+    if len(blob) >= 8:
+        return [DemandedOutput(value=int.from_bytes(blob[:8], "little"), script=blob[8:])]
+    return None
+
+
+def decode_rswp_order(op_return_script: bytes) -> RswpOrder:
+    """Decode a v2 RSWP ``OP_RETURN`` script into an :class:`RswpOrder`. Raises ``ValidationError`` on a
+    malformed / non-v2 / non-RSWP frame."""
+    items = _items(op_return_script)
+    i = 0
+
+    def _data(field: str, length: int | None = None) -> bytes:
+        nonlocal i
+        if i >= len(items) or not isinstance(items[i], bytes):
+            raise ValidationError(f"RSWP frame: expected a data push for {field}")
+        v = items[i]
+        if length is not None and len(v) != length:
+            raise ValidationError(f"RSWP {field}: expected {length} bytes, got {len(v)}")
+        i += 1
+        return v
+
+    def _small_int(field: str) -> int:
+        """A 1-byte value field, which minimal-push encoding may emit as OP_0/OP_1..OP_16."""
+        nonlocal i
+        if i >= len(items):
+            raise ValidationError(f"RSWP frame truncated at {field}")
+        v = items[i]
+        i += 1
+        if isinstance(v, int):
+            return v
+        if len(v) == 1:
+            return v[0]
+        raise ValidationError(f"RSWP {field}: expected a 1-byte value")
+
+    if _data("magic", 4) != _RSWP_MAGIC:
+        raise ValidationError("not an RSWP order (missing magic)")
+    version = _small_int("version")
+    if version != 2:
+        raise ValidationError(f"unsupported RSWP version {version} (this decoder handles v2)")
+    flags = _small_int("flags")
+    offered_type = _small_int("offeredType")
+    terms_type = _small_int("termsType")
+    token_id = _data("tokenID", 32)
+    want_token_id = _data("wantTokenID", 32) if (flags & _FLAG_HAS_WANT) else None
+    offered_utxo_hash = _data("offeredUTXOHash", 32)
+    # offeredUTXOIndex: OP_0..OP_16 OR a minimal CScriptNum push.
+    if i >= len(items):
+        raise ValidationError("RSWP frame truncated at offeredUTXOIndex")
+    idx_item = items[i]
+    i += 1
+    offered_utxo_index = idx_item if isinstance(idx_item, int) else _decode_scriptnum(idx_item)
+
+    tail = items[i:]
+    if len(tail) < 2 or not all(isinstance(t, bytes) for t in tail):
+        raise ValidationError("RSWP frame: tail must be >= 2 data pushes (priceTerms… + signature)")
+    price_terms = b"".join(tail[:-1])
+    signature = tail[-1]
+
+    return RswpOrder(
+        version=version,
+        flags=flags,
+        offered_type=offered_type,
+        terms_type=terms_type,
+        token_id=token_id,
+        want_token_id=want_token_id,
+        offered_utxo_hash=offered_utxo_hash,
+        offered_utxo_index=offered_utxo_index,
+        price_terms=price_terms,
+        demanded_outputs=parse_price_terms(price_terms),
+        signature=signature,
+    )

--- a/tests/test_swap_order.py
+++ b/tests/test_swap_order.py
@@ -1,0 +1,144 @@
+"""Tests for the RSWP on-chain swap-order decoder (read side)."""
+
+from __future__ import annotations
+
+import pytest
+
+from pyrxd.gravity.swap_order import DemandedOutput, decode_rswp_order, parse_price_terms, parse_price_terms_lenient
+from pyrxd.security.errors import ValidationError
+
+_OP_RETURN = b"\x6a"
+
+
+def _push(data: bytes) -> bytes:
+    """A canonical data push (1-byte length prefix; data <= 75 bytes)."""
+    assert len(data) <= 75
+    return bytes([len(data)]) + data
+
+
+def _op_n(n: int) -> bytes:
+    """OP_0 / OP_1..OP_16 as a single opcode byte."""
+    return b"\x00" if n == 0 else bytes([0x50 + n])
+
+
+def _frame(pushes: list[bytes]) -> bytes:
+    return _OP_RETURN + b"".join(pushes)
+
+
+def _v2_frame(
+    *,
+    flags=0,
+    offered_type=0,
+    terms_type=1,
+    token_id=b"\x00" * 32,
+    want=None,
+    offered_hash=b"\xaa" * 32,
+    idx_item=_op_n(0),
+    tail: list[bytes] | None = None,
+) -> bytes:
+    pushes = [
+        _push(b"RSWP"),
+        _push(b"\x02"),
+        _push(bytes([flags])),
+        _push(bytes([offered_type])),
+        _push(bytes([terms_type])),
+        _push(token_id),
+    ]
+    if want is not None:
+        pushes.append(_push(want))
+    pushes += [_push(offered_hash), idx_item] + (tail or [])
+    return _frame(pushes)
+
+
+# --------------------------------------------------------------------------- frame reassembly
+
+
+def test_radiant_core_verified_vector_frame_reassembly():
+    # From docs/swap-order-wire-format.md (Radiant-Core feature_swap.py): two price-term pushes
+    # 0102030405 + 060708090a + signature 04050607 → price_terms="0102030405060708090a", sig="04050607".
+    order = decode_rswp_order(
+        _v2_frame(
+            tail=[
+                _push(bytes.fromhex("0102030405")),
+                _push(bytes.fromhex("060708090a")),
+                _push(bytes.fromhex("04050607")),
+            ]
+        )
+    )
+    assert order.version == 2
+    assert order.price_terms.hex() == "0102030405060708090a"
+    assert order.signature.hex() == "04050607"
+    assert order.demanded_outputs is None  # this synthetic blob isn't valid MultiTxOutV1
+
+
+def test_want_token_id_present_iff_flag():
+    want = b"\xbb" * 32
+    with_want = decode_rswp_order(_v2_frame(flags=0x01, want=want, tail=[_push(b"pt"), _push(b"sig")]))
+    assert with_want.flags == 0x01 and with_want.want_token_id == want
+    without = decode_rswp_order(_v2_frame(flags=0x00, tail=[_push(b"pt"), _push(b"sig")]))
+    assert without.want_token_id is None
+
+
+def test_offered_utxo_index_opcode_and_scriptnum():
+    # OP_0 → vout 0
+    o0 = decode_rswp_order(_v2_frame(idx_item=_op_n(0), tail=[_push(b"pt"), _push(b"sig")]))
+    assert o0.offered_utxo_index == 0
+    # a CScriptNum push for a vout > 16 (e.g. 300 = 0x2c 0x01 LE)
+    o300 = decode_rswp_order(_v2_frame(idx_item=_push(bytes.fromhex("2c01")), tail=[_push(b"pt"), _push(b"sig")]))
+    assert o300.offered_utxo_index == 300
+
+
+def test_offered_txid_and_rxd_flag():
+    internal = bytes.fromhex("01" + "00" * 31)  # internal (little-endian); display txid = reversed
+    o = decode_rswp_order(_v2_frame(offered_hash=internal, token_id=b"\x00" * 32, tail=[_push(b"pt"), _push(b"sig")]))
+    assert o.offered_txid == internal[::-1].hex() == "00" * 31 + "01"
+    assert o.offered_is_rxd is True
+
+
+# --------------------------------------------------------------------------- price_terms (MultiTxOutV1)
+
+
+def test_parse_multitxoutv1_single_output():
+    script = bytes.fromhex("76a914" + "33" * 20 + "88ac")  # a P2PKH
+    blob = b"\x01" + (1000).to_bytes(8, "little") + bytes([len(script)]) + script  # count=1
+    outs = parse_price_terms(blob)
+    assert outs == [DemandedOutput(value=1000, script=script)]
+
+
+def test_decode_with_real_multitxoutv1_price_terms():
+    script = bytes.fromhex("76a914" + "44" * 20 + "88ac")
+    pt = b"\x01" + (50_000).to_bytes(8, "little") + bytes([len(script)]) + script
+    order = decode_rswp_order(_v2_frame(tail=[_push(pt), _push(b"\x04\x05\x06\x07")]))
+    assert order.demanded_outputs == [DemandedOutput(value=50_000, script=script)]
+
+
+def test_lenient_fallback_for_non_multitxoutv1():
+    # The Photonic bare fallback: value(8 LE) || script(rest).
+    blob = (7).to_bytes(8, "little") + b"\xde\xad\xbe\xef"
+    assert parse_price_terms(blob) is None  # not clean MultiTxOutV1
+    lenient = parse_price_terms_lenient(blob)
+    assert lenient == [DemandedOutput(value=7, script=b"\xde\xad\xbe\xef")]
+
+
+# --------------------------------------------------------------------------- error cases
+
+
+def test_rejects_non_op_return():
+    with pytest.raises(ValidationError, match="OP_RETURN"):
+        decode_rswp_order(bytes.fromhex("76a914" + "00" * 20 + "88ac"))
+
+
+def test_rejects_missing_magic():
+    with pytest.raises(ValidationError, match="magic"):
+        decode_rswp_order(_frame([_push(b"XXXX"), _push(b"\x02")]))
+
+
+def test_rejects_non_v2_version():
+    with pytest.raises(ValidationError, match="version"):
+        decode_rswp_order(_frame([_push(b"RSWP"), _push(b"\x01")]))
+
+
+def test_rejects_short_tail():
+    # Only one tail push (no separate signature) → must be >= 2.
+    with pytest.raises(ValidationError, match="tail"):
+        decode_rswp_order(_v2_frame(tail=[_push(b"onlyone")]))


### PR DESCRIPTION
The **RSWP read side** (the roadmap's ecosystem item). Two parts:

- **Commit `docs/swap-order-wire-format.md`** — the source-confirmed RSWP v2 wire-format spec (was an untracked working draft; verified clean of private references).
- **`pyrxd.gravity.swap_order.decode_rswp_order`** — a read-only reference decoder for the v2 `OP_RETURN` frame, including the Photonic `MultiTxOutV1` `price_terms` parse. It follows the **canonical** sources (Photonic producer + Radiant-Core node parser), **not** RXinDexer — which mis-decodes `price_terms` as small integers and produces garbage against real on-chain orders. So it's the correct second decoder to **differential-test the buggy indexer against** (spec §Conflicts #1).

Handles minimal-push encoding (small fields as `OP_0`/`OP_N`), the tail reassembly rule, `OP_0..OP_16`/CScriptNum vout, the want-token flag, and MultiTxOutV1 + bare fallback. **Read-only** — builds/signs nothing (the offer *builder* stays scoped, not built).

11 tests incl. the Radiant-Core `feature_swap.py` verified vector; lint clean. Reporting the RXinDexer bug **upstream** is the remaining external follow-up.