### PR TITLE
fix(security): 0.10.0 pre-release red-team punch-list

### DIFF
--- a/scripts/mutation_test.sh
+++ b/scripts/mutation_test.sh
@@ -48,5 +48,21 @@ EOF
   printf '  %-9s %4d mutants  %4d killed  %4d survived  (%d%% killed)\n' "$f" "$t" "$((t - s))" "$s" "$pct"
   total=$((total + t)); killed=$((killed + t - s)); surv=$((surv + s))
 done
-tpct=0; [ "$total" -gt 0 ] && tpct=$(( killed * 100 / total ))
+# Fail closed on a broken run: zero mutants means cosmic-ray init/exec silently no-op'd (missing tool,
+# wrong module path, env breakage) and the redirected stderr hid it — otherwise this would print
+# "0% killed" and exit 0, indistinguishable from a healthy run to a CI consumer.
+if [ "$total" -eq 0 ]; then
+  echo "ERROR: cosmic-ray produced 0 mutants — the run is broken (tool missing, wrong path, or every step no-op'd). Failing." >&2
+  exit 1
+fi
+tpct=$(( killed * 100 / total ))
 printf 'TOTAL: %d mutants, %d killed, %d survived (%d%% killed)\n' "$total" "$killed" "$surv" "$tpct"
+
+# Opt-in gate: when MUTATION_MIN_KILL_PCT is set, exit non-zero if the total kill rate is below it.
+# Unset (the default) => report-only measurement. The score includes known equivalent mutants that
+# cannot be killed (see docs/how-to/mutation-testing.md), so pick a threshold below 100.
+MIN_KILL="${MUTATION_MIN_KILL_PCT:-}"
+if [ -n "$MIN_KILL" ] && [ "$tpct" -lt "$MIN_KILL" ]; then
+  echo "FAIL: total kill rate ${tpct}% < threshold ${MIN_KILL}% (MUTATION_MIN_KILL_PCT)" >&2
+  exit 1
+fi

--- a/scripts/watchtower_run.py
+++ b/scripts/watchtower_run.py
@@ -32,7 +32,9 @@ import argparse
 import asyncio
 import contextlib
 import logging
+import os
 import signal
+from pathlib import Path
 
 import aiohttp
 
@@ -177,11 +179,17 @@ def _build_funding_reader(network: str, esploras: list[str], quorum: int) -> Mul
     A wrong/mainnet base on a signet run reads the wrong chain → the funding is never found → the maturity
     gate stays WATCH (fail-closed, never a wrongful broadcast)."""
     if network == "bc":
+        # Mainnet: the three default independent endpoints (2-of-3). from_endpoints fails closed if the
+        # endpoints ever resolve to < quorum distinct hosts — no silent single-source above-dust arming.
         return MultiSourceBtcFundingReader.default_mainnet(quorum=quorum)
-    # from_endpoints clamps the effective quorum to the number of DISTINCT hosts (not URL count) and warns
-    # — so two same-host esploras can't masquerade as a real 2-of-2 quorum (false corroboration).
+    # Non-mainnet (signet/testnet) is a NO-REAL-VALUE test network and is typically 1-of-1, so it
+    # explicitly accepts insufficient host diversity (allow_insufficient_diversity) and clamps the
+    # effective quorum to the distinct-host count with a loud warning — the mainnet fail-closed above is
+    # the one that guards real value.
     api_urls = [u.rstrip("/") + "/api" for u in esploras]
-    return MultiSourceBtcFundingReader.from_endpoints(api_urls, quorum=quorum, dust_cap_sats=10_000)
+    return MultiSourceBtcFundingReader.from_endpoints(
+        api_urls, quorum=quorum, dust_cap_sats=10_000, allow_insufficient_diversity=True
+    )
 
 
 #: Default INDEPENDENT public Radiant ElectrumX endpoints (distinct operators), verified live
@@ -362,8 +370,24 @@ def _parse_args(argv=None) -> argparse.Namespace:
     p.add_argument("--allow-insecure", action="store_true", help="allow non-TLS ElectrumX")
     # #1 notification channel (in addition to the always-on log)
     p.add_argument("--webhook-url", help="POST pages to this webhook (ntfy/Pushover/Slack/custom)")
-    p.add_argument("--webhook-auth-header", help="optional 'Header: value' sent with the webhook (e.g. a bearer token)")
-    p.add_argument("--webhook-secret", help="optional HMAC-SHA256 secret -> X-Watchtower-Signature header")
+    p.add_argument(
+        "--webhook-auth-header",
+        help="DEPRECATED (process-table/shell-history exposure) optional 'Header: value' sent with the "
+        "webhook; prefer --webhook-auth-header-file or PYRXD_WATCHTOWER_WEBHOOK_AUTH_HEADER",
+    )
+    p.add_argument(
+        "--webhook-auth-header-file",
+        help="read the 'Header: value' auth header from this (0600) file instead of the command line",
+    )
+    p.add_argument(
+        "--webhook-secret",
+        help="DEPRECATED (process-table/shell-history exposure) optional HMAC-SHA256 secret -> "
+        "X-Watchtower-Signature header; prefer --webhook-secret-file or PYRXD_WATCHTOWER_WEBHOOK_SECRET",
+    )
+    p.add_argument(
+        "--webhook-secret-file",
+        help="read the HMAC-SHA256 secret from this (0600) file instead of the command line",
+    )
     # #2 dead-man's switch: write a liveness file each tick (watched by watchtower_deadman.py)
     p.add_argument("--heartbeat-file", help="write a liveness heartbeat here each tick")
     # ETH counter-leg (alert-only v3): watch RXD↔ETH swaps too. Read-only, no key, never touches p.
@@ -415,17 +439,48 @@ def _parse_args(argv=None) -> argparse.Namespace:
     return p.parse_args(argv)
 
 
+def _resolve_secret(inline: str | None, file_path: str | None, env_name: str, *, flag: str) -> str | None:
+    """Resolve a webhook secret from (in precedence) the inline CLI flag, a 0600 file, or an env var.
+
+    The inline flag is accepted for backward compatibility but warned against: process arguments are
+    world-readable via ``/proc/<pid>/cmdline`` / ``ps`` and are captured in shell history (SECRET-1).
+    The file/env paths keep the secret off the process table.
+    """
+    if inline:
+        logger.warning(
+            "%s passed on the command line is visible in the process table (ps / /proc/<pid>/cmdline) and "
+            "shell history; prefer %s-file or the %s env var.",
+            flag,
+            flag,
+            env_name,
+        )
+        return inline
+    if file_path:
+        return Path(file_path).read_text(encoding="utf-8").strip() or None
+    return os.environ.get(env_name) or None
+
+
 def _build_alert_channel(args: argparse.Namespace, session):
     """Always log; additionally POST to an authenticated webhook if configured."""
     channels = [LoggingAlertChannel()]
     if args.webhook_url:
         auth = None
-        if args.webhook_auth_header:
-            key, _, val = args.webhook_auth_header.partition(":")
-            auth = {key.strip(): val.strip()}
-        channels.append(
-            WebhookAlertChannel(args.webhook_url, session=session, auth_header=auth, hmac_secret=args.webhook_secret)
+        auth_header = _resolve_secret(
+            args.webhook_auth_header,
+            args.webhook_auth_header_file,
+            "PYRXD_WATCHTOWER_WEBHOOK_AUTH_HEADER",
+            flag="--webhook-auth-header",
         )
+        if auth_header:
+            key, _, val = auth_header.partition(":")
+            auth = {key.strip(): val.strip()}
+        secret = _resolve_secret(
+            args.webhook_secret,
+            args.webhook_secret_file,
+            "PYRXD_WATCHTOWER_WEBHOOK_SECRET",
+            flag="--webhook-secret",
+        )
+        channels.append(WebhookAlertChannel(args.webhook_url, session=session, auth_header=auth, hmac_secret=secret))
     return channels[0] if len(channels) == 1 else CompositeAlertChannel(*channels)
 
 

--- a/src/pyrxd/cli/format.py
+++ b/src/pyrxd/cli/format.py
@@ -16,6 +16,22 @@ import json as _json
 from typing import Any
 
 
+def sanitize_terminal(value: object, *, max_len: int | None = None) -> str:
+    """Render an UNTRUSTED string safe to print to an interactive terminal.
+
+    Replaces C0/C1 control bytes (ord < 0x20, DEL 0x7f, and 0x80–0x9f) — including ESC 0x1b — with a
+    visible ``\\xNN`` escape, so an attacker-controlled field (e.g. a hand-supplied swap recovery file)
+    cannot inject ANSI / cursor-movement / bidi-override sequences that spoof or hide the rendered output
+    (notably the safety-critical "next action" guidance). ``click.echo`` does NOT strip these on an
+    interactive tty. JSON mode is already protected by ``ensure_ascii=True``; this is the human-mode peer.
+    Optional ``max_len`` truncates over-long fields (with an ellipsis) before escaping.
+    """
+    s = "" if value is None else str(value)
+    if max_len is not None and len(s) > max_len:
+        s = s[:max_len] + "…"
+    return "".join(f"\\x{o:02x}" if (o := ord(ch)) < 0x20 or o == 0x7F or 0x80 <= o <= 0x9F else ch for ch in s)
+
+
 def format_photons(n: int, *, with_rxd: bool = True) -> str:
     """Format an integer photon count for human display.
 

--- a/src/pyrxd/cli/swap_cmds.py
+++ b/src/pyrxd/cli/swap_cmds.py
@@ -21,7 +21,7 @@ from pathlib import Path
 import click
 
 from .context import CliContext
-from .format import emit
+from .format import emit, sanitize_terminal
 
 # --------------------------------------------------------------------------- recovery-file parsing
 
@@ -240,16 +240,28 @@ def swap_status_cmd(ctx: CliContext, swap_file: Path, check_chain: bool) -> None
         click.echo(emit(payload, mode="quiet", quiet_field="situation" if check_chain else "counter_chain"))
         return
 
+    # Every field below is interpolated from the (untrusted) recovery file. Sanitize each so a crafted
+    # file cannot inject ANSI/control sequences into the operator's terminal and spoof the rendered
+    # status or the "next action" guidance (CLI-1). Numeric fields are int-typed (parse_recovery_file)
+    # and safe as-is; only the free-form strings need escaping.
+    _chain = sanitize_terminal(facts.counter_chain, max_len=16)
     lines = [
-        f"Swap: {facts.counter_chain.upper()}↔RXD  ({facts.asset_variant})   stage={facts.stage or '?'}",
-        f"  hashlock H : {facts.hashlock_hex}",
-        f"  covenant   : {facts.rxd_covenant_spk[:24]}…  (rxd_network={facts.rxd_network})",
+        f"Swap: {_chain.upper()}↔RXD  ({sanitize_terminal(facts.asset_variant, max_len=16)})   "
+        f"stage={sanitize_terminal(facts.stage, max_len=32) or '?'}",
+        f"  hashlock H : {sanitize_terminal(facts.hashlock_hex, max_len=64)}",
+        f"  covenant   : {sanitize_terminal(facts.rxd_covenant_spk[:24])}…  "
+        f"(rxd_network={sanitize_terminal(facts.rxd_network, max_len=16)})",
         f"  t_rxd      : {facts.t_rxd_blocks} blocks (Radiant refund / claim deadline window)",
     ]
     if facts.counter_chain == "btc":
-        lines.append(f"  t_btc      : {facts.t_btc_blocks} blocks   BTC HTLC: {facts.btc_htlc_address}")
+        lines.append(
+            f"  t_btc      : {facts.t_btc_blocks} blocks   "
+            f"BTC HTLC: {sanitize_terminal(facts.btc_htlc_address, max_len=120)}"
+        )
     else:
-        lines.append(f"  eth        : {facts.eth_chain}   timeout_unix={facts.eth_timeout_unix_s}")
+        lines.append(
+            f"  eth        : {sanitize_terminal(facts.eth_chain, max_len=32)}   timeout_unix={facts.eth_timeout_unix_s}"
+        )
     if facts.has_preimage or facts.has_keys:
         lines.append("  ⚠ this file holds keys/preimage — keep it mode 0600 and shred after the swap settles.")
     if check_chain:

--- a/src/pyrxd/gravity/swap_order.py
+++ b/src/pyrxd/gravity/swap_order.py
@@ -107,7 +107,11 @@ def parse_price_terms(blob: bytes) -> list[DemandedOutput] | None:
         if vb is None or len(vb) != 8:
             return None
         slen = r.read_var_int_num()
-        if slen is None or slen < 0:
+        # Bound slen by the blob length: a script can never exceed the remaining blob, and an
+        # unbounded slen (a 0xff varint up to 2**64-1) would otherwise reach BytesIO.read and raise
+        # OverflowError — leaking out of the public decode_rswp_order, which documents ValidationError
+        # only. Reject out-of-range lengths as "not clean MultiTxOutV1" (None), the documented outcome.
+        if slen is None or slen < 0 or slen > len(blob):
             return None
         script = r.read_bytes(slen) if slen else b""
         if script is None or len(script) != slen:

--- a/src/pyrxd/gravity/watch/claim_executor.py
+++ b/src/pyrxd/gravity/watch/claim_executor.py
@@ -54,7 +54,7 @@ from pyrxd.btc_wallet.taproot import TimeUnit, btc_input_outpoints_from_raw, btc
 from pyrxd.gravity.finality import CounterClaimFinality
 from pyrxd.gravity.swap_coordinator import ClaimFinality, MarginPolicy, assess_claim_finality, max_protected_value
 from pyrxd.gravity.swap_state import SwapRecord
-from pyrxd.gravity.watch.decide import Decision, Intent
+from pyrxd.gravity.watch.decide import Decision, Intent, _value_at_risk_photons
 from pyrxd.gravity.watch.executor import ExecOutcome
 from pyrxd.security.errors import NetworkError, ValidationError
 
@@ -501,6 +501,12 @@ class ClaimExecutor:
                 asset_locked_at_height=funded_h,
                 t_rxd=record.terms.t_rxd,
                 policy=self._policy,
+                # Pass the SAME per-record value-at-risk decide() uses (radiant_amount for rxd, None
+                # for ft/nft). Without it the fresh re-assess fell back to policy.value_at_risk_photons
+                # — None in the recommended value-scaled config — so the value-scaled gate returned
+                # SQUEEZED for EVERY swap and the executor silently never fired (autonomous claim
+                # degraded to alert-only). FT/NFT still fail closed (None → SQUEEZED), as intended.
+                value_at_risk_photons=_value_at_risk_photons(record.terms),
             )
         except ValidationError as exc:
             return ExecOutcome.DECLINED, f"fresh finality un-assessable, fail-closed: {exc}"

--- a/src/pyrxd/network/bitcoin.py
+++ b/src/pyrxd/network/bitcoin.py
@@ -1128,28 +1128,48 @@ class MultiSourceBtcFundingReader:
 
     @classmethod
     def from_endpoints(
-        cls, urls: Sequence[str], *, quorum: int = 2, dust_cap_sats: int = 10_000
+        cls,
+        urls: Sequence[str],
+        *,
+        quorum: int = 2,
+        dust_cap_sats: int = 10_000,
+        allow_insufficient_diversity: bool = False,
     ) -> MultiSourceBtcFundingReader:
-        """Build the reader from Esplora base URLs, **clamping the effective quorum to the number of
-        DISTINCT hosts**. A quorum of same-host endpoints is false corroboration (one hostile/buggy host
-        satisfies it), so e.g. two ``mempool.space`` URLs can never form a 2-of-2 quorum. A clamp is
-        logged loudly so the operator sees the real corroboration level."""
+        """Build the reader from Esplora base URLs, requiring at least ``quorum`` DISTINCT hosts.
+
+        A quorum of same-host endpoints is false corroboration (one hostile/buggy/MITM'd host satisfies
+        the whole "quorum"), so e.g. two ``mempool.space`` URLs can never form a genuine 2-of-2. By
+        default this **fails closed** (raises ``ValidationError``) when the endpoints resolve to fewer
+        than ``quorum`` distinct hosts, rather than silently clamping the effective quorum down to 1 —
+        a log-only clamp could arm single-source above-dust custody (the F-17 SPOF) on a misconfig.
+
+        Pass ``allow_insufficient_diversity=True`` to explicitly accept the degraded low-/single-source
+        posture (mirrors the executor's ``--accept-single-source`` dust opt-in); the clamp is then logged
+        loudly so the operator sees the real corroboration level."""
         if not urls:
             raise ValidationError("from_endpoints requires at least one endpoint URL")
         distinct = count_distinct_hosts(urls)
-        effective = max(1, min(quorum, distinct))
-        if effective < quorum:
+        if distinct < quorum:
+            if not allow_insufficient_diversity:
+                raise ValidationError(
+                    f"BTC funding quorum: {len(urls)} endpoint(s) resolve to only {distinct} distinct "
+                    f"host(s), short of quorum={quorum}. A quorum of same-host endpoints is false "
+                    f"corroboration (one hostile/buggy host satisfies it), so this fails closed. "
+                    f"Configure >= {quorum} INDEPENDENT hosts, or pass allow_insufficient_diversity=True "
+                    f"to explicitly accept the degraded single-/low-source posture."
+                )
             logger.warning(
                 "BTC funding quorum: %d endpoint(s) resolve to only %d distinct host(s); clamping quorum "
-                "%d -> %d. A quorum of same-host endpoints is false corroboration — configure >= %d "
-                "INDEPENDENT hosts for genuine %d-of-N safety.",
+                "%d -> %d (allow_insufficient_diversity). A quorum of same-host endpoints is false "
+                "corroboration — configure >= %d INDEPENDENT hosts for genuine %d-of-N safety.",
                 len(urls),
                 distinct,
                 quorum,
-                effective,
+                max(1, distinct),
                 quorum,
                 quorum,
             )
+        effective = max(1, min(quorum, distinct))
         readers = [MempoolSpaceFundingReader(base_url=u) for u in urls]
         return cls(readers, quorum=effective, dust_cap_sats=dust_cap_sats)
 

--- a/tests/cli/test_format.py
+++ b/tests/cli/test_format.py
@@ -6,7 +6,27 @@ import json
 
 import pytest
 
-from pyrxd.cli.format import emit, emit_table, format_photons
+from pyrxd.cli.format import emit, emit_table, format_photons, sanitize_terminal
+
+
+class TestSanitizeTerminal:
+    def test_plain_text_unchanged(self) -> None:
+        assert sanitize_terminal("bc1qexample") == "bc1qexample"
+        assert sanitize_terminal("rxd ↔ btc") == "rxd ↔ btc"  # printable non-ASCII passes
+
+    def test_escapes_c0_control_and_esc(self) -> None:
+        assert sanitize_terminal("\x1b[2J") == "\\x1b[2J"  # ESC escaped, '[2J' printable
+        assert sanitize_terminal("a\nb\tc") == "a\\x0ab\\x09c"
+        assert sanitize_terminal("x\x7fy") == "x\\x7fy"  # DEL
+
+    def test_escapes_c1_control(self) -> None:
+        assert sanitize_terminal("\x9b") == "\\x9b"  # C1 CSI
+
+    def test_none_is_empty(self) -> None:
+        assert sanitize_terminal(None) == ""
+
+    def test_max_len_truncates_before_escaping(self) -> None:
+        assert sanitize_terminal("abcdef", max_len=3) == "abc…"
 
 
 class TestFormatPhotons:

--- a/tests/cli/test_swap_cmds.py
+++ b/tests/cli/test_swap_cmds.py
@@ -158,3 +158,26 @@ def test_cli_status_rejects_garbage_file(tmp_path):
     res = CliRunner().invoke(cli, ["swap", "status", "--swap-file", str(p)])
     assert res.exit_code != 0
     assert "could not parse swap file" in res.output
+
+
+def test_cli_status_human_sanitizes_terminal_escapes(tmp_path):
+    # CLI-1: a hand-supplied recovery file must not be able to inject ANSI/control sequences into the
+    # operator's terminal via the default (human) output. A crafted field carrying ESC[2J (clear screen)
+    # + fake "settled" guidance must be rendered as visible \x.. escapes, never as raw control bytes.
+    p = tmp_path / ".gravity_dust_run_keys.json"
+    inject = "\x1b[2J\x1b[H situation: SETTLED — no action needed"
+    p.write_text(
+        json.dumps(
+            {
+                "stage": inject,
+                "rxd_network": "bc",
+                "hashlock_H": "ab" * 32,
+                "rxd_covenant_spk": _COV_SPK,
+                "t_rxd_blocks": 20,
+            }
+        )
+    )
+    res = CliRunner().invoke(cli, ["swap", "status", "--swap-file", str(p)])
+    assert res.exit_code == 0, res.output
+    assert "\x1b" not in res.output  # no raw ESC reaches the terminal
+    assert "\\x1b" in res.output  # it is shown as a visible escape instead

--- a/tests/test_dmint_conformance_vectors.py
+++ b/tests/test_dmint_conformance_vectors.py
@@ -3,6 +3,13 @@
 Keeps ``conformance/dmint-v2-contract-vectors.json`` honest: a builder change that diverges from the
 published canonical bytecode fails CI. Other Radiant implementations byte-compare their own V2 dMint
 contract build against this JSON.
+
+HONESTY NOTE: because pyrxd is the reference *producer*, this roundtrip is a REGRESSION-LOCK for the
+five reference-sourced vectors (it catches the builder silently drifting from its own committed bytes),
+NOT independent cross-impl validation of those bytes. Only the ``v2-fixed-mainnet`` vector is
+independently anchored — to the live mainnet FIXED deploy (see ``test_dmint_v2_mainnet_golden.py``).
+Independent anchoring of the non-FIXED DAA modes would require a second implementation's output. See
+``conformance/README.md`` §"Authority & honesty".
 """
 
 from __future__ import annotations

--- a/tests/test_endpoint_diversity.py
+++ b/tests/test_endpoint_diversity.py
@@ -37,12 +37,24 @@ def test_default_mainnet_endpoints_are_independent():
     assert count_distinct_hosts(MultiSourceBtcFundingReader.DEFAULT_MAINNET_ENDPOINTS) >= 2
 
 
-def test_from_endpoints_clamps_same_host_quorum(caplog):
-    with caplog.at_level(logging.WARNING):
-        r = MultiSourceBtcFundingReader.from_endpoints(
+def test_from_endpoints_fails_closed_on_same_host_quorum():
+    # Default: insufficient host diversity FAILS CLOSED rather than silently clamping the quorum to 1
+    # (a log-only clamp could arm single-source above-dust custody — the F-17 SPOF).
+    with pytest.raises(ValidationError, match="fails closed"):
+        MultiSourceBtcFundingReader.from_endpoints(
             ["https://mempool.space/api", "https://mempool.space/signet/api"], quorum=2
         )
-    assert r._quorum == 1  # 2 URLs but only 1 distinct host → clamped
+
+
+def test_from_endpoints_clamps_same_host_quorum_with_opt_in(caplog):
+    # Explicit opt-in (mirrors --accept-single-source): clamp to the distinct-host count + warn loudly.
+    with caplog.at_level(logging.WARNING):
+        r = MultiSourceBtcFundingReader.from_endpoints(
+            ["https://mempool.space/api", "https://mempool.space/signet/api"],
+            quorum=2,
+            allow_insufficient_diversity=True,
+        )
+    assert r._quorum == 1  # 2 URLs but only 1 distinct host → clamped under the explicit opt-in
     assert "false corroboration" in caplog.text
 
 

--- a/tests/test_htlc_covenant.py
+++ b/tests/test_htlc_covenant.py
@@ -5,8 +5,9 @@ during the spike (recorded in ``docs/brainstorms/gravity-ref-spike/.live_swap_{n
 NOTE (v2): the OP_SIZE<0x20> preimage-length pin (security review: preimage-length asset
 theft) intentionally SUPERSEDES the v1 mainnet covenant *scriptPubKey*, so the full SPK no
 longer reproduces v1 byte-for-byte — the holder scripts (unchanged by the pin) still do, and
-every claim branch now carries the 32-byte pin. v2 consensus validity is proven by the regtest
-spend/reject test (live node).
+every claim branch now carries the 32-byte pin. v2 consensus validity (that the OP_SIZE pin rejects a
+non-32-byte spend at consensus) is reasoned from the opcodes and exercised at the builder level; an
+executed live-node spend/reject test is a recommended follow-up, not yet in the tree.
 
 The remaining tests pin the two static guards (bare-0xbd opcode walk + ref count)
 and the fail-closed parameter validation — the covenant moves real value, so every
@@ -104,8 +105,15 @@ def test_all_three_covenant_variants_pin_preimage_to_32_bytes():
     claim branch must consensus-pin p to exactly 32 bytes via OP_SIZE<0x20>OP_EQUALVERIFY
     immediately before the preimage OP_SHA256 (fragment 82 0120 88 a8), so a malicious maker
     cannot reveal a non-32-byte p' that the 32-byte-only scrape_secret silently skips. CI-safe
-    (synthetic inputs, no private vectors). Full consensus rejection of a non-32-byte spend is
-    proven by the regtest spend/reject test (live radiant-core node)."""
+    (synthetic inputs, no private vectors).
+
+    Scope of this test: STRUCTURAL — it asserts the pin opcodes are present and ordered before the
+    claim hashlock. The builder-level length rejection (a non-32-byte preimage raises before a tx is
+    even built) is covered by ``test_build_htlc_claim_tx_rejects_non_32_byte_preimage`` in
+    ``tests/test_htlc_spend_productized.py``. A live-node test that hand-crafts a non-32-byte spend and
+    observes CONSENSUS rejection is NOT yet in the tree — that the OP_SIZE pin rejects at consensus
+    rests on opcode reasoning, not an executed negative test (a recommended follow-up before external
+    audit)."""
     h = hashlib.sha256(b"p" * 32).digest()
     tp, mp, gt = bytes(range(20)), bytes([0x22] * 20), "ab" * 32
     pin = b"\x82\x01\x20\x88\xa8"  # OP_SIZE  push(0x20)  OP_EQUALVERIFY  OP_SHA256

--- a/tests/test_htlc_spend_productized.py
+++ b/tests/test_htlc_spend_productized.py
@@ -79,6 +79,19 @@ def test_claim_scriptsig_is_preimage_then_op0_selector():
     assert ss[33:] == b"\x00"  # OP_0 claim selector (LAST / on top)
 
 
+@pytest.mark.parametrize("bad", [b"", b"\x11" * 31, b"\x11" * 33, b"\x11" * 64])
+def test_build_htlc_claim_tx_rejects_non_32_byte_preimage(bad):
+    # Preimage-length asset-theft guard (builder level), peer to the consensus OP_SIZE<0x20> pin
+    # asserted structurally in tests/test_htlc_covenant.py. A non-32-byte p' must raise BEFORE any tx
+    # is built, so a wrong-length preimage can never be relayed into a claim. Covers the 0/31/33/64-byte
+    # cases that the existing happy-path tests (always 32 bytes) never exercised.
+    cov = _rxd_cov()
+    with pytest.raises(ValidationError, match="32 bytes"):
+        build_htlc_claim_tx(
+            covenant=cov, covenant_outpoint="cd" * 32 + ":0", carrier_value=100_000, preimage=bad, fee=_fee()
+        )
+
+
 def test_claim_single_output_to_taker_holder():
     cov = _rxd_cov()
     tx = build_htlc_claim_tx(

--- a/tests/test_watch_claim_executor.py
+++ b/tests/test_watch_claim_executor.py
@@ -474,6 +474,48 @@ async def test_shallow_btc_claim_waits_or_declines():
     assert leg.claimed_with is None
 
 
+async def test_fresh_reassess_passes_per_record_value_at_risk(monkeypatch):
+    # CLAIM-1 regression: the executor's fresh pre-broadcast re-assess must pass the SAME per-record
+    # value-at-risk that decide() uses (radiant_amount for an rxd swap), not let it default to None.
+    # Otherwise, under the recommended value-scaled policy (rxd_reorg_cost_per_block set,
+    # value_at_risk_photons=None), assess_claim_finality returns SQUEEZED for EVERY swap and the
+    # autonomous claim silently never fires (degrades to alert-only). Spy on the call to lock the kwarg.
+    import pyrxd.gravity.watch.claim_executor as ce
+
+    captured: dict = {}
+    real = ce.assess_claim_finality
+
+    def _spy(**kw):
+        captured.update(kw)
+        return real(**kw)
+
+    monkeypatch.setattr(ce, "assess_claim_finality", _spy)
+    ex, _leg, rec, _p = await _armed_executor(radiant_amount=1_234)
+    assert await ex.execute("s1", rec, _claim_decision()) is ExecOutcome.BROADCAST
+    assert captured.get("value_at_risk_photons") == 1_234  # the rxd per-record value reached the gate, not None
+
+
+async def test_fresh_reassess_value_at_risk_is_none_for_ft_nft(monkeypatch):
+    # The FT/NFT peer of the above: their on-chain radiant_amount is carrier dust, not market value, so
+    # decide()'s _value_at_risk_photons returns None and the gate still fails closed (SQUEEZED) under a
+    # value-scaled policy. Lock that the executor passes None (not the dust amount) for nft.
+    import pyrxd.gravity.watch.claim_executor as ce
+
+    captured: dict = {}
+    real = ce.assess_claim_finality
+
+    def _spy(**kw):
+        captured.update(kw)
+        return real(**kw)
+
+    monkeypatch.setattr(ce, "assess_claim_finality", _spy)
+    # unbounded dust opt-in so an nft swap reaches the fresh re-assess on bcrt (past the value cap).
+    ex, _leg, rec, _ = await _armed_executor(variant="nft", radiant_amount=1, accept_unbounded_reorg_risk=True)
+    await ex.execute("s1", rec, _claim_decision())
+    assert "value_at_risk_photons" in captured
+    assert captured["value_at_risk_photons"] is None  # ft/nft carrier dust is NOT treated as economic value
+
+
 # --------------------------------------------------------------------------- FIX 1: fire-once guard
 
 


### PR DESCRIPTION
## Context

An internal security + red-team audit of the **0.10.0 surface** (everything changed since `v0.9.0`) found **no fund-safety blocker** — the two highest-risk new surfaces (the autonomous claim executor and the RSWP decoder) are unwired in the shipped tree — but surfaced a set of LOW/MEDIUM hardening items plus two accuracy issues worth fixing before tag. This PR closes that punch-list. None of these change the as-shipped posture; they harden the paths before they go live.

## Security / robustness

- **claim_executor** — the fresh pre-broadcast re-assess now passes the same per-record value-at-risk that `decide()` uses (`radiant_amount` for rxd, `None` for ft/nft). Without it, a value-scaled policy returned `SQUEEZED` for every swap and the autonomous claim silently never fired (degraded to alert-only). Fails closed unchanged for ft/nft. (+2 regression tests)
- **`bitcoin.from_endpoints`** — fail **closed** when endpoints resolve to fewer than `quorum` distinct hosts instead of silently clamping to 1 (a log-only clamp could arm single-source above-dust custody). Adds an explicit `allow_insufficient_diversity` opt-in; non-mainnet test networks opt in so only mainnet custody is guarded.
- **`swap status` CLI** — sanitize C0/C1 control bytes (incl. ESC) in the default human output so a crafted recovery file can't inject terminal-control sequences that spoof the safety-critical "next action" line. (JSON mode was already `ensure_ascii`-hardened.)
- **watchtower_run** — accept the webhook HMAC secret + auth header via file or env var (process-table / shell-history exposure); CLI flags retained as deprecated, warning aliases.
- **`swap_order.parse_price_terms`** — bound the per-entry script length by the blob length so an out-of-range varint can't leak `OverflowError` out of `decode_rswp_order` (documented to raise `ValidationError` only).

## Accuracy / honesty

- **mutation_test.sh** — fail on a broken run (0 mutants) instead of printing "0% killed" and exiting 0; add an opt-in `MUTATION_MIN_KILL_PCT` threshold so the tool can actually gate, not just measure.
- **HTLC preimage-pin tests** — correct docstrings that claimed a live-node spend/reject test proves the `OP_SIZE` preimage pin at consensus (no such test exists; the pin is reasoned from opcodes + now exercised at the builder level). Adds a builder-level negative test feeding 0/31/33/64-byte preimages.
- **dMint conformance test** — note the 5 reference vectors are a regression-lock (producer vs its own bytes), not independent validation; only the FIXED mainnet vector is independently anchored.

## Verification

Local `task ci` green: full suite passes, security coverage 100%, overall **87.96%** (≥85% gate), mypy clean, private-links OK. (One pre-existing live-network CLI test flakes under random ordering, unrelated to this diff.)

> The cross-chain swap stack remains unaudited pending an external audit + a two-party adversarial run — that is the hard gate, not this internal review.