### PR TITLE
test(spv): mutation-testing gate + close the validation gaps it found

### DIFF
--- a/docs/how-to/mutation-testing.md
+++ b/docs/how-to/mutation-testing.md
@@ -1,0 +1,74 @@
+# Mutation testing the SPV verifier
+
+Mutation testing measures **test quality**, not just line coverage: it mutates the source (e.g. flips
+`!= 80` to `< 80`, `i - 1` to `i + 1`) and checks whether the suite *catches* each change. A **killed**
+mutant means a test failed (good); a **survived** mutant means the line runs but no assertion pins its
+behavior — a potential gap.
+
+## Running it
+
+```bash
+poetry install --with dev   # brings in cosmic-ray
+poetry run task mutate
+```
+
+This runs [`scripts/mutation_test.sh`](../../scripts/mutation_test.sh) over the consensus-critical SPV
+verification modules — `pow.py` (PoW/difficulty), `merkle.py` (proof), `chain.py` (header-chain link +
+nBits pin), `payment.py` (output parse). It mutates `src/pyrxd/spv/<file>.py` **in place** (the editable
+install picks it up), runs the SPV tests, and restores via `git` (a trap restores on any exit). It is an
+**occasional gate, not part of `task ci`** (slow). Don't run concurrent git ops on `src/pyrxd/spv` while
+it runs.
+
+> The parser modules `proof.py` / `witness.py` are **excluded** here on purpose: they're covered by the
+> fuzz harness (`tests/test_fuzz_spv_parsers.py`), and the full test command that covers them is ~30×
+> slower per mutant. Mutation-testing the *verification arithmetic* is the high-value scope.
+
+## Baseline results (2026-06)
+
+| Module | Mutants | Killed | Survived | Killed |
+|---|---|---|---|---|
+| `pow.py` | 143 | 120 | 23 | 84% |
+| `merkle.py` | 354 | 288 | 66 | 81% |
+| `chain.py` | 132 | 78 | 54 | 59% |
+| `payment.py` | 268 | 219 | 49 | 82% |
+
+## Reading the score — survivors are not all bugs
+
+A large share of survivors are **equivalent mutants** that *cannot* be killed because they don't change
+behavior. In this codebase they cluster into:
+
+- **Type annotations** — `bytes | None` → `bytes - None`. Harmless: `from __future__ import annotations`
+  makes annotations strings, never evaluated.
+- **Error-message f-strings** — `f"…header[{i - 1}]"` → `{i + 1}`. Only the *text* of an exception
+  message; no test asserts the exact wording, and it shouldn't.
+- **Unreachable invariants** — `pow.py`'s `if len(target_le) != 32` is dead by construction (the
+  validated nBits exponent guarantees 32); it's deliberate defense kept out of `python -O`'s reach.
+- **Redundant guards** — `chain.py`'s per-header `len(header) != 80` is masked by `verify_header_pow`'s
+  own length check (defense in depth). Bypassing one still trips the other.
+
+So the raw kill-rate **understates** real assertion quality. The value of the run is finding the
+*genuine* gaps — branches that execute with no behavioral test.
+
+## What the 2026-06 run found and closed
+
+Mutation testing surfaced genuine, security-relevant gaps in **input validation**: the length guards and
+the chain-link check executed, but no test fed an adversarial length or a broken link.
+[`tests/test_spv_validation_hardening.py`](../../tests/test_spv_validation_hardening.py) closes them:
+
+- `pow.py` / `chain.py` **length guards** — wrong-length header / chain-anchor / nBits inputs (using a
+  real header ± a byte so a mutated guard falls through to a *different* error). Killed the
+  `len(...) != N` → `< N` / `> N` mutants (pow survivors 25 → 23, chain 64 → 54).
+- `chain.py` **link verification** — a valid 2-header consecutive chain (must pass) plus a broken link
+  (reversed order, must raise), exercising the core `prevHash == hash(prev)` check that had no
+  break-case test.
+
+## Known remaining survivors (deferred)
+
+Harder gaps that need crafted/mined fixtures — tracked for a follow-up, lower marginal value:
+
+- `merkle.py` — the `i * 33` branch-index arithmetic survives because tests use only **single-level**
+  (1-sibling) proofs; for `i = 0` every mutant operator collapses to 0. Needs a **multi-level** proof
+  fixture.
+- `pow.py` — the chunked `hash_be` vs `target_be` comparison and the `< 3` exponent boundary need
+  headers with hashes/targets crafted to the chunk/boundary (effectively requires mining).
+- `payment.py` — the size/offset guards need boundary-exact transactions (a tx exactly at `min_output_size`).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,6 +66,11 @@ check-private-links = "python3 scripts/check-no-private-links.py"
 # the push-fail-fix-push loop. ~3-5 min.
 # For a faster pre-commit pass, just run `task lint && task format-check && task test`.
 ci = "task lint && task format-check && task test && task coverage-security && task coverage-overall && task typecheck && task check-private-links"
+# `task mutate` runs cosmic-ray mutation testing on the consensus-critical SPV
+# verification modules (pow/merkle/chain/payment). Slow + mutates src/pyrxd/spv in
+# place (restored via git on exit) — an occasional gate, NOT part of `task ci`. See
+# docs/how-to/mutation-testing.md. Don't run concurrent git ops while it's running.
+mutate = "bash scripts/mutation_test.sh"
 docs = "sphinx-build -b html docs docs/_build/html"
 docs-clean = "rm -rf docs/_build"
 docs-serve = "sphinx-autobuild docs docs/_build/html --open-browser"
@@ -95,6 +100,7 @@ mypy = "^2.1.0"
 ruff = "^0.15.17"
 hypothesis = "^6.155.2"
 pytest-asyncio = ">=1.4.0"
+cosmic-ray = "^8.4.6"
 
 [tool.poetry.group.test.dependencies]
 bandit = {version = "^1.9.4", extras = ["toml"]}

--- a/scripts/mutation_test.sh
+++ b/scripts/mutation_test.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+# Mutation-test the consensus-critical SPV verification modules with cosmic-ray.
+#
+# Scope: the verification ARITHMETIC — pow.py (PoW/difficulty), merkle.py (proof), chain.py
+# (header-chain link + nBits pin), payment.py (output parse). The parser modules proof.py /
+# witness.py are intentionally excluded here: they are covered by the fuzz harness
+# (tests/test_fuzz_spv_parsers.py), and the full test command needed to cover them is ~30x slower
+# per mutant, so mixing them in would make this gate impractical.
+#
+# Mechanism: cosmic-ray mutates src/pyrxd/spv/<file>.py IN PLACE (the editable install picks it up),
+# runs the SPV verification tests, then we restore the file via git. A trap restores the whole
+# directory on any exit. Do NOT run concurrent git ops on src/pyrxd/spv while this runs.
+#
+# See docs/how-to/mutation-testing.md for the survivor analysis and what the score means.
+set -uo pipefail
+
+cd "$(git rev-parse --show-toplevel)" || { echo "not in a git repo"; exit 1; }
+
+PYTEST="$(command -v pytest || true)"
+if [ -z "$PYTEST" ]; then echo "pytest not found — run inside the project venv (poetry run task mutate)"; exit 1; fi
+if ! command -v cosmic-ray >/dev/null 2>&1; then echo "cosmic-ray not installed — poetry install --with dev"; exit 1; fi
+
+FILES="pow merkle chain payment"
+TESTS="tests/test_spv.py tests/test_merkle_path.py tests/test_spv_validation_hardening.py"
+WORK="$(mktemp -d)"
+trap 'git checkout -- src/pyrxd/spv/ 2>/dev/null; rm -rf "$WORK"' EXIT
+
+total=0; killed=0; surv=0
+for f in $FILES; do
+  cfg="$WORK/cr-$f.toml"; sess="$WORK/$f.sqlite"
+  cat > "$cfg" <<EOF
+[cosmic-ray]
+module-path = "src/pyrxd/spv/$f.py"
+timeout = 30.0
+excluded-modules = []
+test-command = "$PYTEST $TESTS -x -q -p no:randomly -p no:cacheprovider -o addopts= --no-cov"
+
+[cosmic-ray.distributor]
+name = "local"
+EOF
+  cosmic-ray init "$cfg" "$sess" >/dev/null 2>&1
+  cosmic-ray exec "$cfg" "$sess" >/dev/null 2>&1
+  git checkout -- "src/pyrxd/spv/$f.py" 2>/dev/null
+  t="$(cr-report "$sess" 2>/dev/null | grep -oE 'total jobs: [0-9]+' | grep -oE '[0-9]+')"
+  s="$(cr-report "$sess" 2>/dev/null | grep -oE 'surviving mutants: [0-9]+' | grep -oE '[0-9]+' | head -1)"
+  : "${t:=0}"; : "${s:=0}"
+  pct=0; [ "$t" -gt 0 ] && pct=$(( (t - s) * 100 / t ))
+  printf '  %-9s %4d mutants  %4d killed  %4d survived  (%d%% killed)\n' "$f" "$t" "$((t - s))" "$s" "$pct"
+  total=$((total + t)); killed=$((killed + t - s)); surv=$((surv + s))
+done
+tpct=0; [ "$total" -gt 0 ] && tpct=$(( killed * 100 / total ))
+printf 'TOTAL: %d mutants, %d killed, %d survived (%d%% killed)\n' "$total" "$killed" "$surv" "$tpct"

--- a/tests/test_spv_validation_hardening.py
+++ b/tests/test_spv_validation_hardening.py
@@ -1,0 +1,74 @@
+"""Mutation-driven SPV input-validation hardening tests.
+
+cosmic-ray mutation testing of ``src/pyrxd/spv`` (2026-06) surfaced surviving mutants in the **length
+guards** and the **chain-link check** of ``pow.py`` / ``chain.py`` — those branches execute, but no
+existing test fed an adversarial length or a broken link, so flipping ``!= 80`` to ``< 80`` (etc.) went
+undetected. Each test here kills a specific surviving mutant, hardening the SPV verifier's input
+validation — the first line of defense before any PoW/Merkle math runs.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from pyrxd.security.errors import SpvVerificationError, ValidationError
+from pyrxd.spv.chain import verify_chain
+from pyrxd.spv.pow import verify_header_pow
+
+# Real, consecutive mainnet headers: block 840000 -> 840001 (840001.prevHash == hash256(840000)).
+BLOCK_840000 = bytes.fromhex(
+    "00e05f2aab948491071265ad552351d0ad625745668da54b01720100000000000000"
+    "00004f89a5d73bd4d4887f25981fe81892ccafda10c27f52d6f3dd28183a7c411b03"
+    "b7072366194203177d9863ea"
+)
+BLOCK_840001 = bytes.fromhex(
+    "04002020a583da1c3ff29b687248ff737822f8ce4827033a28200300000000000000"
+    "0000bcc07f8618b7b063f833100724e2b40d6ee9dfa78087bfbe5d3441058a63de38"
+    "0e082366194203176d9026cc"
+)
+
+
+class TestPowHeaderLengthGuard:
+    # Use a REAL header +/- a byte (not all-zeros): the length guard must reject as ValidationError BEFORE
+    # any PoW math. A mutated guard (`< 80` / `> 80`) falls through to PoW on the wrong-length data, which
+    # raises SpvVerificationError instead -> the mismatch kills the mutant. (All-zeros wouldn't work: the
+    # downstream Nbits check rejects zero-mantissa as ValidationError either way, masking the mutation.)
+    @pytest.mark.parametrize("header", [BLOCK_840000 + b"\x00", BLOCK_840000[:79]], ids=["81-byte", "79-byte"])
+    def test_rejects_wrong_length_header(self, header: bytes) -> None:
+        with pytest.raises(ValidationError):
+            verify_header_pow(header)
+
+
+class TestChainLengthGuards:
+    @pytest.mark.parametrize("n", [79, 81])
+    def test_rejects_wrong_length_header(self, n: int) -> None:
+        with pytest.raises(ValidationError):
+            verify_chain([b"\x00" * n])
+
+    @pytest.mark.parametrize("n", [31, 33])
+    def test_rejects_wrong_length_chain_anchor(self, n: int) -> None:
+        with pytest.raises(ValidationError, match="chain_anchor"):
+            verify_chain([BLOCK_840000], chain_anchor=b"\x00" * n)
+
+    @pytest.mark.parametrize("n", [3, 5])
+    def test_rejects_wrong_length_expected_nbits(self, n: int) -> None:
+        with pytest.raises(ValidationError, match="expected_nbits"):
+            verify_chain([BLOCK_840000], expected_nbits=b"\x00" * n)
+
+    @pytest.mark.parametrize("n", [3, 5])
+    def test_rejects_wrong_length_expected_nbits_next(self, n: int) -> None:
+        with pytest.raises(ValidationError, match="expected_nbits_next"):
+            verify_chain([BLOCK_840000], expected_nbits=b"\xff\xff\x00\x1d", expected_nbits_next=b"\x00" * n)
+
+
+class TestChainLinkVerification:
+    def test_valid_consecutive_link_passes(self) -> None:
+        # A genuinely linked 2-header chain must NOT raise — kills `!=` -> `==` / `>=` / `<=` on the
+        # link check (those wrongly reject a valid link where prevHash == hash(prev)).
+        hashes = verify_chain([BLOCK_840000, BLOCK_840001])
+        assert len(hashes) == 2
+
+    def test_broken_link_rejected(self) -> None:
+        # Reversed order: header[1] (840000).prevHash != hash256(840001) -> broken link.
+        with pytest.raises(SpvVerificationError, match="chain link broken"):
+            verify_chain([BLOCK_840001, BLOCK_840000])


### PR DESCRIPTION
Resolves the deferred mutation-testing item (mutmut v3's aggregation didn't integrate with this src-layout; **cosmic-ray does**). Three parts:

**1. Measure** — cosmic-ray over the 4 consensus-critical SPV verification modules:

| Module | Mutants | Killed |
|---|---|---|
| `pow.py` | 143 | 84% |
| `merkle.py` | 354 | 81% |
| `chain.py` | 132 | 59% |
| `payment.py` | 268 | 82% |

A large share of survivors are **equivalent mutants** (type annotations under `from __future__ import annotations`, error-message f-strings, the unreachable `target_le != 32` invariant, the `chain.py` header-length guard redundant with `verify_header_pow`) — so raw kill-rate understates assertion quality.

**2. Close** — `tests/test_spv_validation_hardening.py` kills the **genuine** gaps it surfaced: the pow/chain **length guards** (wrong-length header/anchor/nBits — using a real header ± a byte so a mutated guard falls through to a *different* error) and **chain-link verification** (valid 2-header link must pass; broken/reversed link must raise). Measured: pow survivors **25→23**, chain **64→54**. 12 new tests, green.

**3. Repeat** — `task mutate` (`scripts/mutation_test.sh`) + a cosmic-ray dev-dep make it a standing gate (per-file, fast SPV command, git-restore trap; **not** in `task ci`). `docs/how-to/mutation-testing.md` documents the score, the equivalent-vs-genuine split, and the deferred harder gaps (merkle multi-level, pow chunk/exponent, payment boundary).