### PR TITLE
audit: mutation testing + differential/property/conformance hardening

### DIFF
--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -1,0 +1,128 @@
+name: Fuzz (scheduled)
+
+# Weekly deep-fuzz lane. Two independent engines over the attacker-exposed
+# parsers and the byte-exact consensus builders:
+#
+#   hypothesis-deep — scripts/fuzz_deep.sh deep (25 000 examples per test,
+#     replaying the committed corpus in tests/.hypothesis-corpus first, per
+#     tests/conftest.py). Covers the property/differential suites including
+#     the FORKID sighash + CBOR envelope + dMint vector-derivation corpora.
+#   atheris — the coverage-guided libFuzzer harnesses under
+#     scripts/fuzz_atheris/, with a corpus accumulated across runs via the
+#     Actions cache so each week explores beyond the last.
+#
+# Deliberately NOT on the per-commit path (docs/security-review-playbook.md):
+# per-commit CI keeps the fast unit gate; this lane does the slow exploration
+# on a schedule. Manual runs: gh workflow run "Fuzz (scheduled)".
+
+on:
+  schedule:
+    - cron: "23 5 * * 1" # Mondays 05:23 UTC
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
+
+jobs:
+  hypothesis-deep:
+    # Don't burn scheduled minutes on forks; manual dispatch still works anywhere.
+    if: github.event_name != 'schedule' || github.repository == 'MudwoodLabs/pyrxd'
+    runs-on: ubuntu-latest
+    timeout-minutes: 150
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
+        with:
+          python-version: "3.12"
+      - name: Cache Poetry packages
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: ~/.cache/pypoetry
+          key: poetry-${{ runner.os }}-py3.12-${{ hashFiles('poetry.lock') }}
+          restore-keys: |
+            poetry-${{ runner.os }}-py3.12-
+      - name: Install Poetry
+        run: pip install -r ci/poetry-pin.txt --require-hashes
+      - name: Install dependencies
+        run: poetry install --sync --no-interaction
+      - name: Deep Hypothesis run (25k examples/test, corpus replayed first)
+        run: poetry run bash scripts/fuzz_deep.sh deep
+      - name: Upload shrunk counterexamples + log
+        # On failure the corpus dir holds the shrunk reproducer(s) — commit
+        # them alongside the fix per tests/.hypothesis-corpus/README.md.
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: hypothesis-deep-output
+          path: |
+            logs/
+            tests/.hypothesis-corpus/
+          retention-days: 30
+
+  atheris:
+    if: github.event_name != 'schedule' || github.repository == 'MudwoodLabs/pyrxd'
+    runs-on: ubuntu-latest
+    timeout-minutes: 90
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
+        with:
+          python-version: "3.12"
+      - name: Cache Poetry packages
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: ~/.cache/pypoetry
+          key: poetry-${{ runner.os }}-py3.12-${{ hashFiles('poetry.lock') }}
+          restore-keys: |
+            poetry-${{ runner.os }}-py3.12-
+      # Accumulated libFuzzer corpus: restore the newest previous save, write
+      # this run's additions under a fresh key (a per-run key is how you get
+      # an append-style cache out of actions/cache's immutable entries).
+      - name: Restore accumulated libFuzzer corpus
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: .atheris-corpus
+          key: atheris-corpus-${{ github.run_id }}
+          restore-keys: |
+            atheris-corpus-
+      - name: Install Poetry
+        run: pip install -r ci/poetry-pin.txt --require-hashes
+      - name: Install dependencies
+        run: poetry install --sync --no-interaction
+      - name: Install atheris
+        # Not a poetry dep on purpose (overnight/scheduled tool, not a dev
+        # requirement — docs/security-review-playbook.md). Bump deliberately.
+        run: poetry run pip install "atheris==2.3.0"
+      - name: Run coverage-guided harnesses
+        # Every harness runs even if an earlier one finds a crash; findings
+        # drop reproducers in logs/ (uploaded below) and fail the job at the
+        # end. The committed Hypothesis corpus rides along as extra seeds.
+        run: |
+          set -uo pipefail
+          mkdir -p logs
+          rc=0
+          for h in scripts/fuzz_atheris/harness_*.py; do
+            name="$(basename "$h" .py)"
+            mkdir -p ".atheris-corpus/$name"
+            echo "== $name =="
+            if ! poetry run python "$h" \
+                 -max_total_time=360 \
+                 -print_final_stats=1 \
+                 -artifact_prefix="logs/${name}-" \
+                 ".atheris-corpus/$name" tests/.hypothesis-corpus; then
+              echo "::error::atheris finding in $name (reproducer in logs/)"
+              rc=1
+            fi
+          done
+          exit "$rc"
+      - name: Upload reproducers
+        if: failure()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: atheris-findings
+          path: logs/
+          retention-days: 90

--- a/docs/how-to/mutation-testing.md
+++ b/docs/how-to/mutation-testing.md
@@ -1,4 +1,4 @@
-# Mutation testing the SPV verifier
+# Mutation testing the consensus-critical modules
 
 Mutation testing measures **test quality**, not just line coverage: it mutates the source (e.g. flips
 `!= 80` to `< 80`, `i - 1` to `i + 1`) and checks whether the suite *catches* each change. A **killed**
@@ -9,21 +9,40 @@ behavior — a potential gap.
 
 ```bash
 poetry install --with dev   # brings in cosmic-ray
-poetry run task mutate
+poetry run task mutate                    # default scope: spv (the original gate)
+poetry run task mutate script             # script/ primitives
+poetry run task mutate transaction        # transaction/ incl. the FORKID sighash preimage
+poetry run task mutate dmint              # glyph/dmint/ covenant builders + DAA + parser
+poetry run task mutate all                # everything, sequentially (hours)
 ```
 
-This runs [`scripts/mutation_test.sh`](../../scripts/mutation_test.sh) over the consensus-critical SPV
-verification modules — `pow.py` (PoW/difficulty), `merkle.py` (proof), `chain.py` (header-chain link +
-nBits pin), `payment.py` (output parse). It mutates `src/pyrxd/spv/<file>.py` **in place** (the editable
-install picks it up), runs the SPV tests, and restores via `git` (a trap restores on any exit). It is an
-**occasional gate, not part of `task ci`** (slow). Don't run concurrent git ops on `src/pyrxd/spv` while
-it runs.
+This runs [`scripts/mutation_test.sh`](../../scripts/mutation_test.sh). It mutates
+`src/pyrxd/<scope>/<file>.py` **in place** (the editable install picks it up), runs a scope-targeted
+fast test command per mutant, and restores via `git` (a trap restores on any exit). It is an
+**occasional gate, not part of `task ci`** (slow). Don't run concurrent git ops on `src/pyrxd` while it
+runs — when other sessions/worktrees are active, run the whole thing in a detached worktree (see
+`docs/solutions/integration-issues/task-ci-spurious-failures-from-concurrent-worktrees.md`).
 
-> The parser modules `proof.py` / `witness.py` are **excluded** here on purpose: they're covered by the
-> fuzz harness (`tests/test_fuzz_spv_parsers.py`), and the full test command that covers them is ~30×
-> slower per mutant. Mutation-testing the *verification arithmetic* is the high-value scope.
+Useful environment knobs:
 
-## Baseline results (2026-06)
+- `MUTATION_SESSION_DIR=dir` — keep the cosmic-ray session `.sqlite` files for survivor triage
+  (query them with `cr-report`, `cr-html`, or a `mutation_specs ⋈ work_results` join for diffs).
+- `MUTATION_MIN_KILL_PCT=N` — opt-in gate: exit non-zero below N% total kill rate.
+
+> Scope exclusions, on purpose: `spv/proof.py` / `spv/witness.py` (covered by the fuzz harness, ~30×
+> slower per mutant), `__init__.py` re-export shims, `script/unlocking_template.py` (17-line ABC), and
+> `glyph/dmint/__init__.py`. The whole-file scope for `glyph/dmint/miner.py` includes the mining
+> dispatch loops; their kills come mostly from the DAA/preimage tests, not the multiprocessing paths.
+
+## Scopes and test commands
+
+Each scope uses a fast targeted test list (defined in `mutation_test.sh`) so a full file sweep stays
+tractable — the per-mutant cost is the test command's wall time. `tests/test_mutation_hardening.py`
+(the survivor-killing assertions) leads every list so `-x` exits cheapest on the pinned mutants; the
+property/differential suites (`test_preimage_differential.py`, `test_dmint_vector_derivations.py`)
+close the transaction/dmint lists as the wide net.
+
+## Baseline results — spv (2026-06)
 
 | Module | Mutants | Killed | Survived | Killed |
 |---|---|---|---|---|
@@ -32,43 +51,90 @@ it runs.
 | `chain.py` | 132 | 78 | 54 | 59% |
 | `payment.py` | 268 | 219 | 49 | 82% |
 
+## Baseline + hardening results — script/, transaction/, glyph/dmint/ (2026-07)
+
+The 2026-07 run measured each file with the PRE-hardening test lists (baseline), then every surviving
+mutant was re-checked individually — its stored diff applied to a clean worktree and the UPDATED test
+command run — to measure the post-hardening score without a second multi-hour sweep. A full re-run of
+one scope (`script`) spot-checked that the per-survivor method matches a fresh sweep.
+
+| Module | Mutants | Baseline killed | After hardening | Still surviving | …of which annotation-equivalent |
+|---|---|---|---|---|---|
+| `transaction/transaction.py` | 509 | 285 (56%) | 360 (71%) | 149 | 99 |
+| `transaction/transaction_input.py` | 104 | 44 (42%) | 47 (45%) | 57 | 55 |
+| `transaction/transaction_output.py` | 53 | 16 (30%) | 19 (36%) | 34 | 33 |
+| `transaction/transaction_preimage.py` | 675 | 322 (48%) | **622 (92%)** | 53 | 0 |
+| `script/script.py` | 299 | 172 (58%) | 207 (69%) | 92 | 33 |
+| `script/timelock.py` | 257 | 249 (97%) | 253 (98%) | 4 | 0 |
+| `script/type.py` | 340 | 241 (71%) | 272 (80%) | 68 | 55 |
+| `glyph/dmint/builders.py` | 2197 | 2024 (92%) | **2179 (99%)** | 18 | 0 |
+| `glyph/dmint/chain.py` | 1251 | 803 (64%) | 930 (74%) | 321 | 28 |
+| `glyph/dmint/types.py` | 364 | 232 (64%) | 326 (90%) | 38 | 0 |
+| `glyph/dmint/miner.py` | 1909 | 1430 (75%) | 1453 (76%) | 456 | 39 |
+
+The annotation-equivalent column is a conservative lower bound (surviving `BitOr`-family mutants
+whose diff touches only a signature/annotation line). Excluding just that class, the
+annotation-adjusted post-hardening scores are e.g. transaction.py 88%, transaction_input 96%,
+type.py 95%, transaction_output 95% — the honest view of files whose raw score is dragged by
+`str | bytes | Reader`-style signatures.
+
+**Spot-check:** a full fresh sweep of the `script` scope at the same commit reported 92 / 4 / 68
+survivors for script.py / timelock.py / type.py — identical, file for file, to the per-survivor
+re-check's prediction.
+
 ## Reading the score — survivors are not all bugs
 
 A large share of survivors are **equivalent mutants** that *cannot* be killed because they don't change
 behavior. In this codebase they cluster into:
 
 - **Type annotations** — `bytes | None` → `bytes - None`. Harmless: `from __future__ import annotations`
-  makes annotations strings, never evaluated.
-- **Error-message f-strings** — `f"…header[{i - 1}]"` → `{i + 1}`. Only the *text* of an exception
-  message; no test asserts the exact wording, and it shouldn't.
-- **Unreachable invariants** — `pow.py`'s `if len(target_le) != 32` is dead by construction (the
-  validated nBits exponent guarantees 32); it's deliberate defense kept out of `python -O`'s reach.
-- **Redundant guards** — `chain.py`'s per-header `len(header) != 80` is masked by `verify_header_pow`'s
-  own length check (defense in depth). Bypassing one still trips the other.
+  makes annotations strings, never evaluated. This is the single largest class in every file (e.g. 33 of
+  transaction.py's survivors sit on two `str | bytes | Reader` signatures).
+- **Error-message f-strings** — `f"…offset {i - 1}"` → `{i + 1}`. Only the *text* of an exception
+  message; no test asserts exact wording, and it shouldn't.
+- **Interpreter-detail equivalents** — `==` → `is` on small interned ints / single-char strings /
+  enum members; `x & (1<<31)` → `x // (1<<31)` inside a range-checked 32-bit domain; `<` → `!=` on a
+  monotonically increasing loop counter.
+- **Equivalent-for-valid-inputs** — e.g. `to_ef`'s `source_txid` branch (both branches produce the same
+  bytes when `source_txid == source_transaction.txid()`, which construction guarantees), or comparison
+  rewrites that only diverge for inputs outside the documented domain (`change_distribution` strings
+  other than `"equal"`/`"random"`).
+- **Outcome-equivalent guards** — `from_hex` length checks where `!=` vs `<` cannot differ because
+  `Reader.read_bytes` never over-returns, and any fall-through still ends in the same `None` via the
+  surrounding `suppress(Exception)`.
 
 So the raw kill-rate **understates** real assertion quality. The value of the run is finding the
 *genuine* gaps — branches that execute with no behavioral test.
 
-## What the 2026-06 run found and closed
+## What the 2026-07 run found and closed
 
-Mutation testing surfaced genuine, security-relevant gaps in **input validation**: the length guards and
-the chain-link check executed, but no test fed an adversarial length or a broken link.
-[`tests/test_spv_validation_hardening.py`](../../tests/test_spv_validation_hardening.py) closes them:
+Survivor triage produced `tests/test_mutation_hardening.py` — every test there names the mutant class
+it kills. The genuine gaps were real and some were consensus-adjacent:
 
-- `pow.py` / `chain.py` **length guards** — wrong-length header / chain-anchor / nBits inputs (using a
-  real header ± a byte so a mutated guard falls through to a *different* error). Killed the
-  `len(...) != N` → `< N` / `> N` mutants (pow survivors 25 → 23, chain 64 → 54).
-- `chain.py` **link verification** — a valid 2-header consecutive chain (must pass) plus a broken link
-  (reversed order, must raise), exercising the core `prevHash == hash(prev)` check that had no
-  break-case test.
+- **`Transaction.txid()` byte order had no test.** The `hash()[::-1]` reversal could be deleted and the
+  suite stayed green. Now pinned against a stdlib-only double-SHA256 re-derivation.
+- **The FORKID preimage module was killable almost at will** (56%+ survival at baseline): the ref-scanner
+  push-skip arithmetic, SIGHASH branch selection, and field assembly had only fixed-vector coverage.
+  The spec-derived differential (`tests/test_preimage_differential.py`, anchored to the radiantjs golden
+  vectors) now catches these, plus direct pins for the truncated-pushref guards the (deliberately
+  well-formed) differential generator can't reach.
+- **Script chunk parsing asserted nothing about chunk data** — push-boundary (75 B), PUSHDATA1/2/4
+  dispatch, `from_asm` token handling ("-1" vs "0", push-size cliffs, unknown opcodes), `find_and_delete`
+  retention, `__eq__` vs ordering.
+- **Validation guards lacked boundary-exact tests** — dMint deploy params (`__post_init__` rules),
+  CSV/CLTV ranges and the disable-bit ordering, BEEF version magic, `parse_script_offsets` skip
+  arithmetic, minimal-push sign-bit padding (`0x90` → `90 00`).
+- **dMint state re-derivation guards** — the script-number parser pinned to the encoding spec from both
+  sides (parse + encode), and surgical corruption of valid contracts at documented layout offsets.
 
 ## Known remaining survivors (deferred)
 
-Harder gaps that need crafted/mined fixtures — tracked for a follow-up, lower marginal value:
-
-- `merkle.py` — the `i * 33` branch-index arithmetic survives because tests use only **single-level**
-  (1-sibling) proofs; for `i = 0` every mutant operator collapses to 0. Needs a **multi-level** proof
-  fixture.
-- `pow.py` — the chunked `hash_be` vs `target_be` comparison and the `< 3` exponent boundary need
-  headers with hashes/targets crafted to the chunk/boundary (effectively requires mining).
-- `payment.py` — the size/offset guards need boundary-exact transactions (a tx exactly at `min_output_size`).
+- `spv/merkle.py` — the `i * 33` branch-index arithmetic needs a **multi-level** proof fixture;
+  `spv/pow.py` chunked compare needs mined boundary headers; `spv/payment.py` needs boundary-exact
+  transactions (unchanged from 2026-06).
+- `transaction.py` BEEF **bump-combine** branches (`to_beef` path_index dedup/merge) need
+  MerklePath-carrying fixtures; BEEF/EF are BSV interchange formats, not Radiant consensus surfaces, so
+  these are documented rather than chased.
+- `glyph/dmint/chain.py` async ElectrumX discovery flows and `glyph/dmint/miner.py` mining-dispatch
+  loops — operational (not byte-consensus) paths whose remaining survivors are timing/IO-shaped; the
+  regtest e2e suites cover them end-to-end.

--- a/docs/security-review-playbook.md
+++ b/docs/security-review-playbook.md
@@ -299,7 +299,11 @@ golden-vector concern, not a §3 fuzz concern.
 **Cost.** The Hypothesis suite runs in ~1.5 s at CI budget (400
 examples per target). The atheris harnesses are overnight-run
 material — invoke via `scripts/fuzz_overnight.sh` against an 8-core
-box. Don't put atheris on the per-commit CI path.
+box. Don't put atheris on the per-commit CI path. Both engines DO
+run on the weekly scheduled lane (`.github/workflows/fuzz.yml`):
+`fuzz_deep.sh deep` for Hypothesis, and the atheris harnesses with a
+libFuzzer corpus accumulated across runs via the Actions cache —
+scheduled exploration is where their cost belongs.
 
 **Anti-pattern.** A `try/except: pass` with no comment looks like a
 broad swallow even when it's correct. Either add a comment naming

--- a/scripts/fuzz_deep.sh
+++ b/scripts/fuzz_deep.sh
@@ -65,6 +65,9 @@ PYTHONUNBUFFERED=1 \
     tests/test_fuzz_parsers.py \
     tests/test_property_based.py \
     tests/test_fuzz_spv_parsers.py \
+    tests/test_preimage_differential.py \
+    tests/test_glyph_cbor_roundtrip.py \
+    tests/test_dmint_vector_derivations.py \
     --no-cov \
     -p no:cacheprovider \
     -v \

--- a/scripts/mutation_test.sh
+++ b/scripts/mutation_test.sh
@@ -1,17 +1,35 @@
 #!/usr/bin/env bash
-# Mutation-test the consensus-critical SPV verification modules with cosmic-ray.
+# Mutation-test the consensus-critical modules with cosmic-ray.
 #
-# Scope: the verification ARITHMETIC — pow.py (PoW/difficulty), merkle.py (proof), chain.py
-# (header-chain link + nBits pin), payment.py (output parse). The parser modules proof.py /
-# witness.py are intentionally excluded here: they are covered by the fuzz harness
-# (tests/test_fuzz_spv_parsers.py), and the full test command needed to cover them is ~30x slower
-# per mutant, so mixing them in would make this gate impractical.
+# Usage:
+#   scripts/mutation_test.sh                # default: spv (the original scope)
+#   scripts/mutation_test.sh script         # script/ primitives
+#   scripts/mutation_test.sh transaction    # transaction/ incl. FORKID sighash preimage
+#   scripts/mutation_test.sh dmint          # glyph/dmint/ covenant builders + DAA + parser
+#   scripts/mutation_test.sh all            # every group, sequentially
 #
-# Mechanism: cosmic-ray mutates src/pyrxd/spv/<file>.py IN PLACE (the editable install picks it up),
-# runs the SPV verification tests, then we restore the file via git. A trap restores the whole
-# directory on any exit. Do NOT run concurrent git ops on src/pyrxd/spv while this runs.
+# Scope by group (why these files — the verification/byte-exact arithmetic):
+#   spv          pow.py (PoW/difficulty), merkle.py (proof), chain.py (header-chain link +
+#                nBits pin), payment.py (output parse). The parser modules proof.py/witness.py
+#                are intentionally excluded: covered by the fuzz harness
+#                (tests/test_fuzz_spv_parsers.py) and ~30x slower per mutant.
+#   script       script.py (push parse/encode), timelock.py (CLTV/CSV), type.py (P2PKH &c.
+#                lock/unlock builders). __init__/unlocking_template are trivial re-exports.
+#   transaction  serialization, txid, input/output wire parse, and the Radiant FORKID
+#                sighash preimage (transaction_preimage.py) — the fund-loss surface.
+#   dmint        builders.py (covenant script bytes), chain.py (state re-derivation parse),
+#                types.py (params validation/CBOR), miner.py (DAA target arithmetic + mint
+#                tx/preimage construction).
 #
-# See docs/how-to/mutation-testing.md for the survivor analysis and what the score means.
+# Mechanism: cosmic-ray mutates src/pyrxd/<path>.py IN PLACE (the editable install picks it up),
+# runs the module-targeted tests, then we restore the file via git. A trap restores the whole
+# scope on any exit. Do NOT run concurrent git ops on src/pyrxd while this runs — prefer running
+# the whole thing in a detached worktree (see docs/how-to/mutation-testing.md).
+#
+# Env:
+#   MUTATION_SESSION_DIR   keep cosmic-ray session .sqlite files here (default: mktemp, deleted
+#                          on exit). Set it to triage survivors afterwards with cr-report/cr-html.
+#   MUTATION_MIN_KILL_PCT  opt-in gate: fail if total kill rate is below this percentage.
 set -uo pipefail
 
 cd "$(git rev-parse --show-toplevel)" || { echo "not in a git repo"; exit 1; }
@@ -20,33 +38,85 @@ PYTEST="$(command -v pytest || true)"
 if [ -z "$PYTEST" ]; then echo "pytest not found — run inside the project venv (poetry run task mutate)"; exit 1; fi
 if ! command -v cosmic-ray >/dev/null 2>&1; then echo "cosmic-ray not installed — poetry install --with dev"; exit 1; fi
 
-FILES="pow merkle chain payment"
-TESTS="tests/test_spv.py tests/test_merkle_path.py tests/test_spv_validation_hardening.py"
-WORK="$(mktemp -d)"
-trap 'git checkout -- src/pyrxd/spv/ 2>/dev/null; rm -rf "$WORK"' EXIT
+# Shared fast test files that hold the long-tail assertions for core primitives.
+GAPS="tests/test_coverage_gaps.py tests/test_coverage_gaps2.py tests/test_coverage_gaps3.py tests/test_coverage_gaps4.py tests/test_coverage_gaps5.py tests/test_coverage_gaps6.py tests/test_coverage_gaps7.py tests/test_coverage_gaps8.py"
+
+group_files() {
+  case "$1" in
+    spv)         echo "spv/pow spv/merkle spv/chain spv/payment" ;;
+    script)      echo "script/script script/timelock script/type" ;;
+    transaction) echo "transaction/transaction transaction/transaction_input transaction/transaction_output transaction/transaction_preimage" ;;
+    dmint)       echo "glyph/dmint/builders glyph/dmint/chain glyph/dmint/types glyph/dmint/miner" ;;
+    *)           return 1 ;;
+  esac
+}
+
+group_tests() {
+  case "$1" in
+    spv)         echo "tests/test_spv.py tests/test_merkle_path.py tests/test_spv_validation_hardening.py" ;;
+    script)      echo "tests/test_script.py tests/test_timelock.py tests/test_covenant.py tests/test_glyph_timelock.py tests/test_transaction.py tests/test_preimage.py tests/test_htlc_spend.py $GAPS" ;;
+    transaction) echo "tests/test_transaction.py tests/test_preimage.py tests/test_htlc_spend.py tests/test_glyph_transfer.py tests/test_ft_transfer.py tests/test_swap_partial.py tests/test_swap_resolve.py tests/test_fuzz_parsers.py $GAPS" ;;
+    dmint)       echo "tests/test_dmint_module.py tests/test_glyph_dmint.py tests/test_dmint_v2_canonical.py tests/test_dmint_v2_daa_canonical.py tests/test_dmint_conformance_vectors.py tests/test_dmint_v2_mainnet_golden.py tests/test_dmint_daa_offchain_onchain_differential.py tests/test_dmint_v1_deploy.py tests/test_dmint_v1_mint.py tests/test_dmint_end_to_end.py tests/test_dmint_deploy_integration.py $GAPS" ;;
+  esac
+}
+
+# Per-mutant timeout: ~5-8x the group's clean-suite wall time, so a slowed (not hung)
+# mutant still gets a fair run while true hangs are bounded.
+group_timeout() {
+  case "$1" in
+    spv)    echo "30.0" ;;
+    script) echo "30.0" ;;
+    *)      echo "45.0" ;;
+  esac
+}
+
+GROUPS_REQUESTED="${*:-spv}"
+[ "$GROUPS_REQUESTED" = "all" ] && GROUPS_REQUESTED="spv script transaction dmint"
+for g in $GROUPS_REQUESTED; do
+  group_files "$g" >/dev/null || { echo "unknown group: $g (use spv|script|transaction|dmint|all)"; exit 2; }
+done
+
+WORK="${MUTATION_SESSION_DIR:-$(mktemp -d)}"
+mkdir -p "$WORK"
+cleanup() {
+  git checkout -- src/pyrxd/spv/ src/pyrxd/script/ src/pyrxd/transaction/ src/pyrxd/glyph/dmint/ 2>/dev/null
+  [ -z "${MUTATION_SESSION_DIR:-}" ] && rm -rf "$WORK"
+}
+trap cleanup EXIT
 
 total=0; killed=0; surv=0
-for f in $FILES; do
-  cfg="$WORK/cr-$f.toml"; sess="$WORK/$f.sqlite"
-  cat > "$cfg" <<EOF
+for g in $GROUPS_REQUESTED; do
+  TESTS="$(group_tests "$g")"
+  TIMEOUT="$(group_timeout "$g")"
+  g_total=0; g_surv=0
+  echo "== group: $g =="
+  for path in $(group_files "$g"); do
+    name="${path//\//-}"
+    cfg="$WORK/cr-$name.toml"; sess="$WORK/$name.sqlite"
+    rm -f "$sess"
+    cat > "$cfg" <<EOF
 [cosmic-ray]
-module-path = "src/pyrxd/spv/$f.py"
-timeout = 30.0
+module-path = "src/pyrxd/$path.py"
+timeout = $TIMEOUT
 excluded-modules = []
 test-command = "$PYTEST $TESTS -x -q -p no:randomly -p no:cacheprovider -o addopts= --no-cov"
 
 [cosmic-ray.distributor]
 name = "local"
 EOF
-  cosmic-ray init "$cfg" "$sess" >/dev/null 2>&1
-  cosmic-ray exec "$cfg" "$sess" >/dev/null 2>&1
-  git checkout -- "src/pyrxd/spv/$f.py" 2>/dev/null
-  t="$(cr-report "$sess" 2>/dev/null | grep -oE 'total jobs: [0-9]+' | grep -oE '[0-9]+')"
-  s="$(cr-report "$sess" 2>/dev/null | grep -oE 'surviving mutants: [0-9]+' | grep -oE '[0-9]+' | head -1)"
-  : "${t:=0}"; : "${s:=0}"
-  pct=0; [ "$t" -gt 0 ] && pct=$(( (t - s) * 100 / t ))
-  printf '  %-9s %4d mutants  %4d killed  %4d survived  (%d%% killed)\n' "$f" "$t" "$((t - s))" "$s" "$pct"
-  total=$((total + t)); killed=$((killed + t - s)); surv=$((surv + s))
+    cosmic-ray init "$cfg" "$sess" >/dev/null 2>&1
+    cosmic-ray exec "$cfg" "$sess" >/dev/null 2>&1
+    git checkout -- "src/pyrxd/$path.py" 2>/dev/null
+    t="$(cr-report "$sess" 2>/dev/null | grep -oE 'total jobs: [0-9]+' | grep -oE '[0-9]+')"
+    s="$(cr-report "$sess" 2>/dev/null | grep -oE 'surviving mutants: [0-9]+' | grep -oE '[0-9]+' | head -1)"
+    : "${t:=0}"; : "${s:=0}"
+    pct=0; [ "$t" -gt 0 ] && pct=$(( (t - s) * 100 / t ))
+    printf '  %-28s %4d mutants  %4d killed  %4d survived  (%d%% killed)\n' "$path" "$t" "$((t - s))" "$s" "$pct"
+    g_total=$((g_total + t)); g_surv=$((g_surv + s))
+  done
+  gpct=0; [ "$g_total" -gt 0 ] && gpct=$(( (g_total - g_surv) * 100 / g_total ))
+  printf '  %-28s %4d mutants  %4d killed  %4d survived  (%d%% killed)\n' "[$g total]" "$g_total" "$((g_total - g_surv))" "$g_surv" "$gpct"
+  total=$((total + g_total)); killed=$((killed + g_total - g_surv)); surv=$((surv + g_surv))
 done
 # Fail closed on a broken run: zero mutants means cosmic-ray init/exec silently no-op'd (missing tool,
 # wrong module path, env breakage) and the redirected stderr hid it — otherwise this would print

--- a/scripts/mutation_test.sh
+++ b/scripts/mutation_test.sh
@@ -52,11 +52,15 @@ group_files() {
 }
 
 group_tests() {
+  # tests/test_mutation_hardening.py leads each list: it holds the targeted
+  # mutant-killing assertions and runs in ~0.05s, so `-x` exits cheapest on
+  # the mutants it pins. The property/differential suites close each list
+  # (the expensive net for whatever the unit files miss).
   case "$1" in
     spv)         echo "tests/test_spv.py tests/test_merkle_path.py tests/test_spv_validation_hardening.py" ;;
-    script)      echo "tests/test_script.py tests/test_timelock.py tests/test_covenant.py tests/test_glyph_timelock.py tests/test_transaction.py tests/test_preimage.py tests/test_htlc_spend.py $GAPS" ;;
-    transaction) echo "tests/test_transaction.py tests/test_preimage.py tests/test_htlc_spend.py tests/test_glyph_transfer.py tests/test_ft_transfer.py tests/test_swap_partial.py tests/test_swap_resolve.py tests/test_fuzz_parsers.py $GAPS" ;;
-    dmint)       echo "tests/test_dmint_module.py tests/test_glyph_dmint.py tests/test_dmint_v2_canonical.py tests/test_dmint_v2_daa_canonical.py tests/test_dmint_conformance_vectors.py tests/test_dmint_v2_mainnet_golden.py tests/test_dmint_daa_offchain_onchain_differential.py tests/test_dmint_v1_deploy.py tests/test_dmint_v1_mint.py tests/test_dmint_end_to_end.py tests/test_dmint_deploy_integration.py $GAPS" ;;
+    script)      echo "tests/test_mutation_hardening.py tests/test_script.py tests/test_timelock.py tests/test_covenant.py tests/test_glyph_timelock.py tests/test_transaction.py tests/test_preimage.py tests/test_htlc_spend.py $GAPS" ;;
+    transaction) echo "tests/test_mutation_hardening.py tests/test_transaction.py tests/test_preimage.py tests/test_htlc_spend.py tests/test_glyph_transfer.py tests/test_ft_transfer.py tests/test_swap_partial.py tests/test_swap_resolve.py $GAPS tests/test_fuzz_parsers.py tests/test_preimage_differential.py" ;;
+    dmint)       echo "tests/test_mutation_hardening.py tests/test_dmint_module.py tests/test_glyph_dmint.py tests/test_dmint_v2_canonical.py tests/test_dmint_v2_daa_canonical.py tests/test_dmint_conformance_vectors.py tests/test_dmint_v2_mainnet_golden.py tests/test_dmint_daa_offchain_onchain_differential.py tests/test_dmint_v1_deploy.py tests/test_dmint_v1_mint.py tests/test_dmint_end_to_end.py tests/test_dmint_deploy_integration.py $GAPS tests/test_dmint_vector_derivations.py" ;;
   esac
 }
 

--- a/tests/cli/test_security_paths.py
+++ b/tests/cli/test_security_paths.py
@@ -1,0 +1,340 @@
+"""CLI security-path coverage (docs/cli-security-backlog.md priorities).
+
+Targets the paths the backlog names as security-relevant but which had no
+behavioral tests:
+
+* ``wallet send`` **in-process fallback** (#8) — the mnemonic re-entry path
+  taken when no agent is unlocked: happy path, empty/wrong mnemonic, user
+  decline, no-funds. Wrong-mnemonic output must never echo the input back.
+* ``agent unlock`` **lifecycle** (#8) — mnemonic → decrypt → daemon serve →
+  lock-on-exit (both the clean return and the Ctrl-C path must zeroize).
+* **query commands' shared ``_load_wallet``** — passphrase branch, internal
+  (change) chain walk, balance/utxos query bodies, and the ElectrumX
+  boundary error (no stack trace, no input echo, without ``--debug``).
+* ``errors.py`` debug-flag plumbing and the three-line error block.
+
+The mnemonic below is the canonical BIP39 test vector already used across
+tests/cli/ — a published, fundless vector, never a hand-written key.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from click.testing import CliRunner
+
+from pyrxd.cli.agent_cmds import agent_group
+from pyrxd.cli.config import Config
+from pyrxd.cli.context import CliContext
+from pyrxd.cli.errors import CliError, is_debug, render_error, set_debug
+from pyrxd.cli.query_cmds import address_cmd, balance_cmd, utxos_cmd
+from pyrxd.cli.wallet_cmds import wallet_group
+from pyrxd.hd.wallet import HdWallet
+from pyrxd.network.electrumx import NetworkError, UtxoRecord, script_hash_for_address
+from pyrxd.script.type import P2PKH
+from pyrxd.transaction.transaction import Transaction
+from pyrxd.transaction.transaction_output import TransactionOutput
+
+MNEMONIC = "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about"
+DEST = "1LqBGSKuX5yYUonjxT5qGfpUsXKYYWeabA"
+WRONG_MNEMONIC = "legal winner thank year wave sausage worth useful legal winner thank yellow"
+
+
+@pytest.fixture
+def runner() -> CliRunner:
+    return CliRunner()
+
+
+def _ctx(
+    wallet_path: Path,
+    client: MagicMock | None = None,
+    *,
+    output_mode: str = "human",
+    yes: bool = False,
+) -> CliContext:
+    return CliContext(
+        config=Config(network="mainnet", electrumx="wss://test/", fee_rate=10_000, wallet_path=wallet_path),
+        network="mainnet",
+        electrumx_url="wss://test/",
+        fee_rate=10_000,
+        wallet_path=wallet_path,
+        output_mode=output_mode,
+        yes=yes,
+        client_factory=(lambda: client) if client is not None else None,
+    )
+
+
+def _saved_wallet(path: Path) -> HdWallet:
+    wallet = HdWallet.from_mnemonic(MNEMONIC)
+    wallet.save(path)
+    return wallet
+
+
+def _funded_client_for(addr: str, *, value: int = 100_000_000) -> MagicMock:
+    """Mock ElectrumX where *addr* has history + one UTXO paying it."""
+    src = Transaction()
+    src.add_output(TransactionOutput(P2PKH().lock(addr), value))
+    src_txid = src.txid()
+    target_sh = script_hash_for_address(addr)
+
+    async def _history(sh):
+        return [{"tx_hash": src_txid}] if sh == target_sh else []
+
+    async def _utxos(sh):
+        return [UtxoRecord(tx_hash=src_txid, tx_pos=0, value=value, height=800_000)] if sh == target_sh else []
+
+    async def _get_tx(_txid):
+        return src.serialize()
+
+    client = MagicMock()
+    client.get_history = _history
+    client.get_utxos = _utxos
+    client.get_transaction = _get_tx
+    client.get_balance = AsyncMock(return_value=(value, 0))
+    client.broadcast = AsyncMock(return_value="cd" * 32)
+    client.__aenter__ = AsyncMock(return_value=client)
+    client.__aexit__ = AsyncMock(return_value=None)
+    return client
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# wallet send — in-process mnemonic-re-entry fallback (#8)
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+class TestSendInProcessFallback:
+    def test_happy_path_signs_and_broadcasts(self, runner: CliRunner, tmp_path: Path) -> None:
+        wallet = _saved_wallet(tmp_path / "wallet.dat")
+        client = _funded_client_for(wallet._derive_address(0, 0))
+        ctx = _ctx(tmp_path / "wallet.dat", client, yes=True)
+        result = runner.invoke(
+            wallet_group,
+            ["send", "--to", DEST, "--amount", "10000000"],
+            obj=ctx,
+            input=f"{MNEMONIC}\n",
+        )
+        assert result.exit_code == 0, result.output
+        assert "in-process" in result.output
+        client.broadcast.assert_awaited_once()
+
+    def test_empty_mnemonic_is_rejected(self, runner: CliRunner, tmp_path: Path) -> None:
+        _saved_wallet(tmp_path / "wallet.dat")
+        client = _funded_client_for(DEST)
+        ctx = _ctx(tmp_path / "wallet.dat", client, yes=True)
+        result = runner.invoke(
+            wallet_group, ["send", "--to", DEST, "--amount", "10000000"], obj=ctx, input="\n"
+        )
+        assert result.exit_code != 0
+        assert "mnemonic is required" in result.output
+        client.broadcast.assert_not_awaited()
+
+    def test_wrong_mnemonic_fails_without_echoing_input(self, runner: CliRunner, tmp_path: Path) -> None:
+        """Decrypt failure must not leak which words the user typed (#9
+        output-snapshot hygiene: result.output is exactly what a pytest
+        traceback or CI log would capture)."""
+        _saved_wallet(tmp_path / "wallet.dat")
+        client = _funded_client_for(DEST)
+        ctx = _ctx(tmp_path / "wallet.dat", client, yes=True)
+        result = runner.invoke(
+            wallet_group,
+            ["send", "--to", DEST, "--amount", "10000000"],
+            obj=ctx,
+            input=f"{WRONG_MNEMONIC}\n",
+        )
+        assert result.exit_code != 0
+        assert "Could not decrypt" in result.output
+        for word in ("legal", "winner", "sausage", "yellow"):
+            assert word not in result.output, "typed mnemonic words leaked into CLI output"
+        client.broadcast.assert_not_awaited()
+
+    def test_user_decline_aborts_before_broadcast(self, runner: CliRunner, tmp_path: Path) -> None:
+        wallet = _saved_wallet(tmp_path / "wallet.dat")
+        client = _funded_client_for(wallet._derive_address(0, 0))
+        ctx = _ctx(tmp_path / "wallet.dat", client, yes=False)
+        result = runner.invoke(
+            wallet_group,
+            ["send", "--to", DEST, "--amount", "10000000"],
+            obj=ctx,
+            input=f"{MNEMONIC}\nn\n",
+        )
+        assert result.exit_code != 0
+        assert "aborted by user" in result.output
+        client.broadcast.assert_not_awaited()
+
+    def test_no_spendable_funds_is_clean_error(self, runner: CliRunner, tmp_path: Path) -> None:
+        _saved_wallet(tmp_path / "wallet.dat")
+        client = _funded_client_for(DEST)  # funds at an address the wallet doesn't own
+        ctx = _ctx(tmp_path / "wallet.dat", client, yes=True)
+        result = runner.invoke(
+            wallet_group,
+            ["send", "--to", DEST, "--amount", "10000000"],
+            obj=ctx,
+            input=f"{MNEMONIC}\n",
+        )
+        assert result.exit_code != 0
+        assert "no spendable funds" in result.output
+        client.broadcast.assert_not_awaited()
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# agent unlock — mnemonic → daemon → lock-on-exit (#8)
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+class TestAgentUnlockLifecycle:
+    @pytest.fixture
+    def daemon_cls(self, monkeypatch: pytest.MonkeyPatch) -> MagicMock:
+        """Replace AgentDaemon with a mock and neutralize the process-global
+        signal/atexit hooks the command installs."""
+        daemon_cls = MagicMock()
+        monkeypatch.setattr("pyrxd.cli.agent_cmds.AgentDaemon", daemon_cls)
+        monkeypatch.setattr("pyrxd.cli.agent_cmds.signal", MagicMock())
+        monkeypatch.setattr("pyrxd.cli.agent_cmds.atexit", MagicMock())
+        return daemon_cls
+
+    def test_unlock_serves_then_reports_locked(
+        self, runner: CliRunner, tmp_path: Path, daemon_cls: MagicMock
+    ) -> None:
+        _saved_wallet(tmp_path / "wallet.dat")
+        ctx = _ctx(tmp_path / "wallet.dat")
+        result = runner.invoke(agent_group, ["unlock"], obj=ctx, input=f"{MNEMONIC}\n")
+        assert result.exit_code == 0, result.output
+        assert "unlocked" in result.output
+        assert "agent locked (seed zeroized)" in result.output
+        daemon_cls.return_value.serve_forever.assert_called_once()
+        # Socket must live next to the wallet file, not in a world-visible tmp.
+        assert str(tmp_path) in str(daemon_cls.call_args.kwargs["socket_path"])
+
+    def test_unlock_ctrl_c_still_zeroizes(
+        self, runner: CliRunner, tmp_path: Path, daemon_cls: MagicMock
+    ) -> None:
+        _saved_wallet(tmp_path / "wallet.dat")
+        daemon_cls.return_value.serve_forever.side_effect = KeyboardInterrupt
+        ctx = _ctx(tmp_path / "wallet.dat")
+        result = runner.invoke(agent_group, ["unlock"], obj=ctx, input=f"{MNEMONIC}\n")
+        assert "agent locked (seed zeroized)" in result.output
+        daemon_cls.return_value.lock.assert_called()
+
+    def test_unlock_empty_mnemonic_rejected(
+        self, runner: CliRunner, tmp_path: Path, daemon_cls: MagicMock
+    ) -> None:
+        _saved_wallet(tmp_path / "wallet.dat")
+        ctx = _ctx(tmp_path / "wallet.dat")
+        result = runner.invoke(agent_group, ["unlock"], obj=ctx, input="\n")
+        assert result.exit_code != 0
+        assert "mnemonic is required" in result.output
+        daemon_cls.assert_not_called()
+
+    def test_unlock_wrong_mnemonic_no_echo(
+        self, runner: CliRunner, tmp_path: Path, daemon_cls: MagicMock
+    ) -> None:
+        _saved_wallet(tmp_path / "wallet.dat")
+        ctx = _ctx(tmp_path / "wallet.dat")
+        result = runner.invoke(agent_group, ["unlock"], obj=ctx, input=f"{WRONG_MNEMONIC}\n")
+        assert result.exit_code != 0
+        assert "Could not decrypt" in result.output
+        for word in ("legal", "winner", "sausage", "yellow"):
+            assert word not in result.output
+        daemon_cls.assert_not_called()
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# Query commands — the shared mnemonic prompt surface
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+class TestQueryCommandPaths:
+    def test_address_with_passphrase_prompt(self, runner: CliRunner, tmp_path: Path) -> None:
+        """--passphrase adds a second hidden prompt; a wallet saved without a
+        passphrase must fail to decrypt under a non-empty one (and never echo
+        either secret)."""
+        _saved_wallet(tmp_path / "wallet.dat")
+        ctx = _ctx(tmp_path / "wallet.dat")
+        result = runner.invoke(
+            address_cmd, ["--index", "0", "--passphrase"], obj=ctx, input=f"{MNEMONIC}\nhunter2\n"
+        )
+        assert result.exit_code != 0
+        assert "Could not decrypt" in result.output
+        assert "hunter2" not in result.output
+
+    def test_address_next_on_change_chain(self, runner: CliRunner, tmp_path: Path) -> None:
+        _saved_wallet(tmp_path / "wallet.dat")
+        ctx = _ctx(tmp_path / "wallet.dat", output_mode="json")
+        result = runner.invoke(address_cmd, ["--change"], obj=ctx, input=f"{MNEMONIC}\n")
+        assert result.exit_code == 0, result.output
+        assert "'/1/" in result.output  # internal (change) chain path
+
+    def test_balance_refresh_reports_confirmed(self, runner: CliRunner, tmp_path: Path) -> None:
+        wallet = _saved_wallet(tmp_path / "wallet.dat")
+        client = _funded_client_for(wallet._derive_address(0, 0))
+        ctx = _ctx(tmp_path / "wallet.dat", client, output_mode="json")
+        result = runner.invoke(balance_cmd, ["--refresh"], obj=ctx, input=f"{MNEMONIC}\n")
+        assert result.exit_code == 0, result.output
+        assert '"confirmed_photons": 100000000' in result.output
+
+    def test_balance_network_error_is_boundary_error(self, runner: CliRunner, tmp_path: Path) -> None:
+        """ElectrumX failure surfaces as the three-line boundary error —
+        no traceback, no mnemonic echo (without --debug)."""
+        _saved_wallet(tmp_path / "wallet.dat")
+        client = MagicMock()
+        client.__aenter__ = AsyncMock(side_effect=NetworkError("boom"))
+        client.__aexit__ = AsyncMock(return_value=None)
+        ctx = _ctx(tmp_path / "wallet.dat", client)
+        result = runner.invoke(balance_cmd, [], obj=ctx, input=f"{MNEMONIC}\n")
+        assert result.exit_code != 0
+        assert "could not reach ElectrumX" in result.output
+        assert "Traceback" not in result.output
+        assert "abandon" not in result.output
+
+    def test_utxos_lists_and_filters(self, runner: CliRunner, tmp_path: Path) -> None:
+        # utxos_cmd queries the wallet's KNOWN used addresses (no implicit
+        # rescan), so persist the funded address as used before invoking.
+        from pyrxd.hd.wallet import AddressRecord
+
+        wallet = HdWallet.from_mnemonic(MNEMONIC)
+        funded = wallet._derive_address(0, 0)
+        wallet.addresses[wallet._path_key(0, 0)] = AddressRecord(address=funded, change=0, index=0, used=True)
+        wallet.save(tmp_path / "wallet.dat")
+        client = _funded_client_for(funded)
+        ctx = _ctx(tmp_path / "wallet.dat", client, output_mode="json")
+        result = runner.invoke(utxos_cmd, [], obj=ctx, input=f"{MNEMONIC}\n")
+        assert result.exit_code == 0, result.output
+        assert "100000000" in result.output
+        # A min-photons filter above the UTXO value must yield an empty list.
+        client2 = _funded_client_for(funded)
+        ctx2 = _ctx(tmp_path / "wallet.dat", client2, output_mode="json")
+        result2 = runner.invoke(
+            utxos_cmd, ["--min-photons", "200000000"], obj=ctx2, input=f"{MNEMONIC}\n"
+        )
+        assert result2.exit_code == 0, result2.output
+        assert "100000000" not in result2.output
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# errors.py — debug plumbing + error block shape
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+class TestErrorPlumbing:
+    def test_set_debug_roundtrip(self) -> None:
+        original = is_debug()
+        try:
+            set_debug(True)
+            assert is_debug() is True
+            set_debug(False)
+            assert is_debug() is False
+        finally:
+            set_debug(original)
+
+    def test_exit_code_override(self) -> None:
+        err = CliError("msg", exit_code=42)
+        assert err.exit_code == 42
+
+    def test_render_error_three_line_block(self) -> None:
+        err = CliError("bad thing", cause="the reason", fix="do this instead")
+        block = render_error(err)
+        assert "error: bad thing" in block
+        assert "cause: the reason" in block
+        assert "do this instead" in block

--- a/tests/cli/test_security_paths.py
+++ b/tests/cli/test_security_paths.py
@@ -123,9 +123,7 @@ class TestSendInProcessFallback:
         _saved_wallet(tmp_path / "wallet.dat")
         client = _funded_client_for(DEST)
         ctx = _ctx(tmp_path / "wallet.dat", client, yes=True)
-        result = runner.invoke(
-            wallet_group, ["send", "--to", DEST, "--amount", "10000000"], obj=ctx, input="\n"
-        )
+        result = runner.invoke(wallet_group, ["send", "--to", DEST, "--amount", "10000000"], obj=ctx, input="\n")
         assert result.exit_code != 0
         assert "mnemonic is required" in result.output
         client.broadcast.assert_not_awaited()
@@ -194,9 +192,7 @@ class TestAgentUnlockLifecycle:
         monkeypatch.setattr("pyrxd.cli.agent_cmds.atexit", MagicMock())
         return daemon_cls
 
-    def test_unlock_serves_then_reports_locked(
-        self, runner: CliRunner, tmp_path: Path, daemon_cls: MagicMock
-    ) -> None:
+    def test_unlock_serves_then_reports_locked(self, runner: CliRunner, tmp_path: Path, daemon_cls: MagicMock) -> None:
         _saved_wallet(tmp_path / "wallet.dat")
         ctx = _ctx(tmp_path / "wallet.dat")
         result = runner.invoke(agent_group, ["unlock"], obj=ctx, input=f"{MNEMONIC}\n")
@@ -207,9 +203,7 @@ class TestAgentUnlockLifecycle:
         # Socket must live next to the wallet file, not in a world-visible tmp.
         assert str(tmp_path) in str(daemon_cls.call_args.kwargs["socket_path"])
 
-    def test_unlock_ctrl_c_still_zeroizes(
-        self, runner: CliRunner, tmp_path: Path, daemon_cls: MagicMock
-    ) -> None:
+    def test_unlock_ctrl_c_still_zeroizes(self, runner: CliRunner, tmp_path: Path, daemon_cls: MagicMock) -> None:
         _saved_wallet(tmp_path / "wallet.dat")
         daemon_cls.return_value.serve_forever.side_effect = KeyboardInterrupt
         ctx = _ctx(tmp_path / "wallet.dat")
@@ -217,9 +211,7 @@ class TestAgentUnlockLifecycle:
         assert "agent locked (seed zeroized)" in result.output
         daemon_cls.return_value.lock.assert_called()
 
-    def test_unlock_empty_mnemonic_rejected(
-        self, runner: CliRunner, tmp_path: Path, daemon_cls: MagicMock
-    ) -> None:
+    def test_unlock_empty_mnemonic_rejected(self, runner: CliRunner, tmp_path: Path, daemon_cls: MagicMock) -> None:
         _saved_wallet(tmp_path / "wallet.dat")
         ctx = _ctx(tmp_path / "wallet.dat")
         result = runner.invoke(agent_group, ["unlock"], obj=ctx, input="\n")
@@ -227,9 +219,7 @@ class TestAgentUnlockLifecycle:
         assert "mnemonic is required" in result.output
         daemon_cls.assert_not_called()
 
-    def test_unlock_wrong_mnemonic_no_echo(
-        self, runner: CliRunner, tmp_path: Path, daemon_cls: MagicMock
-    ) -> None:
+    def test_unlock_wrong_mnemonic_no_echo(self, runner: CliRunner, tmp_path: Path, daemon_cls: MagicMock) -> None:
         _saved_wallet(tmp_path / "wallet.dat")
         ctx = _ctx(tmp_path / "wallet.dat")
         result = runner.invoke(agent_group, ["unlock"], obj=ctx, input=f"{WRONG_MNEMONIC}\n")
@@ -252,9 +242,7 @@ class TestQueryCommandPaths:
         either secret)."""
         _saved_wallet(tmp_path / "wallet.dat")
         ctx = _ctx(tmp_path / "wallet.dat")
-        result = runner.invoke(
-            address_cmd, ["--index", "0", "--passphrase"], obj=ctx, input=f"{MNEMONIC}\nhunter2\n"
-        )
+        result = runner.invoke(address_cmd, ["--index", "0", "--passphrase"], obj=ctx, input=f"{MNEMONIC}\nhunter2\n")
         assert result.exit_code != 0
         assert "Could not decrypt" in result.output
         assert "hunter2" not in result.output
@@ -305,9 +293,7 @@ class TestQueryCommandPaths:
         # A min-photons filter above the UTXO value must yield an empty list.
         client2 = _funded_client_for(funded)
         ctx2 = _ctx(tmp_path / "wallet.dat", client2, output_mode="json")
-        result2 = runner.invoke(
-            utxos_cmd, ["--min-photons", "200000000"], obj=ctx2, input=f"{MNEMONIC}\n"
-        )
+        result2 = runner.invoke(utxos_cmd, ["--min-photons", "200000000"], obj=ctx2, input=f"{MNEMONIC}\n")
         assert result2.exit_code == 0, result2.output
         assert "100000000" not in result2.output
 

--- a/tests/test_dmint_vector_derivations.py
+++ b/tests/test_dmint_vector_derivations.py
@@ -1,0 +1,259 @@
+"""dMint V2 contract-script derivation tests against the published
+conformance vectors (``conformance/dmint-v2-contract-vectors.json``).
+
+The existing ``test_dmint_conformance_vectors.py`` regression-locks the
+builder to the committed bytes. This file adds the *derivation* nets the
+lock alone can't provide, each asserting against the vector JSON or the
+documented layout — never against the builder's own prior output:
+
+1. **Vector bytes → state fields**: the independent state parser
+   (``DmintState.from_script``, the code the miner trusts to re-derive
+   on-chain state) must recover every JSON param from the committed
+   contract bytes — including the mainnet-anchored vector. The expected
+   ``target`` is derived in-test from the documented formula
+   ``MAX_SHA256D_TARGET // difficulty`` with the constant inlined.
+2. **Builder ↔ parser round-trip property**: for Hypothesis-generated
+   valid deploy params across all five DAA modes, parsing the built
+   contract recovers every state field.
+3. **State-layout byte check**: the state prefix (before the 0xbd
+   OP_STATESEPARATOR) of a built contract is re-read with a test-local
+   reader implementing the documented 10-slot layout (canonical redesign
+   §4.2) and Bitcoin MINIMALDATA push rules — heights/targets must use
+   minimal pushes (the non-minimal height push was rejected by radiantd's
+   mempool policy on mainnet), refs must be raw ``d8/d0 + 36B`` outpoint
+   bytes (txid LE + vout LE4).
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import struct
+from pathlib import Path
+
+from hypothesis import HealthCheck, given, settings
+from hypothesis import strategies as st
+
+from pyrxd.glyph.dmint import (
+    DaaMode,
+    DmintAlgo,
+    DmintDeployParams,
+    build_dmint_contract_script,
+)
+from pyrxd.glyph.dmint.chain import DmintState
+from pyrxd.glyph.types import GlyphRef
+
+_BUDGET_MULT = int(os.environ.get("FUZZ_BUDGET_MULTIPLIER", "1"))
+
+
+def _budget(n: int) -> int:
+    return n * _BUDGET_MULT
+
+
+_VECTORS = Path(__file__).resolve().parent.parent / "conformance" / "dmint-v2-contract-vectors.json"
+
+# Documented target formula constants (types.py cites the canonical redesign;
+# inlined here so the assertion does not route through the code under test).
+_MAX_SHA256D_TARGET = 0x7FFFFFFFFFFFFFFF
+_MAX_256BIT_TARGET = (1 << 256) - 1
+_EPOCH_MAX_SAFE_TARGET = 1 << 48
+
+
+def _params_from_json(p: dict) -> DmintDeployParams:
+    return DmintDeployParams(
+        contract_ref=GlyphRef(txid=p["contract_ref"]["txid"], vout=p["contract_ref"]["vout"]),
+        token_ref=GlyphRef(txid=p["token_ref"]["txid"], vout=p["token_ref"]["vout"]),
+        max_height=p["max_height"],
+        reward=p["reward"],
+        difficulty=p["difficulty"],
+        algo=DmintAlgo[p["algo"]],
+        daa_mode=DaaMode[p["daa_mode"]],
+        target_time=p["target_time"],
+        half_life=p["half_life"],
+        height=p["height"],
+        last_time=p["last_time"],
+        epoch_length=p["epoch_length"],
+        max_adjustment_log2=p["max_adjustment_log2"],
+        schedule=tuple(tuple(x) for x in p["schedule"]),
+    )
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# 1. Committed vector bytes re-parse to their own JSON params
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+def test_committed_vector_bytes_reparse_to_their_params():
+    doc = json.loads(_VECTORS.read_text())
+    assert doc["vectors"], "no conformance vectors"
+    for v in doc["vectors"]:
+        p = v["params"]
+        st_ = DmintState.from_script(bytes.fromhex(v["contract_script_hex"]))
+        ctx = f"vector {v['id']!r}"
+        assert not st_.is_v1, ctx
+        assert st_.height == p["height"], ctx
+        assert st_.contract_ref.txid == p["contract_ref"]["txid"], ctx
+        assert st_.contract_ref.vout == p["contract_ref"]["vout"], ctx
+        assert st_.token_ref.txid == p["token_ref"]["txid"], ctx
+        assert st_.token_ref.vout == p["token_ref"]["vout"], ctx
+        assert st_.max_height == p["max_height"], ctx
+        assert st_.reward == p["reward"], ctx
+        assert st_.algo.name == p["algo"], ctx
+        assert st_.daa_mode.name == p["daa_mode"], ctx
+        assert st_.target_time == p["target_time"], ctx
+        assert st_.last_time == p["last_time"], ctx
+        max_target = _MAX_SHA256D_TARGET if p["algo"] == "SHA256D" else _MAX_256BIT_TARGET
+        assert st_.target == max_target // p["difficulty"], ctx
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# 2. Builder ↔ parser round-trip over generated params
+# ═══════════════════════════════════════════════════════════════════════════════
+
+_txid = st.binary(min_size=32, max_size=32).map(bytes.hex)
+_ref = st.builds(GlyphRef, txid=_txid, vout=st.integers(min_value=0, max_value=0xFFFFFFFF))
+
+
+@st.composite
+def _deploy_params(draw) -> DmintDeployParams:
+    daa_mode = draw(st.sampled_from(list(DaaMode)))
+    algo = draw(st.sampled_from(list(DmintAlgo)))
+    if daa_mode == DaaMode.EPOCH:
+        # EPOCH caps the initial target at 2^48 (OP_MUL overflow guard), so
+        # difficulty must be at least maxTarget / 2^48.
+        max_target = _MAX_SHA256D_TARGET if algo == DmintAlgo.SHA256D else _MAX_256BIT_TARGET
+        min_diff = max_target // _EPOCH_MAX_SAFE_TARGET + 1
+        difficulty = draw(st.integers(min_value=min_diff, max_value=min_diff * 1024))
+    else:
+        difficulty = draw(st.integers(min_value=1, max_value=2**40))
+    if daa_mode == DaaMode.SCHEDULE:
+        heights = draw(st.lists(st.integers(min_value=0, max_value=10**6), min_size=1, max_size=10, unique=True))
+        targets = draw(
+            st.lists(
+                st.integers(min_value=1, max_value=_MAX_SHA256D_TARGET),
+                min_size=len(heights),
+                max_size=len(heights),
+            )
+        )
+        schedule = tuple(zip(sorted(heights), targets))
+    else:
+        schedule = ()
+    max_height = draw(st.integers(min_value=1, max_value=10**9))
+    return DmintDeployParams(
+        contract_ref=draw(_ref),
+        token_ref=draw(_ref),
+        max_height=max_height,
+        reward=draw(st.integers(min_value=1, max_value=10**12)),
+        difficulty=difficulty,
+        algo=algo,
+        daa_mode=daa_mode,
+        target_time=draw(st.integers(min_value=1, max_value=86_400)),
+        half_life=draw(st.integers(min_value=1, max_value=10**6)),
+        height=draw(st.integers(min_value=0, max_value=max_height)),
+        last_time=draw(st.integers(min_value=0, max_value=0x7FFFFFFF)),
+        epoch_length=draw(st.integers(min_value=1, max_value=10**5)),
+        max_adjustment_log2=draw(st.sampled_from([1, 2, 3, 4])),
+        schedule=schedule,
+    )
+
+
+@given(p=_deploy_params())
+@settings(max_examples=_budget(200), deadline=None, suppress_health_check=[HealthCheck.too_slow])
+def test_builder_parser_roundtrip(p):
+    """The miner re-derives contract state from on-chain bytes with
+    DmintState.from_script; every deploy-params field encoded into the state
+    must survive build → parse exactly."""
+    st_ = DmintState.from_script(build_dmint_contract_script(p))
+    assert not st_.is_v1
+    assert st_.height == p.height
+    assert st_.contract_ref == p.contract_ref
+    assert st_.token_ref == p.token_ref
+    assert st_.max_height == p.max_height
+    assert st_.reward == p.reward
+    assert st_.algo == p.algo
+    assert st_.daa_mode == p.daa_mode
+    assert st_.target_time == p.target_time
+    assert st_.last_time == p.last_time
+    max_target = _MAX_SHA256D_TARGET if p.algo == DmintAlgo.SHA256D else _MAX_256BIT_TARGET
+    assert st_.target == max_target // p.difficulty
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# 3. State-layout byte check (documented layout + MINIMALDATA rules)
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+def _read_minimal_number(script: bytes, i: int) -> tuple[int, int]:
+    """Read one MINIMALDATA-compliant script-number push at offset i.
+
+    Returns (value, next_offset). Fails the test on any non-minimal
+    encoding — rules per the Bitcoin/Radiant MINIMALDATA policy:
+    0 → OP_0; 1..16 → OP_1..OP_16; -1 → OP_1NEGATE; otherwise the
+    shortest little-endian signed-magnitude byte string.
+    """
+    op = script[i]
+    if op == 0x00:
+        return 0, i + 1
+    if 0x51 <= op <= 0x60:
+        return op - 0x50, i + 1
+    assert 1 <= op <= 0x4B, f"expected direct push at offset {i}, got opcode {op:#x}"
+    data = script[i + 1 : i + 1 + op]
+    assert len(data) == op, "truncated push"
+    # minimality: single bytes 1..16 / 0x81 must have used OP_N / OP_1NEGATE
+    assert not (op == 1 and (1 <= data[0] <= 16 or data[0] == 0x81)), "non-minimal single-byte push"
+    # minimality: a trailing 0x00 is only allowed to clear a sign bit
+    if op > 1 and data[-1] == 0x00:
+        assert data[-2] & 0x80, "non-minimal number: redundant trailing zero byte"
+    negative = bool(data[-1] & 0x80)
+    magnitude = bytes(data[:-1]) + bytes([data[-1] & 0x7F])
+    value = int.from_bytes(magnitude, "little")
+    return (-value if negative else value), i + 1 + op
+
+
+def _read_state_slots(contract: bytes, p: DmintDeployParams) -> None:
+    """Walk the documented 10-slot state layout and compare every slot."""
+    i = 0
+    height, i = _read_minimal_number(contract, i)
+    assert height == p.height
+    assert contract[i] == 0xD8, "slot 2 must be OP_PUSHINPUTREFSINGLETON"
+    ref = contract[i + 1 : i + 37]
+    assert ref == bytes.fromhex(p.contract_ref.txid)[::-1] + struct.pack("<I", p.contract_ref.vout)
+    i += 37
+    assert contract[i] == 0xD0, "slot 3 must be OP_PUSHINPUTREF"
+    ref = contract[i + 1 : i + 37]
+    assert ref == bytes.fromhex(p.token_ref.txid)[::-1] + struct.pack("<I", p.token_ref.vout)
+    i += 37
+    max_height, i = _read_minimal_number(contract, i)
+    assert max_height == p.max_height
+    reward, i = _read_minimal_number(contract, i)
+    assert reward == p.reward
+    algo, i = _read_minimal_number(contract, i)
+    assert algo == int(p.algo)
+    daa, i = _read_minimal_number(contract, i)
+    assert daa == int(p.daa_mode)
+    target_time, i = _read_minimal_number(contract, i)
+    assert target_time == p.target_time
+    # slot 9: lastTime is documented as a fixed 4-byte push (Part C rebuilds
+    # it with 04 || NUM2BIN(4, locktime))
+    assert contract[i] == 0x04, "lastTime must be a 4-byte push"
+    assert contract[i + 1 : i + 5] == struct.pack("<I", p.last_time)
+    i += 5
+    target, i = _read_minimal_number(contract, i)
+    max_target = _MAX_SHA256D_TARGET if p.algo == DmintAlgo.SHA256D else _MAX_256BIT_TARGET
+    assert target == max_target // p.difficulty
+    assert contract[i] == 0xBD, "state must end at OP_STATESEPARATOR"
+
+
+@given(p=_deploy_params())
+@settings(max_examples=_budget(150), deadline=None, suppress_health_check=[HealthCheck.too_slow])
+def test_state_script_layout_and_minimality(p):
+    _read_state_slots(build_dmint_contract_script(p), p)
+
+
+def test_mainnet_anchored_vector_state_layout():
+    """The same byte-level walk over the mainnet-anchored committed vector."""
+    doc = json.loads(_VECTORS.read_text())
+    anchored = [v for v in doc["vectors"] if v["source"].startswith("mainnet:")]
+    assert anchored, "no mainnet-anchored vector in the suite"
+    for v in anchored:
+        _read_state_slots(bytes.fromhex(v["contract_script_hex"]), _params_from_json(v["params"]))

--- a/tests/test_glyph_cbor_roundtrip.py
+++ b/tests/test_glyph_cbor_roundtrip.py
@@ -1,0 +1,234 @@
+"""Property corpus for the Glyph CBOR envelope: encode/decode round-trip,
+canonical-form stability, and reveal-scriptSig push framing.
+
+Three independent nets over ``pyrxd.glyph.payload``:
+
+1. **Round-trip** — ``decode_payload(encode_payload(m)) == m`` for
+   Hypothesis-generated ``GlyphMetadata`` across valid protocol combos,
+   nested media, attrs, and dMint params. A field silently dropped or
+   coerced on either side breaks equality.
+2. **Canonical stability** — ``encode_payload`` promises RFC 8949
+   canonical/deterministic form (module docstring): an indexer must be able
+   to re-encode decoded metadata and reproduce the on-chain commit hash.
+   Asserted with cbor2 directly (``loads`` → ``dumps(canonical=True)`` is
+   byte-identical), never via pyrxd's own decoder.
+3. **Envelope framing** — ``build_reveal_scriptsig_suffix`` must pick the
+   push opcode by payload length (direct ≤75, PUSHDATA1 ≤255, PUSHDATA2
+   ≤65535, PUSHDATA4 ≤256 KiB — the mainnet GLYPH reveal b965b32d…9dd6
+   needed PUSHDATA4). Parsed back with a test-local script-chunk reader
+   (same shape as the RXinDexer port in tests/test_cbor_cross_decoder.py),
+   not with pyrxd's Script class.
+"""
+
+from __future__ import annotations
+
+import os
+
+import cbor2
+import pytest
+from hypothesis import HealthCheck, given, settings
+from hypothesis import strategies as st
+
+from pyrxd.glyph.dmint.types import DaaMode, DmintAlgo, DmintCborPayload
+from pyrxd.glyph.payload import (
+    _MAX_CBOR_PAYLOAD_BYTES,
+    build_reveal_scriptsig_suffix,
+    decode_payload,
+    encode_payload,
+)
+from pyrxd.glyph.types import GlyphMedia, GlyphMetadata
+from pyrxd.security.errors import ValidationError
+
+_BUDGET_MULT = int(os.environ.get("FUZZ_BUDGET_MULTIPLIER", "1"))
+
+
+def _budget(n: int) -> int:
+    return n * _BUDGET_MULT
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# Strategies
+# ═══════════════════════════════════════════════════════════════════════════════
+
+# Valid protocol combinations per the Photonic protocols.ts §3.5 rules
+# enforced in GlyphMetadata.__post_init__ (FT/NFT exclusive; extensions
+# require their base co-protocols).
+_PROTOCOL_COMBOS = [
+    (1,),  # FT
+    (2,),  # NFT
+    (3,),  # DAT
+    (1, 4),  # FT + DMINT
+    (2, 5),  # NFT + MUT
+    (2, 7),  # NFT + CONTAINER
+    (2, 8),  # NFT + ENCRYPTED
+    (2, 8, 9),  # NFT + ENCRYPTED + TIMELOCK
+    (2, 10),  # NFT + AUTHORITY
+    (2, 5, 11),  # NFT + MUT + WAVE
+]
+
+_text = st.text(max_size=32)
+_hex64 = st.text(alphabet="0123456789abcdef", min_size=64, max_size=64)
+
+_media = st.builds(
+    GlyphMedia,
+    mime_type=st.sampled_from(["image/webp", "image/png", "text/plain", "application/octet-stream"]),
+    data=st.binary(min_size=0, max_size=64),
+)
+
+
+@st.composite
+def _dmint_payload(draw) -> DmintCborPayload:
+    daa_mode = draw(st.sampled_from(list(DaaMode)))
+    # Fields that from_cbor_dict resets to defaults when absent must be
+    # generated in their encoded-when-set shape, or equality is vacuous:
+    # FIXED omits the whole daa object, so its dependents stay at defaults.
+    if daa_mode == DaaMode.FIXED:
+        target_block_time, half_life, window_size = 60, 0, 0
+    else:
+        target_block_time = draw(st.integers(min_value=1, max_value=86_400))
+        half_life = draw(st.integers(min_value=1, max_value=10**6)) if daa_mode == DaaMode.ASERT else 0
+        window_size = draw(st.integers(min_value=1, max_value=1000)) if daa_mode == DaaMode.LWMA else 0
+    return DmintCborPayload(
+        algo=draw(st.sampled_from(list(DmintAlgo))),
+        num_contracts=draw(st.integers(min_value=1, max_value=64)),
+        max_height=draw(st.integers(min_value=1, max_value=10**9)),
+        reward=draw(st.integers(min_value=0, max_value=10**12)),
+        premine=draw(st.integers(min_value=0, max_value=10**12)),
+        diff=draw(st.integers(min_value=1, max_value=2**32)),
+        daa_mode=daa_mode,
+        target_block_time=target_block_time,
+        half_life=half_life,
+        window_size=window_size,
+    )
+
+
+@st.composite
+def _metadata(draw) -> GlyphMetadata:
+    protocol = draw(st.sampled_from(_PROTOCOL_COMBOS))
+    dmint = draw(_dmint_payload()) if 4 in protocol else None
+    return GlyphMetadata(
+        protocol=list(protocol),
+        name=draw(_text),
+        ticker=draw(st.text(max_size=16)),
+        description=draw(_text),
+        token_type=draw(_text),
+        main=draw(st.none() | _media),
+        attrs=draw(st.dictionaries(st.text(min_size=1, max_size=16), st.text(max_size=16), max_size=8)),
+        loc=draw(_text),
+        loc_hash=draw(_text),
+        decimals=draw(st.integers(min_value=0, max_value=18)),
+        image_url=draw(_text),
+        image_ipfs=draw(_text),
+        image_sha256=draw(st.just("") | _hex64),
+        v=draw(st.none() | st.just(2)),
+        dmint_params=dmint,
+        created=draw(_text),
+        commit_outpoint=draw(_text),
+    )
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# 1. Round-trip
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+@given(m=_metadata())
+@settings(max_examples=_budget(300), deadline=None, suppress_health_check=[HealthCheck.too_slow])
+def test_encode_decode_roundtrip(m):
+    cbor_bytes, payload_hash = encode_payload(m)
+    assert len(payload_hash) == 32
+    decoded = decode_payload(cbor_bytes)
+    assert decoded == m, "decode(encode(m)) must reproduce every field of m"
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# 2. Canonical form, checked against cbor2 directly
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+@given(m=_metadata())
+@settings(max_examples=_budget(200), deadline=None, suppress_health_check=[HealthCheck.too_slow])
+def test_encoding_is_canonical_fixed_point(m):
+    """An independent decode→canonical-re-encode must be byte-identical:
+    the property an indexer needs to verify a payload against its on-chain
+    commit hash. Uses cbor2 alone — pyrxd's decoder is not in the loop."""
+    cbor_bytes, _ = encode_payload(m)
+    re_encoded = cbor2.dumps(cbor2.loads(cbor_bytes), canonical=True)
+    assert re_encoded == cbor_bytes
+
+
+@given(m=_metadata())
+@settings(max_examples=_budget(100), deadline=None, suppress_health_check=[HealthCheck.too_slow])
+def test_protocol_field_survives_as_int_list(m):
+    """'p' must decode (via cbor2 alone) to the exact int list — indexers
+    dispatch on it before any pyrxd code runs."""
+    cbor_bytes, _ = encode_payload(m)
+    raw = cbor2.loads(cbor_bytes)
+    assert raw["p"] == list(m.protocol)
+    assert all(type(p) is int for p in raw["p"])
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# 3. Reveal scriptSig envelope framing
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+def _read_pushes(script: bytes) -> list[bytes]:
+    """Test-local script-chunk reader (mirrors the RXinDexer port in
+    tests/test_cbor_cross_decoder.py). Returns push payloads in order."""
+    pushes = []
+    i = 0
+    while i < len(script):
+        op = script[i]
+        i += 1
+        if 1 <= op <= 0x4B:
+            pushes.append(script[i : i + op])
+            i += op
+        elif op == 0x4C:
+            n = script[i]
+            i += 1
+            pushes.append(script[i : i + n])
+            i += n
+        elif op == 0x4D:
+            n = int.from_bytes(script[i : i + 2], "little")
+            i += 2
+            pushes.append(script[i : i + n])
+            i += n
+        elif op == 0x4E:
+            n = int.from_bytes(script[i : i + 4], "little")
+            i += 4
+            pushes.append(script[i : i + n])
+            i += n
+        else:
+            raise AssertionError(f"unexpected opcode {op:#x} in reveal suffix")
+    assert i == len(script), "suffix must parse exactly, no trailing bytes"
+    return pushes
+
+
+# Push-boundary lengths (the off-by-one cliffs) plus random interior sizes.
+_boundary_lengths = st.sampled_from([1, 74, 75, 76, 255, 256, 65_535, 65_536, _MAX_CBOR_PAYLOAD_BYTES])
+_interior_lengths = st.integers(min_value=1, max_value=4096)
+
+
+@given(n=_boundary_lengths | _interior_lengths)
+@settings(max_examples=_budget(150), deadline=None, suppress_health_check=[HealthCheck.too_slow])
+def test_reveal_suffix_framing(n):
+    payload = b"\xab" * n
+    suffix = build_reveal_scriptsig_suffix(payload)
+    pushes = _read_pushes(suffix)
+    assert pushes == [b"gly", payload]
+    # Opcode selection per spec: direct/PUSHDATA1/2/4 by length.
+    op = suffix[4]  # byte after the 4-byte "\x03gly" marker push
+    if n <= 75:
+        assert op == n
+    elif n <= 255:
+        assert op == 0x4C
+    elif n <= 65_535:
+        assert op == 0x4D
+    else:
+        assert op == 0x4E
+
+
+def test_reveal_suffix_rejects_oversize():
+    with pytest.raises(ValidationError):
+        build_reveal_scriptsig_suffix(b"\x00" * (_MAX_CBOR_PAYLOAD_BYTES + 1))

--- a/tests/test_mutation_hardening.py
+++ b/tests/test_mutation_hardening.py
@@ -587,9 +587,20 @@ class TestTimelockScriptBytes:
         from pyrxd.script.timelock import CsvKind, build_csv_sequence
         from pyrxd.security.errors import ValidationError
 
+        assert build_csv_sequence(0, CsvKind.BLOCKS) == 0  # zero units valid
         for bad in (-1, 0x1_0000):
             with pytest.raises(ValidationError):
                 build_csv_sequence(bad, CsvKind.BLOCKS)
+
+    def test_csv_max_sequence_fails_on_disable_bit_not_range(self):
+        """sequence 0xFFFFFFFF is INSIDE the 32-bit range; it must be
+        rejected by the disable-bit guard specifically (kills the range
+        `<=` → `<` mutant, which would fire the wrong error first)."""
+        from pyrxd.script.timelock import build_p2pkh_with_csv_script
+        from pyrxd.security.errors import ValidationError
+
+        with pytest.raises(ValidationError, match="disable"):
+            build_p2pkh_with_csv_script(b"\xaa" * 20, 0xFFFFFFFF)
 
     def test_csv_script_rejects_disable_bit(self):
         from pyrxd.script.timelock import build_p2pkh_with_csv_script

--- a/tests/test_mutation_hardening.py
+++ b/tests/test_mutation_hardening.py
@@ -533,6 +533,82 @@ class TestDmintStateParserRejectsCorruption:
             DmintState.from_script(bytes(script))
 
 
+class TestTimelockScriptBytes:
+    """script/timelock.py — CSV/CLTV builder mutants. Expected bytes are
+    hand-assembled from the BIP-65/BIP-112 reference shapes in the module
+    docstring, never from the builders."""
+
+    def test_cltv_script_exact_bytes(self):
+        """Byte-for-byte against the BIP-65 reference shape:
+        <locktime> OP_CHECKLOCKTIMEVERIFY(0xb1) OP_DROP(0x75)
+        OP_DUP(0x76) OP_HASH160(0xa9) 0x14 <pkh> OP_EQUALVERIFY(0x88)
+        OP_CHECKSIG(0xac), locktime as a minimal script number (LE,
+        sign-bit padding)."""
+        from pyrxd.script.timelock import build_p2pkh_with_cltv_script
+
+        pkh = b"\xaa" * 20
+        tail = b"\x76\xa9\x14" + pkh + b"\x88\xac"
+        # 100 = 0x64, no sign bit → single-byte push
+        assert build_p2pkh_with_cltv_script(pkh, 100) == b"\x01\x64\xb1\x75" + tail
+        # 500_000_000 = 0x1DCD6500 → LE 00 65 cd 1d, 4-byte push (the
+        # BIP-65 height/time threshold value itself)
+        assert build_p2pkh_with_cltv_script(pkh, 500_000_000) == b"\x04\x00\x65\xcd\x1d\xb1\x75" + tail
+
+    def test_csv_script_exact_bytes_with_sign_padding(self):
+        """144 = 0x90 has the sign bit set, so the minimal script number is
+        90 00 (two bytes) — a padding rule a wrong encoder silently breaks.
+        OP_CHECKSEQUENCEVERIFY is 0xb2."""
+        from pyrxd.script.timelock import build_p2pkh_with_csv_script
+
+        pkh = b"\xaa" * 20
+        tail = b"\x76\xa9\x14" + pkh + b"\x88\xac"
+        assert build_p2pkh_with_csv_script(pkh, 144) == b"\x02\x90\x00\xb2\x75" + tail
+
+    def test_cltv_locktime_bounds(self):
+        from pyrxd.script.timelock import build_p2pkh_with_cltv_script
+        from pyrxd.security.errors import ValidationError
+
+        pkh = b"\xaa" * 20
+        assert build_p2pkh_with_cltv_script(pkh, 0)  # boundary: 0 valid
+        assert build_p2pkh_with_cltv_script(pkh, 0xFFFFFFFF)  # max valid
+        for bad in (-1, 0x1_0000_0000):
+            with pytest.raises(ValidationError):
+                build_p2pkh_with_cltv_script(pkh, bad)
+
+    def test_csv_sequence_encoding_per_bip112(self):
+        from pyrxd.script.timelock import CsvKind, build_csv_sequence
+
+        # blocks: the value IS the unit count; time: bit 22 set, per BIP-112.
+        assert build_csv_sequence(144, CsvKind.BLOCKS) == 144
+        assert build_csv_sequence(144, CsvKind.TIME_512_SECONDS) == 144 | (1 << 22)
+        assert build_csv_sequence(0xFFFF, CsvKind.BLOCKS) == 0xFFFF  # max units
+
+    def test_csv_sequence_bounds(self):
+        from pyrxd.script.timelock import CsvKind, build_csv_sequence
+        from pyrxd.security.errors import ValidationError
+
+        for bad in (-1, 0x1_0000):
+            with pytest.raises(ValidationError):
+                build_csv_sequence(bad, CsvKind.BLOCKS)
+
+    def test_csv_script_rejects_disable_bit(self):
+        from pyrxd.script.timelock import build_p2pkh_with_csv_script
+        from pyrxd.security.errors import ValidationError
+
+        pkh = b"\xaa" * 20
+        assert build_p2pkh_with_csv_script(pkh, 144)  # valid sequence
+        with pytest.raises(ValidationError, match="disable"):
+            build_p2pkh_with_csv_script(pkh, 144 | (1 << 31))
+
+    def test_pkh_length_guard(self):
+        from pyrxd.script.timelock import build_p2pkh_with_cltv_script
+        from pyrxd.security.errors import ValidationError
+
+        for bad in (b"\xaa" * 19, b"\xaa" * 21):
+            with pytest.raises(ValidationError):
+                build_p2pkh_with_cltv_script(bad, 100)
+
+
 class TestSignValidation:
     """transaction.py — sign()'s missing-amount validation mutants (L106–108)."""
 

--- a/tests/test_mutation_hardening.py
+++ b/tests/test_mutation_hardening.py
@@ -1050,6 +1050,79 @@ class TestDmintV1StateParserGuards:
         assert DmintState.__dataclass_params__.frozen is True
 
 
+class TestDmintV1BuilderGuards:
+    """glyph/dmint/builders.py — V1 builder constants and guards."""
+
+    def test_v1_algo_byte_map_exact(self):
+        """The algo selector bytes are consensus bytes in the V1 epilogue:
+        OP_HASH256 0xAA / OP_BLAKE3 0xEE / OP_K12 0xEF."""
+        from pyrxd.glyph.dmint import DmintAlgo
+        from pyrxd.glyph.dmint.builders import _V1_ALGO_BYTE_TO_ENUM, _V1_ENUM_TO_ALGO_BYTE
+
+        assert _V1_ALGO_BYTE_TO_ENUM == {
+            0xAA: DmintAlgo.SHA256D,
+            0xEE: DmintAlgo.BLAKE3,
+            0xEF: DmintAlgo.K12,
+        }
+        assert _V1_ENUM_TO_ALGO_BYTE[DmintAlgo.BLAKE3] == 0xEE
+
+    def test_v1_epilogue_length_is_145(self):
+        """docs/dmint-research-mainnet.md §2.2: the V1 code epilogue is a
+        145-byte fixed template (prefix + 1 algo byte + suffix)."""
+        from pyrxd.glyph.dmint import DmintAlgo
+        from pyrxd.glyph.dmint.builders import _V1_EPILOGUE_LEN, build_dmint_v1_code_script
+
+        assert _V1_EPILOGUE_LEN == 145
+        assert len(build_dmint_v1_code_script(DmintAlgo.SHA256D)) == 145
+
+    def test_v1_code_script_rejects_unknown_algo(self):
+        from pyrxd.glyph.dmint.builders import build_dmint_v1_code_script
+        from pyrxd.security.errors import ValidationError
+
+        with pytest.raises(ValidationError):
+            build_dmint_v1_code_script(99)  # not a DmintAlgo member
+
+    def test_v1_state_script_guards(self):
+        from pyrxd.glyph.dmint.builders import build_dmint_v1_state_script
+        from pyrxd.glyph.types import GlyphRef
+        from pyrxd.security.errors import ValidationError
+
+        refs = dict(contract_ref=GlyphRef(txid="33" * 32, vout=1), token_ref=GlyphRef(txid="33" * 32, vout=0))
+        ok = dict(height=0, max_height=1, reward=1, target=1, **refs)
+        assert build_dmint_v1_state_script(**ok)
+        assert build_dmint_v1_state_script(**{**ok, "target": 0x7FFFFFFFFFFFFFFF})
+        for field, bad in (("max_height", 0), ("reward", 0), ("target", 0)):
+            with pytest.raises(ValidationError):
+                build_dmint_v1_state_script(**{**ok, field: bad})
+        # exhausted contract: height == max_height must be rejected,
+        # height == max_height - 1 accepted
+        with pytest.raises(ValidationError):
+            build_dmint_v1_state_script(**{**ok, "height": 1})
+
+    def test_v1_ft_output_pkh_guard(self):
+        from pyrxd.glyph.dmint.builders import build_dmint_v1_ft_output_script
+        from pyrxd.glyph.types import GlyphRef
+        from pyrxd.security.errors import ValidationError
+
+        ref = GlyphRef(txid="33" * 32, vout=0)
+        script = build_dmint_v1_ft_output_script(b"\xaa" * 20, ref)
+        assert len(script) == 75  # documented total (§4 vout[1])
+        for bad in (b"\xaa" * 19, b"\xaa" * 21):
+            with pytest.raises(ValidationError):
+                build_dmint_v1_ft_output_script(bad, ref)
+
+    def test_part_b_defaults_match_explicit(self):
+        """The documented defaults (half_life 3600, epoch 2016, log2 2) must
+        be what the no-arg form actually builds."""
+        from pyrxd.glyph.dmint import DaaMode
+        from pyrxd.glyph.dmint.builders import _build_part_b
+
+        assert _build_part_b(DaaMode.ASERT) == _build_part_b(DaaMode.ASERT, 3600)
+        assert _build_part_b(DaaMode.EPOCH) == _build_part_b(
+            DaaMode.EPOCH, 3600, epoch_length=2016, max_adjustment_log2=2
+        )
+
+
 class TestSignValidation:
     """transaction.py — sign()'s missing-amount validation mutants (L106–108)."""
 

--- a/tests/test_mutation_hardening.py
+++ b/tests/test_mutation_hardening.py
@@ -384,6 +384,155 @@ class TestDmintParamsValidation:
                 DmintCborPayload(**kwargs)
 
 
+class TestTransactionInputConstruction:
+    """transaction_input.py — constructor mutants."""
+
+    def test_default_output_index_is_zero(self):
+        assert TransactionInput(source_txid="ab" * 32).source_output_index == 0
+
+    def test_no_source_at_all_leaves_txid_none(self):
+        """Kills the L28 `and not` → `or not` survivor, which would call
+        .txid() on a None source_transaction."""
+        tx_in = TransactionInput()
+        assert tx_in.source_txid is None
+
+
+class TestTransactionOutputWire:
+    """transaction_output.py — constructor default + from_hex guard mutants."""
+
+    def test_default_is_not_change(self):
+        assert TransactionOutput(Script(_P2PKH_AA), 1_000).change is False
+
+    def test_from_hex_accepts_large_script_exactly(self):
+        """Kills the L54 `!=` → `is not` survivor: for a >256-byte script the
+        two equal lengths are distinct int objects, so `is not` would reject
+        a VALID output. 300 bytes also exercises the 0xfd varint form."""
+        script = bytes([0x4C, 0x2C]) + b"\xee" * 44 + b"\x51" * 254  # 300 bytes total
+        raw = (5_000).to_bytes(8, "little") + b"\xfd\x2c\x01" + script
+        out = TransactionOutput.from_hex(raw)
+        assert out is not None
+        assert out.locking_script.serialize() == script
+        assert out.satoshis == 5_000
+
+    def test_from_hex_rejects_truncated_script(self):
+        """The varint over-claim guard (hashOutputHashes corruption class):
+        claiming 300 bytes with fewer available must yield None, not a
+        silently truncated output."""
+        script = b"\x51" * 100
+        raw = (5_000).to_bytes(8, "little") + b"\xfd\x2c\x01" + script
+        assert TransactionOutput.from_hex(raw) is None
+
+
+class TestDmintScriptIntParser:
+    """glyph/dmint/chain.py — _parse_script_int/_decode_script_le_int
+    mutants. Expected values re-derived from the Bitcoin script-number
+    encoding rules (little-endian, sign bit = MSB of last byte)."""
+
+    def test_opcode_forms(self):
+        from pyrxd.glyph.dmint.chain import _parse_script_int
+
+        assert _parse_script_int(b"\x00", 0) == (0, 1)
+        assert _parse_script_int(b"\x4f", 0) == (-1, 1)
+        assert _parse_script_int(b"\x51", 0) == (1, 1)  # OP_1 boundary
+        assert _parse_script_int(b"\x60", 0) == (16, 1)  # OP_16 boundary
+
+    def test_direct_push_forms_and_positions(self):
+        from pyrxd.glyph.dmint.chain import _parse_script_int
+
+        assert _parse_script_int(b"\x01\x11", 0) == (0x11, 2)
+        # little-endian multi-byte with position advance
+        assert _parse_script_int(b"\xff\x02\x34\x12\xff", 1) == (0x1234, 4)
+        # sign bit: 0x81 encodes -1, 0xff,0x80 encodes -255
+        assert _parse_script_int(b"\x01\x81", 0) == (-1, 2)
+        assert _parse_script_int(b"\x02\xff\x80", 0) == (-255, 3)
+
+    def test_pushdata1_form(self):
+        from pyrxd.glyph.dmint.chain import _parse_script_int
+
+        payload = (123456789).to_bytes(4, "little")
+        assert _parse_script_int(b"\x4c\x04" + payload, 0) == (123456789, 6)
+
+    def test_truncated_pushes_raise(self):
+        from pyrxd.glyph.dmint.chain import _parse_script_int
+
+        for bad in (b"\x02\x01", b"\x4c", b"\x4c\x04\x01"):
+            with pytest.raises(Exception):
+                _parse_script_int(bad, 0)
+
+
+class TestDmintStateParserRejectsCorruption:
+    """glyph/dmint/chain.py — _from_v2_script guard mutants: a valid built
+    contract corrupted at documented layout offsets must be REJECTED, and
+    the offsets are computed from the layout, not the parser."""
+
+    @staticmethod
+    def _contract() -> bytes:
+        from pyrxd.glyph.dmint import DaaMode, DmintAlgo, DmintDeployParams, build_dmint_contract_script
+        from pyrxd.glyph.types import GlyphRef
+
+        return build_dmint_contract_script(
+            DmintDeployParams(
+                contract_ref=GlyphRef(txid="11" * 32, vout=1),
+                token_ref=GlyphRef(txid="11" * 32, vout=0),
+                max_height=10,
+                reward=1000,
+                difficulty=1,
+                algo=DmintAlgo.SHA256D,
+                daa_mode=DaaMode.FIXED,
+            )
+        )
+
+    def test_valid_contract_parses(self):
+        from pyrxd.glyph.dmint.chain import DmintState
+
+        assert DmintState.from_script(self._contract()).max_height == 10
+
+    def test_wrong_tokenref_opcode_rejected(self):
+        from pyrxd.glyph.dmint.chain import DmintState
+        from pyrxd.security.errors import ValidationError
+
+        script = bytearray(self._contract())
+        # layout: height push (1B for height 0) + d8+36 → tokenRef d0 at 38
+        assert script[38] == 0xD0
+        script[38] = 0xD1
+        with pytest.raises(ValidationError):
+            DmintState.from_script(bytes(script))
+
+    def test_truncated_contract_ref_rejected(self):
+        from pyrxd.glyph.dmint.chain import DmintState
+        from pyrxd.security.errors import ValidationError
+
+        script = self._contract()
+        # cut inside the 36-byte contractRef payload (offset 2..37)
+        with pytest.raises(ValidationError):
+            DmintState.from_script(script[:20])
+
+    def test_wrong_lasttime_push_width_rejected(self):
+        from pyrxd.glyph.dmint.chain import DmintState
+        from pyrxd.security.errors import ValidationError
+
+        script = bytearray(self._contract())
+        # lastTime is the fixed 4-byte push after the five numeric slots;
+        # locate it from the layout: 1 (height) + 37 + 37 + 5 pushes for
+        # maxHeight(1B opcode-form? no: 10 → 0x01 0x0a = 2B) …
+        # Simpler and layout-true: find the documented 04-push preceding the
+        # target slot by scanning for the exact 0x04 || last_time(=0) window.
+        idx = bytes(script).index(b"\x04\x00\x00\x00\x00")
+        script[idx] = 0x05
+        with pytest.raises(ValidationError):
+            DmintState.from_script(bytes(script))
+
+    def test_missing_state_separator_rejected(self):
+        from pyrxd.glyph.dmint.chain import DmintState
+        from pyrxd.security.errors import ValidationError
+
+        script = bytearray(self._contract())
+        sep = bytes(script).index(b"\xbd")
+        script[sep] = 0xBE
+        with pytest.raises(ValidationError):
+            DmintState.from_script(bytes(script))
+
+
 class TestSignValidation:
     """transaction.py — sign()'s missing-amount validation mutants (L106–108)."""
 

--- a/tests/test_mutation_hardening.py
+++ b/tests/test_mutation_hardening.py
@@ -993,6 +993,63 @@ class TestDmintDaaBoundaries:
             mine_solution(preimage, 1, algo=DmintAlgo.BLAKE3)
 
 
+class TestDmintV1StateParserGuards:
+    """glyph/dmint/chain.py — _from_v1_script slot guards (L362–L400),
+    exercised by corrupting a valid built V1 contract at the fixed-width
+    layout offsets (docs/dmint-research-mainnet.md §2.2)."""
+
+    @staticmethod
+    def _v1_contract() -> bytes:
+        from pyrxd.glyph.dmint import DmintAlgo
+        from pyrxd.glyph.dmint.builders import build_dmint_v1_contract_script
+        from pyrxd.glyph.types import GlyphRef
+
+        return build_dmint_v1_contract_script(
+            height=3,
+            contract_ref=GlyphRef(txid="22" * 32, vout=1),
+            token_ref=GlyphRef(txid="22" * 32, vout=0),
+            max_height=100,
+            reward=5000,
+            target=0x00000000FFFF0000,
+            algo=DmintAlgo.SHA256D,
+        )
+
+    def test_v1_roundtrip(self):
+        from pyrxd.glyph.dmint.chain import DmintState
+
+        st = DmintState.from_script(self._v1_contract())
+        assert st.is_v1
+        assert (st.height, st.max_height, st.reward) == (3, 100, 5000)
+        assert st.target == 0x00000000FFFF0000
+        assert st.contract_ref.vout == 1
+        assert st.token_ref.vout == 0
+
+    def test_v1_corruptions_rejected(self):
+        from pyrxd.glyph.dmint.chain import DmintState
+        from pyrxd.security.errors import ValidationError
+
+        good = self._v1_contract()
+        # V1 layout: 04 height(4) | d8 ref(36) | d0 ref(36) | maxHeight |
+        # reward | 08 target(8) | 0xbd epilogue
+        assert good[0] == 0x04
+        assert good[5] == 0xD8
+        assert good[42] == 0xD0
+        corruptions = [
+            bytes([0x05]) + good[1:],  # wrong height push width
+            good[:5] + bytes([0xD1]) + good[6:],  # wrong contractRef opcode
+            good[:42] + bytes([0xD1]) + good[43:],  # wrong tokenRef opcode
+            good[:30],  # truncated inside contractRef
+        ]
+        for bad in corruptions:
+            with pytest.raises(ValidationError):
+                DmintState.from_script(bad)
+
+    def test_chain_dataclasses_frozen(self):
+        from pyrxd.glyph.dmint.chain import DmintState
+
+        assert DmintState.__dataclass_params__.frozen is True
+
+
 class TestSignValidation:
     """transaction.py — sign()'s missing-amount validation mutants (L106–108)."""
 

--- a/tests/test_mutation_hardening.py
+++ b/tests/test_mutation_hardening.py
@@ -270,6 +270,21 @@ class TestFromAsm:
         with pytest.raises(ValueError):
             Script.from_asm("zz")
 
+    def test_non_canonical_hex_token_rejected(self):
+        """Uppercase hex parses via fromhex but is NOT canonical; the
+        round-trip check must reject it (kills the `!=` → `is` survivor,
+        which never fires because .hex() returns a fresh string)."""
+        with pytest.raises(ValueError):
+            Script.from_asm("AA")
+
+    def test_token_index_arithmetic_at_distinguishing_positions(self):
+        """Token cursors advance by +1/+3; the XOR/OR mutants coincide with
+        addition at index 0/1, so pin shapes where they diverge (hex token
+        at odd index, PUSHDATA form starting at index 2)."""
+        assert Script.from_asm("OP_1 aa OP_1").hex() == "5101aa51"
+        s = Script.from_asm("OP_1 OP_1 OP_PUSHDATA1 4c " + "ef" * 76)
+        assert s.hex() == "5151" + "4c4c" + "ef" * 76
+
 
 class TestDmintParamsValidation:
     """glyph/dmint/types.py — __post_init__ boundary mutants. Each guard

--- a/tests/test_mutation_hardening.py
+++ b/tests/test_mutation_hardening.py
@@ -708,6 +708,65 @@ class TestPushRefScannerGuards:
         assert _get_push_refs(b"\x01\xd0") == []
 
 
+class TestDmintCborPayloadDecode:
+    """glyph/dmint/types.py — from_cbor_dict default/except mutants."""
+
+    def test_minimal_dict_defaults(self):
+        """Absent optional keys must take the DOCUMENTED defaults (Photonic
+        DmintPayload semantics): numContracts 1, premine 0, FIXED DAA at
+        60s target."""
+        from pyrxd.glyph.dmint import DaaMode, DmintAlgo
+        from pyrxd.glyph.dmint.types import DmintCborPayload
+
+        p = DmintCborPayload.from_cbor_dict({"algo": 0, "maxHeight": 5, "reward": 10, "diff": 1})
+        assert p.algo == DmintAlgo.SHA256D
+        assert p.num_contracts == 1
+        assert p.premine == 0
+        assert p.daa_mode == DaaMode.FIXED
+        assert p.target_block_time == 60
+        assert p.half_life == 0
+        assert p.window_size == 0
+
+    def test_daa_subdict_defaults(self):
+        from pyrxd.glyph.dmint import DaaMode
+        from pyrxd.glyph.dmint.types import DmintCborPayload
+
+        p = DmintCborPayload.from_cbor_dict({"algo": 0, "maxHeight": 5, "reward": 10, "diff": 1, "daa": {"mode": 2}})
+        assert p.daa_mode == DaaMode.ASERT
+        assert p.target_block_time == 60  # daa present, targetBlockTime absent
+
+    def test_missing_and_invalid_algo_are_validation_errors(self):
+        """Kills the ExceptionReplacer mutants on the (KeyError, ValueError)
+        handler: BOTH failure shapes must surface as ValidationError, never
+        a raw KeyError/ValueError."""
+        from pyrxd.glyph.dmint.types import DmintCborPayload
+        from pyrxd.security.errors import ValidationError
+
+        with pytest.raises(ValidationError, match="algo"):
+            DmintCborPayload.from_cbor_dict({"maxHeight": 5, "reward": 10, "diff": 1})
+        with pytest.raises(ValidationError, match="algo"):
+            DmintCborPayload.from_cbor_dict({"algo": 99, "maxHeight": 5, "reward": 10, "diff": 1})
+
+    def test_missing_required_field_is_validation_error(self):
+        from pyrxd.glyph.dmint.types import DmintCborPayload
+        from pyrxd.security.errors import ValidationError
+
+        with pytest.raises(ValidationError):
+            DmintCborPayload.from_cbor_dict({"algo": 0, "reward": 10, "diff": 1})  # no maxHeight
+
+    def test_payload_dataclasses_frozen(self):
+        import dataclasses
+
+        from pyrxd.glyph.dmint import DmintAlgo
+        from pyrxd.glyph.dmint.types import DmintCborPayload, DmintV1ContractInitialState
+
+        p = DmintCborPayload(algo=DmintAlgo.SHA256D, num_contracts=1, max_height=1, reward=0, premine=0, diff=1)
+        with pytest.raises(dataclasses.FrozenInstanceError):
+            p.reward = 5
+        assert dataclasses.fields(DmintV1ContractInitialState)  # class exists, frozen checked below
+        assert DmintV1ContractInitialState.__dataclass_params__.frozen is True
+
+
 class TestSignValidation:
     """transaction.py — sign()'s missing-amount validation mutants (L106–108)."""
 

--- a/tests/test_mutation_hardening.py
+++ b/tests/test_mutation_hardening.py
@@ -151,6 +151,239 @@ class TestTransactionAccounting:
             tx.fee(0, change_distribution="random")
 
 
+class TestWireFormats:
+    """transaction.py — from_beef guard and parse_script_offsets mutants."""
+
+    def test_from_beef_rejects_wrong_version_below_magic(self):
+        """Kills the L244 `!=` → `>` survivor: a version BELOW the BEEF magic
+        (4022206465) must raise, not fall through to parsing garbage."""
+        tx = Transaction(tx_outputs=[_out(_P2PKH_AA, 1_000)])
+        good = (4022206465).to_bytes(4, "little") + b"\x00" + b"\x01" + tx.serialize() + b"\x00"
+        assert Transaction.from_beef(good).txid() == tx.txid()
+        bad = (1).to_bytes(4, "little") + good[4:]
+        with pytest.raises(ValueError, match="BEEF version"):
+            Transaction.from_beef(bad)
+
+    def test_parse_script_offsets_exact_slices(self):
+        """Kills the parse_script_offsets skip-arithmetic survivors
+        (L416–L429): every reported (offset, length) must slice the raw tx
+        back to the exact script bytes, across multiple inputs/outputs with
+        distinct script lengths."""
+        in_a, in_b = _in(txid="11" * 32), _in(txid="22" * 32)
+        in_a.unlocking_script = Script(b"\x51" * 7)
+        in_b.unlocking_script = Script(b"\x52" * 19)
+        tx = Transaction(
+            tx_inputs=[in_a, in_b],
+            tx_outputs=[_out(_P2PKH_AA, 1_000), _out(_P2PKH_BB, 2_000)],
+        )
+        raw = tx.serialize()
+        offsets = Transaction.parse_script_offsets(raw)
+        assert [i["vin"] for i in offsets["inputs"]] == [0, 1]
+        assert [o["vout"] for o in offsets["outputs"]] == [0, 1]
+        for rec, script in zip(offsets["inputs"], [b"\x51" * 7, b"\x52" * 19]):
+            assert raw[rec["offset"] : rec["offset"] + rec["length"]] == script
+        for rec, script in zip(offsets["outputs"], [_P2PKH_AA, _P2PKH_BB]):
+            assert raw[rec["offset"] : rec["offset"] + rec["length"]] == script
+
+
+class TestScriptChunkParsing:
+    """script/script.py — _build_chunks parser mutants (L45–L67). The chunk
+    view feeds to_asm/find_and_delete; no prior test asserted parsed chunk
+    DATA, so every push-dispatch comparison survived."""
+
+    def test_p2pkh_chunks_carry_exact_push_data(self):
+        s = Script(_P2PKH_AA)
+        ops = [c.op for c in s.chunks]
+        assert ops == [b"\x76", b"\xa9", b"\x14", b"\x88", b"\xac"]
+        assert s.chunks[2].data == b"\xaa" * 20
+        assert s.chunks[0].data is None
+
+    def test_direct_push_boundary_75_bytes(self):
+        """op == 0x4b is the LAST direct-push opcode; `<= 0x4b` → `< 0x4b`
+        must not drop its payload."""
+        payload = bytes(range(75))
+        s = Script(bytes([0x4B]) + payload)
+        assert len(s.chunks) == 1
+        assert s.chunks[0].data == payload
+
+    def test_pushdata_1_2_4_dispatch(self):
+        payload = b"\xcd" * 80
+        for opcode, len_bytes in (
+            (b"\x4c", (80).to_bytes(1, "little")),
+            (b"\x4d", (80).to_bytes(2, "little")),
+            (b"\x4e", (80).to_bytes(4, "little")),
+        ):
+            s = Script(opcode + len_bytes + payload)
+            assert len(s.chunks) == 1, f"opcode {opcode.hex()}"
+            assert s.chunks[0].data == payload, f"opcode {opcode.hex()}"
+
+    def test_script_equality_is_not_ordering(self):
+        """__eq__ `==` → `>=` survivor: equality must be symmetric-false for
+        two different scripts regardless of byte order."""
+        lo, hi = Script(b"\x51"), Script(b"\x52")
+        assert lo == Script(b"\x51")
+        # NB: `!=` falls back to object identity (no __ne__), so the kill
+        # must go through __eq__ from both sides explicitly.
+        assert (lo == hi) is False
+        assert (hi == lo) is False
+
+    def test_find_and_delete_keeps_nonmatching_chunks(self):
+        source = Script.from_chunks(Script(_P2PKH_AA).chunks)
+        pattern = Script(b"\x76")  # OP_DUP
+        remaining = Script.find_and_delete(source, pattern)
+        assert remaining.serialize() == _P2PKH_AA[1:]
+
+
+class TestFromAsm:
+    """script/script.py — from_asm token handling mutants (L113–L162)."""
+
+    def test_op_false_normalizes_to_op_0(self):
+        assert Script.from_asm("OP_FALSE").hex() == "00"
+        assert Script.from_asm("0").hex() == "00"
+
+    def test_minus_one_is_op_1negate_not_zero(self):
+        """Kills the L126 `== "0"` → `<= "0"` survivor ("-1" sorts before
+        "0" lexicographically and would be swallowed by the zero branch)."""
+        assert Script.from_asm("-1").hex() == "4f"
+
+    def test_hex_push_encodings_by_length(self):
+        """Kills the L142–L148 push-size boundary survivors: 75 bytes stays
+        a direct push, 76..255 → PUSHDATA1, 256..65535 → PUSHDATA2."""
+        for n, prefix in ((75, "4b"), (76, "4c4c"), (255, "4cff"), (256, "4d0001")):
+            asm = "ab" * n
+            assert Script.from_asm(asm).hex() == prefix + "ab" * n, f"len {n}"
+
+    def test_pushdata_token_form_roundtrip(self):
+        """OP_PUSHDATAx SIZE DATA consumes exactly three tokens (L151–L158
+        index arithmetic)."""
+        s = Script.from_asm("OP_PUSHDATA1 4c " + "ef" * 76 + " OP_CHECKSIG")
+        assert s.hex() == "4c4c" + "ef" * 76 + "ac"
+
+    def test_unknown_op_token_is_value_error(self):
+        """Kills the L122 `and` → `or` survivor: an OP_-prefixed token that
+        is NOT a known opcode must fail hex validation (ValueError), not
+        KeyError into the opcode table."""
+        with pytest.raises(ValueError):
+            Script.from_asm("OP_NOT_A_REAL_OPCODE")
+
+    def test_invalid_hex_token_rejected(self):
+        with pytest.raises(ValueError):
+            Script.from_asm("zz")
+
+
+class TestDmintParamsValidation:
+    """glyph/dmint/types.py — __post_init__ boundary mutants. Each guard
+    gets its exact boundary: the smallest VALID value must construct and the
+    first INVALID value must raise, so `<` → `<=` (and friends) all die."""
+
+    @staticmethod
+    def _params(**overrides):
+        from pyrxd.glyph.dmint import DaaMode, DmintAlgo, DmintDeployParams
+        from pyrxd.glyph.types import GlyphRef
+
+        base = dict(
+            contract_ref=GlyphRef(txid="11" * 32, vout=1),
+            token_ref=GlyphRef(txid="11" * 32, vout=0),
+            max_height=10,
+            reward=1000,
+            difficulty=1,
+            algo=DmintAlgo.SHA256D,
+            daa_mode=DaaMode.FIXED,
+        )
+        base.update(overrides)
+        return DmintDeployParams(**base)
+
+    def test_boundary_minimums(self):
+        from pyrxd.security.errors import ValidationError
+
+        p = self._params(max_height=1, reward=1, difficulty=1, target_time=1, half_life=1)
+        assert (p.max_height, p.reward, p.difficulty, p.target_time, p.half_life) == (1, 1, 1, 1, 1)
+        for field, bad in (
+            ("max_height", 0),
+            ("reward", 0),
+            ("difficulty", 0),
+            ("target_time", 0),
+            ("half_life", 0),
+            ("height", -1),
+            ("last_time", -1),
+        ):
+            with pytest.raises(ValidationError):
+                self._params(**{field: bad})
+
+    def test_documented_defaults(self):
+        p = self._params()
+        assert p.target_time == 60
+        assert p.half_life == 3600
+        assert p.height == 0
+        assert p.last_time == 0
+        assert p.epoch_length == 2016
+        assert p.max_adjustment_log2 == 2
+
+    def test_params_are_frozen(self):
+        import dataclasses
+
+        with pytest.raises(dataclasses.FrozenInstanceError):
+            self._params().max_height = 99
+
+    def test_max_v2_target_is_2_256_minus_1(self):
+        from pyrxd.glyph.dmint import DmintAlgo
+
+        p = self._params(algo=DmintAlgo.BLAKE3, difficulty=1)
+        assert p.initial_target == (1 << 256) - 1
+
+    def test_schedule_boundaries(self):
+        from pyrxd.glyph.dmint import DaaMode
+        from pyrxd.security.errors import ValidationError
+
+        # height 0 in the first entry is VALID (prev_h starts at -1, not -0)
+        p = self._params(daa_mode=DaaMode.SCHEDULE, schedule=((0, 1000),))
+        assert p.schedule == ((0, 1000),)
+        # exactly 10 entries allowed, 11 rejected
+        ok = tuple((h, 1000) for h in range(10))
+        assert self._params(daa_mode=DaaMode.SCHEDULE, schedule=ok).schedule == ok
+        with pytest.raises(ValidationError, match="at most"):
+            self._params(daa_mode=DaaMode.SCHEDULE, schedule=tuple((h, 1000) for h in range(11)))
+        with pytest.raises(ValidationError, match="height must be >= 0"):
+            self._params(daa_mode=DaaMode.SCHEDULE, schedule=((-1, 1000),))
+        with pytest.raises(ValidationError, match="ascending"):
+            self._params(daa_mode=DaaMode.SCHEDULE, schedule=((5, 1000), (5, 2000)))
+        with pytest.raises(ValidationError, match="non-empty"):
+            self._params(daa_mode=DaaMode.SCHEDULE, schedule=())
+
+    def test_epoch_guards(self):
+        from pyrxd.glyph.dmint import DaaMode
+        from pyrxd.security.errors import ValidationError
+
+        min_diff = 0x7FFFFFFFFFFFFFFF // (1 << 48) + 1
+        p = self._params(daa_mode=DaaMode.EPOCH, difficulty=min_diff, epoch_length=1)
+        assert p.epoch_length == 1
+        with pytest.raises(ValidationError):
+            self._params(daa_mode=DaaMode.EPOCH, difficulty=min_diff, epoch_length=0)
+        with pytest.raises(ValidationError, match="2\\^48"):
+            self._params(daa_mode=DaaMode.EPOCH, difficulty=1)
+        with pytest.raises(ValidationError, match="max_adjustment_log2"):
+            self._params(daa_mode=DaaMode.EPOCH, difficulty=min_diff, max_adjustment_log2=5)
+
+    def test_cbor_payload_guards(self):
+        from pyrxd.glyph.dmint import DmintAlgo
+        from pyrxd.glyph.dmint.types import DmintCborPayload
+        from pyrxd.security.errors import ValidationError
+
+        ok = DmintCborPayload(algo=DmintAlgo.SHA256D, num_contracts=1, max_height=1, reward=0, premine=0, diff=1)
+        assert (ok.num_contracts, ok.max_height, ok.reward, ok.premine, ok.diff) == (1, 1, 0, 0, 1)
+        for field, bad in (
+            ("num_contracts", 0),
+            ("max_height", 0),
+            ("reward", -1),
+            ("premine", -1),
+            ("diff", 0),
+        ):
+            kwargs = dict(algo=DmintAlgo.SHA256D, num_contracts=1, max_height=1, reward=0, premine=0, diff=1)
+            kwargs[field] = bad
+            with pytest.raises(ValidationError):
+                DmintCborPayload(**kwargs)
+
+
 class TestSignValidation:
     """transaction.py — sign()'s missing-amount validation mutants (L106–108)."""
 

--- a/tests/test_mutation_hardening.py
+++ b/tests/test_mutation_hardening.py
@@ -679,6 +679,35 @@ class TestDmintPushEncoders:
         assert _encode_data_push(b"\xee" * 65536) == b"\x4e\x00\x00\x01\x00" + b"\xee" * 65536
 
 
+class TestPushRefScannerGuards:
+    """transaction_preimage.py — _get_push_refs truncation guards. The
+    differential suite only generates WELL-FORMED scripts, so the malformed
+    branch needs direct pins (consensus context: a silently short ref would
+    corrupt hashOutputHashes)."""
+
+    def test_ref_ending_exactly_at_script_end_is_valid(self):
+        from pyrxd.transaction.transaction_preimage import _get_push_refs
+
+        ref = bytes(range(36))
+        assert _get_push_refs(b"\xd0" + ref) == [ref]
+        assert _get_push_refs(b"\xd8" + ref) == [ref]
+
+    def test_truncated_ref_raises(self):
+        from pyrxd.security.errors import ValidationError
+        from pyrxd.transaction.transaction_preimage import _get_push_refs
+
+        for short in (0, 1, 35):
+            with pytest.raises(ValidationError, match="truncated pushref"):
+                _get_push_refs(b"\xd0" + bytes(range(short)))
+
+    def test_single_byte_push_is_not_an_opcode(self):
+        """A 1-byte direct push must consume its payload: [0x01, 0xd0]
+        contains NO pushref (the 0xd0 is data, not an opcode)."""
+        from pyrxd.transaction.transaction_preimage import _get_push_refs
+
+        assert _get_push_refs(b"\x01\xd0") == []
+
+
 class TestSignValidation:
     """transaction.py — sign()'s missing-amount validation mutants (L106–108)."""
 

--- a/tests/test_mutation_hardening.py
+++ b/tests/test_mutation_hardening.py
@@ -1064,6 +1064,40 @@ class TestDmintV1StateParserGuards:
 
         assert DmintState.__dataclass_params__.frozen is True
 
+    def test_is_exhausted_beyond_max_height(self):
+        """`>=` → `==` survivor: a state with height PAST max_height (e.g.
+        parsed from a hostile UTXO) must still read as exhausted."""
+        from pyrxd.glyph.dmint import DaaMode, DmintAlgo
+        from pyrxd.glyph.dmint.chain import DmintState
+        from pyrxd.glyph.types import GlyphRef
+
+        ref = GlyphRef(txid="44" * 32, vout=0)
+        st = DmintState(
+            height=5,
+            contract_ref=ref,
+            token_ref=ref,
+            max_height=3,
+            reward=1,
+            algo=DmintAlgo.SHA256D,
+            daa_mode=DaaMode.FIXED,
+            target_time=60,
+            last_time=0,
+            target=1,
+        )
+        assert st.is_exhausted
+        assert not DmintState(
+            height=2,
+            contract_ref=ref,
+            token_ref=ref,
+            max_height=3,
+            reward=1,
+            algo=DmintAlgo.SHA256D,
+            daa_mode=DaaMode.FIXED,
+            target_time=60,
+            last_time=0,
+            target=1,
+        ).is_exhausted
+
 
 class TestDmintV1BuilderGuards:
     """glyph/dmint/builders.py — V1 builder constants and guards."""

--- a/tests/test_mutation_hardening.py
+++ b/tests/test_mutation_hardening.py
@@ -609,6 +609,65 @@ class TestTimelockScriptBytes:
                 build_p2pkh_with_cltv_script(bad, 100)
 
 
+class TestDmintPushEncoders:
+    """glyph/dmint/builders.py — _push_minimal/_encode_data_push mutants.
+    The negative-number and PUSHDATA branches never execute for valid dMint
+    params, so they only die to direct unit pins against the script
+    minimal-encoding rules (same rules as TestDmintScriptIntParser, from
+    the encode side)."""
+
+    def test_push_minimal_opcode_forms(self):
+        from pyrxd.glyph.dmint.builders import _push_minimal
+
+        assert _push_minimal(0) == b"\x00"
+        assert _push_minimal(-1) == b"\x4f"
+        assert _push_minimal(1) == b"\x51"
+        assert _push_minimal(16) == b"\x60"
+        assert _push_minimal(17) == b"\x01\x11"  # first non-opcode value
+
+    def test_push_minimal_sign_bit_rules(self):
+        from pyrxd.glyph.dmint.builders import _push_minimal
+
+        # 0x90 needs a 00 pad; negative counterpart pads with 0x80
+        assert _push_minimal(0x90) == b"\x02\x90\x00"
+        assert _push_minimal(-0x90) == b"\x02\x90\x80"
+        # small negatives set the sign bit in the last byte
+        assert _push_minimal(-2) == b"\x01\x82"
+        assert _push_minimal(-255) == b"\x02\xff\x80"
+        # positive multi-byte little-endian
+        assert _push_minimal(0x1234) == b"\x02\x34\x12"
+
+    def test_push_minimal_length_cliffs(self):
+        from pyrxd.glyph.dmint.builders import _push_minimal
+        from pyrxd.security.errors import ValidationError
+
+        # 75-byte payload → direct push; 76 → PUSHDATA1; >255 → error
+        n75 = int.from_bytes(b"\x7f" * 75, "little")
+        assert _push_minimal(n75) == bytes([75]) + b"\x7f" * 75
+        n76 = int.from_bytes(b"\x7f" * 76, "little")
+        assert _push_minimal(n76) == b"\x4c\x4c" + b"\x7f" * 76
+        n255 = int.from_bytes(b"\x7f" * 255, "little")
+        assert _push_minimal(n255) == b"\x4c\xff" + b"\x7f" * 255
+        with pytest.raises(ValidationError):
+            _push_minimal(int.from_bytes(b"\x7f" * 256, "little"))
+
+    def test_push_4bytes_le(self):
+        from pyrxd.glyph.dmint.builders import _push_4bytes_le
+
+        assert _push_4bytes_le(0) == b"\x04\x00\x00\x00\x00"
+        assert _push_4bytes_le(0x01020304) == b"\x04\x04\x03\x02\x01"
+
+    def test_encode_data_push_cliffs(self):
+        from pyrxd.glyph.dmint.builders import _encode_data_push
+
+        assert _encode_data_push(b"\xee" * 75) == bytes([75]) + b"\xee" * 75
+        assert _encode_data_push(b"\xee" * 76) == b"\x4c\x4c" + b"\xee" * 76
+        assert _encode_data_push(b"\xee" * 255) == b"\x4c\xff" + b"\xee" * 255
+        assert _encode_data_push(b"\xee" * 256) == b"\x4d\x00\x01" + b"\xee" * 256
+        assert _encode_data_push(b"\xee" * 65535) == b"\x4d\xff\xff" + b"\xee" * 65535
+        assert _encode_data_push(b"\xee" * 65536) == b"\x4e\x00\x00\x01\x00" + b"\xee" * 65536
+
+
 class TestSignValidation:
     """transaction.py — sign()'s missing-amount validation mutants (L106–108)."""
 

--- a/tests/test_mutation_hardening.py
+++ b/tests/test_mutation_hardening.py
@@ -1,0 +1,165 @@
+"""Targeted assertions that kill surviving cosmic-ray mutants.
+
+Each test names the mutant class it kills (module + line refers to the
+2026-07 baseline run; see docs/how-to/mutation-testing.md). These are
+behavior pins, not implementation mirrors: every expected value is derived
+in-test from the spec (stdlib hashing, documented formulas, docstring
+examples), never from the code under test.
+
+Grouped by mutation scope so the per-scope cosmic-ray test commands stay
+fast: `task mutate transaction|script|dmint` all include this file.
+"""
+
+from __future__ import annotations
+
+import hashlib
+
+import pytest
+
+from pyrxd.script.script import Script
+from pyrxd.script.type import P2PKH
+from pyrxd.transaction.transaction import Transaction
+from pyrxd.transaction.transaction_input import TransactionInput
+from pyrxd.transaction.transaction_output import TransactionOutput
+
+_P2PKH_AA = bytes.fromhex("76a914" + "aa" * 20 + "88ac")
+_P2PKH_BB = bytes.fromhex("76a914" + "bb" * 20 + "88ac")
+
+
+def _sha256d(b: bytes) -> bytes:
+    return hashlib.sha256(hashlib.sha256(b).digest()).digest()
+
+
+def _out(script: bytes, sats: int, change: bool = False) -> TransactionOutput:
+    return TransactionOutput(Script(script), sats, change=change)
+
+
+def _in(txid: str = "ab" * 32, vout: int = 0, sequence: int = 0xFFFFFFFF) -> TransactionInput:
+    tx_in = TransactionInput(source_txid=txid, source_output_index=vout, sequence=sequence)
+    tx_in.satoshis = 10_000
+    tx_in.locking_script = Script(_P2PKH_AA)
+    return tx_in
+
+
+class TestTransactionIdentity:
+    """transaction.py — txid/hash/serialize mutants."""
+
+    def test_txid_is_reversed_double_sha256_of_serialization(self):
+        """Kills the L91 `hash()[::-1]` → `hash()[::1]` survivors: txid MUST
+        be the byte-reversed double-SHA256, re-derived here with hashlib
+        alone. An unreversed txid would silently break every outpoint
+        reference this SDK ever signs."""
+        tx = Transaction(tx_inputs=[_in()], tx_outputs=[_out(_P2PKH_AA, 5_000)])
+        raw = tx.serialize()
+        assert tx.txid() == _sha256d(raw)[::-1].hex()
+        assert tx.hash() == _sha256d(raw)
+
+    def test_is_coinbase_requires_exactly_one_all_zero_input(self):
+        """Kills the L83 `== 1` → `>= 1` and txid-comparison survivors."""
+        coinbase = Transaction(tx_inputs=[_in(txid="00" * 32)])
+        assert coinbase.is_coinbase()
+        normal = Transaction(tx_inputs=[_in(txid="ab" * 32)])
+        assert not normal.is_coinbase()
+        two_inputs = Transaction(tx_inputs=[_in(txid="00" * 32), _in(txid="ab" * 32)])
+        assert not two_inputs.is_coinbase()
+
+    def test_preimage_index_bounds(self):
+        """Kills the L97 guard survivors (`0 <=` → `-1 <=`, `<` → `<=`):
+        out-of-range indexes must raise, never wrap to inputs[-1]."""
+        tx = Transaction(tx_inputs=[_in()], tx_outputs=[_out(_P2PKH_AA, 5_000)])
+        with pytest.raises(ValueError):
+            tx.preimage(-1)
+        with pytest.raises(ValueError):
+            tx.preimage(1)
+
+    def test_constructor_preserves_extra_kwargs(self):
+        """Kills the L45 `dict(**kwargs) or {}` → `and {}` survivor, which
+        would silently drop caller metadata."""
+        tx = Transaction(note="keepme")
+        assert tx.kwargs == {"note": "keepme"}
+
+
+class TestTransactionAccounting:
+    """transaction.py — fee/value arithmetic mutants."""
+
+    def test_get_fee_is_subtraction(self):
+        """Kills the L133 `-` → `%` survivor: 10_000 in − 3_000 out = 7_000
+        (the `%` mutant would report 1_000)."""
+        tx = Transaction(tx_inputs=[_in()], tx_outputs=[_out(_P2PKH_AA, 3_000)])
+        assert tx.total_value_in() == 10_000
+        assert tx.total_value_out() == 3_000
+        assert tx.get_fee() == 7_000
+
+    def test_estimated_byte_length_formula(self):
+        """Kills the L156 `41` NumberReplacer survivors by pinning the
+        documented per-input formula: 4 (version) + varint(#in) +
+        varint(#out) + 4 (locktime) + per-input (40 outpoint/sequence + 1
+        script-len varint = 41, + template estimate) + per-output (8 +
+        script varint + script)."""
+        from pyrxd.keys import PrivateKey
+
+        pk_template = P2PKH().unlock(PrivateKey())  # fresh throwaway key
+        tx_in = _in()
+        tx_in.unlocking_script_template = pk_template
+        tx = Transaction(tx_inputs=[tx_in], tx_outputs=[_out(_P2PKH_AA, 5_000)])
+        expected = 4 + 1 + 1 + 4 + (41 + 107) + (8 + 1 + len(_P2PKH_AA))
+        assert tx.estimated_byte_length() == expected
+
+    def test_fee_change_distribution_docstring_example(self):
+        """Kills the L181–L217 change-distribution survivors with the
+        docstring's own worked example: change=10 over 3 change outputs
+        must yield [4, 3, 3] (sum preserved, remainder to the first)."""
+        src = Transaction(tx_outputs=[_out(_P2PKH_AA, 1_010)])
+        tx_in = TransactionInput(source_transaction=src, source_output_index=0)
+        tx = Transaction(
+            tx_inputs=[tx_in],
+            tx_outputs=[
+                _out(_P2PKH_BB, 1_000),
+                _out(_P2PKH_AA, None, change=True),
+                _out(_P2PKH_AA, None, change=True),
+                _out(_P2PKH_AA, None, change=True),
+            ],
+        )
+        tx.fee(0)  # explicit zero fee → change pool is exactly 10
+        assert [o.satoshis for o in tx.outputs if o.change] == [4, 3, 3]
+
+    def test_fee_drops_change_outputs_when_dust(self):
+        """Kills the `change <= change_count` branch survivors: when the
+        pool can't give each change output more than 1 photon, ALL change
+        outputs are removed and the surplus goes to miners."""
+        src = Transaction(tx_outputs=[_out(_P2PKH_AA, 1_002)])
+        tx_in = TransactionInput(source_transaction=src, source_output_index=0)
+        tx = Transaction(
+            tx_inputs=[tx_in],
+            tx_outputs=[
+                _out(_P2PKH_BB, 1_000),
+                _out(_P2PKH_AA, None, change=True),
+                _out(_P2PKH_AA, None, change=True),
+            ],
+        )
+        tx.fee(0)  # change pool = 2 == change_count → drop them
+        assert [o for o in tx.outputs if o.change] == []
+        assert len(tx.outputs) == 1
+
+    def test_fee_random_distribution_not_implemented(self):
+        """Pins the L203 'random' branch: it must raise NotImplementedError,
+        not fall through to equal distribution."""
+        src = Transaction(tx_outputs=[_out(_P2PKH_AA, 2_000)])
+        tx_in = TransactionInput(source_transaction=src, source_output_index=0)
+        tx = Transaction(tx_inputs=[tx_in], tx_outputs=[_out(_P2PKH_AA, None, change=True)])
+        with pytest.raises(NotImplementedError):
+            tx.fee(0, change_distribution="random")
+
+
+class TestSignValidation:
+    """transaction.py — sign()'s missing-amount validation mutants (L106–108)."""
+
+    def test_sign_rejects_uncomputed_change_output(self):
+        tx = Transaction(tx_inputs=[_in()], tx_outputs=[_out(_P2PKH_AA, None, change=True)])
+        with pytest.raises(ValueError, match="fee\\(\\)"):
+            tx.sign()
+
+    def test_sign_rejects_missing_amount_on_regular_output(self):
+        tx = Transaction(tx_inputs=[_in()], tx_outputs=[_out(_P2PKH_AA, None)])
+        with pytest.raises(ValueError, match="missing an amount"):
+            tx.sign()

--- a/tests/test_mutation_hardening.py
+++ b/tests/test_mutation_hardening.py
@@ -902,6 +902,97 @@ class TestScriptTemplates:
         assert pub_push.data == pk.public_key().serialize()
 
 
+class TestDmintDaaBoundaries:
+    """glyph/dmint/miner.py — DAA target-arithmetic mutants. Every expected
+    value below is computed from the documented formula in the function's
+    docstring, with the boundary chosen to distinguish the mutant."""
+
+    _MAX = 0x7FFFFFFFFFFFFFFF
+
+    def test_asert_doubling_cap_boundary(self):
+        """current_target == MAX//2 doubles to MAX-1 (it is NOT above the
+        cap threshold); the `MAX//2` → `MAX//3` mutant would clamp to MAX."""
+        from pyrxd.glyph.dmint.miner import compute_next_target_asert
+
+        got = compute_next_target_asert(
+            current_target=self._MAX // 2, last_time=0, current_time=60 + 3600, target_time=60, half_life=3600
+        )
+        assert got == (self._MAX // 2) * 2  # == MAX - 1
+
+    def test_asert_halving_and_clamp(self):
+        from pyrxd.glyph.dmint.miner import compute_next_target_asert
+
+        # drift −1 → exact halving
+        assert compute_next_target_asert(1000, 0, 60 - 3600, 60, 3600) == 500
+        # huge positive excess clamps at drift +4 → ×16
+        assert compute_next_target_asert(1000, 0, 60 + 100 * 3600, 60, 3600) == 16_000
+        # floor at 1
+        assert compute_next_target_asert(1, 0, 60 - 100 * 3600, 60, 3600) == 1
+
+    def test_linear_formula_at_target_cap(self):
+        """target cap is MAX//4 exactly (LWMA difficulty floor 4)."""
+        from pyrxd.glyph.dmint.miner import compute_next_target_linear
+
+        got = compute_next_target_linear(self._MAX, last_time=0, current_time=60, target_time=60)
+        assert got == (self._MAX // 4 // 60) * 60
+        # negative delta floors at 0 → minimum target 1
+        assert compute_next_target_linear(self._MAX, last_time=100, current_time=40, target_time=60) == 1
+        # delta caps at 4× target_time
+        assert compute_next_target_linear(1_000_000, 0, 10_000_000, 60) == (1_000_000 // 60) * 240
+
+    def test_epoch_retargets_only_at_boundary(self):
+        from pyrxd.glyph.dmint.miner import compute_next_target_epoch
+
+        kwargs = dict(
+            current_target=1 << 40,
+            last_time=0,
+            current_time=120,
+            target_time=60,
+            epoch_length=10,
+            max_adjustment_log2=2,
+        )
+        # boundary hit: (target // 60) * clamped(120) per the docstring
+        assert compute_next_target_epoch(height=10, **kwargs) == ((1 << 40) // 60) * 120
+        # non-boundary heights leave the target untouched, including 0
+        assert compute_next_target_epoch(height=11, **kwargs) == 1 << 40
+        assert compute_next_target_epoch(height=0, **kwargs) == 1 << 40
+
+    def test_schedule_boundary_is_inclusive(self):
+        from pyrxd.glyph.dmint.miner import compute_next_target_schedule
+
+        sched = ((10, 111), (20, 222))
+        assert compute_next_target_schedule(999, 9, sched) == 999  # below lowest
+        assert compute_next_target_schedule(999, 10, sched) == 111  # AT boundary
+        assert compute_next_target_schedule(999, 20, sched) == 222  # highest match wins
+        assert compute_next_target_schedule(999, 25, sched) == 222
+
+    def test_difficulty_target_conversions(self):
+        from pyrxd.glyph.dmint import DmintAlgo
+        from pyrxd.glyph.dmint.miner import difficulty_to_target, target_to_difficulty
+        from pyrxd.security.errors import ValidationError
+
+        assert difficulty_to_target(1) == self._MAX
+        assert difficulty_to_target(1, DmintAlgo.BLAKE3) == (1 << 256) - 1  # 256-bit max, not SHA256D's
+        assert target_to_difficulty(1) == self._MAX  # target=1 boundary valid
+        assert target_to_difficulty(self._MAX) == 1
+        for fn in (difficulty_to_target, target_to_difficulty):
+            with pytest.raises(ValidationError):
+                fn(0)
+
+    def test_mine_solution_guards(self):
+        from pyrxd.glyph.dmint import DmintAlgo
+        from pyrxd.glyph.dmint.miner import mine_solution
+        from pyrxd.security.errors import ValidationError
+
+        preimage = bytes(64)
+        with pytest.raises(ValidationError):
+            mine_solution(preimage, 0)
+        with pytest.raises(ValidationError):
+            mine_solution(preimage, 1, max_attempts=0)
+        with pytest.raises(NotImplementedError):
+            mine_solution(preimage, 1, algo=DmintAlgo.BLAKE3)
+
+
 class TestSignValidation:
     """transaction.py — sign()'s missing-amount validation mutants (L106–108)."""
 

--- a/tests/test_mutation_hardening.py
+++ b/tests/test_mutation_hardening.py
@@ -767,6 +767,141 @@ class TestDmintCborPayloadDecode:
         assert DmintV1ContractInitialState.__dataclass_params__.frozen is True
 
 
+class TestScriptTemplates:
+    """script/type.py — template lock/unlock mutants. Locking bytes are
+    hand-assembled from the canonical script shapes; sighash suffixes are
+    pinned to exactly ONE byte (the `to_bytes(1)` → `to_bytes(2)` class
+    would produce node-invalid signatures)."""
+
+    def test_abstract_template_rejects_incomplete_subclass(self):
+        from pyrxd.script.type import ScriptTemplate
+
+        class Incomplete(ScriptTemplate):
+            pass
+
+        with pytest.raises(TypeError):
+            Incomplete()
+
+    def test_op_return_lock_uses_non_minimal_push(self):
+        """0x01 as OP_RETURN data must stay a literal `01 01` push — the
+        minimal-push form (OP_1) would CHANGE the pushed byte semantics for
+        data carriers that read raw pushdata."""
+        from pyrxd.script.type import OpReturn
+
+        assert OpReturn().lock([b"\x01"]).serialize() == b"\x00\x6a\x01\x01"
+        assert OpReturn().lock(["hi"]).serialize() == b"\x00\x6a\x02hi"
+
+    def test_p2pk_lock_bytes_and_length_guard(self):
+        from pyrxd.keys import PrivateKey
+        from pyrxd.script.type import P2PK
+        from pyrxd.security.errors import ValidationError
+
+        pub = PrivateKey().public_key().serialize()  # 33-byte compressed
+        assert P2PK().lock(pub).serialize() == b"\x21" + pub + b"\xac"
+        with pytest.raises(ValidationError):
+            P2PK().lock(b"\x02" * 32)
+
+    def test_bare_multisig_lock_bytes_and_threshold_guards(self):
+        from pyrxd.keys import PrivateKey
+        from pyrxd.script.type import BareMultisig
+        from pyrxd.security.errors import ValidationError
+
+        keys = [PrivateKey().public_key().serialize() for _ in range(3)]
+        script = BareMultisig().lock(keys, 2).serialize()
+        expected = b"\x52" + b"".join(b"\x21" + k for k in keys) + b"\x53\xae"
+        assert script == expected
+        for bad in (0, 4):
+            with pytest.raises(ValidationError):
+                BareMultisig().lock(keys, bad)
+
+    def test_rpuzzle_lock_hash_op_dispatch(self):
+        from pyrxd.script.type import RPuzzle
+
+        value = b"\x99" * 32
+        base_prefix = bytes.fromhex("78537f7751 7f7c7f75".replace(" ", ""))
+        raw = RPuzzle("raw").lock(value).serialize()
+        sha = RPuzzle("SHA256").lock(value).serialize()
+        assert raw == base_prefix + b"\x20" + value + b"\x88\xac"
+        assert sha == base_prefix + b"\xa8" + b"\x20" + value + b"\x88\xac"
+
+    def test_estimated_unlocking_lengths(self):
+        from pyrxd.keys import PrivateKey
+        from pyrxd.script.type import P2PK, BareMultisig, RPuzzle
+
+        pk = PrivateKey()
+        assert P2PKH().unlock(pk).estimated_unlocking_byte_length() == 107
+        pk_uncompressed = PrivateKey()
+        pk_uncompressed.compressed = False
+        assert P2PKH().unlock(pk_uncompressed).estimated_unlocking_byte_length() == 139
+        assert P2PK().unlock(pk).estimated_unlocking_byte_length() == 73
+        assert BareMultisig().unlock([pk, pk]).estimated_unlocking_byte_length() == 1 + 73 * 2 + 1
+        assert RPuzzle().unlock(k=12345).estimated_unlocking_byte_length() == 108
+
+    @staticmethod
+    def _signed_input(template):
+        tx_in = _in()
+        tx_in.unlocking_script_template = template
+        tx = Transaction(tx_inputs=[tx_in], tx_outputs=[_out(_P2PKH_AA, 1_000)])
+        tx.sign()
+        return tx_in
+
+    def test_p2pkh_sign_appends_exactly_one_sighash_byte(self):
+        from pyrxd.keys import PrivateKey
+
+        pk = PrivateKey()
+        tx_in = self._signed_input(P2PKH().unlock(pk))
+        sig_push, pub_push = tx_in.unlocking_script.chunks
+        assert pub_push.data == pk.public_key().serialize()
+        assert sig_push.data[0] == 0x30  # DER sequence tag
+        assert sig_push.data[-1] == int(tx_in.sighash)  # single 0x41 byte
+        assert len(sig_push.data) <= 73  # DER sig (<=72) + 1 sighash byte
+
+    def test_p2pk_and_multisig_sign_sighash_suffix(self):
+        from pyrxd.keys import PrivateKey
+        from pyrxd.script.type import P2PK, BareMultisig
+
+        tx_in = self._signed_input(P2PK().unlock(PrivateKey()))
+        (sig_push,) = tx_in.unlocking_script.chunks
+        assert sig_push.data[-1] == int(tx_in.sighash)
+
+        tx_in = self._signed_input(BareMultisig().unlock([PrivateKey(), PrivateKey()]))
+        chunks = tx_in.unlocking_script.chunks
+        assert len(chunks) == 3  # OP_0 + two signatures (NULLDUMMY + loop ran)
+        assert chunks[0].op == b"\x00"
+        for sig in chunks[1:]:
+            assert sig.data[-1] == int(tx_in.sighash)
+
+    def test_rpuzzle_sign_sighash_flag_branches(self):
+        """sign_outputs/anyone_can_pay must map to the exact FORKID sighash
+        bytes (ALL 0x41, NONE 0x42, SINGLE 0x43, |0x80 for ACP) — and the
+        flags are WRITTEN BACK to the input before preimaging."""
+        from pyrxd.script.type import RPuzzle
+
+        cases = [
+            (dict(sign_outputs="all"), 0x41),
+            (dict(sign_outputs="none"), 0x42),
+            (dict(sign_outputs="single"), 0x43),
+            (dict(sign_outputs="single", anyone_can_pay=True), 0xC3),
+        ]
+        for kwargs, expected in cases:
+            tx_in = self._signed_input(RPuzzle().unlock(k=12345, **kwargs))
+            sig_push = tx_in.unlocking_script.chunks[0]
+            assert int(tx_in.sighash) == expected, kwargs
+            assert sig_push.data[-1] == expected, kwargs
+
+    def test_rpuzzle_honors_provided_private_key(self):
+        """Kills the L259 `if private_key is None` negation: a caller's key
+        must be used, not silently replaced with a fresh one (nonce-reuse
+        safety depends on the caller controlling which key signs)."""
+        from pyrxd.keys import PrivateKey
+        from pyrxd.script.type import RPuzzle
+
+        pk = PrivateKey()
+        tx_in = self._signed_input(RPuzzle().unlock(k=999, private_key=pk))
+        pub_push = tx_in.unlocking_script.chunks[-1]
+        assert pub_push.data == pk.public_key().serialize()
+
+
 class TestSignValidation:
     """transaction.py — sign()'s missing-amount validation mutants (L106–108)."""
 

--- a/tests/test_preimage_differential.py
+++ b/tests/test_preimage_differential.py
@@ -1,0 +1,360 @@
+"""Differential property tests for the Radiant FORKID sighash preimage.
+
+An INDEPENDENT reference implementation of the preimage — written from the
+specification, not from ``pyrxd.transaction.transaction_preimage`` — is
+compared byte-for-byte against the production builder over Hypothesis-generated
+transaction shapes. A sighash preimage bug means signing something other than
+what the node verifies (fund loss), so this layer earns a differential net
+beyond the fixed golden vectors in ``tests/test_preimage.py``.
+
+Specification sources for the reference implementation:
+
+* BIP143 field order as used by the BCH/BSV FORKID sighash algorithm
+  (nVersion, hashPrevouts, hashSequence, outpoint, scriptCode, value,
+  nSequence, hashOutputs, nLockTime, sighash type), including the
+  ANYONECANPAY / SINGLE / NONE zero-field rules.
+* Radiant's extension: a ``hashOutputHashes`` field inserted before
+  ``hashOutputs`` — per Radiant-Core ``src/primitives/transaction.h``
+  (``GetHashOutputHashes`` / ``getRefHashDataSummary`` /
+  ``writeOutputDataSummaryVector``) and radiantjs
+  ``lib/transaction/sighash.js``. Per output: value (8 LE) +
+  hash256(script) + ref count (4 LE) + (hash256(sorted refs) or 32 zero
+  bytes); the concatenation is hash256'd.
+* Refs sort ascending by the **uint288 numeric value** of the 36-byte ref,
+  which is little-endian (byte[35] most significant), and are
+  **deduplicated** — Radiant collects them into a ``std::set<uint288>``.
+  The reference sorts *integers* (``int.from_bytes(ref, "little")``),
+  deliberately a different derivation than the production code's byte-wise
+  sort key, so a sort-order regression cannot hide in shared code.
+
+The reference is itself anchored to the radiantjs-generated golden vectors
+committed in ``tests/test_preimage.py`` (verified against mainnet reveal tx
+dac1e2df…b407) — see ``TestReferenceAnchoredToRadiantjsVectors``. The
+property tests then assert production == reference over generated shapes;
+they never assert the production code against its own prior output.
+"""
+
+from __future__ import annotations
+
+import os
+import struct
+
+from hypothesis import HealthCheck, given, settings
+from hypothesis import strategies as st
+
+from pyrxd.constants import SIGHASH
+from pyrxd.hash import hash256
+from pyrxd.script.script import Script
+from pyrxd.transaction.transaction_input import TransactionInput
+from pyrxd.transaction.transaction_output import TransactionOutput
+from pyrxd.transaction.transaction_preimage import tx_preimage, tx_preimages
+
+_BUDGET_MULT = int(os.environ.get("FUZZ_BUDGET_MULTIPLIER", "1"))
+
+
+def _budget(n: int) -> int:
+    return n * _BUDGET_MULT
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# Reference implementation (from the spec — see module docstring for sources)
+# ═══════════════════════════════════════════════════════════════════════════════
+
+_ANYONECANPAY = 0x80
+_BASE_MASK = 0x1F
+_SINGLE = 0x03
+_NONE = 0x02
+
+_PUSHREF_OPS = (0xD0, 0xD8)  # OP_PUSHINPUTREF, OP_PUSHINPUTREFSINGLETON
+
+
+def _ref_compactsize(n: int) -> bytes:
+    """Bitcoin CompactSize (varint) — independent of pyrxd.utils."""
+    if n < 0xFD:
+        return struct.pack("<B", n)
+    if n <= 0xFFFF:
+        return b"\xfd" + struct.pack("<H", n)
+    if n <= 0xFFFFFFFF:
+        return b"\xfe" + struct.pack("<I", n)
+    return b"\xff" + struct.pack("<Q", n)
+
+
+def _ref_scan_refs(script: bytes) -> list[bytes]:
+    """Collect pushref payloads, dedup, and sort by uint288 numeric value.
+
+    The sort is done on INTEGERS decoded little-endian and the bytes are
+    reconstructed with ``to_bytes(36, "little")`` — the literal reading of
+    "std::set<uint288> iteration order".
+    """
+    values: set[int] = set()
+    i, n = 0, len(script)
+    while i < n:
+        op = script[i]
+        i += 1
+        if op in _PUSHREF_OPS:
+            assert i + 36 <= n, "generator must only emit well-formed pushrefs"
+            values.add(int.from_bytes(script[i : i + 36], "little"))
+            i += 36
+        elif 0x01 <= op <= 0x4B:
+            i += op
+        elif op == 0x4C:
+            i += 1 + script[i]
+        elif op == 0x4D:
+            i += 2 + int.from_bytes(script[i : i + 2], "little")
+        elif op == 0x4E:
+            i += 4 + int.from_bytes(script[i : i + 4], "little")
+    return [v.to_bytes(36, "little") for v in sorted(values)]
+
+
+def _ref_output_data_summary(value: int, script: bytes) -> bytes:
+    """One output's entry in the hashOutputHashes blob."""
+    refs = _ref_scan_refs(script)
+    entry = struct.pack("<Q", value) + hash256(script) + struct.pack("<I", len(refs))
+    entry += hash256(b"".join(refs)) if refs else b"\x00" * 32
+    return entry
+
+
+def _ref_hash_output_hashes(outputs: list[tuple[int, bytes]]) -> bytes:
+    return hash256(b"".join(_ref_output_data_summary(v, s) for v, s in outputs))
+
+
+def _ref_serialize_output(value: int, script: bytes) -> bytes:
+    return struct.pack("<Q", value) + _ref_compactsize(len(script)) + script
+
+
+def _ref_preimage(
+    input_index: int,
+    inputs: list[dict],
+    outputs: list[tuple[int, bytes]],
+    version: int,
+    locktime: int,
+) -> bytes:
+    """Radiant FORKID sighash preimage, assembled per BIP143 + Radiant ext.
+
+    ``inputs`` entries: dicts with txid (bytes, display order), vout,
+    script (scriptCode bytes), value, sequence, sighash.
+    """
+    me = inputs[input_index]
+    sighash = me["sighash"]
+    base = sighash & _BASE_MASK
+    acp = bool(sighash & _ANYONECANPAY)
+
+    if acp:
+        hash_prevouts = b"\x00" * 32
+    else:
+        hash_prevouts = hash256(
+            b"".join(i["txid"][::-1] + struct.pack("<I", i["vout"]) for i in inputs)
+        )
+
+    if not acp and base != _SINGLE and base != _NONE:
+        hash_sequence = hash256(b"".join(struct.pack("<I", i["sequence"]) for i in inputs))
+    else:
+        hash_sequence = b"\x00" * 32
+
+    if base != _SINGLE and base != _NONE:
+        hash_outputs = hash256(b"".join(_ref_serialize_output(v, s) for v, s in outputs))
+        hash_output_hashes = _ref_hash_output_hashes(outputs)
+    elif base == _SINGLE and input_index < len(outputs):
+        hash_outputs = hash256(_ref_serialize_output(*outputs[input_index]))
+        hash_output_hashes = _ref_hash_output_hashes([outputs[input_index]])
+    else:
+        hash_outputs = b"\x00" * 32
+        hash_output_hashes = b"\x00" * 32
+
+    return (
+        struct.pack("<I", version)
+        + hash_prevouts
+        + hash_sequence
+        + me["txid"][::-1]
+        + struct.pack("<I", me["vout"])
+        + _ref_compactsize(len(me["script"]))
+        + me["script"]
+        + struct.pack("<Q", me["value"])
+        + struct.pack("<I", me["sequence"])
+        + hash_output_hashes
+        + hash_outputs
+        + struct.pack("<I", locktime)
+        + struct.pack("<I", sighash)
+    )
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# Anchor the reference to the external radiantjs vectors
+# ═══════════════════════════════════════════════════════════════════════════════
+
+_P2PKH_AA = bytes.fromhex("76a914" + "aa" * 20 + "88ac")
+_P2PKH_BB = bytes.fromhex("76a914" + "bb" * 20 + "88ac")
+_REF_HEX = "b73ea8b33a8d8f15b25d25b9e6892926f893a7fdb6a97695d029732aa4ae01cd00000000"
+_NFT_SCRIPT = bytes.fromhex("d8" + _REF_HEX + "7576a914" + "cc" * 20 + "88ac")
+
+
+class TestReferenceAnchoredToRadiantjsVectors:
+    """The reference impl must reproduce the radiantjs-generated golden
+    hashes (tests/test_preimage.py, verified against mainnet reveal tx
+    dac1e2df…b407). This pins the reference to an implementation the
+    production code never shared a line with."""
+
+    def test_two_p2pkh_outputs(self):
+        got = _ref_hash_output_hashes([(100_000, _P2PKH_AA), (50_000, _P2PKH_BB)])
+        assert got.hex() == "131577023e4b1972c69b79fe851412e64390576ea90514ed5b83e9bfcc261304"
+
+    def test_single_p2pkh_output(self):
+        got = _ref_hash_output_hashes([(546, _P2PKH_AA)])
+        assert got.hex() == "42053adc8c31d4299864f45101c180c7397471cd13b2ac0451217754649b33cf"
+
+    def test_nft_singleton_output(self):
+        got = _ref_hash_output_hashes([(442_546, _NFT_SCRIPT)])
+        assert got.hex() == "148f582c4c97db5fe686d68a5ed054a4b6946c0f498051a5f9df0040af48e791"
+
+    def test_nft_plus_p2pkh(self):
+        got = _ref_hash_output_hashes([(442_546, _NFT_SCRIPT), (100_000, _P2PKH_AA)])
+        assert got.hex() == "049613e42ad3c0e25a8bfa55065d8481e35633dd9df743c7e98914d401edf4b2"
+
+    def test_single_index_1(self):
+        got = _ref_hash_output_hashes([(100_000, _P2PKH_AA)])
+        assert got.hex() == "d3a62446cf608f656518faa07460984194bb21a7c43e5af8584e4b6a70228ae4"
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# Script-shape strategies
+# ═══════════════════════════════════════════════════════════════════════════════
+
+# A ref pool with crafted LE-sort stressors: pairs that order differently
+# under uint288-LE vs raw-lexicographic comparison, plus refs sharing bytes
+# to exercise dedup.
+_REF_POOL = [
+    b"\xff" + bytes(35),          # huge first byte, tiny uint288
+    bytes(35) + b"\x01",          # tiny bytes, huge uint288
+    b"\x01" + bytes(35),
+    bytes(35) + b"\xff",
+    bytes.fromhex(_REF_HEX),
+    bytes(range(36)),
+]
+
+_ref_strategy = st.one_of(
+    st.sampled_from(_REF_POOL),
+    st.binary(min_size=36, max_size=36),
+)
+
+# Non-push single-byte opcodes (never 0xd0/0xd8 — pushrefs are emitted only
+# as well-formed <op><36-byte ref> elements by _pushref below).
+_plain_opcodes = st.sampled_from(
+    [b"\x00", b"\x4f", b"\x51", b"\x60", b"\x61", b"\x69", b"\x75", b"\x76", b"\x87", b"\x88", b"\xa9", b"\xac"]
+)
+
+# Data pushes across all four encodings. Payloads may contain 0xd0/0xd8
+# bytes on purpose: a correct scanner must skip push payloads, never
+# interpret them as pushref opcodes.
+_direct_push = st.binary(min_size=0, max_size=0x4B).map(
+    lambda d: (bytes([len(d)]) + d) if d else b"\x00"
+)
+_pushdata1 = st.binary(min_size=0, max_size=80).map(lambda d: b"\x4c" + bytes([len(d)]) + d)
+_pushdata2 = st.binary(min_size=0, max_size=80).map(lambda d: b"\x4d" + struct.pack("<H", len(d)) + d)
+_pushdata4 = st.binary(min_size=0, max_size=80).map(lambda d: b"\x4e" + struct.pack("<I", len(d)) + d)
+_pushref = st.tuples(st.sampled_from([b"\xd0", b"\xd8"]), _ref_strategy).map(lambda t: t[0] + t[1])
+
+_script_element = st.one_of(_plain_opcodes, _direct_push, _pushdata1, _pushdata2, _pushdata4, _pushref)
+
+_script_strategy = st.lists(_script_element, min_size=0, max_size=8).map(b"".join)
+
+# Scripts guaranteed to carry 2+ refs, biasing toward the interesting
+# sort/dedup paths.
+_multi_ref_script = st.lists(_pushref, min_size=2, max_size=5).map(b"".join)
+
+_sighash_strategy = st.sampled_from(
+    [
+        int(SIGHASH.ALL_FORKID),
+        int(SIGHASH.NONE_FORKID),
+        int(SIGHASH.SINGLE_FORKID),
+        int(SIGHASH.ALL_ANYONECANPAY_FORKID),
+        int(SIGHASH.NONE_ANYONECANPAY_FORKID),
+        int(SIGHASH.SINGLE_ANYONECANPAY_FORKID),
+    ]
+)
+
+_input_strategy = st.fixed_dictionaries(
+    {
+        "txid": st.binary(min_size=32, max_size=32),
+        "vout": st.integers(min_value=0, max_value=0xFFFFFFFF),
+        "script": _script_strategy,
+        "value": st.integers(min_value=0, max_value=2**63 - 1),
+        "sequence": st.integers(min_value=0, max_value=0xFFFFFFFF),
+        "sighash": _sighash_strategy,
+    }
+)
+
+
+@st.composite
+def _tx_shape(draw, output_scripts=_script_strategy):
+    inputs = draw(st.lists(_input_strategy, min_size=1, max_size=4))
+    outputs = draw(
+        st.lists(
+            st.tuples(st.integers(min_value=0, max_value=2**63 - 1), output_scripts),
+            min_size=0,
+            max_size=4,
+        )
+    )
+    version = draw(st.integers(min_value=0, max_value=0x7FFFFFFF))
+    locktime = draw(st.integers(min_value=0, max_value=0xFFFFFFFF))
+    return inputs, outputs, version, locktime
+
+
+def _to_pyrxd(inputs: list[dict], outputs: list[tuple[int, bytes]]):
+    tx_ins = []
+    for i in inputs:
+        tx_in = TransactionInput(
+            source_txid=i["txid"].hex(),
+            source_output_index=i["vout"],
+            sequence=i["sequence"],
+            sighash=i["sighash"],
+        )
+        tx_in.locking_script = Script(i["script"])
+        tx_in.satoshis = i["value"]
+        tx_ins.append(tx_in)
+    tx_outs = [TransactionOutput(Script(s), v) for v, s in outputs]
+    return tx_ins, tx_outs
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# Differential properties
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+@given(shape=_tx_shape())
+@settings(max_examples=_budget(300), deadline=None, suppress_health_check=[HealthCheck.too_slow])
+def test_preimage_matches_reference(shape):
+    """tx_preimage (per-index path) == spec-derived reference, byte-for-byte,
+    for every input index of every generated transaction shape."""
+    inputs, outputs, version, locktime = shape
+    tx_ins, tx_outs = _to_pyrxd(inputs, outputs)
+    for idx in range(len(inputs)):
+        got = tx_preimage(idx, tx_ins, tx_outs, version, locktime)
+        want = _ref_preimage(idx, inputs, outputs, version, locktime)
+        assert got == want, f"preimage diverges from spec reference at input {idx}"
+
+
+@given(shape=_tx_shape())
+@settings(max_examples=_budget(200), deadline=None, suppress_health_check=[HealthCheck.too_slow])
+def test_preimages_batch_matches_reference(shape):
+    """tx_preimages (batch path with cached hashes) must agree with the
+    reference too — it is a separate implementation of the same derivation
+    and has historically been where caching shortcuts would hide."""
+    inputs, outputs, version, locktime = shape
+    tx_ins, tx_outs = _to_pyrxd(inputs, outputs)
+    got = tx_preimages(tx_ins, tx_outs, version, locktime)
+    want = [_ref_preimage(i, inputs, outputs, version, locktime) for i in range(len(inputs))]
+    assert got == want
+
+
+@given(shape=_tx_shape(output_scripts=_multi_ref_script))
+@settings(max_examples=_budget(200), deadline=None, suppress_health_check=[HealthCheck.too_slow])
+def test_preimage_matches_reference_multi_ref_outputs(shape):
+    """Force every output to carry 2+ pushrefs so the consensus-required
+    uint288-LE sort + dedup path is exercised on every example (the ~50%
+    dMint signing failure of PR #228 lived exactly here)."""
+    inputs, outputs, version, locktime = shape
+    tx_ins, tx_outs = _to_pyrxd(inputs, outputs)
+    for idx in range(len(inputs)):
+        got = tx_preimage(idx, tx_ins, tx_outs, version, locktime)
+        want = _ref_preimage(idx, inputs, outputs, version, locktime)
+        assert got == want

--- a/tests/test_preimage_differential.py
+++ b/tests/test_preimage_differential.py
@@ -142,9 +142,7 @@ def _ref_preimage(
     if acp:
         hash_prevouts = b"\x00" * 32
     else:
-        hash_prevouts = hash256(
-            b"".join(i["txid"][::-1] + struct.pack("<I", i["vout"]) for i in inputs)
-        )
+        hash_prevouts = hash256(b"".join(i["txid"][::-1] + struct.pack("<I", i["vout"]) for i in inputs))
 
     if not acp and base != _SINGLE and base != _NONE:
         hash_sequence = hash256(b"".join(struct.pack("<I", i["sequence"]) for i in inputs))
@@ -223,8 +221,8 @@ class TestReferenceAnchoredToRadiantjsVectors:
 # under uint288-LE vs raw-lexicographic comparison, plus refs sharing bytes
 # to exercise dedup.
 _REF_POOL = [
-    b"\xff" + bytes(35),          # huge first byte, tiny uint288
-    bytes(35) + b"\x01",          # tiny bytes, huge uint288
+    b"\xff" + bytes(35),  # huge first byte, tiny uint288
+    bytes(35) + b"\x01",  # tiny bytes, huge uint288
     b"\x01" + bytes(35),
     bytes(35) + b"\xff",
     bytes.fromhex(_REF_HEX),
@@ -245,9 +243,7 @@ _plain_opcodes = st.sampled_from(
 # Data pushes across all four encodings. Payloads may contain 0xd0/0xd8
 # bytes on purpose: a correct scanner must skip push payloads, never
 # interpret them as pushref opcodes.
-_direct_push = st.binary(min_size=0, max_size=0x4B).map(
-    lambda d: (bytes([len(d)]) + d) if d else b"\x00"
-)
+_direct_push = st.binary(min_size=0, max_size=0x4B).map(lambda d: (bytes([len(d)]) + d) if d else b"\x00")
 _pushdata1 = st.binary(min_size=0, max_size=80).map(lambda d: b"\x4c" + bytes([len(d)]) + d)
 _pushdata2 = st.binary(min_size=0, max_size=80).map(lambda d: b"\x4d" + struct.pack("<H", len(d)) + d)
 _pushdata4 = st.binary(min_size=0, max_size=80).map(lambda d: b"\x4e" + struct.pack("<I", len(d)) + d)


### PR DESCRIPTION
# audit: mutation testing + differential/property/conformance hardening

Raises the correctness floor on the byte-exact consensus surfaces ahead of the external audit.
Four phases, all offline-verifiable; suite green at every commit; no `src/` changes.

## P1 — cosmic-ray mutation scope extended beyond `spv/`

`task mutate` now takes scope groups (`spv|script|transaction|dmint|all`); sessions persist via
`MUTATION_SESSION_DIR` for survivor triage. Full baseline sweeps were run for every file in the
three new scopes (7,958 mutants), every surviving mutant was triaged, and the genuine gaps were
killed with targeted assertions (`tests/test_mutation_hardening.py`, 95 tests — each names the
mutant class it kills and derives its expected values from spec/stdlib/docstring formulas, never
from the code under test).

**Method note (honest measurement):** baseline = pre-hardening test lists. The post-hardening
score was measured by re-applying each surviving mutant's stored diff in a clean worktree and
running the updated test command — a per-mutant measurement equivalent to a full re-run restricted
to prior survivors. A full fresh sweep of the `script` scope cross-checked the method
— the fresh sweep reported 92/4/68 survivors for script.py/timelock.py/type.py, identical file-for-file to the per-survivor prediction.

### Mutation-score deltas per module

| Module | Mutants | Baseline killed | After hardening | Surviving (annotation-equiv) |
|---|---|---|---|---|
| transaction.py | 509 | 285 (56%) | 360 (71%) | 149 (99) |
| transaction_input.py | 104 | 44 (42%) | 47 (45%) | 57 (55) |
| transaction_output.py | 53 | 16 (30%) | 19 (36%) | 34 (33) |
| **transaction_preimage.py** | 675 | 322 (48%) | **622 (92%)** | 53 (0) |
| script/script.py | 299 | 172 (58%) | 207 (69%) | 92 (33) |
| script/timelock.py | 257 | 249 (97%) | 253 (98%) | 4 (0) |
| script/type.py | 340 | 241 (71%) | 272 (80%) | 68 (55) |
| **glyph/dmint/builders.py** | 2197 | 2024 (92%) | **2179 (99%)** | 18 (0) |
| glyph/dmint/chain.py | 1251 | 803 (64%) | 930 (74%) | 321 (28) |
| glyph/dmint/types.py | 364 | 232 (64%) | 326 (90%) | 38 (0) |
| glyph/dmint/miner.py | 1909 | 1430 (75%) | 1453 (76%) | 456 (39) |
| **Total** | **7,958** | **5,818 (73.1%)** | **6,668 (83.8%)** | **1,290 (342)** |

Remaining survivors are dominated by **equivalent mutants** (type annotations under
`from __future__ import annotations` — never evaluated; error-message f-strings; interned-int
`is` rewrites; guards unreachable for valid inputs) and two **documented-deferred** clusters
(BEEF bump-combine branches — BSV interchange format, not a Radiant consensus surface; async
ElectrumX discovery flows + mining/subprocess plumbing — operational paths covered by regtest
e2e). Full classification in `docs/how-to/mutation-testing.md`.

## P2 — differential / property / conformance corpora (Hypothesis)

- **FORKID sighash differential** (`tests/test_preimage_differential.py`): an independent
  reference preimage implementation written from BIP143 + the Radiant `hashOutputHashes`
  extension (uint288-LE ref sort implemented via *integer* sort), anchored to the committed
  radiantjs golden vectors, compared byte-for-byte against `tx_preimage`/`tx_preimages` over
  generated tx shapes including forced multi-ref outputs (the PR #228 bug class). Verified to
  fail under a deliberate ref-sort regression.
- **Glyph CBOR envelope** (`tests/test_glyph_cbor_roundtrip.py`): decode(encode(m)) == m over
  generated metadata; canonical-form fixed point checked with cbor2 alone (the indexer
  commit-hash re-encode property); reveal scriptSig framing across the 75/255/65535 push cliffs.
- **dMint V2 vs conformance vectors** (`tests/test_dmint_vector_derivations.py`): the committed
  vector bytes (incl. the mainnet-anchored deploy) must re-parse via `DmintState.from_script` to
  their own JSON params with target re-derived from the documented difficulty formula;
  builder↔parser round-trip across all five DAA modes; byte-level state-layout walk enforcing
  MINIMALDATA pushes (the mainnet mempool-rejection class).

All three verified non-vacuous by sabotage (deliberate src regressions make them fail; reverted).

## P3 — scheduled fuzz lane (`.github/workflows/fuzz.yml`)

Weekly cron + manual dispatch, two jobs: `fuzz_deep.sh deep` (25k examples/test, committed
corpus `tests/.hypothesis-corpus` replayed first; file list now includes the three new corpora)
and the seven `scripts/fuzz_atheris/` harnesses with a libFuzzer corpus accumulated across runs
via the Actions cache. Findings upload as artifacts; fork-schedule guarded; actions hash-pinned.

## P4 — CLI security-path coverage (docs/cli-security-backlog.md #8/#9)

`tests/cli/test_security_paths.py`: in-process send fallback (happy/empty/wrong-mnemonic/decline/
no-funds — typed mnemonics must never echo into output), `agent unlock` lifecycle (serve→lock,
Ctrl-C zeroize), query-command mnemonic+passphrase prompts, ElectrumX boundary-error hygiene,
`--debug` plumbing. Coverage: agent_cmds 62→94%, query_cmds 44→82%, errors 91→100%,
wallet_cmds 77→85%, prompts 86→95%; `pyrxd.cli` total 71→75% (remaining gap is glyph_cmds UI
plumbing, not security paths).

## Findings (separate from test-only gaps)

**No consensus/fund-safety bug was found.** The items below are real but non-consensus:

1. **Dead code in `Script.from_asm`** (`src/pyrxd/script/script.py` L141–150): the push-opcode
   selection for hex tokens is computed and then *discarded* — `Script.from_chunks` re-derives
   the opcode via `encode_pushdata`. Proven by ~45 mutants in that block being behaviorally
   unkillable. Suggest removing the dead computation in a follow-up (kept out of this PR: no
   `src/` edits).
2. **Stale `# pragma: no cover` on `Transaction.sign()`** (`transaction.py` L101): the method is
   exercised by multiple tests; the pragma hides it from coverage. Follow-up one-liner.
3. **Assertion gaps that were worth closing on their own** (now closed): `Transaction.txid()`
   byte-reversal had no pinning test; the FORKID preimage module was ~50% killable at baseline;
   `from_hex` output-truncation guard could be rewritten to int-identity (`is not`) without any
   test noticing for >256-byte scripts.

## CI-parity evidence

- Full suite: 4554 passed (quiesced run) · security coverage 100% · overall coverage 88.9% (85% gate)
- ruff + ruff-format + bandit + mypy + private-link check: clean
- Sphinx docs build: unchanged warnings only (pre-existing docstring issues in `src/`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
