### PR TITLE
fix(deps): pin dev msgpack >=1.2.1 (GHSA-6v7p-g79w-8964)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -101,6 +101,11 @@ ruff = "^0.15.17"
 hypothesis = "^6.155.2"
 pytest-asyncio = ">=1.4.0"
 cosmic-ray = "^8.4.6"
+# Transitive security floor (dev-only): pip-audit -> cachecontrol pulls msgpack, which had an
+# out-of-bounds-read / crash on Unpacker reuse after a caught error in <= 1.2.0
+# (GHSA-6v7p-g79w-8964). cachecontrol allows < 2.0.0, so pin the patched floor. Dev-scope only —
+# msgpack is not a pyrxd runtime dependency and never ships in the published package.
+msgpack = ">=1.2.1"
 
 [tool.poetry.group.test.dependencies]
 bandit = {version = "^1.9.4", extras = ["toml"]}


### PR DESCRIPTION
Resolves Dependabot alert #3 (HIGH).

`msgpack <= 1.2.0` has an out-of-bounds read / crash on `Unpacker` reuse after a caught error (GHSA-6v7p-g79w-8964; patched in 1.2.1). It reaches the project **only as a transitive dev dependency**: `pip-audit` → `cachecontrol` → `msgpack`. `cachecontrol` allows `msgpack >=0.5.2,<2.0.0`, so this adds the patched floor (`>=1.2.1`) to `[tool.poetry.group.dev.dependencies]`.

- **Dev-scope only** — msgpack is not a pyrxd runtime dependency and never ships in the published package.
- **Real risk is low** — its only use here is `cachecontrol` deserializing `pip-audit`'s own local HTTP cache, not adversarial input. The floor clears the alert deterministically for all contributors/CI.
- No runtime/API change.

CI (`poetry install --sync`) verifies the floor resolves.