### PR TITLE
feat(swap): RSWP on-chain orderbook — post / take / cancel / browse (write side)

### DIFF
--- a/conformance/README.md
+++ b/conformance/README.md
@@ -10,6 +10,7 @@ byte-compare against the expected hex.
 | File | Covers | Anchor |
 |---|---|---|
 | `dmint-v2-contract-vectors.json` | The V2 dMint **contract script** for given deploy params, across all 5 DAA modes (FIXED / LWMA / ASERT / EPOCH / SCHEDULE) | One vector is byte-anchored to the first **mainnet** V2 deploy (`source: mainnet:…`); the rest are reference vectors |
+| `rswp-order-vectors.json` | The **RSWP swap-order advertisement** (v2 + v3 frames), `MultiTxOutV1` price terms, and swap token-id derivation | Reference vectors byte-derived from the canonical producers/parsers (Radiant-Core `swapindex.cpp`, Photonic builder); the reassembly vector reproduces the Radiant-Core functional test. **No mainnet-anchored vector yet** (tracked follow-up). Guarded by `tests/test_rswp_conformance_vectors.py`. |
 
 ## Format (`dmint-v2-contract-vectors/1`)
 

--- a/conformance/rswp-order-vectors.json
+++ b/conformance/rswp-order-vectors.json
@@ -1,0 +1,181 @@
+{
+  "schema": "radiant-rswp-order/1",
+  "builder": "pyrxd.swap.rswp: encode_rswp_order / encode_price_terms / swap_token_id",
+  "provenance": "REFERENCE vectors produced by pyrxd, byte-derived from the canonical sources (Radiant-Core src/index/swapindex.cpp parser; Photonic-Wallet buildSwapAdvertisementScript / encodeScriptNum / assetToSwapTokenId / MultiTxOutV1). No vector here is yet anchored to a live mainnet order \u2014 a mainnet golden vector is a tracked follow-up. The reassembly vector reproduces the Radiant-Core functional test (test/functional/feature_swap.py). The v3 frame follows the Photonic Phase-2 layout (expiry_height 4-byte LE after wantTokenID, flag 0x02); NOTE the deployed Radiant-Core swapindex parses v2 only and drops v3 adverts.",
+  "notes": {
+    "signature_field": "opaque at the frame layer (the full maker scriptSig); vectors use a fixed synthetic value",
+    "token_id": "sha256 of the 36-byte little-endian ref (txid reversed || vout LE); display orientation in this file; pushed byte-reversed on chain",
+    "small_fields": "version/flags/offeredType/termsType MUST be 1-byte direct data pushes (node requires data.size()==1; OP_N is dropped)",
+    "vout": "OP_0 for 0, else minimal CScriptNum direct push; must fit a 4-byte CScriptNum (node reads CScriptNum(data,false,4))"
+  },
+  "token_id_vectors": [
+    {
+      "id": "rxd-native",
+      "ref": null,
+      "token_id_display_hex": "0000000000000000000000000000000000000000000000000000000000000000"
+    },
+    {
+      "id": "glyph-ref-a",
+      "ref": {
+        "txid": "e0e0e0e0e0e0e0e0e0e0e0e0e0e0e0e0e0e0e0e0e0e0e0e0e0e0e0e0e0e0e001",
+        "vout": 1
+      },
+      "token_id_display_hex": "35fa0b2776848ba33b9ebc8f2ce4739325e773c7cba1b2525c33cab421ef597e"
+    },
+    {
+      "id": "glyph-ref-b",
+      "ref": {
+        "txid": "f1f1f1f1f1f1f1f1f1f1f1f1f1f1f1f1f1f1f1f1f1f1f1f1f1f1f1f1f1f1f102",
+        "vout": 0
+      },
+      "token_id_display_hex": "2ae9f433a0292548c6ffe3aa386453c49ae024878c7a11eda920e2d7881858c3"
+    }
+  ],
+  "price_terms_vectors": [
+    {
+      "id": "single-p2pkh",
+      "outputs": [
+        {
+          "value": 123456789,
+          "script_hex": "76a914aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa88ac"
+        }
+      ],
+      "price_terms_hex": "0115cd5b07000000001976a914aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa88ac"
+    },
+    {
+      "id": "two-outputs",
+      "outputs": [
+        {
+          "value": 1,
+          "script_hex": "76a914aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa88ac"
+        },
+        {
+          "value": 4294967295,
+          "script_hex": "51"
+        }
+      ],
+      "price_terms_hex": "0201000000000000001976a914aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa88acffffffff000000000151"
+    },
+    {
+      "id": "long-script",
+      "outputs": [
+        {
+          "value": 600,
+          "script_hex": "6a4c96bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+        }
+      ],
+      "price_terms_hex": "015802000000000000996a4c96bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+    }
+  ],
+  "frame_vectors": [
+    {
+      "id": "v2-ft-for-rxd",
+      "source": "reference",
+      "params": {
+        "offered_type": 2,
+        "token_ref": {
+          "txid": "e0e0e0e0e0e0e0e0e0e0e0e0e0e0e0e0e0e0e0e0e0e0e0e0e0e0e0e0e0e0e001",
+          "vout": 1
+        },
+        "want_token_ref": null,
+        "offered_txid": "abababababababababababababababababababababababababababababababab",
+        "offered_vout": 0,
+        "price_terms_outputs": [
+          {
+            "value": 123456789,
+            "script_hex": "76a914aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa88ac"
+          }
+        ],
+        "signature_hex": "4730440220111111111111111111111111111111111111111111111111111111111111111102202222222222222222222222222222222222222222222222222222222222222222c321023333333333333333333333333333333333333333333333333333333333333333",
+        "expiry_height": null
+      },
+      "advert_script_hex": "6a04525357500102010001020101207e59ef21b4ca335c52b2a1cbc773e7259373e42c8fbc9e3ba38b8476270bfa3520abababababababababababababababababababababababababababababababab00230115cd5b07000000001976a914aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa88ac4c6a4730440220111111111111111111111111111111111111111111111111111111111111111102202222222222222222222222222222222222222222222222222222222222222222c321023333333333333333333333333333333333333333333333333333333333333333"
+    },
+    {
+      "id": "v2-rxd-for-ft",
+      "source": "reference",
+      "params": {
+        "offered_type": 0,
+        "token_ref": null,
+        "want_token_ref": {
+          "txid": "e0e0e0e0e0e0e0e0e0e0e0e0e0e0e0e0e0e0e0e0e0e0e0e0e0e0e0e0e0e0e001",
+          "vout": 1
+        },
+        "offered_txid": "cdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcd",
+        "offered_vout": 1,
+        "price_terms_outputs": [
+          {
+            "value": 123456789,
+            "script_hex": "76a914aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa88ac"
+          }
+        ],
+        "signature_hex": "4730440220111111111111111111111111111111111111111111111111111111111111111102202222222222222222222222222222222222222222222222222222222222222222c321023333333333333333333333333333333333333333333333333333333333333333",
+        "expiry_height": null
+      },
+      "advert_script_hex": "6a04525357500102010101000101200000000000000000000000000000000000000000000000000000000000000000207e59ef21b4ca335c52b2a1cbc773e7259373e42c8fbc9e3ba38b8476270bfa3520cdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcd0101230115cd5b07000000001976a914aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa88ac4c6a4730440220111111111111111111111111111111111111111111111111111111111111111102202222222222222222222222222222222222222222222222222222222222222222c321023333333333333333333333333333333333333333333333333333333333333333"
+    },
+    {
+      "id": "v2-vout-128-scriptnum-pad",
+      "source": "reference",
+      "params": {
+        "offered_type": 2,
+        "token_ref": {
+          "txid": "f1f1f1f1f1f1f1f1f1f1f1f1f1f1f1f1f1f1f1f1f1f1f1f1f1f1f1f1f1f1f102",
+          "vout": 0
+        },
+        "want_token_ref": {
+          "txid": "e0e0e0e0e0e0e0e0e0e0e0e0e0e0e0e0e0e0e0e0e0e0e0e0e0e0e0e0e0e0e001",
+          "vout": 1
+        },
+        "offered_txid": "efefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefef",
+        "offered_vout": 128,
+        "price_terms_outputs": [
+          {
+            "value": 1,
+            "script_hex": "76a914aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa88ac"
+          },
+          {
+            "value": 4294967295,
+            "script_hex": "51"
+          }
+        ],
+        "signature_hex": "4730440220111111111111111111111111111111111111111111111111111111111111111102202222222222222222222222222222222222222222222222222222222222222222c321023333333333333333333333333333333333333333333333333333333333333333",
+        "expiry_height": null
+      },
+      "advert_script_hex": "6a0452535750010201010102010120c3581888d7e220a9ed117a8c8724e09ac4536438aae3ffc6482529a033f4e92a207e59ef21b4ca335c52b2a1cbc773e7259373e42c8fbc9e3ba38b8476270bfa3520efefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefef0280002d0201000000000000001976a914aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa88acffffffff0000000001514c6a4730440220111111111111111111111111111111111111111111111111111111111111111102202222222222222222222222222222222222222222222222222222222222222222c321023333333333333333333333333333333333333333333333333333333333333333"
+    },
+    {
+      "id": "v3-with-expiry",
+      "source": "reference",
+      "params": {
+        "offered_type": 0,
+        "token_ref": null,
+        "want_token_ref": {
+          "txid": "e0e0e0e0e0e0e0e0e0e0e0e0e0e0e0e0e0e0e0e0e0e0e0e0e0e0e0e0e0e0e001",
+          "vout": 1
+        },
+        "offered_txid": "cdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcd",
+        "offered_vout": 0,
+        "price_terms_outputs": [
+          {
+            "value": 123456789,
+            "script_hex": "76a914aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa88ac"
+          }
+        ],
+        "signature_hex": "4730440220111111111111111111111111111111111111111111111111111111111111111102202222222222222222222222222222222222222222222222222222222222222222c321023333333333333333333333333333333333333333333333333333333333333333",
+        "expiry_height": 840000
+      },
+      "advert_script_hex": "6a04525357500103010301000101200000000000000000000000000000000000000000000000000000000000000000207e59ef21b4ca335c52b2a1cbc773e7259373e42c8fbc9e3ba38b8476270bfa350440d10c0020cdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcd00230115cd5b07000000001976a914aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa88ac4c6a4730440220111111111111111111111111111111111111111111111111111111111111111102202222222222222222222222222222222222222222222222222222222222222222c321023333333333333333333333333333333333333333333333333333333333333333"
+    }
+  ],
+  "reassembly_vector": {
+    "id": "radiant-core-feature-swap-tail-rule",
+    "source": "Radiant-Core test/functional/feature_swap.py (see docs/swap-order-wire-format.md)",
+    "description": "price_terms = concat of all middle pushes, signature = final push",
+    "frame_hex": "6a0452535750010201000100010120000000000000000000000000000000000000000000000000000000000000000020aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa0005010203040505060708090a0404050607",
+    "expected": {
+      "price_terms_hex": "0102030405060708090a",
+      "signature_hex": "04050607"
+    }
+  }
+}

--- a/docs/plans/2026-07-05-rswp-orderbook-design.md
+++ b/docs/plans/2026-07-05-rswp-orderbook-design.md
@@ -1,0 +1,279 @@
+---
+title: RSWP same-chain swap primitive + on-chain orderbook — design
+type: plan
+date: 2026-07-05
+status: Phase 0 design — revised after a divergent review panel (simplicity / security / python-shape, run independently in parallel); §"Panel revisions" records what changed and why
+parent: docs/plans/2026-06-26-pyrxd-next-steps-brainstorm.md
+---
+
+# RSWP on-chain orderbook — design note
+
+Implements the top RSWP cluster of the 2026-06-26 brainstorm: the **write side** of the
+on-chain swap orderbook (pyrxd already ships the read/decode side in
+`pyrxd/gravity/swap_order.py`). Everything here is **same-chain** (RXD ↔ Glyph FT on
+Radiant); the cross-chain HTLC stack (`pyrxd.gravity`) is untouched.
+
+## Sources of authority (all verified in-source for this note)
+
+| Concern | Source checked |
+|---|---|
+| Frame layout + node acceptance rules | Radiant-Core `src/index/swapindex.cpp` (`WriteBlock` parser; v2 + legacy-v1 branches; swapindex present since the 2.0.0 initial release, so the pinned regtest binary `v3.1.1` serves `getopenorders*`) |
+| Producer byte choices | Photonic-Wallet `packages/app/src/pages/Swap.tsx` → `buildSwapAdvertisementScript` + `encodeScriptNum` |
+| `ContractType` enum | Photonic `packages/app/src/types.ts`: **RXD=0, NFT=1, FT=2, VAULT=3** — note this is *not* the RXD=0/FT=1/NFT=2 guess the wire-format doc warned about; verified here |
+| `tokenID` derivation | Photonic `swapBroadcast.ts` → `assetToSwapTokenId`: `sha256(ref_le)` where `ref_le` is the 36-byte little-endian script-operand ref (== `GlyphRef.to_bytes()`), and the *digest is pushed byte-reversed* on chain |
+| `price_terms` (MultiTxOutV1) | Photonic `swapBroadcast.ts` `encodeOutput`/`encodeCompactSize`; already mirrored by the pyrxd decoder |
+| RSWP **v3** (expiry) + refund covenant | Photonic (MudwoodLabs fork) `docs/swap-offer-expiry-cancellation.md` §4 + `packages/lib/src/swapRefundCovenant.ts` — regtest-proven 2026-06-09 on the wallet side; Radiant-Core/RXinDexer v3 parsers NOT yet landed (a v3 advert is dropped by the current node parser, not misparsed) |
+| Reference vector | `docs/swap-order-wire-format.md` (Radiant-Core `feature_swap.py` tail-reassembly vector) |
+
+## What already exists / is reused (no re-derivation)
+
+- **Decoder**: `pyrxd.gravity.swap_order.decode_rswp_order` (v2) + `parse_price_terms`.
+  Stays the single canonical decoder; gets an **additive** v3 extension (below).
+- **Maker partial-tx signing**: `pyrxd.swap.partial.create_offer` already builds exactly
+  the PSRT the RSWP book needs — one input signed `SIGHASH_SINGLE|ANYONECANPAY|FORKID`
+  (`0xC3`) committing to one output. The RSWP `signature` push **is** that input's full
+  scriptSig.
+- **Taker completion + verification**: `pyrxd.swap.partial.accept_offer` (outpoint/source
+  verification, terms reconciliation, maker-sig re-verification pre/post, FT conservation,
+  change). The RSWP take path is a **bridge** into it, not a re-implementation.
+- **Regtest harness**: `pyrxd.devnet.RegtestNode` (docker, official release binary).
+
+## Wire format (encoder rules — byte-compatible with Photonic, accepted by the node)
+
+```
+OP_RETURN "RSWP" <version:1> <flags:1> <offeredType:1> <termsType=0x01:1> <tokenID:32>
+  [wantTokenID:32          if flags & 0x01]
+  [expiry_height:4 LE      if flags & 0x02]      # v3 only
+  <offeredUTXOHash:32> <offeredUTXOIndex> <priceTerms> <signature>
+```
+
+Encoder byte choices that are **load-bearing** (the node's parser is strict where the
+pyrxd decoder is lenient — the encoder must satisfy the strictest consumer):
+
+1. `version`, `flags`, `offeredType`, `termsType` are **1-byte direct data pushes**
+   (`0x01 <b>`), never `OP_N`. The node requires `data.size() == 1`; `GetOp` on `OP_2`
+   yields empty data, so an `OP_N`-encoded version byte makes the node **drop the order**.
+2. `tokenID` / `wantTokenID`: `sha256(GlyphRef.to_bytes())` **pushed byte-reversed**;
+   32 zero bytes for native RXD. When the want side is RXD: omit `wantTokenID`, clear
+   flag bit 0 (Photonic behavior).
+3. `offeredUTXOHash`: txid bytes reversed (internal LE order).
+4. `offeredUTXOIndex`: `OP_0` when 0, else a minimal-CScriptNum direct push (matches
+   Photonic `encodeScriptNum`; the node accepts both `CScriptNum` and `OP_N`, Photonic
+   emits this form, so we byte-match Photonic).
+5. `priceTerms`: **one** push of the MultiTxOutV1 blob
+   (`CompactSize(count) || [value:8 LE || CompactSize(len) || script]*`). The node
+   concatenates all middle pushes, but Photonic emits one — we byte-match Photonic.
+6. `signature`: final push = the **entire scriptSig** of the maker's signed input
+   (`PUSH(DER||0xC3) PUSH(pubkey)`), not a bare signature.
+7. v3 only: `expiry_height` = 4-byte LE unsigned, inserted after `wantTokenID` /
+   before the outpoint; `version=0x03`, flag `0x02`. v2 and v3 paths must be
+   byte-for-byte identical apart from these two fields.
+
+The advertisement is a value-0 OP_RETURN output in an otherwise ordinary funded tx.
+
+## Covenant approach (the open design point — decision, REVISED by the panel)
+
+**No new covenant is invented, and no covenant ships in this PR.**
+
+- **v2 (this PR): no covenant.** The offered UTXO is a plain P2PKH/FT output owned by the
+  maker. This is what the live mainnet book runs on; the current Radiant-Core swapindex
+  **drops** v3 adverts, so v2 is the only interoperable posting format today.
+  *Cancel = self-spend* of the offered UTXO (the only hard revocation in v2 — the
+  `0xC3` signature has no expiry).
+- **v3 write-side (CUT to a follow-up PR): Photonic's timelocked-refund covenant.**
+  The original draft scoped posting into
+  `OP_IF <inner> OP_ELSE <expiry> OP_CHECKLOCKTIMEVERIFY OP_DROP <inner> OP_ENDIF`
+  (the MudwoodLabs Photonic Phase-2 design, wallet-side regtest-proven). The panel cut
+  it, for reasons this note originally missed:
+  1. *No deployed consumer can see a v3 advert* (the node drops them), so shipped
+     write-side has zero interoperable users; the cross-repo parser rollout needs
+     **frame vectors**, which the decode side supplies.
+  2. *The "bridge into `accept_offer`" premise breaks*: a covenant prevout fails
+     `_owner_pkh_of` / `_asset_of` / `_verify_owner_signature`, and the `OP_1` branch
+     selector breaks the strict two-push scriptSig parser — v3 take is surgery on the
+     battle-tested v2 primitives (asset/owner from the INNER script, BIP143 scriptCode
+     = the FULL covenant SPK), deserving its own PR and red-team.
+  3. *FT-in-covenant may be consensus-blocked* (the FT codeScript epilogue forbids
+     foreign covenants — a known pyrxd finding; Photonic itself has only proven RXD
+     on-chain). A v3 follow-up starts RXD-only.
+  4. The follow-up must also address two covenant findings from the security pass:
+     the refund tx is third-party **txid-malleable** via the unsigned branch selector
+     (track refunds by outpoint-spent, never chain off an unconfirmed refund), and
+     **expiry does not stop fills** (CLTV is valid-from; a post-expiry fill remains
+     consensus-valid and binding — the maker must actively win the refund race).
+
+**What this PR ships for v3:** additive decode support (`expiry_height`, strict
+"version 3 iff flag 0x02" rule) + v3 frame conformance vectors, seeding the
+Radiant-Core/RXinDexer parser rollout. The take path refuses any order carrying an
+expiry, both because the covenant is unspendable by this code and because expiry
+comparison (`tip >= expiry`, Photonic `isOfferExpiredByHeight`) belongs with the
+covenant work.
+
+## Module layout (additive)
+
+```
+src/pyrxd/swap/rswp/
+    __init__.py    public surface (re-exports, incl. the gravity decoder names —
+                   pyrxd.swap.rswp becomes the documented import home; the decoder
+                   implementation stays in gravity/swap_order.py)
+    wire.py        encode_price_terms / encode_rswp_order / swap_token_id
+    orders.py      pure builders: create_rswp_order, prepare_offered_utxo,
+                   build_advert_tx, order→SwapOffer bridge + take, cancel self-spend,
+                   verify_offer_signature
+    book.py        OrderbookClient over a named async OrderbookSource Protocol
+                   (@runtime_checkable, fail-closed — house style, not a bare callable)
+```
+
+(The panel cut `covenant.py` with the v3 write-side, and cut the block-scan book
+source — regtest e2e gets `-swapindex=1` via a one-line additive `RegtestNode.start`
+extension instead. The RXinDexer `swap.*` adapter remains the practical second source,
+already tracked as a follow-up.)
+
+`pyrxd/gravity/swap_order.py` gets the **only** shared-code touch: additive v3 decode
+(`expiry_height: int | None = None` appended to the frozen dataclass; `version in (2,3)`).
+Every existing v2 test must pass unchanged — that is the equivalence proof.
+
+## Flows
+
+**Post (maker)**  
+1. (optional) `prepare_offered_utxo` — exact-amount self-send, since `SINGLE` gives the
+   whole UTXO.  
+2. `create_rswp_order` — signs the offered input `0xC3` against the single demanded
+   output (via the `create_offer` mechanics), derives token ids, returns the offer +
+   the advert OP_RETURN script.  
+3. `build_advert_tx` — wraps the advert in a funded tx (plain-RXD funding + change;
+   FT funding is refused — it would strand token value). Broadcast both (the library
+   never broadcasts by itself; regtest tests do).
+
+**Take (taker)**  
+1. Decode advert (`decode_rswp_order`), fetch + txid-verify the offered UTXO's source
+   tx (`pyrxd.swap.resolve.fetch_transaction`).  
+2. `rswp_order_to_swap_offer` bridge — the trust boundary; see the invariants below.
+   Reconstructs the maker's partial tx from `(outpoint, signature push, demanded
+   output)` with the **pinned tx shape** `nVersion=1, nLockTime=0,
+   nSequence=0xFFFFFFFF` — these fields are inside the signed preimage but absent
+   from the advert; the pinned values are simultaneously the pyrxd *and* radiantjs
+   defaults (verified in radiantjs 1.9.6 `transaction.js` / `input.js`), so
+   pyrxd- and Photonic-produced orders both reconstruct correctly, and any maker
+   using a non-default shape fails signature verification fail-safe (refused, no
+   fund risk).  
+3. Existing `accept_offer` does signature re-verification (pre- and post-completion) +
+   completion + conservation + change.
+
+**Cancel (maker)**  
+Self-spend of the offered UTXO (`build_cancel_tx`) — works for RXD and FT offers
+(conservation returns the full token amount; plain-RXD funding covers the fee for an
+FT cancel).
+
+**Browse**  
+`OrderbookClient` over one injectable `OrderbookSource` Protocol (the node swapindex
+RPCs `getopenorders` / `getopenordersbywant`, plus `getrawtransaction` / `gettxout`).
+Every index row is treated as HOSTILE: (a) decoded, (b) classified open/spent by
+`gettxout` on the offered outpoint (a liveness *hint* — a lying "open" dies at fill
+as a double-spend; a lying "spent" is censorship only), (c) source-tx fetched with
+the computed-txid-equals-requested check, (d) run through the same bridge +
+signature verification the take path uses — so *fillable* means exactly "what
+`accept_offer` would accept". Rows that fail are returned with `problem` set, never
+silently dropped.
+
+## Security invariants (tested, not assumed; #6–#9 added by the security pass)
+
+1. **Maker sig binds the trade**: tampering with the demanded output (value or script)
+   or the offered outpoint invalidates the `0xC3` signature → `accept_offer` rejects
+   (unit) and the node rejects (regtest).
+2. **Single-winner**: the offered UTXO can be spent once. Double-take and
+   cancel-vs-take races settle to exactly one confirmed spend (regtest).
+3. **No replay**: after the offered UTXO is spent, rebroadcast of the completion (or a
+   re-post of the same advert) cannot move funds (regtest).
+4. **SINGLE index discipline**: maker input and demanded output are both at index 0 in
+   the completion; the take path refuses orders whose MultiTxOutV1 has ≠ 1 output
+   (indexes ≥ 1 would be *unsigned* demands — fillable but unenforceable; we decode
+   them for display, refuse to take, and say why).
+5. **Parser robustness**: the encoder round-trips through the decoder
+   (property-based), and malformed frames/price-terms never crash.
+6. **Sighash flag pinned to `0xC3`** (security finding F1): the flag byte rides in
+   the *untrusted* signature push, and `0xC2` (`NONE|ANYONECANPAY|FORKID`) is the one
+   flag that verifies both before AND after completion while committing to **no
+   outputs** — an order that *looks* enforceable but whose demand is unbound.
+   Enforced in the shared `_verify_owner_signature` (all existing swap suites pass —
+   equivalence proof) and re-checked early in the bridge for a precise error.
+7. **The advertisement's claims are verified against the chain** (python-shape pass):
+   `token_id` / `want_token_id` / `offeredType` must match the REAL offered UTXO and
+   demanded-output scripts — a lying advert is rejected at the bridge rather than
+   surviving to display or completion (without this, the bridge's synthesized terms
+   would make `accept_offer`'s terms reconciliation a tautology).
+8. **Fillable = what `accept_offer` accepts** (F6): the book's fillability predicate
+   runs the same bridge + signature verification as the take path, and demanded
+   values are capped at MAX_MONEY (an unfundable 2⁶⁴-ish demand is not "fillable").
+9. **Hostile index rows can't crash or spoof** (F7/F8): a negative/huge CScriptNum
+   vout is rejected at the bridge before any `TransactionInput` is constructed, and
+   the browse-time source-tx fetch recomputes the txid rather than trusting the
+   indexer.
+
+## Explicit design decisions (brainstorm left these open)
+
+| # | Decision | Rationale |
+|---|---|---|
+| D1 | **v2 is the default posting format; v3 is opt-in experimental** | Current Radiant-Core swapindex drops v3 adverts; posting v3 by default would make orders invisible to the live book. Photonic gates v3 the same way (`SWAP_RESERVE_INTO_REFUND_COVENANT = false`). |
+| D2 | `ContractType`: **RXD=0, NFT=1, FT=2** | Verified in Photonic `types.ts`; the wire-format doc explicitly warned against assuming FT=1/NFT=2. |
+| D3 | `tokenID = sha256(36-byte LE ref)`, digest pushed reversed | Verified in `assetToSwapTokenId` (incl. its on-chain-verified comment); `GlyphRef.to_bytes()` already produces the LE ref. |
+| D4 | **Adopt Photonic's refund covenant byte-for-byte; invent nothing** | It is regtest-proven, documented, and cross-repo coordination is already planned around it. A pyrxd-specific covenant would fork the book and add unaudited consensus-critical surface. |
+| D5 | Encoder emits Photonic's exact byte choices (1-byte direct pushes; `OP_0`/minimal-CScriptNum vout; single priceTerms push) | The node parser is stricter than the pyrxd decoder; Photonic's output is the de-facto conformance target; byte-identity makes golden vectors meaningful. |
+| D6 | Take path requires exactly one demanded output | `SIGHASH_SINGLE` signs only output[0]; extra demanded outputs are unenforceable — honoring them silently would let a malicious maker fake "demands" the signature doesn't back. |
+| D7 | Take = bridge into the existing `accept_offer` | Reuses the battle-tested verification/conservation path instead of a parallel implementation that could drift. |
+| D8 | Asset scope: RXD + Glyph FT (NFT decode/display only) | Matches `pyrxd.swap` v1 scope; NFT (singleton semantics) is its own brainstorm item and does not block the book. |
+| D9 | Library + example first; `pyrxd swap post/fill/orders` CLI is a follow-up | Keeps this slice reviewable; the CLI is a thin wrapper once the library is proven. Library code never broadcasts on its own. |
+| D10 | Orderbook client source: ONE injectable `OrderbookSource` Protocol (swapindex RPCs) | REVISED by panel: the block-scan fallback was cut — its stated justification (regtest independence) is void once `RegtestNode.start` grows an additive `extra_args`, and a block walk is impractical at mainnet scale anyway. The practical second source is the RXinDexer `swap.*` adapter (follow-up). |
+| D11 | v3 decode goes into the existing canonical decoder (additive) | One decoder; two would drift. Existing v2 tests unchanged = equivalence proof. Strict rule: `version == 3` iff flag `0x02` (a mis-gated 4-byte push would otherwise be silently folded into `price_terms` by the greedy tail rule). |
+| D12 | Expiry boundary: expired iff `tip_height >= expiry_height` | Mirrors Photonic `isOfferExpiredByHeight`; applies to the v3 follow-up (this PR refuses to take any order carrying an expiry). |
+| D13 | v3 WRITE-side (covenant posting / refund / take) deferred to its own PR | Panel consensus (independent simplicity + python-shape findings): no deployed consumer parses v3, and the covenant breaks the `accept_offer`-bridge premise — it needs its own red-teamed change, starting RXD-only (FT-in-covenant consensus blocker). |
+| D14 | Sighash flag pinned to `0xC3` inside the shared `_verify_owner_signature` | Security finding F1 (`0xC2` binds no outputs yet verifies pre- and post-completion). A shared-code touch, accepted deliberately: the maker input of the offer pattern is only ever `0xC3`, and every existing swap suite passes unchanged. |
+| D15 | Reconstructed partial tx shape pinned to `nVersion=1, nLockTime=0, nSequence=0xFFFFFFFF` | Security finding F5: these preimage-committed fields are absent from the advert. The pinned values are the pyrxd AND radiantjs defaults (verified in radiantjs 1.9.6), so both producers reconstruct; anything else fails signature verification fail-safe. |
+| D16 | Keep `getopenordersbywant` alongside `getopenorders` on the Protocol | Deviation from the simplicity pass's "one RPC + client filter": the want-side book cannot be client-filtered without enumerating every token's offer-side book. Two symmetrical one-line methods. |
+
+## Test plan (trimmed by the simplicity pass: one regtest case per consensus
+invariant — single-winner and no-replay are node double-spend semantics, not pyrxd
+code paths; both *trade directions* stay, they exercise different classification paths)
+
+- **Unit/property (`tests/test_rswp_wire.py`)**: Hypothesis round-trip
+  encode→decode over the parameter space (v2/v3, RXD/FT both sides, vout ranges,
+  multi-output price terms); targeted malformed-frame rejections (version/flag
+  mismatch both ways, wrong push sizes); token-id derivation.
+- **Flows unit (`tests/test_rswp_orders.py`)**: post/take/cancel builders pure-path;
+  bridge → `accept_offer` end-to-end offline; the invariant list above as explicit
+  cases (0xC2 flag, lying token ids, ≠1 demanded output, negative vout, MAX_MONEY
+  cap, expiry refusal, tampered demanded output).
+- **Conformance (`conformance/rswp-order-vectors.json` + re-derive test)**: frame
+  vectors (v2 RXD↔FT, FT↔RXD, v3 with expiry), MultiTxOutV1 vectors, token-id
+  vectors, the Radiant-Core functional-test reassembly vector. CI re-derives
+  byte-for-byte (same shape as the dMint suite).
+- **Regtest e2e (`tests/test_rswp_regtest_e2e.py`, `@pytest.mark.integration` +
+  `RSWP_REGTEST=1`)**: happy path post→`getopenorders`-visible→take→settle, both
+  directions (RXD→FT, FT→RXD); one double-take case; one cancel-then-take-rejected
+  case; one tampered-completion-rejected case. `RegtestNode.start` gains additive
+  `extra_args` for `-swapindex=1`.
+- **Example**: `examples/rswp_orderbook_demo.py` against `pyrxd regtest` (offline).
+
+## Panel revisions (what the divergent review changed)
+
+Three reviewers (code-simplicity, security-sentinel, kieran-python) ran in parallel on
+the first draft of this note, writing independently. Adopted: v3 write-side cut to a
+follow-up PR (both simplicity and python-shape independently proved the
+`accept_offer`-bridge premise false for covenant prevouts); block-scan book source cut;
+`encode_rswp_advert` renamed `encode_rswp_order` to mirror the decoder; bare-callable
+transport replaced with a named `@runtime_checkable` async Protocol; strict v3
+version/flag decode rule; advertised-ids-vs-reality bridge check; sighash-flag pin
+(F1); tx-shape pinning (F5); fillable-predicate parity + MAX_MONEY cap (F6);
+negative-vout bridge rejection (F7); browse-time txid-verified fetch (F8); adversarial
+regtest matrix reduced to one case per consensus invariant. Rejected (with reason):
+collapsing `getopenordersbywant` into a client-side filter (D16 — not derivable
+client-side); folding `wire.py` into `orders.py` (the encoder is the conformance-vector
+target and the reviewer marked the split acceptable either way).
+
+## Out of scope (tracked follow-ups)
+
+RSWP v3 write-side (refund covenant, covenant-aware take, expiry enforcement — its own
+red-teamed PR, RXD-only first; must address the refund-selector txid malleability and
+the post-expiry fill race documented above), CLI (`swap post/fill/orders`),
+market-maker quoting toolkit, maker lifecycle tracker, RXinDexer `swap.*` source
+adapter, NFT take/post, atheris harness for the encoder.

--- a/examples/README.md
+++ b/examples/README.md
@@ -103,6 +103,16 @@ it runs with **no node and no network** — it exercises the real swap API
 (signing, conservation, maker-signature re-verification) but never broadcasts.
 → [`../docs/concepts/partial-tx-swaps.md`](../docs/concepts/partial-tx-swaps.md)
 
+### `rswp_orderbook_demo.py` — no network
+The **on-chain RSWP orderbook** (`pyrxd.swap.rswp`): the public version of the
+partial-tx swap. Maker posts an `OP_RETURN` advertisement any wallet can
+discover; taker decodes the advert **bytes**, re-verifies every claim against
+the offered UTXO (lying adverts are rejected — demonstrated), completes the
+swap; maker cancel = the self-spend hard revocation. Runs with **no node and
+no network**; the live-node version (real `-swapindex` book, double-take and
+cancel races on real consensus) is `tests/test_rswp_regtest_e2e.py`.
+→ [`../docs/plans/2026-07-05-rswp-orderbook-design.md`](../docs/plans/2026-07-05-rswp-orderbook-design.md)
+
 ---
 
 ## Cross-chain swaps (pre-audit)

--- a/examples/rswp_orderbook_demo.py
+++ b/examples/rswp_orderbook_demo.py
@@ -1,0 +1,141 @@
+#!/usr/bin/env python3
+"""RSWP on-chain swap orderbook (``pyrxd.swap.rswp``) — post → decode → take demo.
+
+The on-chain book is the public version of the ``pyrxd.swap`` partial-tx
+swap: instead of handing the signed offer to a counterparty over a private
+transport, the maker broadcasts an ``OP_RETURN`` advertisement ("RSWP" frame)
+that any taker — any wallet, not just pyrxd — can discover, verify, and fill.
+
+    Maker:  offers a 1000-unit FT UTXO, demands 800 RXD photons,
+            signs SIGHASH_SINGLE|ANYONECANPAY|FORKID, posts the advert.
+    Taker:  decodes the advert BYTES from the chain, re-verifies every claim
+            against the offered UTXO, completes and signs the swap tx.
+
+This demo is self-contained: it synthesises the source UTXOs in memory so it
+runs with no node and no network, while exercising the REAL wire encoder,
+decoder, verification bridge, and signing. To run it against a live regtest
+node with the actual swap index (``getopenorders``), see
+``tests/test_rswp_regtest_e2e.py`` — the flow is identical, plus broadcasts.
+
+Usage::
+
+    python examples/rswp_orderbook_demo.py
+
+Design + wire authority: docs/plans/2026-07-05-rswp-orderbook-design.md,
+docs/swap-order-wire-format.md.
+"""
+
+from __future__ import annotations
+
+from pyrxd.glyph.script import build_ft_locking_script
+from pyrxd.glyph.types import GlyphRef
+from pyrxd.keys import PrivateKey
+from pyrxd.script.script import Script
+from pyrxd.script.type import P2PKH
+from pyrxd.security.errors import ValidationError
+from pyrxd.security.types import Hex20, Txid
+from pyrxd.swap import Asset, FundingInput
+from pyrxd.swap.rswp import (
+    build_advert_tx,
+    build_cancel_tx,
+    create_rswp_order,
+    decode_rswp_order,
+    rswp_order_to_swap_offer,
+    take_rswp_order,
+)
+from pyrxd.transaction.transaction import Transaction
+from pyrxd.transaction.transaction_output import TransactionOutput
+
+FT_REF = GlyphRef(txid=Txid("aa" * 32), vout=0)
+
+
+def _p2pkh_source(pkh: bytes, value: int) -> Transaction:
+    tx = Transaction()
+    tx.add_output(TransactionOutput(P2PKH().lock(pkh), value))
+    return tx
+
+
+def _ft_source(pkh: bytes, ref: GlyphRef, value: int) -> Transaction:
+    tx = Transaction()
+    tx.add_output(TransactionOutput(Script(build_ft_locking_script(Hex20(pkh), ref)), value))
+    return tx
+
+
+def main() -> None:
+    maker = PrivateKey()
+    taker = PrivateKey()
+    maker_pkh = maker.public_key().hash160()
+    taker_pkh = taker.public_key().hash160()
+
+    # ── Maker: post ──────────────────────────────────────────────────────────
+    # The offered UTXO is given WHOLE (SINGLE binds only the demanded output),
+    # so real makers first mint an exact-amount UTXO — see prepare_offered_utxo.
+    ft_source = _ft_source(maker_pkh, FT_REF, 1000)
+    post = create_rswp_order(
+        give_source_tx=ft_source,
+        give_vout=0,
+        maker_key=maker,
+        receive=Asset(kind="rxd", amount=800),
+        maker_receive_pkh=maker_pkh,
+    )
+    advert_tx = build_advert_tx(
+        advert_script=post.advert_script,
+        funding=[FundingInput(_p2pkh_source(maker_pkh, 5_000), 0, maker)],
+        change_pkh=maker_pkh,
+        fee=500,
+    )
+    print(f"advert OP_RETURN script ({len(post.advert_script)} bytes):")
+    print(f"  {post.advert_script.hex()}")
+    print(f"advert tx to broadcast: {advert_tx.txid()}\n")
+
+    # ── Taker: discover + verify + take ─────────────────────────────────────
+    # On a live chain the taker gets these bytes from the swap index (see
+    # OrderbookClient) or an OP_RETURN scan, and fetches the offered UTXO's
+    # source tx with pyrxd.swap.resolve.fetch_transaction (txid-verified).
+    order = decode_rswp_order(post.advert_script)
+    print("decoded order:")
+    print(
+        f"  offers   : {'RXD' if order.offered_is_rxd else 'FT'} UTXO {order.offered_txid[:16]}…:{order.offered_utxo_index}"
+    )
+    print(f"  demands  : {order.demanded_outputs[0].value} photons → maker script")
+    print(f"  signature: {len(order.signature)} bytes, sighash 0xc3\n")
+
+    swap_tx = take_rswp_order(
+        order,
+        give_source_tx=ft_source,  # in production: fetch_transaction(client, order.offered_txid)
+        funding=[FundingInput(_p2pkh_source(taker_pkh, 2_000), 0, taker)],
+        taker_receive_pkh=taker_pkh,
+        taker_change_pkh=taker_pkh,
+        fee=300,
+    )
+    print(f"completion tx to broadcast: {swap_tx.txid()}")
+    print(f"  output[0] (maker receives): {swap_tx.outputs[0].satoshis} photons")
+    print(f"  output[1] (taker receives): {swap_tx.outputs[1].satoshis} FT units\n")
+
+    # ── The verification is not cosmetic ─────────────────────────────────────
+    # A lying advertisement (here: claiming to offer a different token) dies at
+    # the bridge, before any funds are committed.
+    lying = decode_rswp_order(post.advert_script)
+    fields = {f: getattr(lying, f) for f in type(lying).__dataclass_fields__}
+    fields["token_id"] = b"\x11" * 32
+    try:
+        rswp_order_to_swap_offer(type(lying)(**fields), give_source_tx=ft_source)
+    except ValidationError as exc:
+        print(f"lying advert rejected: {exc}\n")
+
+    # ── Maker: cancel (the only hard revocation) ────────────────────────────
+    # The 0xC3 signature never expires; self-spending the offered UTXO is what
+    # kills the order. FT cancels conserve the token and fund the fee with RXD.
+    cancel_tx = build_cancel_tx(
+        offered_source_tx=ft_source,
+        offered_vout=0,
+        maker_key=maker,
+        refund_pkh=maker_pkh,
+        fee=400,
+        funding=[FundingInput(_p2pkh_source(maker_pkh, 3_000), 0, maker)],
+    )
+    print(f"cancel tx (broadcast INSTEAD of letting the order rest): {cancel_tx.txid()}")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/pyrxd/devnet.py
+++ b/src/pyrxd/devnet.py
@@ -203,8 +203,13 @@ class RegtestNode:
 
     # ----------------------------------------------------------------- lifecycle
 
-    def start(self, *, fresh: bool = False, initial_blocks: int = 101) -> None:
+    def start(self, *, fresh: bool = False, initial_blocks: int = 101, extra_args: tuple[str, ...] = ()) -> None:
         """Start the regtest node, create the dev wallet, and mature a coinbase.
+
+        ``extra_args`` are appended verbatim to the ``radiantd`` argv — e.g.
+        ``("-swapindex=1",)`` to serve the RSWP orderbook RPCs
+        (``getopenorders`` / ``getopenordersbywant``). Ignored when an already
+        running container is reused (start with ``fresh=True`` to apply).
 
         Idempotent unless ``fresh`` is set: if the container is already running
         it is left untouched (the chain state is preserved). ``fresh=True``
@@ -238,6 +243,7 @@ class RegtestNode:
                 f"-rpcpassword={self.RPC_PASSWORD}",
                 "-rpcbind=127.0.0.1",
                 "-rpcallowip=127.0.0.1",
+                *extra_args,
             ],
             capture_output=True,
             text=True,

--- a/src/pyrxd/gravity/swap_order.py
+++ b/src/pyrxd/gravity/swap_order.py
@@ -1,6 +1,6 @@
 """Decoder for the Radiant on-chain swap-order ("RSWP") OP_RETURN wire format — the READ side.
 
-Decodes a **v2** RSWP order advertised in an ``OP_RETURN`` output into structured fields, including the
+Decodes a **v2 or v3** RSWP order advertised in an ``OP_RETURN`` output into structured fields, including the
 Photonic ``MultiTxOutV1`` ``price_terms`` (the outputs the maker demands). This is the **canonical**
 decode: it follows the on-chain producer (Photonic-Wallet) and the consensus-node parser
 (Radiant-Core ``swapindex.cpp``). It matches current ``Radiant-Core/RXinDexer``, which decodes the same
@@ -9,9 +9,15 @@ garbage against real orders; that was fixed upstream 2026-06-01, commit ``24572c
 ``docs/swap-order-wire-format.md`` §Conflicts. Read-only: this builds and signs nothing.
 
 The frame (pushes after ``OP_RETURN``): ``"RSWP" version flags offeredType termsType tokenID
-[wantTokenID] offeredUTXOHash offeredUTXOIndex priceTerms… signature``. The tail rule (node
-``swapindex.cpp:642-659``): of the remaining pushes, ``price_terms = concat(tail[:-1])`` and
+[wantTokenID] [expiryHeight] offeredUTXOHash offeredUTXOIndex priceTerms… signature``. The tail rule
+(node ``swapindex.cpp:642-659``): of the remaining pushes, ``price_terms = concat(tail[:-1])`` and
 ``signature = tail[-1]`` (require ``len(tail) >= 2``).
+
+**v3** (Photonic ``docs/swap-offer-expiry-cancellation.md`` §4) bumps the version byte to ``0x03`` and,
+when flag bit ``0x02`` is set, inserts a 4-byte little-endian absolute ``expiry_height`` between the
+want-token id and the outpoint. The v2 field layout is otherwise unchanged. NOTE: the deployed
+Radiant-Core swapindex parses v2 only and *drops* v3 adverts — decode support here is part of the
+cross-repo v3 parser rollout, not evidence of live-network support.
 """
 
 from __future__ import annotations
@@ -25,6 +31,7 @@ from ..utils import Reader
 
 _RSWP_MAGIC = b"RSWP"
 _FLAG_HAS_WANT = 0x01
+_FLAG_HAS_EXPIRY = 0x02  # v3 only
 _RXD_TOKEN_ID = b"\x00" * 32
 
 
@@ -38,7 +45,7 @@ class DemandedOutput:
 
 @dataclass(frozen=True)
 class RswpOrder:
-    """A decoded v2 RSWP swap order. ``price_terms`` is the raw opaque blob; ``demanded_outputs`` is the
+    """A decoded v2/v3 RSWP swap order. ``price_terms`` is the raw opaque blob; ``demanded_outputs`` is the
     parsed ``MultiTxOutV1`` view (``None`` if the blob isn't valid MultiTxOutV1 — use ``price_terms``)."""
 
     version: int
@@ -52,6 +59,15 @@ class RswpOrder:
     price_terms: bytes  # opaque concat of the middle pushes
     demanded_outputs: list[DemandedOutput] | None  # parsed MultiTxOutV1, or None
     signature: bytes  # the full scriptSig: PUSH(DER||0xC3) PUSH(pubkey)
+    expiry_height: int | None = None  # v3 only: absolute block height (4-byte LE on the wire)
+
+    def __post_init__(self) -> None:
+        # v3 iff expiry (Photonic emits v3 exactly when an expiry is present; a
+        # v2 frame has no field to carry one). Keeps hand-built orders honest.
+        if self.version == 2 and self.expiry_height is not None:
+            raise ValidationError("a v2 RSWP order cannot carry an expiry_height")
+        if self.version == 3 and self.expiry_height is None:
+            raise ValidationError("a v3 RSWP order requires an expiry_height")
 
     @property
     def offered_txid(self) -> str:
@@ -133,8 +149,10 @@ def parse_price_terms_lenient(blob: bytes) -> list[DemandedOutput] | None:
 
 
 def decode_rswp_order(op_return_script: bytes) -> RswpOrder:
-    """Decode a v2 RSWP ``OP_RETURN`` script into an :class:`RswpOrder`. Raises ``ValidationError`` on a
-    malformed / non-v2 / non-RSWP frame."""
+    """Decode a v2/v3 RSWP ``OP_RETURN`` script into an :class:`RswpOrder`. Raises ``ValidationError``
+    on a malformed / unknown-version / non-RSWP frame, including a version/expiry-flag mismatch
+    (``version == 3`` iff flag ``0x02`` — a mis-gated 4-byte push would otherwise be silently folded
+    into ``price_terms`` by the greedy tail rule)."""
     items = _items(op_return_script)
     i = 0
 
@@ -164,13 +182,16 @@ def decode_rswp_order(op_return_script: bytes) -> RswpOrder:
     if _data("magic", 4) != _RSWP_MAGIC:
         raise ValidationError("not an RSWP order (missing magic)")
     version = _small_int("version")
-    if version != 2:
-        raise ValidationError(f"unsupported RSWP version {version} (this decoder handles v2)")
+    if version not in (2, 3):
+        raise ValidationError(f"unsupported RSWP version {version} (this decoder handles v2/v3)")
     flags = _small_int("flags")
+    if bool(flags & _FLAG_HAS_EXPIRY) != (version == 3):
+        raise ValidationError(f"RSWP version {version} is inconsistent with expiry flag 0x02 (v3 iff expiry)")
     offered_type = _small_int("offeredType")
     terms_type = _small_int("termsType")
     token_id = _data("tokenID", 32)
     want_token_id = _data("wantTokenID", 32) if (flags & _FLAG_HAS_WANT) else None
+    expiry_height = int.from_bytes(_data("expiryHeight", 4), "little") if (flags & _FLAG_HAS_EXPIRY) else None
     offered_utxo_hash = _data("offeredUTXOHash", 32)
     # offeredUTXOIndex: OP_0..OP_16 OR a minimal CScriptNum push.
     if i >= len(items):
@@ -197,4 +218,5 @@ def decode_rswp_order(op_return_script: bytes) -> RswpOrder:
         price_terms=price_terms,
         demanded_outputs=parse_price_terms(price_terms),
         signature=signature,
+        expiry_height=expiry_height,
     )

--- a/src/pyrxd/swap/partial.py
+++ b/src/pyrxd/swap/partial.py
@@ -130,6 +130,16 @@ def _verify_owner_signature(tx: Transaction, index: int) -> None:
     if len(sig_with_flag) < 2:
         raise ValidationError("malformed signature push")
     der, flag = sig_with_flag[:-1], sig_with_flag[-1]  # signature + its trailing sighash-type byte
+    # The maker input of an offer must be signed EXACTLY SINGLE|ANYONECANPAY|FORKID.
+    # The flag byte comes from the untrusted scriptSig, and NONE|ANYONECANPAY|FORKID
+    # (0xC2) is the one flag that verifies both before AND after the taker completes
+    # the transaction while committing to NO outputs at all — i.e. the offer's
+    # receive terms would not be bound by the signature it "verifies" under.
+    if flag != _OFFER_SIGHASH:
+        raise ValidationError(
+            f"offer input {index} is signed with sighash 0x{flag:02x}; only "
+            f"SINGLE|ANYONECANPAY|FORKID (0x{int(_OFFER_SIGHASH):02x}) binds the offer terms"
+        )
     # The sighash type is NOT carried in the tx wire format (it lives only in
     # the signature byte), so a parsed input always reports the default flag.
     # Restore the actual flag from the signature before computing the preimage,

--- a/src/pyrxd/swap/rswp/__init__.py
+++ b/src/pyrxd/swap/rswp/__init__.py
@@ -1,0 +1,103 @@
+"""RSWP on-chain swap orderbook — post, take, cancel, and browse (same-chain).
+
+The public import home for everything RSWP. The wire *decoder* implementation
+lives in :mod:`pyrxd.gravity.swap_order` for historical reasons and is
+re-exported here; new code should import from ``pyrxd.swap.rswp``.
+
+Quick start (regtest — the library never broadcasts by itself)::
+
+    from pyrxd.swap import Asset, FundingInput
+    from pyrxd.swap.rswp import (
+        create_rswp_order, build_advert_tx, decode_rswp_order, take_rswp_order,
+    )
+
+    # Maker: offer the exact-amount UTXO at source:0, demand 50 units of an FT.
+    post = create_rswp_order(
+        give_source_tx=source_tx, give_vout=0, maker_key=maker_key,
+        receive=Asset(kind="ft", amount=50, ref=ft_ref),
+        maker_receive_pkh=maker_pkh,
+    )
+    advert_tx = build_advert_tx(
+        advert_script=post.advert_script, funding=[...], change_pkh=maker_pkh, fee=500,
+    )
+    # broadcast advert_tx through your own node → the order is on the book.
+
+    # Taker: decode from chain, verify EVERYTHING, complete.
+    order = decode_rswp_order(op_return_script)
+    tx = take_rswp_order(
+        order, give_source_tx=fetched_and_txid_verified_source,
+        funding=[...], taker_receive_pkh=taker_pkh, taker_change_pkh=taker_pkh, fee=500,
+    )
+
+Design + byte-level authority: ``docs/plans/2026-07-05-rswp-orderbook-design.md``
+and ``docs/swap-order-wire-format.md``. Value mechanics are the proven
+``SIGHASH_SINGLE | ANYONECANPAY | FORKID`` primitives of :mod:`pyrxd.swap.partial`.
+"""
+
+from __future__ import annotations
+
+from ...gravity.swap_order import (
+    DemandedOutput,
+    RswpOrder,
+    decode_rswp_order,
+    parse_price_terms,
+    parse_price_terms_lenient,
+)
+from .book import BookEntry, OrderbookClient, OrderbookSource
+from .orders import (
+    RswpOrderPost,
+    build_advert_tx,
+    build_cancel_tx,
+    create_rswp_order,
+    prepare_offered_utxo,
+    rswp_order_to_swap_offer,
+    take_rswp_order,
+    verify_offer_signature,
+)
+from .wire import (
+    CONTRACT_TYPE_FT,
+    CONTRACT_TYPE_NFT,
+    CONTRACT_TYPE_RXD,
+    CONTRACT_TYPE_VAULT,
+    FLAG_HAS_EXPIRY,
+    FLAG_HAS_WANT,
+    RSWP_MAGIC,
+    RSWP_VERSION_V2,
+    RSWP_VERSION_V3,
+    RXD_TOKEN_ID,
+    encode_price_terms,
+    encode_rswp_order,
+    swap_token_id,
+)
+
+__all__ = [
+    "CONTRACT_TYPE_FT",
+    "CONTRACT_TYPE_NFT",
+    "CONTRACT_TYPE_RXD",
+    "CONTRACT_TYPE_VAULT",
+    "FLAG_HAS_EXPIRY",
+    "FLAG_HAS_WANT",
+    "RSWP_MAGIC",
+    "RSWP_VERSION_V2",
+    "RSWP_VERSION_V3",
+    "RXD_TOKEN_ID",
+    "BookEntry",
+    "DemandedOutput",
+    "OrderbookClient",
+    "OrderbookSource",
+    "RswpOrder",
+    "RswpOrderPost",
+    "build_advert_tx",
+    "build_cancel_tx",
+    "create_rswp_order",
+    "decode_rswp_order",
+    "encode_price_terms",
+    "encode_rswp_order",
+    "parse_price_terms",
+    "parse_price_terms_lenient",
+    "prepare_offered_utxo",
+    "rswp_order_to_swap_offer",
+    "swap_token_id",
+    "take_rswp_order",
+    "verify_offer_signature",
+]

--- a/src/pyrxd/swap/rswp/book.py
+++ b/src/pyrxd/swap/rswp/book.py
@@ -1,0 +1,153 @@
+"""Read-only client for the on-chain RSWP orderbook (network edge of :mod:`pyrxd.swap.rswp`).
+
+Pulls open orders from a Radiant node running ``-swapindex=1`` (RPCs
+``getopenorders`` / ``getopenordersbywant``; in the index since Radiant-Core
+2.0.0), then treats every entry as HOSTILE input: the offered source
+transaction is fetched with the computed-txid-equals-requested check
+(:func:`pyrxd.swap.resolve.fetch_transaction`), the advertisement's claims are
+verified against the chain by the :func:`~pyrxd.swap.rswp.orders.rswp_order_to_swap_offer`
+bridge, and the maker's ``0xC3`` signature is verified — an order is reported
+*fillable* only after all three pass. Orders that fail are still returned,
+with ``problem`` set, so a browser can show a lying advertisement for what it
+is instead of silently dropping it.
+
+This module never broadcasts and never signs.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Protocol, runtime_checkable
+
+from ...glyph.types import GlyphRef
+from ...gravity.swap_order import RswpOrder, parse_price_terms
+from ...security.errors import ValidationError
+from ...security.types import Txid
+from ..resolve import fetch_transaction
+from ..types import SwapOffer
+from .orders import rswp_order_to_swap_offer, verify_offer_signature
+from .wire import swap_token_id
+
+
+@runtime_checkable
+class OrderbookSource(Protocol):
+    """Read surface of a Radiant node with ``-swapindex=1`` (and ``-txindex=1`` for source fetch).
+
+    Implementations MUST raise on transport failure or an unreachable/disabled
+    index — returning ``[]`` / ``None`` for "could not check" would present a
+    healthy-but-empty book (fail-open). The swapindex RPCs raise
+    ``Swap index not enabled`` when started without the flag; let that
+    propagate.
+    """
+
+    async def get_open_orders(self, token_id_hex: str, *, limit: int = 100, offset: int = 0) -> list[dict]:
+        """``getopenorders <token_ref> <limit> <offset>`` — orders OFFERING the given token id."""
+        ...  # pragma: no cover
+
+    async def get_open_orders_by_want(self, want_token_id_hex: str, *, limit: int = 100, offset: int = 0) -> list[dict]:
+        """``getopenordersbywant <want_token_ref> <limit> <offset>`` — orders WANTING the given token id."""
+        ...  # pragma: no cover
+
+    async def get_transaction(self, txid: str | Txid) -> bytes:
+        """Raw transaction bytes for *txid*; raise if unknown. (Shape shared with ``ElectrumXClient``
+        so :func:`pyrxd.swap.resolve.fetch_transaction` can do its server-honesty check.)"""
+        ...  # pragma: no cover
+
+    async def is_unspent(self, txid: str, vout: int) -> bool:
+        """Whether the outpoint is currently unspent (``gettxout``, mempool-aware). Raise on failure."""
+        ...  # pragma: no cover
+
+
+@dataclass(frozen=True)
+class BookEntry:
+    """One orderbook row, verified as far as it could be.
+
+    ``status`` is chain fact (offered UTXO unspent = the order is still open;
+    spent = filled or cancelled — the spending tx is the settlement proof).
+    ``fillable`` means the full hostile-input pipeline passed and ``offer`` is
+    ready for :func:`pyrxd.swap.partial.accept_offer`; otherwise ``problem``
+    says exactly which verification failed.
+    """
+
+    order: RswpOrder
+    status: str  # "open" | "spent"
+    fillable: bool
+    offer: SwapOffer | None
+    problem: str | None
+    block_height: int | None
+
+
+def _order_from_rpc(entry: dict) -> RswpOrder:
+    """Rebuild an :class:`RswpOrder` from a ``getopenorders*`` response row.
+
+    The RPC reports 32-byte ids in display (big-endian) hex; the dataclass
+    carries them in on-chain pushed orientation, so they are reversed back.
+    """
+    try:
+        version = int(entry["version"])
+        want_hex = entry.get("want_tokenid")
+        price_terms = bytes.fromhex(entry["price_terms"])
+        return RswpOrder(
+            version=version,
+            flags=int(entry["flags"]),
+            offered_type=int(entry["offered_type"]),
+            terms_type=int(entry["terms_type"]),
+            token_id=bytes.fromhex(entry["tokenid"])[::-1],
+            want_token_id=None if want_hex is None else bytes.fromhex(want_hex)[::-1],
+            offered_utxo_hash=bytes.fromhex(entry["utxo"]["txid"])[::-1],
+            offered_utxo_index=int(entry["utxo"]["vout"]),
+            price_terms=price_terms,
+            demanded_outputs=parse_price_terms(price_terms),
+            signature=bytes.fromhex(entry["signature"]),
+            # The deployed index parses v2 only; a future v3-aware index will
+            # report an expiry field, at which point this gains a real value.
+            expiry_height=None,
+        )
+    except ValidationError:
+        raise
+    except (KeyError, TypeError, ValueError) as exc:
+        raise ValidationError(f"malformed swapindex response row: {exc!r}") from exc
+
+
+class OrderbookClient:
+    """Browse the on-chain book through any :class:`OrderbookSource`, verifying before trusting."""
+
+    def __init__(self, source: OrderbookSource) -> None:
+        self._source = source
+
+    async def orders_offering(self, ref: GlyphRef | None, *, limit: int = 100, offset: int = 0) -> list[BookEntry]:
+        """Open orders OFFERING the given asset (``None`` = native RXD)."""
+        rows = await self._source.get_open_orders(swap_token_id(ref).hex(), limit=limit, offset=offset)
+        return [await self._verify_row(row) for row in rows]
+
+    async def orders_wanting(self, ref: GlyphRef, *, limit: int = 100, offset: int = 0) -> list[BookEntry]:
+        """Open orders WANTING the given Glyph token (the ask side of that token's book)."""
+        rows = await self._source.get_open_orders_by_want(swap_token_id(ref).hex(), limit=limit, offset=offset)
+        return [await self._verify_row(row) for row in rows]
+
+    async def _verify_row(self, row: dict) -> BookEntry:
+        """The hostile-input pipeline for one index row. Transport errors propagate (fail closed);
+        per-order verification failures become ``problem`` entries."""
+        block_height = row.get("block_height")
+        order = _order_from_rpc(row)  # malformed rows raise — an index handing back garbage is transport-level
+        unspent = await self._source.is_unspent(order.offered_txid, order.offered_utxo_index)
+        status = "open" if unspent else "spent"
+        try:
+            give_source_tx = await fetch_transaction(self._source, order.offered_txid)
+            offer = rswp_order_to_swap_offer(order, give_source_tx=give_source_tx)
+            verify_offer_signature(offer)
+        except ValidationError as exc:
+            return BookEntry(
+                order=order, status=status, fillable=False, offer=None, problem=str(exc), block_height=block_height
+            )
+        return BookEntry(
+            order=order,
+            status=status,
+            fillable=unspent,
+            offer=offer,
+            problem=None if unspent else "offered UTXO already spent (order filled or cancelled)",
+            block_height=block_height,
+        )
+
+
+__all__ = ["BookEntry", "OrderbookClient", "OrderbookSource"]

--- a/src/pyrxd/swap/rswp/orders.py
+++ b/src/pyrxd/swap/rswp/orders.py
@@ -246,7 +246,7 @@ def rswp_order_to_swap_offer(order: RswpOrder, *, give_source_tx: Transaction) -
     if not 0 <= order.offered_utxo_index < len(give_source_tx.outputs):
         # Also rejects a hostile advert whose CScriptNum vout decodes negative or huge
         # (the decoder is deliberately permissive about representing such frames).
-        raise ValidationError("advertised offered vout does not exist in the source transaction")
+        raise ValidationError("advertised offered vout is not present in give_source_tx")
     give_out = give_source_tx.outputs[order.offered_utxo_index]
     if not 0 < demanded.value <= _MAX_PHOTONS:
         raise ValidationError(f"demanded output value {demanded.value} is outside the fundable range")

--- a/src/pyrxd/swap/rswp/orders.py
+++ b/src/pyrxd/swap/rswp/orders.py
@@ -1,0 +1,381 @@
+"""Pure builders for the RSWP on-chain orderbook flows: post / take / cancel.
+
+Everything here is network-free (the house ``partial.py`` / ``resolve.py``
+split): callers fetch transactions with :mod:`pyrxd.swap.resolve` and broadcast
+through their own node. The maker/taker *value* mechanics are the proven
+:mod:`pyrxd.swap.partial` primitives — the maker's partial transaction is built
+by :func:`pyrxd.swap.partial.create_offer` (``SIGHASH_SINGLE | ANYONECANPAY |
+FORKID``) and a taker completes through
+:func:`pyrxd.swap.partial.accept_offer`; this module only adds the on-chain
+advertisement around them.
+
+The bridge :func:`rswp_order_to_swap_offer` is the trust boundary of the take
+path: it turns an UNTRUSTED on-chain advertisement plus a txid-verified source
+transaction into a :class:`~pyrxd.swap.types.SwapOffer`, verifying everything
+the advertisement *claims* against what the chain actually *holds* (asset
+scripts, token ids, outpoint) before ``accept_offer`` re-verifies the maker
+signature over the reconstructed transaction.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from ...constants import SIGHASH
+from ...gravity.swap_order import DemandedOutput, RswpOrder
+from ...keys import PrivateKey
+from ...script.script import Script
+from ...script.type import P2PKH
+from ...security.errors import ValidationError
+from ...security.types import Hex20
+from ...transaction.transaction import Transaction
+from ...transaction.transaction_input import TransactionInput
+from ...transaction.transaction_output import TransactionOutput
+from ..partial import (
+    _DUST_PHOTONS,
+    FundingInput,
+    _asset_of,
+    _balance_and_add_change,
+    _build_asset_output,
+    _parse_p2pkh_scriptsig,
+    _verify_owner_signature,
+    accept_offer,
+    create_offer,
+)
+from ..types import Asset, SwapOffer, SwapTerms
+from .wire import (
+    CONTRACT_TYPE_FT,
+    CONTRACT_TYPE_RXD,
+    RXD_TOKEN_ID,
+    encode_price_terms,
+    encode_rswp_order,
+    swap_token_id,
+)
+
+# Radiant MAX_MONEY: 21,000,000,000 RXD × 100,000,000 photons. A demanded value above
+# this can never be funded; reporting such an order "fillable" would be a lie.
+_MAX_PHOTONS = 21_000_000_000 * 100_000_000
+
+
+def _contract_type_of(asset: Asset) -> int:
+    """Photonic ``ContractType`` byte for an asset this module supports (RXD=0, FT=2)."""
+    return CONTRACT_TYPE_FT if asset.kind == "ft" else CONTRACT_TYPE_RXD
+
+
+def _pushed_token_id(asset: Asset) -> bytes:
+    """The 32 token-id bytes as they appear ON CHAIN (display digest reversed; zeros for RXD)."""
+    tid = swap_token_id(asset.ref)
+    return tid if tid == RXD_TOKEN_ID else tid[::-1]
+
+
+@dataclass(frozen=True)
+class RswpOrderPost:
+    """A maker's ready-to-advertise order: the signed offer plus its RSWP OP_RETURN script.
+
+    ``offer`` is the same envelope :func:`pyrxd.swap.partial.create_offer`
+    produces (usable over a private transport as-is); ``advert_script`` is the
+    public on-chain advertisement of that exact offer. Wrap it in a funded
+    transaction with :func:`build_advert_tx` and broadcast to post publicly.
+    """
+
+    offer: SwapOffer
+    advert_script: bytes
+
+
+def create_rswp_order(
+    *,
+    give_source_tx: Transaction,
+    give_vout: int,
+    maker_key: PrivateKey,
+    receive: Asset,
+    maker_receive_pkh: bytes | Hex20,
+) -> RswpOrderPost:
+    """Build a maker's RSWP order: the ``0xC3``-signed partial tx plus its advertisement.
+
+    Same contract as :func:`pyrxd.swap.partial.create_offer` (the whole given
+    UTXO is offered — pre-split with :func:`prepare_offered_utxo` first), plus
+    the v2 RSWP ``OP_RETURN`` script advertising it to the on-chain book.
+    """
+    offer = create_offer(
+        give_source_tx=give_source_tx,
+        give_vout=give_vout,
+        maker_key=maker_key,
+        receive=receive,
+        maker_receive_pkh=maker_receive_pkh,
+    )
+    partial = Transaction.from_hex(bytes.fromhex(offer.partial_tx_hex))
+    if partial is None:  # pragma: no cover — create_offer just produced it
+        raise ValidationError("internal error: offer partial tx does not reparse")
+    demanded = partial.outputs[0]
+    signature = partial.inputs[0].unlocking_script.serialize()
+    advert_script = encode_rswp_order(
+        offered_type=_contract_type_of(offer.terms.give),
+        token_id=swap_token_id(offer.terms.give.ref),
+        want_token_id=None if receive.ref is None else swap_token_id(receive.ref),
+        offered_txid=give_source_tx.txid(),
+        offered_vout=give_vout,
+        price_terms=encode_price_terms(
+            [DemandedOutput(value=demanded.satoshis, script=demanded.locking_script.serialize())]
+        ),
+        signature=signature,
+    )
+    return RswpOrderPost(offer=offer, advert_script=advert_script)
+
+
+def prepare_offered_utxo(
+    *,
+    funding: list[FundingInput],
+    asset: Asset,
+    owner_pkh: bytes | Hex20,
+    change_pkh: bytes | Hex20,
+    fee: int,
+) -> Transaction:
+    """Exact-amount self-send minting the clean UTXO an offer requires, at output 0.
+
+    ``SIGHASH_SINGLE`` binds the maker's demanded output value exactly, and the
+    offered input gives its WHOLE value — so both sides of the book run on
+    exact-amount UTXOs. Token conservation and change are handled as in
+    :func:`pyrxd.swap.partial.accept_offer`.
+    """
+    tx = Transaction()
+    for f in funding:
+        if not 0 <= f.vout < len(f.source_tx.outputs):
+            raise ValidationError("funding input references a non-existent source output")
+        tx.add_input(
+            TransactionInput(
+                source_transaction=f.source_tx,
+                source_output_index=f.vout,
+                unlocking_script_template=P2PKH().unlock(f.key),
+                sighash=SIGHASH.ALL_FORKID,
+            )
+        )
+    tx.add_output(_build_asset_output(asset, bytes(owner_pkh)))
+    _balance_and_add_change(tx, bytes(change_pkh), fee)
+    tx.sign(bypass=True)
+    return tx
+
+
+def build_advert_tx(
+    *,
+    advert_script: bytes,
+    funding: list[FundingInput],
+    change_pkh: bytes | Hex20,
+    fee: int,
+) -> Transaction:
+    """Wrap an advertisement script in an ordinary funded transaction (advert at output 0, value 0).
+
+    Funding must be plain RXD (P2PKH) — an FT funding input would strand token
+    value in the fee/change math of a transaction that has no token outputs.
+    """
+    if not funding:
+        raise ValidationError("at least one funding input is required")
+    if fee < 0:
+        raise ValidationError("fee must be non-negative")
+    tx = Transaction()
+    total_in = 0
+    for f in funding:
+        if not 0 <= f.vout < len(f.source_tx.outputs):
+            raise ValidationError("funding input references a non-existent source output")
+        out = f.source_tx.outputs[f.vout]
+        if _asset_of(out.satoshis, out.locking_script.serialize()).kind != "rxd":
+            raise ValidationError("advert funding must be plain RXD (P2PKH) — do not spend token UTXOs here")
+        total_in += out.satoshis
+        tx.add_input(
+            TransactionInput(
+                source_transaction=f.source_tx,
+                source_output_index=f.vout,
+                unlocking_script_template=P2PKH().unlock(f.key),
+                sighash=SIGHASH.ALL_FORKID,
+            )
+        )
+    tx.add_output(TransactionOutput(Script(advert_script), 0))
+    change = total_in - fee
+    if change < 0:
+        raise ValidationError(f"funding is {-change} photons short of the fee")
+    if change >= _DUST_PHOTONS:
+        tx.add_output(TransactionOutput(P2PKH().lock(bytes(change_pkh)), change))
+    tx.sign(bypass=True)
+    return tx
+
+
+def rswp_order_to_swap_offer(order: RswpOrder, *, give_source_tx: Transaction) -> SwapOffer:
+    """Bridge an UNTRUSTED on-chain order into a :class:`SwapOffer` for ``accept_offer``.
+
+    ``give_source_tx`` must be fetched with a computed-txid-equals-requested
+    check (:func:`pyrxd.swap.resolve.fetch_transaction` does this). Raises
+    ``ValidationError`` unless every advertised claim matches the chain:
+
+    * exactly ONE demanded output (``SIGHASH_SINGLE`` signs only output[0];
+      extra "demands" would be unenforceable — design note D6);
+    * the source tx hashes to the advertised outpoint, and the vout exists;
+    * the offered UTXO is a spendable RXD/FT script (a v3 covenant-held or
+      otherwise exotic script is refused);
+    * the advertised ``token_id`` / ``want_token_id`` / ``offeredType`` match
+      the REAL offered/demanded scripts — a lying advertisement is rejected
+      here rather than surviving to display or completion;
+    * no expiry (v3 orders are not yet takeable by pyrxd — the reserved UTXO
+      sits in the refund covenant this module does not spend).
+
+    The maker's signature itself is verified by ``accept_offer`` over the
+    reconstructed transaction (before and after completion), so a forged or
+    replayed ``signature`` push cannot move value.
+    """
+    if order.expiry_height is not None:
+        raise ValidationError("v3 (expiry/covenant) RSWP orders are not yet takeable by pyrxd")
+    if order.demanded_outputs is None or len(order.demanded_outputs) != 1:
+        n = "unparseable" if order.demanded_outputs is None else str(len(order.demanded_outputs))
+        raise ValidationError(
+            f"refusing order with {n} demanded outputs: SIGHASH_SINGLE enforces exactly one (output[0])"
+        )
+    demanded = order.demanded_outputs[0]
+
+    # Early, explicit sighash pin (security review F1): the flag byte rides in the
+    # untrusted signature push, and 0xC2 (NONE|ANYONECANPAY|FORKID) would verify both
+    # pre- and post-completion while binding NO outputs. _verify_owner_signature
+    # enforces this too; checking here gives the book a precise "why" message.
+    sig_with_flag, _pubkey = _parse_p2pkh_scriptsig(order.signature)
+    if len(sig_with_flag) < 2 or sig_with_flag[-1] != int(SIGHASH.SINGLE_ANYONECANPAY_FORKID):
+        flag = sig_with_flag[-1] if sig_with_flag else None
+        raise ValidationError(
+            f"order signature carries sighash {flag!r}; only SINGLE|ANYONECANPAY|FORKID (0xc3) "
+            "binds the maker's demanded output"
+        )
+
+    if give_source_tx.txid() != order.offered_txid:
+        raise ValidationError("give_source_tx does not hash to the advertised offered outpoint")
+    if not 0 <= order.offered_utxo_index < len(give_source_tx.outputs):
+        # Also rejects a hostile advert whose CScriptNum vout decodes negative or huge
+        # (the decoder is deliberately permissive about representing such frames).
+        raise ValidationError("advertised offered vout does not exist in the source transaction")
+    give_out = give_source_tx.outputs[order.offered_utxo_index]
+    if not 0 < demanded.value <= _MAX_PHOTONS:
+        raise ValidationError(f"demanded output value {demanded.value} is outside the fundable range")
+
+    give = _asset_of(give_out.satoshis, give_out.locking_script.serialize())
+    receive = _asset_of(demanded.value, demanded.script)
+
+    # The advertisement's classification fields must match on-chain reality.
+    if order.token_id != _pushed_token_id(give):
+        raise ValidationError("advertised token_id does not match the real offered UTXO's asset")
+    want_pushed = None if receive.ref is None else _pushed_token_id(receive)
+    advertised_want = None if order.want_token_id in (None, RXD_TOKEN_ID) else order.want_token_id
+    if advertised_want != want_pushed:
+        raise ValidationError("advertised want_token_id does not match the demanded output's asset")
+    if order.offered_type != _contract_type_of(give):
+        raise ValidationError("advertised offeredType does not match the real offered UTXO's asset")
+
+    partial = Transaction(
+        tx_inputs=[
+            TransactionInput(
+                source_transaction=give_source_tx,
+                source_output_index=order.offered_utxo_index,
+                unlocking_script=Script(order.signature),
+                sighash=SIGHASH.SINGLE_ANYONECANPAY_FORKID,
+            )
+        ],
+        tx_outputs=[TransactionOutput(Script(demanded.script), demanded.value)],
+    )
+    return SwapOffer(
+        partial_tx_hex=partial.serialize().hex(),
+        give_source_tx_hex=give_source_tx.serialize().hex(),
+        give_vout=order.offered_utxo_index,
+        terms=SwapTerms(give=give, receive=receive),
+    )
+
+
+def verify_offer_signature(offer: SwapOffer) -> None:
+    """Verify the maker's signature on an offer WITHOUT completing it (read-only pre-check).
+
+    Reconstructs the partial transaction with its prevout populated from the
+    offer's source tx (outpoint-verified) and runs the same owner-signature
+    check ``accept_offer`` uses. Raises ``ValidationError`` on any mismatch.
+    ``accept_offer`` re-verifies regardless — this exists so a browser can
+    label an order fillable before anyone commits funding to it.
+    """
+    partial = Transaction.from_hex(bytes.fromhex(offer.partial_tx_hex))
+    give_source = Transaction.from_hex(bytes.fromhex(offer.give_source_tx_hex))
+    if partial is None or give_source is None or not partial.inputs or not partial.outputs:
+        raise ValidationError("offer does not contain a parseable partial/source transaction")
+    maker_in = partial.inputs[0]
+    if give_source.txid() != maker_in.source_txid:
+        raise ValidationError("give_source_tx does not match the maker input's outpoint")
+    if not 0 <= maker_in.source_output_index < len(give_source.outputs):
+        raise ValidationError("maker input references a non-existent source output")
+    give_out = give_source.outputs[maker_in.source_output_index]
+    maker_in.satoshis = give_out.satoshis
+    maker_in.locking_script = give_out.locking_script
+    _verify_owner_signature(partial, 0)
+
+
+def take_rswp_order(
+    order: RswpOrder,
+    *,
+    give_source_tx: Transaction,
+    funding: list[FundingInput],
+    taker_receive_pkh: bytes | Hex20,
+    taker_change_pkh: bytes | Hex20,
+    fee: int,
+) -> Transaction:
+    """Verify and complete an on-chain order, returning a broadcast-ready transaction.
+
+    Convenience composition of :func:`rswp_order_to_swap_offer` (advertisement
+    vs chain verification) and :func:`pyrxd.swap.partial.accept_offer`
+    (signature re-verification, completion, conservation, change).
+    """
+    offer = rswp_order_to_swap_offer(order, give_source_tx=give_source_tx)
+    return accept_offer(
+        offer,
+        funding=funding,
+        taker_receive_pkh=taker_receive_pkh,
+        taker_change_pkh=taker_change_pkh,
+        fee=fee,
+    )
+
+
+def build_cancel_tx(
+    *,
+    offered_source_tx: Transaction,
+    offered_vout: int,
+    maker_key: PrivateKey,
+    refund_pkh: bytes | Hex20,
+    fee: int,
+    funding: list[FundingInput] | None = None,
+) -> Transaction:
+    """Cancel an order by self-spending the offered UTXO — the ONLY hard revocation in v2.
+
+    The ``0xC3`` signature in the advertisement stays valid as long as the
+    offered UTXO is unspent; once this transaction confirms, any completion
+    attempt is a double-spend and dies at consensus. For an RXD offer the fee
+    comes out of the refunded value; for an FT offer token conservation forces
+    the full token amount back to ``refund_pkh``, so add plain-RXD ``funding``
+    to cover the fee.
+    """
+    if not 0 <= offered_vout < len(offered_source_tx.outputs):
+        raise ValidationError("offered_vout out of range for the source transaction")
+    tx = Transaction()
+    tx.add_input(
+        TransactionInput(
+            source_transaction=offered_source_tx,
+            source_output_index=offered_vout,
+            unlocking_script_template=P2PKH().unlock(maker_key),
+            sighash=SIGHASH.ALL_FORKID,
+        )
+    )
+    for f in funding or []:
+        if not 0 <= f.vout < len(f.source_tx.outputs):
+            raise ValidationError("funding input references a non-existent source output")
+        tx.add_input(
+            TransactionInput(
+                source_transaction=f.source_tx,
+                source_output_index=f.vout,
+                unlocking_script_template=P2PKH().unlock(f.key),
+                sighash=SIGHASH.ALL_FORKID,
+            )
+        )
+    # No explicit outputs: conservation emits the FT amount (if any) and the
+    # remaining RXD, less fee, as "change" to the maker's refund key.
+    _balance_and_add_change(tx, bytes(refund_pkh), fee)
+    if not tx.outputs:
+        raise ValidationError("cancel would produce no outputs — offered value does not cover the fee")
+    tx.sign(bypass=True)
+    return tx

--- a/src/pyrxd/swap/rswp/wire.py
+++ b/src/pyrxd/swap/rswp/wire.py
@@ -1,0 +1,178 @@
+"""RSWP on-chain swap-order wire format — the WRITE side (encoder).
+
+Byte-compatible with the canonical producer (Photonic-Wallet
+``buildSwapAdvertisementScript``) and accepted by the strictest consumer (the
+Radiant-Core ``-swapindex`` parser, ``src/index/swapindex.cpp``). The READ side
+(decoder) lives in :mod:`pyrxd.gravity.swap_order` and is re-exported from
+:mod:`pyrxd.swap.rswp`; the encoder here round-trips through it.
+
+Encoder rules that are load-bearing (the node is stricter than our decoder —
+see docs/plans/2026-07-05-rswp-orderbook-design.md):
+
+* ``version`` / ``flags`` / ``offeredType`` / ``termsType`` are 1-byte **direct
+  data pushes** (``0x01 <b>``), never ``OP_N`` — the node requires
+  ``data.size() == 1`` and ``GetOp`` yields empty data for ``OP_N``, so an
+  ``OP_2`` version byte makes the node silently drop the order.
+* the script starts with a **bare** ``OP_RETURN`` (no ``OP_FALSE`` prefix — the
+  node checks ``scriptPubKey[0] == OP_RETURN``), so this module builds raw
+  bytes instead of using :class:`pyrxd.script.type.OpReturn`.
+* ``tokenID`` / ``wantTokenID`` / ``offeredUTXOHash`` are pushed in internal
+  little-endian orientation (display bytes reversed).
+* ``offeredUTXOIndex`` is ``OP_0`` for 0, else a minimal-``CScriptNum`` direct
+  push — matching Photonic ``encodeScriptNum``. The node decodes it with
+  ``CScriptNum(data, false, 4)``, so the encoding must fit 4 bytes.
+* ``priceTerms`` is ONE push (the node concatenates middle pushes, but the
+  canonical producer emits exactly one).
+"""
+
+from __future__ import annotations
+
+import hashlib
+from collections.abc import Sequence
+
+from ...glyph.types import GlyphRef
+from ...gravity.swap_order import DemandedOutput
+from ...security.errors import ValidationError
+from ...security.types import Txid
+from ...utils import encode_pushdata, unsigned_to_varint
+
+RSWP_MAGIC = b"RSWP"
+RSWP_VERSION_V2 = 0x02
+RSWP_VERSION_V3 = 0x03
+FLAG_HAS_WANT = 0x01
+FLAG_HAS_EXPIRY = 0x02
+
+#: RSWP token id of the native-RXD side (display and wire form coincide).
+RXD_TOKEN_ID = b"\x00" * 32
+
+# Photonic ContractType enum (packages/app/src/types.ts) — the `offeredType`
+# byte. NOTE: NFT=1 and FT=2, *not* the FT=1/NFT=2 ordering one might guess.
+CONTRACT_TYPE_RXD = 0
+CONTRACT_TYPE_NFT = 1
+CONTRACT_TYPE_FT = 2
+CONTRACT_TYPE_VAULT = 3
+
+_OP_RETURN = b"\x6a"
+_OP_0 = b"\x00"
+
+# The node parses the vout with `CScriptNum(data, false, 4)` (max 4 bytes) and
+# `getint32`, so anything above INT32_MAX cannot be advertised.
+_MAX_ADVERTISABLE_VOUT = 0x7FFFFFFF
+
+
+def swap_token_id(ref: GlyphRef | None) -> bytes:
+    """The 32-byte RSWP token id in DISPLAY orientation (== node RPC ``tokenid`` hex).
+
+    ``sha256`` of the 36-byte little-endian script-operand ref (exactly
+    ``GlyphRef.to_bytes()`` — the bytes ``OP_PUSHINPUTREF`` pushes); all-zero
+    for native RXD. Matches Photonic ``assetToSwapTokenId``, which reverses the
+    display ref to little-endian before hashing. The on-chain advertisement
+    pushes these bytes REVERSED (:func:`encode_rswp_advert` does that).
+    """
+    if ref is None:
+        return RXD_TOKEN_ID
+    return hashlib.sha256(ref.to_bytes()).digest()
+
+
+def encode_price_terms(outputs: Sequence[DemandedOutput]) -> bytes:
+    """Serialize demanded outputs as the Photonic ``MultiTxOutV1`` blob.
+
+    ``CompactSize(count) || [value(8 LE) || CompactSize(len(script)) || script]*``.
+    Round-trips through :func:`pyrxd.gravity.swap_order.parse_price_terms`.
+    """
+    if not outputs:
+        raise ValidationError("price terms require at least one demanded output")
+    blob = unsigned_to_varint(len(outputs))
+    for out in outputs:
+        if not 0 <= out.value <= 0xFFFFFFFFFFFFFFFF:
+            raise ValidationError(f"demanded output value {out.value} does not fit in 8 bytes")
+        if not out.script:
+            raise ValidationError("a demanded output requires a non-empty script")
+        blob += out.value.to_bytes(8, "little") + unsigned_to_varint(len(out.script)) + out.script
+    return blob
+
+
+def _scriptnum_push(n: int) -> bytes:
+    """``OP_0`` for 0, else a minimal-CScriptNum direct data push (Photonic ``encodeScriptNum``)."""
+    if n == 0:
+        return _OP_0
+    octets = bytearray()
+    remaining = n
+    while remaining > 0:
+        octets.append(remaining & 0xFF)
+        remaining >>= 8
+    if octets[-1] & 0x80:
+        octets.append(0x00)
+    return encode_pushdata(bytes(octets), minimal_push=False)
+
+
+def _byte_push(field: str, value: int) -> bytes:
+    """A 1-byte direct data push — the only form the node accepts for the small fields."""
+    if not 0 <= value <= 0xFF:
+        raise ValidationError(f"RSWP {field} must be one byte, got {value}")
+    return encode_pushdata(bytes([value]), minimal_push=False)
+
+
+def encode_rswp_order(
+    *,
+    offered_type: int,
+    token_id: bytes,
+    want_token_id: bytes | None,
+    offered_txid: str | Txid,
+    offered_vout: int,
+    price_terms: bytes,
+    signature: bytes,
+    expiry_height: int | None = None,
+    terms_type: int = 0x01,
+) -> bytes:
+    """Build the RSWP advertisement ``OP_RETURN`` script (v2, or v3 when *expiry_height* is given).
+
+    *token_id* / *want_token_id* are in DISPLAY orientation (as returned by
+    :func:`swap_token_id`); *offered_txid* is the display (big-endian) txid.
+    Both are pushed byte-reversed, as the chain expects. Pass
+    ``want_token_id=None`` when the want side is native RXD (flag bit 0 stays
+    clear — Photonic behavior); passing :data:`RXD_TOKEN_ID` is equivalent.
+    Round-trips through :func:`pyrxd.gravity.swap_order.decode_rswp_order`.
+
+    *signature* is the maker input's ENTIRE scriptSig
+    (``PUSH(DER||0xC3) PUSH(pubkey)``), not a bare signature.
+
+    v3 (*expiry_height* set) additionally pushes a 4-byte LE block height
+    between the want-token id and the outpoint and sets flag bit ``0x02``.
+    v3 adverts are DROPPED by the current Radiant-Core swapindex — post v2
+    unless every consumer you care about parses v3 (design note D1).
+    """
+    if len(token_id) != 32:
+        raise ValidationError(f"token_id must be 32 bytes, got {len(token_id)}")
+    if want_token_id is not None and len(want_token_id) != 32:
+        raise ValidationError(f"want_token_id must be 32 bytes, got {len(want_token_id)}")
+    if want_token_id == RXD_TOKEN_ID:
+        want_token_id = None  # RXD want side: omit the field and clear the flag, like Photonic
+    if not 0 <= offered_vout <= _MAX_ADVERTISABLE_VOUT:
+        raise ValidationError(f"offered_vout {offered_vout} cannot be advertised (node reads a 4-byte CScriptNum)")
+    if expiry_height is not None and not 1 <= expiry_height <= 0xFFFFFFFF:
+        raise ValidationError(f"expiry_height {expiry_height} must fit an unsigned 4-byte block height")
+    if not price_terms:
+        raise ValidationError("price_terms must not be empty")
+    if not signature:
+        raise ValidationError("signature must not be empty")
+    txid_bytes = bytes.fromhex(str(Txid(str(offered_txid))))
+    version = RSWP_VERSION_V3 if expiry_height is not None else RSWP_VERSION_V2
+    flags = (FLAG_HAS_WANT if want_token_id is not None else 0) | (FLAG_HAS_EXPIRY if expiry_height is not None else 0)
+
+    script = _OP_RETURN
+    script += encode_pushdata(RSWP_MAGIC, minimal_push=False)
+    script += _byte_push("version", version)
+    script += _byte_push("flags", flags)
+    script += _byte_push("offeredType", offered_type)
+    script += _byte_push("termsType", terms_type)
+    script += encode_pushdata(token_id[::-1], minimal_push=False)
+    if want_token_id is not None:
+        script += encode_pushdata(want_token_id[::-1], minimal_push=False)
+    if expiry_height is not None:
+        script += encode_pushdata(expiry_height.to_bytes(4, "little"), minimal_push=False)
+    script += encode_pushdata(txid_bytes[::-1], minimal_push=False)
+    script += _scriptnum_push(offered_vout)
+    script += encode_pushdata(price_terms, minimal_push=False)
+    script += encode_pushdata(signature, minimal_push=False)
+    return script

--- a/src/pyrxd/swap/rswp/wire.py
+++ b/src/pyrxd/swap/rswp/wire.py
@@ -81,7 +81,9 @@ def encode_price_terms(outputs: Sequence[DemandedOutput]) -> bytes:
     Round-trips through :func:`pyrxd.gravity.swap_order.parse_price_terms`.
     """
     if not outputs:
-        raise ValidationError("price terms require at least one demanded output")
+        # NB: phrased with a digit — 8+ all-lowercase words trip the BIP-39
+        # redaction heuristic in security.errors and would print "<redacted>".
+        raise ValidationError("price terms require at least 1 demanded output")
     blob = unsigned_to_varint(len(outputs))
     for out in outputs:
         if not 0 <= out.value <= 0xFFFFFFFFFFFFFFFF:

--- a/tests/test_rswp_book.py
+++ b/tests/test_rswp_book.py
@@ -109,7 +109,7 @@ def test_fake_source_satisfies_protocol() -> None:
 
 
 async def test_open_verified_order_is_fillable_end_to_end() -> None:
-    source, src, _, _ = _setup_book()
+    source, _src, _, _ = _setup_book()
     entries = await OrderbookClient(source).orders_offering(_REF)
     assert len(entries) == 1
     e = entries[0]
@@ -152,7 +152,7 @@ async def test_spent_offered_utxo_reports_spent_not_fillable() -> None:
 async def test_lying_row_reported_with_problem_not_dropped() -> None:
     """Index row advertises a token id that doesn't match the real UTXO —
     surfaced as a problem entry, never shown fillable, never silently dropped."""
-    source, src, _, _ = _setup_book()
+    source, _src, _, _ = _setup_book()
     source.rows[0]["tokenid"] = swap_token_id(GlyphRef(txid=Txid("ef" * 32), vout=9)).hex()
     entries = await OrderbookClient(source).orders_offering(GlyphRef(txid=Txid("ef" * 32), vout=9))
     assert len(entries) == 1

--- a/tests/test_rswp_book.py
+++ b/tests/test_rswp_book.py
@@ -1,0 +1,180 @@
+"""OrderbookClient: hostile-index pipeline over a fake OrderbookSource.
+
+The index is untrusted: rows are re-verified against chain data fetched with the
+computed-txid check, and *fillable* means exactly "what accept_offer would
+accept". A lying index can at worst censor (hide/mislabel) — it can never make
+a bad order look fillable.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from pyrxd.glyph.script import build_ft_locking_script
+from pyrxd.glyph.types import GlyphRef
+from pyrxd.keys import PrivateKey
+from pyrxd.script.script import Script
+from pyrxd.script.type import P2PKH
+from pyrxd.security.errors import ValidationError
+from pyrxd.security.types import Hex20, Txid
+from pyrxd.swap import Asset, FundingInput, accept_offer
+from pyrxd.swap.rswp import (
+    OrderbookClient,
+    OrderbookSource,
+    create_rswp_order,
+    decode_rswp_order,
+    swap_token_id,
+)
+from pyrxd.transaction.transaction import Transaction
+from pyrxd.transaction.transaction_output import TransactionOutput
+
+_REF = GlyphRef(txid=Txid("cd" * 32), vout=0)
+
+
+def _key():
+    k = PrivateKey()
+    return k, k.public_key().hash160()
+
+
+def _rxd_src(pkh: bytes, value: int) -> Transaction:
+    tx = Transaction()
+    tx.add_output(TransactionOutput(P2PKH().lock(pkh), value))
+    return tx
+
+
+def _ft_src(pkh: bytes, ref: GlyphRef, value: int) -> Transaction:
+    tx = Transaction()
+    tx.add_output(TransactionOutput(Script(build_ft_locking_script(Hex20(pkh), ref)), value))
+    return tx
+
+
+def _rpc_row(order, block_height: int = 10) -> dict:
+    """Shape a decoded order the way getopenorders reports it (display hex ids)."""
+    row = {
+        "version": order.version,
+        "flags": order.flags,
+        "offered_type": order.offered_type,
+        "terms_type": order.terms_type,
+        "tokenid": order.token_id[::-1].hex(),
+        "utxo": {"txid": order.offered_txid, "vout": order.offered_utxo_index},
+        "price_terms": order.price_terms.hex(),
+        "signature": order.signature.hex(),
+        "block_height": block_height,
+    }
+    if order.want_token_id is not None:
+        row["want_tokenid"] = order.want_token_id[::-1].hex()
+    return row
+
+
+class FakeSource:
+    """In-memory OrderbookSource backed by real transactions."""
+
+    def __init__(self) -> None:
+        self.rows: list[dict] = []
+        self.txs: dict[str, bytes] = {}
+        self.spent: set[tuple[str, int]] = set()
+
+    def add_tx(self, tx: Transaction) -> None:
+        self.txs[tx.txid()] = tx.serialize()
+
+    async def get_open_orders(self, token_id_hex: str, *, limit: int = 100, offset: int = 0) -> list[dict]:
+        return [r for r in self.rows if r["tokenid"] == token_id_hex]
+
+    async def get_open_orders_by_want(self, want_token_id_hex: str, *, limit: int = 100, offset: int = 0) -> list[dict]:
+        return [r for r in self.rows if r.get("want_tokenid") == want_token_id_hex]
+
+    async def get_transaction(self, txid) -> bytes:
+        return self.txs[str(txid)]
+
+    async def is_unspent(self, txid: str, vout: int) -> bool:
+        return (txid, vout) not in self.spent
+
+
+def _setup_book() -> tuple[FakeSource, Transaction, PrivateKey, bytes]:
+    """One real maker order (offering 500 FT for 900 RXD) on the fake book."""
+    mk, mk_pkh = _key()
+    src = _ft_src(mk_pkh, _REF, 500)
+    post = create_rswp_order(
+        give_source_tx=src, give_vout=0, maker_key=mk, receive=Asset("rxd", 900), maker_receive_pkh=mk_pkh
+    )
+    order = decode_rswp_order(post.advert_script)
+    source = FakeSource()
+    source.rows.append(_rpc_row(order))
+    source.add_tx(src)
+    return source, src, mk, mk_pkh
+
+
+def test_fake_source_satisfies_protocol() -> None:
+    assert isinstance(FakeSource(), OrderbookSource)
+
+
+async def test_open_verified_order_is_fillable_end_to_end() -> None:
+    source, src, _, _ = _setup_book()
+    entries = await OrderbookClient(source).orders_offering(_REF)
+    assert len(entries) == 1
+    e = entries[0]
+    assert e.status == "open" and e.fillable and e.problem is None and e.block_height == 10
+
+    # The returned offer is directly acceptable — fillable is not a guess.
+    tk, tk_pkh = _key()
+    tx = accept_offer(
+        e.offer,
+        funding=[FundingInput(_rxd_src(tk_pkh, 2000), 0, tk)],
+        taker_receive_pkh=tk_pkh,
+        taker_change_pkh=tk_pkh,
+        fee=200,
+    )
+    assert tx.outputs[0].satoshis == 900
+
+
+async def test_orders_wanting_finds_the_rxd_side() -> None:
+    """An order offering RXD and wanting the FT appears in the want-side book."""
+    mk, mk_pkh = _key()
+    src = _rxd_src(mk_pkh, 1200)
+    post = create_rswp_order(
+        give_source_tx=src, give_vout=0, maker_key=mk, receive=Asset("ft", 50, _REF), maker_receive_pkh=mk_pkh
+    )
+    source = FakeSource()
+    source.rows.append(_rpc_row(decode_rswp_order(post.advert_script)))
+    source.add_tx(src)
+    entries = await OrderbookClient(source).orders_wanting(_REF)
+    assert len(entries) == 1 and entries[0].fillable
+
+
+async def test_spent_offered_utxo_reports_spent_not_fillable() -> None:
+    source, src, _, _ = _setup_book()
+    source.spent.add((src.txid(), 0))
+    (e,) = await OrderbookClient(source).orders_offering(_REF)
+    assert e.status == "spent" and not e.fillable
+    assert "already spent" in e.problem
+
+
+async def test_lying_row_reported_with_problem_not_dropped() -> None:
+    """Index row advertises a token id that doesn't match the real UTXO —
+    surfaced as a problem entry, never shown fillable, never silently dropped."""
+    source, src, _, _ = _setup_book()
+    source.rows[0]["tokenid"] = swap_token_id(GlyphRef(txid=Txid("ef" * 32), vout=9)).hex()
+    entries = await OrderbookClient(source).orders_offering(GlyphRef(txid=Txid("ef" * 32), vout=9))
+    assert len(entries) == 1
+    e = entries[0]
+    assert not e.fillable and e.offer is None
+    assert "token_id does not match" in e.problem
+
+
+async def test_hostile_source_tx_substitution_caught_by_txid_check() -> None:
+    """get_transaction returning a different tx than requested (hostile indexer)
+    is caught by fetch_transaction's computed-txid check → problem entry."""
+    source, src, _, mk_pkh = _setup_book()
+    source.txs[src.txid()] = _rxd_src(mk_pkh, 999).serialize()  # substitute
+    (e,) = await OrderbookClient(source).orders_offering(_REF)
+    assert not e.fillable
+    assert "hash != requested" in e.problem
+
+
+async def test_malformed_index_row_raises_fail_closed() -> None:
+    """A structurally-broken row is index misbehavior — the listing call raises
+    rather than presenting a partial book as healthy."""
+    source, _, _, _ = _setup_book()
+    del source.rows[0]["signature"]
+    with pytest.raises(ValidationError, match="malformed swapindex response row"):
+        await OrderbookClient(source).orders_offering(_REF)

--- a/tests/test_rswp_conformance_vectors.py
+++ b/tests/test_rswp_conformance_vectors.py
@@ -1,0 +1,87 @@
+"""Re-derive every published RSWP conformance vector byte-for-byte.
+
+``conformance/rswp-order-vectors.json`` is the cross-implementation contract
+(same shape as the dMint-v2 suite): if the encoder ever drifts from the
+published hex, this fails CI — the JSON cannot silently rot. The reassembly
+vector additionally locks the DECODER to the Radiant-Core tail rule.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from pyrxd.glyph.types import GlyphRef
+from pyrxd.security.types import Txid
+from pyrxd.swap.rswp import (
+    DemandedOutput,
+    decode_rswp_order,
+    encode_price_terms,
+    encode_rswp_order,
+    swap_token_id,
+)
+
+_VECTORS = json.loads((Path(__file__).parent.parent / "conformance" / "rswp-order-vectors.json").read_text())
+
+
+def _ref(d: dict | None) -> GlyphRef | None:
+    return None if d is None else GlyphRef(txid=Txid(d["txid"]), vout=int(d["vout"]))
+
+
+def _price_terms(outputs: list[dict]) -> bytes:
+    return encode_price_terms(
+        [DemandedOutput(value=int(o["value"]), script=bytes.fromhex(o["script_hex"])) for o in outputs]
+    )
+
+
+def test_schema_marker() -> None:
+    assert _VECTORS["schema"] == "radiant-rswp-order/1"
+
+
+@pytest.mark.parametrize("vec", _VECTORS["token_id_vectors"], ids=lambda v: v["id"])
+def test_token_id_vectors(vec: dict) -> None:
+    assert swap_token_id(_ref(vec["ref"])).hex() == vec["token_id_display_hex"]
+
+
+@pytest.mark.parametrize("vec", _VECTORS["price_terms_vectors"], ids=lambda v: v["id"])
+def test_price_terms_vectors(vec: dict) -> None:
+    assert _price_terms(vec["outputs"]).hex() == vec["price_terms_hex"]
+
+
+@pytest.mark.parametrize("vec", _VECTORS["frame_vectors"], ids=lambda v: v["id"])
+def test_frame_vectors_re_derive(vec: dict) -> None:
+    p = vec["params"]
+    script = encode_rswp_order(
+        offered_type=int(p["offered_type"]),
+        token_id=swap_token_id(_ref(p["token_ref"])),
+        want_token_id=None if p["want_token_ref"] is None else swap_token_id(_ref(p["want_token_ref"])),
+        offered_txid=p["offered_txid"],
+        offered_vout=int(p["offered_vout"]),
+        price_terms=_price_terms(p["price_terms_outputs"]),
+        signature=bytes.fromhex(p["signature_hex"]),
+        expiry_height=p["expiry_height"],
+    )
+    assert script.hex() == vec["advert_script_hex"]
+
+
+@pytest.mark.parametrize("vec", _VECTORS["frame_vectors"], ids=lambda v: v["id"])
+def test_frame_vectors_decode_back(vec: dict) -> None:
+    """The published frames are also decodable — a second implementation can
+    round-trip either direction against this file."""
+    p = vec["params"]
+    order = decode_rswp_order(bytes.fromhex(vec["advert_script_hex"]))
+    assert order.version == (3 if p["expiry_height"] is not None else 2)
+    assert order.expiry_height == p["expiry_height"]
+    assert order.offered_txid == p["offered_txid"]
+    assert order.offered_utxo_index == int(p["offered_vout"])
+    assert order.signature.hex() == p["signature_hex"]
+    assert order.price_terms == _price_terms(p["price_terms_outputs"])
+
+
+def test_reassembly_vector_locks_decoder_tail_rule() -> None:
+    vec = _VECTORS["reassembly_vector"]
+    order = decode_rswp_order(bytes.fromhex(vec["frame_hex"]))
+    assert order.price_terms.hex() == vec["expected"]["price_terms_hex"]
+    assert order.signature.hex() == vec["expected"]["signature_hex"]

--- a/tests/test_rswp_orders.py
+++ b/tests/test_rswp_orders.py
@@ -1,0 +1,379 @@
+"""RSWP order flows (post / take / cancel) — offline, pure-path, adversarial.
+
+The take bridge is the trust boundary: everything an on-chain advertisement
+*claims* must be re-verified against what the chain *holds*. Each security
+invariant from the design note (docs/plans/2026-07-05-rswp-orderbook-design.md)
+appears here as an explicit case.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from pyrxd.constants import SIGHASH
+from pyrxd.glyph.script import build_ft_locking_script, extract_ref_from_ft_script, is_ft_script
+from pyrxd.glyph.types import GlyphRef
+from pyrxd.keys import PrivateKey
+from pyrxd.script.script import Script
+from pyrxd.script.type import P2PKH
+from pyrxd.security.errors import ValidationError
+from pyrxd.security.types import Hex20, Txid
+from pyrxd.swap import Asset, FundingInput
+from pyrxd.swap.partial import _is_p2pkh
+from pyrxd.swap.rswp import (
+    RswpOrder,
+    build_advert_tx,
+    build_cancel_tx,
+    create_rswp_order,
+    decode_rswp_order,
+    prepare_offered_utxo,
+    rswp_order_to_swap_offer,
+    swap_token_id,
+    take_rswp_order,
+    verify_offer_signature,
+)
+from pyrxd.transaction.transaction import Transaction
+from pyrxd.transaction.transaction_output import TransactionOutput
+
+_REF_G = GlyphRef(txid=Txid("aa" * 32), vout=0)  # token the maker gives
+_REF_R = GlyphRef(txid=Txid("bb" * 32), vout=1)  # token the maker wants
+
+
+def _key() -> tuple[PrivateKey, bytes]:
+    k = PrivateKey()
+    return k, k.public_key().hash160()
+
+
+def _rxd_src(pkh: bytes, value: int) -> Transaction:
+    tx = Transaction()
+    tx.add_output(TransactionOutput(P2PKH().lock(pkh), value))
+    return tx
+
+
+def _ft_src(pkh: bytes, ref: GlyphRef, value: int) -> Transaction:
+    tx = Transaction()
+    tx.add_output(TransactionOutput(Script(build_ft_locking_script(Hex20(pkh), ref)), value))
+    return tx
+
+
+def _classify(out: TransactionOutput) -> tuple[str, int, GlyphRef | None]:
+    s = out.locking_script.serialize()
+    if is_ft_script(s.hex()):
+        return ("ft", out.satoshis, extract_ref_from_ft_script(s))
+    assert _is_p2pkh(s)
+    return ("rxd", out.satoshis, None)
+
+
+def _post_and_decode(give_source_tx, maker_key, receive, maker_pkh):
+    """Maker posts; the advert travels the chain as bytes; a taker decodes it fresh."""
+    post = create_rswp_order(
+        give_source_tx=give_source_tx,
+        give_vout=0,
+        maker_key=maker_key,
+        receive=receive,
+        maker_receive_pkh=maker_pkh,
+    )
+    return post, decode_rswp_order(post.advert_script)
+
+
+# ─────────────────────────────── happy paths ─────────────────────────────────
+
+
+def test_post_take_rxd_for_ft_full_loop() -> None:
+    """Maker offers 1000 RXD, demands 50 FT — through the ADVERT bytes, not the envelope."""
+    mk, mk_pkh = _key()
+    tk, tk_pkh = _key()
+    src = _rxd_src(mk_pkh, 1000)
+    post, order = _post_and_decode(src, mk, Asset("ft", 50, _REF_R), mk_pkh)
+
+    assert order.offered_is_rxd and order.want_token_id == swap_token_id(_REF_R)[::-1]
+    assert order.offered_txid == src.txid() and order.offered_utxo_index == 0
+
+    tx = take_rswp_order(
+        order,
+        give_source_tx=src,
+        funding=[FundingInput(_ft_src(tk_pkh, _REF_R, 60), 0, tk), FundingInput(_rxd_src(tk_pkh, 5000), 0, tk)],
+        taker_receive_pkh=tk_pkh,
+        taker_change_pkh=tk_pkh,
+        fee=300,
+    )
+    assert _classify(tx.outputs[0]) == ("ft", 50, _REF_R)  # maker's demand, index 0 (SINGLE)
+    assert _classify(tx.outputs[1]) == ("rxd", 1000, None)  # taker receives the offered RXD
+    kinds = [_classify(o) for o in tx.outputs]
+    assert ("ft", 10, _REF_R) in kinds  # taker FT change
+    assert all(i.unlocking_script is not None for i in tx.inputs)  # broadcast-ready
+
+
+def test_post_take_ft_for_rxd_full_loop() -> None:
+    mk, mk_pkh = _key()
+    tk, tk_pkh = _key()
+    src = _ft_src(mk_pkh, _REF_G, 777)
+    post, order = _post_and_decode(src, mk, Asset("rxd", 900), mk_pkh)
+
+    assert order.token_id == swap_token_id(_REF_G)[::-1]
+    assert order.want_token_id is None and order.flags == 0  # RXD want side: field omitted
+
+    tx = take_rswp_order(
+        order,
+        give_source_tx=src,
+        funding=[FundingInput(_rxd_src(tk_pkh, 2000), 0, tk)],
+        taker_receive_pkh=tk_pkh,
+        taker_change_pkh=tk_pkh,
+        fee=200,
+    )
+    assert _classify(tx.outputs[0]) == ("rxd", 900, None)
+    assert _classify(tx.outputs[1]) == ("ft", 777, _REF_G)
+
+
+def test_bridge_offer_equals_private_envelope() -> None:
+    """The advert round-trip reconstructs byte-identical partial/source hex to the
+    maker's own envelope — the bridge adds no drift."""
+    mk, mk_pkh = _key()
+    src = _ft_src(mk_pkh, _REF_G, 500)
+    post, order = _post_and_decode(src, mk, Asset("rxd", 400), mk_pkh)
+    bridged = rswp_order_to_swap_offer(order, give_source_tx=src)
+    assert bridged == post.offer
+
+
+def test_verify_offer_signature_accepts_fresh_offer() -> None:
+    mk, mk_pkh = _key()
+    src = _rxd_src(mk_pkh, 1000)
+    post, order = _post_and_decode(src, mk, Asset("rxd", 600), mk_pkh)
+    verify_offer_signature(rswp_order_to_swap_offer(order, give_source_tx=src))  # does not raise
+
+
+def test_prepare_offered_utxo_mints_exact_amount_at_vout0() -> None:
+    mk, mk_pkh = _key()
+    funding = [FundingInput(_ft_src(mk_pkh, _REF_G, 120), 0, mk), FundingInput(_rxd_src(mk_pkh, 3000), 0, mk)]
+    tx = prepare_offered_utxo(
+        funding=funding, asset=Asset("ft", 100, _REF_G), owner_pkh=mk_pkh, change_pkh=mk_pkh, fee=200
+    )
+    assert _classify(tx.outputs[0]) == ("ft", 100, _REF_G)
+    kinds = [_classify(o) for o in tx.outputs]
+    assert ("ft", 20, _REF_G) in kinds  # token change conserved
+    # and the minted UTXO is immediately offerable:
+    create_rswp_order(give_source_tx=tx, give_vout=0, maker_key=mk, receive=Asset("rxd", 500), maker_receive_pkh=mk_pkh)
+
+
+def test_build_advert_tx_wraps_script_at_output0_value0() -> None:
+    mk, mk_pkh = _key()
+    src = _rxd_src(mk_pkh, 1000)
+    post, _ = _post_and_decode(src, mk, Asset("rxd", 600), mk_pkh)
+    tx = build_advert_tx(
+        advert_script=post.advert_script,
+        funding=[FundingInput(_rxd_src(mk_pkh, 2000), 0, mk)],
+        change_pkh=mk_pkh,
+        fee=400,
+    )
+    assert tx.outputs[0].satoshis == 0
+    assert tx.outputs[0].locking_script.serialize() == post.advert_script
+    assert decode_rswp_order(tx.outputs[0].locking_script.serialize()).offered_txid == src.txid()
+    assert _classify(tx.outputs[1]) == ("rxd", 1600, None)  # change
+
+
+def test_cancel_rxd_offer_returns_value_to_maker() -> None:
+    mk, mk_pkh = _key()
+    src = _rxd_src(mk_pkh, 1000)
+    tx = build_cancel_tx(offered_source_tx=src, offered_vout=0, maker_key=mk, refund_pkh=mk_pkh, fee=200)
+    assert _classify(tx.outputs[0]) == ("rxd", 800, None)
+
+
+def test_cancel_ft_offer_conserves_token_with_rxd_fee_funding() -> None:
+    mk, mk_pkh = _key()
+    src = _ft_src(mk_pkh, _REF_G, 100)
+    tx = build_cancel_tx(
+        offered_source_tx=src,
+        offered_vout=0,
+        maker_key=mk,
+        refund_pkh=mk_pkh,
+        fee=300,
+        funding=[FundingInput(_rxd_src(mk_pkh, 1000), 0, mk)],
+    )
+    kinds = [_classify(o) for o in tx.outputs]
+    assert ("ft", 100, _REF_G) in kinds  # full token amount back — conservation
+    assert ("rxd", 700, None) in kinds
+
+
+# ─────────────────────────────── adversarial ─────────────────────────────────
+
+
+def _order_with(order: RswpOrder, **overrides) -> RswpOrder:
+    fields = {f: getattr(order, f) for f in RswpOrder.__dataclass_fields__}
+    fields.update(overrides)
+    return RswpOrder(**fields)
+
+
+def test_tampered_demanded_value_breaks_maker_signature() -> None:
+    """Invariant 1: inflating the maker's demand in the advert invalidates the sig."""
+    from pyrxd.gravity.swap_order import DemandedOutput
+    from pyrxd.swap.rswp import encode_price_terms
+
+    mk, mk_pkh = _key()
+    tk, tk_pkh = _key()
+    src = _rxd_src(mk_pkh, 1000)
+    _, order = _post_and_decode(src, mk, Asset("rxd", 600), mk_pkh)
+    inflated = [DemandedOutput(value=6000, script=order.demanded_outputs[0].script)]
+    tampered = _order_with(order, price_terms=encode_price_terms(inflated), demanded_outputs=inflated)
+    with pytest.raises(ValidationError, match="signature does not validate"):
+        take_rswp_order(
+            tampered,
+            give_source_tx=src,
+            funding=[FundingInput(_rxd_src(tk_pkh, 9000), 0, tk)],
+            taker_receive_pkh=tk_pkh,
+            taker_change_pkh=tk_pkh,
+            fee=300,
+        )
+
+
+def test_sighash_flag_0xc2_rejected() -> None:
+    """Invariant 6 (security F1): NONE|ANYONECANPAY|FORKID verifies pre- AND
+    post-completion while binding no outputs — must be refused outright."""
+    mk, mk_pkh = _key()
+    src = _rxd_src(mk_pkh, 1000)
+
+    # Forge a maker partial signed 0xC2 and advertise it.
+    from pyrxd.transaction.transaction_input import TransactionInput
+
+    tx = Transaction()
+    tx.add_input(
+        TransactionInput(
+            source_transaction=src,
+            source_output_index=0,
+            unlocking_script_template=P2PKH().unlock(mk),
+            sighash=SIGHASH.NONE_ANYONECANPAY_FORKID,
+        )
+    )
+    tx.add_output(TransactionOutput(P2PKH().lock(mk_pkh), 600))
+    tx.sign(bypass=True)
+    signature = tx.inputs[0].unlocking_script.serialize()
+    assert signature not in (None, b"")
+
+    from pyrxd.gravity.swap_order import DemandedOutput
+    from pyrxd.swap.rswp import encode_price_terms, encode_rswp_order
+
+    advert = encode_rswp_order(
+        offered_type=0,
+        token_id=swap_token_id(None),
+        want_token_id=None,
+        offered_txid=src.txid(),
+        offered_vout=0,
+        price_terms=encode_price_terms([DemandedOutput(value=600, script=P2PKH().lock(mk_pkh).serialize())]),
+        signature=signature,
+    )
+    order = decode_rswp_order(advert)
+    with pytest.raises(ValidationError, match="sighash"):
+        rswp_order_to_swap_offer(order, give_source_tx=src)
+
+
+def test_lying_token_id_rejected() -> None:
+    """Invariant 7: advert claims an FT token id, UTXO actually holds a different token."""
+    mk, mk_pkh = _key()
+    src = _ft_src(mk_pkh, _REF_G, 500)
+    _, order = _post_and_decode(src, mk, Asset("rxd", 400), mk_pkh)
+    lying = _order_with(order, token_id=swap_token_id(_REF_R)[::-1])
+    with pytest.raises(ValidationError, match="token_id does not match"):
+        rswp_order_to_swap_offer(lying, give_source_tx=src)
+
+
+def test_lying_want_token_id_rejected() -> None:
+    mk, mk_pkh = _key()
+    src = _rxd_src(mk_pkh, 1000)
+    _, order = _post_and_decode(src, mk, Asset("ft", 50, _REF_R), mk_pkh)
+    lying = _order_with(order, want_token_id=swap_token_id(_REF_G)[::-1])
+    with pytest.raises(ValidationError, match="want_token_id does not match"):
+        rswp_order_to_swap_offer(lying, give_source_tx=src)
+
+
+def test_lying_offered_type_rejected() -> None:
+    mk, mk_pkh = _key()
+    src = _rxd_src(mk_pkh, 1000)
+    _, order = _post_and_decode(src, mk, Asset("rxd", 600), mk_pkh)
+    lying = _order_with(order, offered_type=2)  # claims FT, holds RXD
+    with pytest.raises(ValidationError, match="offeredType does not match"):
+        rswp_order_to_swap_offer(lying, give_source_tx=src)
+
+
+def test_multi_output_demand_refused() -> None:
+    """Invariant 4: SINGLE signs only output[0]; extra demands are unenforceable."""
+    from pyrxd.gravity.swap_order import DemandedOutput
+    from pyrxd.swap.rswp import encode_price_terms
+
+    mk, mk_pkh = _key()
+    src = _rxd_src(mk_pkh, 1000)
+    _, order = _post_and_decode(src, mk, Asset("rxd", 600), mk_pkh)
+    two = [order.demanded_outputs[0], DemandedOutput(value=1, script=P2PKH().lock(mk_pkh).serialize())]
+    doubled = _order_with(order, price_terms=encode_price_terms(two), demanded_outputs=two)
+    with pytest.raises(ValidationError, match="exactly one"):
+        rswp_order_to_swap_offer(doubled, give_source_tx=src)
+
+
+def test_wrong_source_tx_rejected() -> None:
+    mk, mk_pkh = _key()
+    src = _rxd_src(mk_pkh, 1000)
+    _, order = _post_and_decode(src, mk, Asset("rxd", 600), mk_pkh)
+    other = _rxd_src(mk_pkh, 999_999)
+    with pytest.raises(ValidationError, match="does not hash to the advertised"):
+        rswp_order_to_swap_offer(order, give_source_tx=other)
+
+
+def test_negative_and_out_of_range_vout_rejected() -> None:
+    """Invariant 9 (security F7): a hostile CScriptNum vout must fail as a clean
+    ValidationError before any TransactionInput is constructed."""
+    mk, mk_pkh = _key()
+    src = _rxd_src(mk_pkh, 1000)
+    _, order = _post_and_decode(src, mk, Asset("rxd", 600), mk_pkh)
+    for hostile in (-1, 1, 2**33):
+        bad = _order_with(order, offered_utxo_index=hostile)
+        with pytest.raises(ValidationError, match="not present in give_source_tx"):
+            rswp_order_to_swap_offer(bad, give_source_tx=src)
+
+
+def test_unfundable_demand_value_rejected() -> None:
+    """Invariant 8 (security F6): a demand above MAX_MONEY is never 'fillable'."""
+    from pyrxd.gravity.swap_order import DemandedOutput
+
+    mk, mk_pkh = _key()
+    src = _rxd_src(mk_pkh, 1000)
+    _, order = _post_and_decode(src, mk, Asset("rxd", 600), mk_pkh)
+    huge = [DemandedOutput(value=2**64 - 1, script=order.demanded_outputs[0].script)]
+    bad = _order_with(order, price_terms=b"\x01" + (2**64 - 1).to_bytes(8, "little"), demanded_outputs=huge)
+    with pytest.raises(ValidationError, match="outside the fundable range"):
+        rswp_order_to_swap_offer(bad, give_source_tx=src)
+
+
+def test_v3_expiry_order_refused_for_take() -> None:
+    """v3 orders sit in a refund covenant this module cannot spend (design D13)."""
+    mk, mk_pkh = _key()
+    src = _rxd_src(mk_pkh, 1000)
+    _, order = _post_and_decode(src, mk, Asset("rxd", 600), mk_pkh)
+    v3 = _order_with(order, version=3, flags=order.flags | 0x02, expiry_height=1000)
+    with pytest.raises(ValidationError, match="not yet takeable"):
+        rswp_order_to_swap_offer(v3, give_source_tx=src)
+
+
+def test_demanded_op_return_script_rejected() -> None:
+    """A demanded output that is not a spendable P2PKH/FT script (e.g. OP_RETURN)
+    cannot be classified — refused rather than blindly paid."""
+    from pyrxd.gravity.swap_order import DemandedOutput
+    from pyrxd.swap.rswp import encode_price_terms
+
+    mk, mk_pkh = _key()
+    src = _rxd_src(mk_pkh, 1000)
+    _, order = _post_and_decode(src, mk, Asset("rxd", 600), mk_pkh)
+    weird = [DemandedOutput(value=600, script=b"\x6a\x04test")]
+    bad = _order_with(order, price_terms=encode_price_terms(weird), demanded_outputs=weird)
+    with pytest.raises(ValidationError, match="unsupported asset"):
+        rswp_order_to_swap_offer(bad, give_source_tx=src)
+
+
+def test_advert_tx_refuses_ft_funding() -> None:
+    mk, mk_pkh = _key()
+    src = _rxd_src(mk_pkh, 1000)
+    post, _ = _post_and_decode(src, mk, Asset("rxd", 600), mk_pkh)
+    with pytest.raises(ValidationError, match="plain RXD"):
+        build_advert_tx(
+            advert_script=post.advert_script,
+            funding=[FundingInput(_ft_src(mk_pkh, _REF_G, 100), 0, mk)],
+            change_pkh=mk_pkh,
+            fee=50,
+        )

--- a/tests/test_rswp_orders.py
+++ b/tests/test_rswp_orders.py
@@ -84,7 +84,7 @@ def test_post_take_rxd_for_ft_full_loop() -> None:
     mk, mk_pkh = _key()
     tk, tk_pkh = _key()
     src = _rxd_src(mk_pkh, 1000)
-    post, order = _post_and_decode(src, mk, Asset("ft", 50, _REF_R), mk_pkh)
+    _post, order = _post_and_decode(src, mk, Asset("ft", 50, _REF_R), mk_pkh)
 
     assert order.offered_is_rxd and order.want_token_id == swap_token_id(_REF_R)[::-1]
     assert order.offered_txid == src.txid() and order.offered_utxo_index == 0
@@ -108,7 +108,7 @@ def test_post_take_ft_for_rxd_full_loop() -> None:
     mk, mk_pkh = _key()
     tk, tk_pkh = _key()
     src = _ft_src(mk_pkh, _REF_G, 777)
-    post, order = _post_and_decode(src, mk, Asset("rxd", 900), mk_pkh)
+    _post, order = _post_and_decode(src, mk, Asset("rxd", 900), mk_pkh)
 
     assert order.token_id == swap_token_id(_REF_G)[::-1]
     assert order.want_token_id is None and order.flags == 0  # RXD want side: field omitted
@@ -138,7 +138,7 @@ def test_bridge_offer_equals_private_envelope() -> None:
 def test_verify_offer_signature_accepts_fresh_offer() -> None:
     mk, mk_pkh = _key()
     src = _rxd_src(mk_pkh, 1000)
-    post, order = _post_and_decode(src, mk, Asset("rxd", 600), mk_pkh)
+    _post, order = _post_and_decode(src, mk, Asset("rxd", 600), mk_pkh)
     verify_offer_signature(rswp_order_to_swap_offer(order, give_source_tx=src))  # does not raise
 
 

--- a/tests/test_rswp_regtest_e2e.py
+++ b/tests/test_rswp_regtest_e2e.py
@@ -1,0 +1,420 @@
+"""RSWP orderbook end-to-end on a REAL radiant-core regtest node with ``-swapindex=1``.
+
+Proves against real consensus + the real swap index what the unit suites prove
+offline (design note: docs/plans/2026-07-05-rswp-orderbook-design.md):
+
+* HAPPY PATH (FT→RXD): maker mints a consensus-valid FT UTXO, posts an RSWP v2
+  advert, the order appears in ``getopenorders`` and the OrderbookClient reports
+  it FILLABLE; the taker completes via ``take_rswp_order``; the node accepts +
+  mines it; the index then drops the order (offered UTXO spent = settlement).
+* HAPPY PATH (RXD→FT): the mirror direction.
+* DOUBLE-TAKE: a second completion of the same order is a double-spend —
+  rejected by the node (single-winner is consensus, not client courtesy).
+* CANCEL-vs-TAKE: after the maker's cancel self-spend confirms, a completion is
+  rejected — cancel is the hard revocation.
+* TAMPER: inflating the maker's demanded output after signing fails script
+  verification at the node (SINGLE binds output[0] exactly).
+
+The FT here is "minted" by spending an outpoint into an FT script carrying that
+outpoint as its ref — consensus enforces ref induction/uniqueness, not Glyph
+mint provenance (see tests/test_htlc_regtest_e2e.py R1), so this is a REAL
+FT-locked UTXO as far as the chain is concerned.
+
+Gating (repo convention): ``@pytest.mark.integration`` + opt-in ``RSWP_REGTEST=1``.
+Skips if docker or the radiant-core image is unavailable. Manages its OWN
+isolated container, never touches a live node, moves no real value.
+
+Run it:  RSWP_REGTEST=1 pytest tests/test_rswp_regtest_e2e.py -m integration -s
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+import time
+
+import pytest
+
+from pyrxd.constants import Network
+from pyrxd.glyph.script import build_ft_locking_script
+from pyrxd.glyph.types import GlyphRef
+from pyrxd.keys import PrivateKey
+from pyrxd.script.script import Script
+from pyrxd.script.type import P2PKH
+from pyrxd.security.types import Hex20, Txid
+from pyrxd.swap import Asset, FundingInput
+from pyrxd.swap.rswp import (
+    OrderbookClient,
+    build_advert_tx,
+    build_cancel_tx,
+    create_rswp_order,
+    decode_rswp_order,
+    swap_token_id,
+    take_rswp_order,
+)
+from pyrxd.transaction.transaction import Transaction
+from pyrxd.transaction.transaction_input import TransactionInput
+from pyrxd.transaction.transaction_output import TransactionOutput
+
+pytestmark = pytest.mark.integration
+
+_IMAGE = "radiant-core:v3.1.1-amd64"
+_CONTAINER = "rswp-regtest-pytest"
+_FEE = 1_000_000  # 0.01 RXD — comfortably above regtest relay for sub-kB txs
+_RXD_TOKEN_HEX = "00" * 32
+
+
+class _Node:
+    """Self-managed isolated radiant-core regtest node with the swap index enabled."""
+
+    def __init__(self) -> None:
+        self.user = "rt_user"
+        self.password = os.urandom(12).hex()
+        self.mine_addr = ""
+
+    def cli(self, *args: str, wallet: bool = False) -> object:
+        base = [
+            "docker",
+            "exec",
+            _CONTAINER,
+            "radiant-cli",
+            "-regtest",
+            f"-rpcuser={self.user}",
+            f"-rpcpassword={self.password}",
+        ]
+        if wallet:
+            base.append("-rpcwallet=rswp")
+        r = subprocess.run(base + list(args), capture_output=True, text=True, timeout=60)
+        if r.returncode != 0:
+            raise RuntimeError(f"radiant-cli {args[0]} failed: {r.stderr.strip()}")
+        out = r.stdout.strip()
+        try:
+            return json.loads(out)
+        except json.JSONDecodeError:
+            return out
+
+    def mine(self, n: int = 1) -> None:
+        self.cli("generatetoaddress", str(n), self.mine_addr)
+
+    def accepts(self, raw_hex: str) -> dict:
+        res = self.cli("testmempoolaccept", json.dumps([raw_hex]))
+        return res[0] if isinstance(res, list) else res
+
+    def send_and_mine(self, tx: Transaction) -> str:
+        txid = str(self.cli("sendrawtransaction", tx.serialize().hex()))
+        self.mine(1)
+        return txid
+
+    def start(self) -> None:
+        subprocess.run(["docker", "rm", "-f", _CONTAINER], capture_output=True)
+        up = subprocess.run(
+            [
+                "docker",
+                "run",
+                "-d",
+                "--name",
+                _CONTAINER,
+                "--entrypoint",
+                "radiantd",
+                _IMAGE,
+                "-regtest",
+                "-server",
+                "-txindex=1",
+                "-swapindex=1",
+                "-disablewallet=0",
+                "-fallbackfee=0.001",
+                f"-rpcuser={self.user}",
+                f"-rpcpassword={self.password}",
+                "-rpcbind=0.0.0.0",
+                "-rpcallowip=0.0.0.0/0",
+            ],
+            capture_output=True,
+            text=True,
+        )
+        if up.returncode != 0:
+            raise RuntimeError(f"failed to start regtest container: {up.stderr.strip()}")
+        deadline = time.monotonic() + 30
+        while time.monotonic() < deadline:
+            try:
+                info = self.cli("getblockchaininfo")
+                if isinstance(info, dict) and info.get("chain") == "regtest":
+                    break
+            except RuntimeError:
+                time.sleep(0.5)
+        else:
+            raise RuntimeError("regtest RPC did not become ready")
+        assert self.cli("getblockchaininfo")["chain"] == "regtest", "node is NOT regtest — aborting"
+        info = self.cli("getswapindexinfo")
+        assert info.get("enabled") is True, f"swap index not enabled: {info}"
+        self.cli("createwallet", "rswp")
+        self.mine_addr = str(self.cli("getnewaddress", wallet=True))
+        self.mine(101)
+
+    def stop(self) -> None:
+        subprocess.run(["docker", "rm", "-f", _CONTAINER], capture_output=True)
+
+
+@pytest.fixture(scope="module")
+def node():
+    if not os.environ.get("RSWP_REGTEST"):
+        pytest.skip("RSWP_REGTEST not set (opt-in for the live regtest e2e)")
+    if shutil.which("docker") is None:
+        pytest.skip("docker not available")
+    if subprocess.run(["docker", "image", "inspect", _IMAGE], capture_output=True).returncode != 0:
+        pytest.skip(f"{_IMAGE} image not available")
+    n = _Node()
+    n.start()
+    try:
+        yield n
+    finally:
+        n.stop()
+
+
+# --------------------------------------------------------------------------- funding helpers
+
+
+def _fund_key(node: _Node, key: PrivateKey, photons: int) -> tuple[Transaction, int]:
+    """Wallet-pay ``photons`` to the key's P2PKH address; return the REAL (funding tx, vout)."""
+    addr_spk = P2PKH().lock(key.public_key().hash160()).serialize()
+    # Radiant regtest shares the testnet address prefix.
+    addr = key.public_key().address(network=Network.TESTNET)
+    txid = str(node.cli("sendtoaddress", addr, f"{photons / 1e8:.8f}", wallet=True))
+    node.mine(1)
+    raw = str(node.cli("getrawtransaction", txid))
+    tx = Transaction.from_hex(bytes.fromhex(raw))
+    assert tx is not None and tx.txid() == txid
+    vout = next(i for i, o in enumerate(tx.outputs) if o.locking_script.serialize() == addr_spk)
+    return tx, vout
+
+
+def _mint_ft(node: _Node, owner: PrivateKey, units: int) -> tuple[Transaction, GlyphRef]:
+    """Create a consensus-valid FT UTXO at vout 0: ref = the spent outpoint (genesis induction)."""
+    fund_tx, fund_vout = _fund_key(node, owner, units + 10_000_000)
+    ref = GlyphRef(txid=Txid(fund_tx.txid()), vout=fund_vout)
+    pkh = owner.public_key().hash160()
+    tx = Transaction()
+    tx.add_input(
+        TransactionInput(
+            source_transaction=fund_tx,
+            source_output_index=fund_vout,
+            unlocking_script_template=P2PKH().unlock(owner),
+        )
+    )
+    tx.add_output(TransactionOutput(Script(build_ft_locking_script(Hex20(pkh), ref)), units))
+    change = fund_tx.outputs[fund_vout].satoshis - units - _FEE
+    tx.add_output(TransactionOutput(P2PKH().lock(pkh), change))
+    tx.sign(bypass=True)
+    node.send_and_mine(tx)
+    return tx, ref
+
+
+class _CliSource:
+    """OrderbookSource over the node's CLI — the regtest incarnation of the Protocol."""
+
+    def __init__(self, node: _Node) -> None:
+        self._node = node
+
+    # NB: radiant-cli lacks client-side type conversion for the swap RPCs, so the
+    # numeric limit/offset args cannot be passed as strings — token-only calls
+    # use the server defaults (limit 100, offset 0), plenty for these tests.
+
+    async def get_open_orders(self, token_id_hex: str, *, limit: int = 100, offset: int = 0) -> list[dict]:
+        rows = self._node.cli("getopenorders", token_id_hex)
+        return rows if isinstance(rows, list) else []
+
+    async def get_open_orders_by_want(self, want_token_id_hex: str, *, limit: int = 100, offset: int = 0) -> list[dict]:
+        rows = self._node.cli("getopenordersbywant", want_token_id_hex)
+        return rows if isinstance(rows, list) else []
+
+    async def get_transaction(self, txid) -> bytes:
+        return bytes.fromhex(str(self._node.cli("getrawtransaction", str(txid))))
+
+    async def is_unspent(self, txid: str, vout: int) -> bool:
+        out = self._node.cli("gettxout", txid, str(vout), "true")
+        return isinstance(out, dict)  # null/empty stdout => spent
+
+
+# --------------------------------------------------------------------------- scenarios
+
+
+def _post_ft_for_rxd_order(node: _Node, maker: PrivateKey, units: int, demand_photons: int):
+    """Maker mints an FT, posts an order offering it for RXD. Returns (order, ft_source_tx, ref)."""
+    mk_pkh = maker.public_key().hash160()
+    ft_tx, ref = _mint_ft(node, maker, units)
+    post = create_rswp_order(
+        give_source_tx=ft_tx,
+        give_vout=0,
+        maker_key=maker,
+        receive=Asset("rxd", demand_photons),
+        maker_receive_pkh=mk_pkh,
+    )
+    advert_fund_tx, advert_vout = _fund_key(node, maker, 20_000_000)
+    advert = build_advert_tx(
+        advert_script=post.advert_script,
+        funding=[FundingInput(advert_fund_tx, advert_vout, maker)],
+        change_pkh=mk_pkh,
+        fee=_FEE,
+    )
+    node.send_and_mine(advert)
+    return decode_rswp_order(post.advert_script), ft_tx, ref
+
+
+async def test_happy_path_ft_for_rxd_post_browse_take_settle(node) -> None:
+    maker, taker = PrivateKey(), PrivateKey()
+    tk_pkh = taker.public_key().hash160()
+    order, ft_tx, ref = _post_ft_for_rxd_order(node, maker, units=100_000, demand_photons=9_000_000)
+
+    # The index sees the order under the FT's swap token id.
+    token_hex = swap_token_id(ref).hex()
+    rows = node.cli("getopenorders", token_hex)
+    assert isinstance(rows, list) and len(rows) == 1
+    assert rows[0]["utxo"]["txid"] == ft_tx.txid()
+
+    # The OrderbookClient's hostile-input pipeline marks it fillable.
+    entries = await OrderbookClient(_CliSource(node)).orders_offering(ref)
+    assert len(entries) == 1 and entries[0].fillable, entries[0].problem
+
+    # Taker completes from the DECODED advert + a txid-verified source fetch.
+    fund_tx, fund_vout = _fund_key(node, taker, 20_000_000)
+    completion = take_rswp_order(
+        order,
+        give_source_tx=ft_tx,
+        funding=[FundingInput(fund_tx, fund_vout, taker)],
+        taker_receive_pkh=tk_pkh,
+        taker_change_pkh=tk_pkh,
+        fee=_FEE,
+    )
+    verdict = node.accepts(completion.serialize().hex())
+    assert verdict.get("allowed") is True, verdict
+    txid = node.send_and_mine(completion)
+
+    # Settlement: taker owns the FT at completion:1; index dropped the order.
+    got = node.cli("gettxout", txid, "1", "true")
+    assert isinstance(got, dict) and round(got["value"] * 1e8) == 100_000
+    assert node.cli("getopenorders", token_hex) == []
+
+
+async def test_happy_path_rxd_for_ft_mirror(node) -> None:
+    """Maker offers RXD, demands the taker's FT — the book's other side."""
+    maker, taker = PrivateKey(), PrivateKey()
+    mk_pkh, tk_pkh = maker.public_key().hash160(), taker.public_key().hash160()
+
+    # Taker owns an FT; maker owns a clean exact-amount RXD UTXO.
+    taker_ft_tx, ref = _mint_ft(node, taker, 50_000)
+    offered_tx, offered_vout = _fund_key(node, maker, 11_000_000)
+
+    post = create_rswp_order(
+        give_source_tx=offered_tx,
+        give_vout=offered_vout,
+        maker_key=maker,
+        receive=Asset("ft", 50_000, ref),
+        maker_receive_pkh=mk_pkh,
+    )
+    advert_fund, af_vout = _fund_key(node, maker, 20_000_000)
+    node.send_and_mine(
+        build_advert_tx(
+            advert_script=post.advert_script,
+            funding=[FundingInput(advert_fund, af_vout, maker)],
+            change_pkh=mk_pkh,
+            fee=_FEE,
+        )
+    )
+
+    # Discoverable by WANT side (the FT's book).
+    entries = await OrderbookClient(_CliSource(node)).orders_wanting(ref)
+    assert len(entries) == 1 and entries[0].fillable, entries[0].problem
+
+    fee_fund, ff_vout = _fund_key(node, taker, 20_000_000)
+    completion = take_rswp_order(
+        decode_rswp_order(post.advert_script),
+        give_source_tx=offered_tx,
+        funding=[FundingInput(taker_ft_tx, 0, taker), FundingInput(fee_fund, ff_vout, taker)],
+        taker_receive_pkh=tk_pkh,
+        taker_change_pkh=tk_pkh,
+        fee=_FEE,
+    )
+    verdict = node.accepts(completion.serialize().hex())
+    assert verdict.get("allowed") is True, verdict
+    node.send_and_mine(completion)
+
+
+async def test_double_take_single_winner(node) -> None:
+    """Two independent takers complete the same order; consensus lets exactly one win."""
+    maker, taker1, taker2 = PrivateKey(), PrivateKey(), PrivateKey()
+    order, ft_tx, _ref = _post_ft_for_rxd_order(node, maker, units=70_000, demand_photons=8_000_000)
+
+    completions = []
+    for taker in (taker1, taker2):
+        fund_tx, fund_vout = _fund_key(node, taker, 20_000_000)
+        completions.append(
+            take_rswp_order(
+                order,
+                give_source_tx=ft_tx,
+                funding=[FundingInput(fund_tx, fund_vout, taker)],
+                taker_receive_pkh=taker.public_key().hash160(),
+                taker_change_pkh=taker.public_key().hash160(),
+                fee=_FEE,
+            )
+        )
+
+    node.send_and_mine(completions[0])
+    second = node.accepts(completions[1].serialize().hex())
+    assert second.get("allowed") is False
+    assert "missing-inputs" in str(second) or "txn-mempool-conflict" in str(second)
+    # replay of the winner is equally dead
+    replay = node.accepts(completions[0].serialize().hex())
+    assert replay.get("allowed") is False
+
+
+async def test_cancel_beats_take(node) -> None:
+    """After the maker's cancel self-spend confirms, the pre-signed completion is worthless."""
+    maker, taker = PrivateKey(), PrivateKey()
+    order, ft_tx, ref = _post_ft_for_rxd_order(node, maker, units=60_000, demand_photons=7_000_000)
+
+    fund_tx, fund_vout = _fund_key(node, taker, 20_000_000)
+    completion = take_rswp_order(
+        order,
+        give_source_tx=ft_tx,
+        funding=[FundingInput(fund_tx, fund_vout, taker)],
+        taker_receive_pkh=taker.public_key().hash160(),
+        taker_change_pkh=taker.public_key().hash160(),
+        fee=_FEE,
+    )
+
+    fee_fund, ff_vout = _fund_key(node, maker, 20_000_000)
+    cancel = build_cancel_tx(
+        offered_source_tx=ft_tx,
+        offered_vout=0,
+        maker_key=maker,
+        refund_pkh=maker.public_key().hash160(),
+        fee=_FEE,
+        funding=[FundingInput(fee_fund, ff_vout, maker)],
+    )
+    node.send_and_mine(cancel)
+
+    verdict = node.accepts(completion.serialize().hex())
+    assert verdict.get("allowed") is False  # hard revocation
+    token_hex = swap_token_id(ref).hex()
+    assert node.cli("getopenorders", token_hex) == []  # index shows it gone
+
+
+async def test_tampered_demand_rejected_by_consensus(node) -> None:
+    """Client checks aside, the CHAIN rejects a completion whose output[0] was inflated."""
+    maker, taker = PrivateKey(), PrivateKey()
+    order, ft_tx, _ = _post_ft_for_rxd_order(node, maker, units=40_000, demand_photons=6_000_000)
+
+    fund_tx, fund_vout = _fund_key(node, taker, 20_000_000)
+    completion = take_rswp_order(
+        order,
+        give_source_tx=ft_tx,
+        funding=[FundingInput(fund_tx, fund_vout, taker)],
+        taker_receive_pkh=taker.public_key().hash160(),
+        taker_change_pkh=taker.public_key().hash160(),
+        fee=_FEE,
+    )
+    completion.outputs[0].satoshis -= 1  # steal one photon from the maker's demand
+    verdict = node.accepts(completion.serialize().hex())
+    assert verdict.get("allowed") is False
+    assert "mandatory-script-verify-flag-failed" in str(verdict)

--- a/tests/test_rswp_wire.py
+++ b/tests/test_rswp_wire.py
@@ -1,0 +1,241 @@
+"""RSWP wire layer: encoder↔decoder round-trip properties + node-strictness byte pins.
+
+The encoder must satisfy the STRICTEST consumer (Radiant-Core ``swapindex.cpp``),
+which is stricter than pyrxd's own decoder — so the byte-pin tests here assert the
+exact push forms (1-byte direct pushes, ``OP_0``/minimal-CScriptNum vout, bare
+``OP_RETURN`` prefix), not just decodability.
+"""
+
+from __future__ import annotations
+
+import hashlib
+
+import pytest
+from hypothesis import given
+from hypothesis import strategies as st
+
+from pyrxd.glyph.types import GlyphRef
+from pyrxd.security.errors import ValidationError
+from pyrxd.security.types import Txid
+from pyrxd.swap.rswp import (
+    RXD_TOKEN_ID,
+    DemandedOutput,
+    RswpOrder,
+    decode_rswp_order,
+    encode_price_terms,
+    encode_rswp_order,
+    parse_price_terms,
+    swap_token_id,
+)
+
+# ------------------------------------------------------------------ strategies
+
+_txid_hex = st.binary(min_size=32, max_size=32).map(lambda b: b.hex())
+_ref = st.builds(
+    lambda txid, vout: GlyphRef(txid=Txid(txid), vout=vout),
+    _txid_hex,
+    st.integers(min_value=0, max_value=0xFFFFFFFF),
+)
+_demanded_output = st.builds(
+    DemandedOutput,
+    value=st.integers(min_value=0, max_value=0xFFFFFFFFFFFFFFFF),
+    script=st.binary(min_size=1, max_size=200),  # exercises direct + PUSHDATA1 pushes
+)
+_vout = st.one_of(
+    st.integers(min_value=0, max_value=20),
+    st.sampled_from([0, 1, 16, 17, 127, 128, 255, 256, 0x7FFF, 0x8000, 0x7FFFFFFF]),
+)
+
+
+@given(
+    offered_ref=st.one_of(st.none(), _ref),
+    want_ref=st.one_of(st.none(), _ref),
+    offered_type=st.integers(min_value=0, max_value=255),
+    offered_txid=_txid_hex,
+    offered_vout=_vout,
+    outputs=st.lists(_demanded_output, min_size=1, max_size=5),
+    signature=st.binary(min_size=1, max_size=120),
+    expiry_height=st.one_of(st.none(), st.integers(min_value=1, max_value=0xFFFFFFFF)),
+)
+def test_encode_decode_round_trip(
+    offered_ref, want_ref, offered_type, offered_txid, offered_vout, outputs, signature, expiry_height
+) -> None:
+    """Everything the encoder writes, the canonical decoder reads back verbatim (v2 and v3)."""
+    token_id = swap_token_id(offered_ref)
+    want_token_id = None if want_ref is None else swap_token_id(want_ref)
+    price_terms = encode_price_terms(outputs)
+    script = encode_rswp_order(
+        offered_type=offered_type,
+        token_id=token_id,
+        want_token_id=want_token_id,
+        offered_txid=offered_txid,
+        offered_vout=offered_vout,
+        price_terms=price_terms,
+        signature=signature,
+        expiry_height=expiry_height,
+    )
+    order = decode_rswp_order(script)
+
+    assert order.version == (3 if expiry_height is not None else 2)
+    assert order.expiry_height == expiry_height
+    assert order.offered_type == offered_type
+    assert order.terms_type == 1
+    # 32-byte ids travel byte-reversed on chain (display digest ↔ pushed form).
+    assert order.token_id == (token_id if token_id == RXD_TOKEN_ID else token_id[::-1])
+    if want_token_id is None:
+        assert order.want_token_id is None
+    else:
+        assert order.want_token_id == want_token_id[::-1]
+    assert order.offered_txid == offered_txid
+    assert order.offered_utxo_index == offered_vout
+    assert order.price_terms == price_terms
+    assert order.demanded_outputs == outputs
+    assert order.signature == signature
+
+
+@given(outputs=st.lists(_demanded_output, min_size=1, max_size=8))
+def test_price_terms_round_trip(outputs) -> None:
+    assert parse_price_terms(encode_price_terms(outputs)) == outputs
+
+
+# ------------------------------------------------------------------ token id
+
+
+def test_swap_token_id_rxd_is_all_zeros() -> None:
+    assert swap_token_id(None) == b"\x00" * 32
+
+
+def test_swap_token_id_hashes_the_le_script_operand_ref() -> None:
+    """sha256 of the 36-byte little-endian ref (GlyphRef.to_bytes()) — the exact
+    bytes OP_PUSHINPUTREF pushes; matches Photonic assetToSwapTokenId, which
+    reverses the display ref before hashing."""
+    ref = GlyphRef(txid=Txid("ee" * 31 + "01"), vout=1)
+    le_ref = bytes.fromhex(str(ref.txid))[::-1] + (1).to_bytes(4, "little")
+    assert swap_token_id(ref) == hashlib.sha256(le_ref).digest()
+
+
+# ------------------------------------------------------------------ node-strictness byte pins
+
+
+def _fixed_order_script(**overrides) -> bytes:
+    params = dict(
+        offered_type=0,
+        token_id=RXD_TOKEN_ID,
+        want_token_id=swap_token_id(GlyphRef(txid=Txid("cc" * 32), vout=2)),
+        offered_txid="ab" * 32,
+        offered_vout=0,
+        price_terms=encode_price_terms([DemandedOutput(value=1234, script=b"\x51")]),
+        signature=b"\x01\x02\x03",
+    )
+    params.update(overrides)
+    return encode_rswp_order(**params)
+
+
+def test_frame_starts_with_bare_op_return() -> None:
+    """The node checks scriptPubKey[0] == OP_RETURN — an OP_FALSE prefix (pyrxd's
+    OpReturn template default) would make the node skip the advertisement."""
+    assert _fixed_order_script()[0] == 0x6A
+
+
+def test_small_fields_are_one_byte_direct_pushes_never_op_n() -> None:
+    """swapindex requires data.size()==1 for version/flags/offeredType/termsType;
+    GetOp yields EMPTY data for OP_N, so OP_2 as the version byte drops the order."""
+    script = _fixed_order_script()
+    # OP_RETURN, PUSH4 "RSWP", then: 01 02 (version), 01 01 (flags=HAS_WANT),
+    # 01 00 (offeredType=0 — NOT OP_0), 01 01 (termsType).
+    prefix = bytes([0x6A, 0x04]) + b"RSWP" + bytes([0x01, 0x02, 0x01, 0x01, 0x01, 0x00, 0x01, 0x01])
+    assert script.startswith(prefix)
+
+
+def test_vout_zero_is_op_0_and_small_vouts_are_scriptnum_pushes() -> None:
+    """Photonic encodeScriptNum: 0 → empty buffer (OP_0); n → minimal LE with sign pad,
+    as a DIRECT push (radiantjs never converts buffers to OP_N)."""
+    tail_zero = _fixed_order_script(offered_vout=0)
+    tail_one = _fixed_order_script(offered_vout=1)
+    tail_128 = _fixed_order_script(offered_vout=128)  # sign bit → 0x00 pad
+    # locate the vout push right after the 32-byte outpoint push (0x20 prefix + 32 bytes)
+    outpoint_push = bytes([0x20]) + bytes.fromhex("ab" * 32)[::-1]
+    for script, expected in ((tail_zero, b"\x00"), (tail_one, b"\x01\x01"), (tail_128, b"\x02\x80\x00")):
+        at = script.index(outpoint_push) + len(outpoint_push)
+        assert script[at : at + len(expected)] == expected
+
+
+def test_token_ids_are_pushed_byte_reversed() -> None:
+    want = swap_token_id(GlyphRef(txid=Txid("cc" * 32), vout=2))
+    script = _fixed_order_script()
+    assert want[::-1] in script and want not in script
+
+
+# ------------------------------------------------------------------ malformed / mismatch rejection
+
+
+def test_v2_frame_with_expiry_flag_rejected() -> None:
+    """flag 0x02 on a v2 frame: the frame has no field to carry an expiry — the greedy
+    tail rule would otherwise silently mis-slice the frame."""
+    script = bytearray(_fixed_order_script())
+    # flags byte is the second 1-byte field: ...RSWP | 01 02 | 01 <flags> ...
+    at = script.index(b"RSWP") + 4 + 2 + 1
+    script[at] |= 0x02
+    with pytest.raises(ValidationError, match="inconsistent with expiry flag"):
+        decode_rswp_order(bytes(script))
+
+
+def test_v3_frame_without_expiry_flag_rejected() -> None:
+    script = bytearray(_fixed_order_script())  # v2 layout, no expiry field
+    at = script.index(b"RSWP") + 4 + 1  # version byte inside its push
+    script[at] = 0x03
+    with pytest.raises(ValidationError, match="inconsistent with expiry flag"):
+        decode_rswp_order(bytes(script))
+
+
+def test_hand_built_rswp_order_enforces_v3_iff_expiry() -> None:
+    kwargs = dict(
+        version=2,
+        flags=0,
+        offered_type=0,
+        terms_type=1,
+        token_id=b"\x00" * 32,
+        want_token_id=None,
+        offered_utxo_hash=b"\xaa" * 32,
+        offered_utxo_index=0,
+        price_terms=b"",
+        demanded_outputs=None,
+        signature=b"\x01",
+    )
+    with pytest.raises(ValidationError, match="cannot carry an expiry"):
+        RswpOrder(**{**kwargs, "expiry_height": 5})
+    with pytest.raises(ValidationError, match="requires an expiry"):
+        RswpOrder(**{**kwargs, "version": 3})
+
+
+@pytest.mark.parametrize(
+    ("kwargs", "match"),
+    [
+        ({"token_id": b"\x00" * 31}, "32 bytes"),
+        ({"offered_vout": -1}, "cannot be advertised"),
+        ({"offered_vout": 0x80000000}, "cannot be advertised"),  # node reads a 4-byte CScriptNum
+        ({"expiry_height": 0}, "expiry_height"),
+        ({"expiry_height": 0x1_0000_0000}, "expiry_height"),
+        ({"price_terms": b""}, "price_terms"),
+        ({"signature": b""}, "signature"),
+        ({"offered_type": 256}, "one byte"),
+    ],
+)
+def test_encoder_rejects_out_of_range_params(kwargs, match) -> None:
+    with pytest.raises(ValidationError, match=match):
+        _fixed_order_script(**kwargs)
+
+
+def test_encode_price_terms_rejects_bad_inputs() -> None:
+    with pytest.raises(ValidationError, match="at least 1"):
+        encode_price_terms([])
+    with pytest.raises(ValidationError, match="8 bytes"):
+        encode_price_terms([DemandedOutput(value=2**64, script=b"\x51")])
+    with pytest.raises(ValidationError, match="non-empty script"):
+        encode_price_terms([DemandedOutput(value=1, script=b"")])
+
+
+def test_rxd_want_token_id_is_equivalent_to_none() -> None:
+    """Passing the all-zero id explicitly must behave exactly like None (flag clear,
+    field omitted) — Photonic's hasWantToken check."""
+    assert _fixed_order_script(want_token_id=None) == _fixed_order_script(want_token_id=RXD_TOKEN_ID)


### PR DESCRIPTION
Implements the top RSWP cluster of the 2026-06-26 next-steps brainstorm: pyrxd goes from orderbook **spectator** (decode-only) to **participant** — posting, taking, cancelling, and browsing v2 RSWP orders on the live on-chain book format.

## What ships

**`pyrxd.swap.rswp`** (new package; the public import home for everything RSWP):
- **`wire.py`** — v2/v3 advertisement encoder, byte-compatible with the canonical producer (Photonic `buildSwapAdvertisementScript`) and satisfying the *strictest* consumer (Radiant-Core `swapindex.cpp`): bare `OP_RETURN` start, 1-byte **direct** pushes for version/flags/types (the node drops `OP_N` there), `OP_0`/minimal-CScriptNum vout, byte-reversed 32-byte ids, single price-terms push. Plus the `MultiTxOutV1` serializer and `swap_token_id` (`sha256` of the 36-byte LE ref).
- **`orders.py`** — `create_rswp_order` / `prepare_offered_utxo` / `build_advert_tx` (post), `rswp_order_to_swap_offer` → existing `accept_offer` (take; the bridge is the trust boundary), `build_cancel_tx` (the v2 hard revocation), `verify_offer_signature`.
- **`book.py`** — `OrderbookClient` over a fail-closed `OrderbookSource` Protocol (`getopenorders`/`getopenordersbywant` + txid-verified source fetch + `gettxout`); **fillable = exactly what `accept_offer` would accept**; lying/spent/malformed rows surface with `problem` set.
- **`gravity/swap_order.py`** — additive **v3 decode** (`expiry_height`, strict `version 3 iff flag 0x02`); all pre-existing v2 tests pass unchanged.
- **Conformance**: `conformance/rswp-order-vectors.json` (`radiant-rswp-order/1`) — frame/price-terms/token-id reference vectors + the Radiant-Core reassembly vector, CI re-derived byte-for-byte. *No mainnet-anchored vector yet (tracked follow-up).*

## Security hardening in shared code (deliberate, equivalence-proven)

`swap/partial.py::_verify_owner_signature` now pins the maker-offer sighash flag to `0xC3`. The flag byte rides in the **untrusted** scriptSig, and `0xC2` (`NONE|ANYONECANPAY|FORKID`) is the one flag that verifies both before *and* after taker completion while committing to **no outputs** — an offer that looks enforceable but whose demand is unbound (divergent-panel security finding F1). Every existing swap suite passes unchanged.

## Design process + explicit decisions

Phase-0 design note: `docs/plans/2026-07-05-rswp-orderbook-design.md`, revised by an independent divergent review panel (simplicity / security / python-shape) before implementation. Where the brainstorm was open-ended, the decisions (full rationale in the note, D1–D16):

1. **Interop first: v2 is the only posting format shipped.** The deployed Radiant-Core swapindex *drops* v3 adverts, so the v3/expiry-covenant **write side is deferred to its own red-teamed PR** (the covenant breaks the `accept_offer`-bridge premise, and FT-in-covenant has a known consensus blocker). This PR ships v3 **decode** + frame vectors to seed the cross-repo parser rollout.
2. **No new covenant invented** — the v3 follow-up adopts the ecosystem's existing timelocked-refund covenant design rather than forking the book.
3. `ContractType` **RXD=0, NFT=1, FT=2** (verified in Photonic source — not the FT=1/NFT=2 guess); `tokenID = sha256(36-byte LE ref)`, pushed reversed.
4. **Take requires exactly one demanded output** — `SINGLE` signs only output[0]; extra "demands" would be unenforceable theater.
5. **Take = bridge into the proven `accept_offer`**, not a parallel implementation; the bridge also verifies every *advertised claim* (token ids, offeredType, outpoint) against chain reality, pins the sighash flag, caps demand at MAX_MONEY, and rejects hostile CScriptNum vouts.
6. **Reconstruction tx shape pinned** to `nVersion=1, nLockTime=0, nSequence=0xFFFFFFFF` — preimage-committed fields absent from the advert; the pinned values are simultaneously the pyrxd and radiantjs defaults (verified in radiantjs 1.9.6), and any other shape fails signature verification fail-safe.
7. Asset scope RXD + Glyph FT (NFT decode/display only); library-first, CLI is a follow-up; scan-based book source cut in favor of `RegtestNode.start(extra_args=("-swapindex=1",))`.

## Test evidence (all run locally, 2026-07-05)

- `task ci` **green**: 4490 passed / 81 skipped / 1 xfailed, coverage 88.04% (≥85% gate), mypy, bandit, link check.
- 64 new offline tests: Hypothesis encode↔decode round-trip, node-strictness byte pins, every design-note security invariant as an explicit adversarial case, hostile-index book pipeline, conformance re-derive.
- **Live regtest e2e (5/5 passed)** against radiant-core v3.1.1 with `-swapindex=1`: post → `getopenorders`-visible → `OrderbookClient` fillable → take → settle → index drops the order, in both directions; double-take single-winner; cancel-beats-take; tampered demand rejected by consensus.

## Follow-ups (tracked in the design note)

RSWP v3 write side (refund covenant; own PR, RXD-only first, must address the refund-selector txid-malleability and post-expiry fill race), `swap post/fill/orders` CLI, market-maker quoting toolkit, lifecycle tracker, RXinDexer `swap.*` source adapter, NFT take/post, mainnet golden vector, encoder atheris harness.

---
Pre-audit posture unchanged: regtest/library work only; nothing here moves real value.

🤖 Generated with [Claude Code](https://claude.com/claude-code)