### PR TITLE
feat(cli): pyrxd swap orders/post/take/cancel — RSWP orderbook CLI

### DIFF
--- a/src/pyrxd/cli/main.py
+++ b/src/pyrxd/cli/main.py
@@ -180,7 +180,16 @@ def run() -> None:
 # and that breaks static analysis even though Python's import system
 # tolerates it at runtime.
 
-from . import agent_cmds, glyph_cmds, query_cmds, regtest_cmds, setup_cmd, swap_cmds, wallet_cmds  # noqa: E402
+from . import (  # noqa: E402
+    agent_cmds,
+    glyph_cmds,
+    query_cmds,
+    regtest_cmds,
+    setup_cmd,
+    swap_book_cmds,
+    swap_cmds,
+    wallet_cmds,
+)
 
 cli.add_command(agent_cmds.agent_group)
 cli.add_command(glyph_cmds.glyph_group)
@@ -191,6 +200,13 @@ cli.add_command(regtest_cmds.regtest_group)
 cli.add_command(setup_cmd.setup_cmd)
 cli.add_command(swap_cmds.swap_group)
 cli.add_command(wallet_cmds.wallet_group)
+
+# RSWP orderbook commands live in their own module but share the `swap` group
+# (same no-import-cycle rule as above: swap_book_cmds does not import swap_cmds).
+swap_cmds.swap_group.add_command(swap_book_cmds.swap_orders_cmd)
+swap_cmds.swap_group.add_command(swap_book_cmds.swap_post_cmd)
+swap_cmds.swap_group.add_command(swap_book_cmds.swap_take_cmd)
+swap_cmds.swap_group.add_command(swap_book_cmds.swap_cancel_cmd)
 
 
 if __name__ == "__main__":

--- a/src/pyrxd/cli/swap_book_cmds.py
+++ b/src/pyrxd/cli/swap_book_cmds.py
@@ -1,0 +1,482 @@
+"""``pyrxd swap orders/post/take/cancel`` — the on-chain RSWP orderbook commands.
+
+Thin CLI over the proven :mod:`pyrxd.swap.rswp` library (design:
+docs/plans/2026-07-05-rswp-orderbook-design.md). Same safety posture as the
+glyph commands:
+
+* **Read side** (``orders``) never signs and never broadcasts. It talks to a
+  Radiant node running ``-swapindex=1`` and re-verifies every row against
+  chain data — *fillable* means the maker signature and every advertised
+  claim checked out, not that the index said so.
+* **Write side** (``post`` / ``take`` / ``cancel``) shows a full value summary
+  and asks for confirmation before ANY broadcast (``--json`` requires
+  ``--yes``, same gate as the glyph commands). Funding comes from the local
+  HD wallet; the offered/give UTXO must be owned by a wallet key.
+
+Wire/format authority: the maker's offer is signed
+``SIGHASH_SINGLE|ANYONECANPAY|FORKID`` — posting publishes a price that stays
+fillable until the offered UTXO is spent. ``cancel`` (a self-spend) is the
+ONLY hard revocation; the confirmation text says so.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass
+
+import click
+
+from ..glyph.types import GlyphRef
+from ..keys import PrivateKey
+from ..security.errors import RxdSdkError, ValidationError
+from ..security.types import Txid
+from ..swap import Asset, FundingInput
+from ..swap.partial import _asset_of, _owner_pkh_of
+from ..swap.resolve import fetch_transaction
+from ..swap.rswp import (
+    NodeRpcSource,
+    OrderbookClient,
+    RswpOrder,
+    build_advert_tx,
+    build_cancel_tx,
+    create_rswp_order,
+    decode_rswp_order,
+    take_rswp_order,
+)
+from ..transaction.transaction import Transaction
+from .context import CliContext
+from .errors import UserError
+from .format import emit, sanitize_terminal
+from .glyph_helpers import _BroadcastSummary, _confirm_or_abort
+from .prompts import _load_wallet
+
+# Broadcast-tx size guesses for the single-pass fee estimate (photons = rate × size/1000,
+# floored at 1000). Deliberately generous — a slight overpay beats a stuck tx; use
+# --fee for exact control.
+_TX_BASE_BYTES = 220
+_TX_PER_INPUT_BYTES = 150
+_TX_PER_OUTPUT_BYTES = 40
+_MIN_FEE_PHOTONS = 1_000
+_MAX_FUNDING_INPUTS = 8
+
+
+# --------------------------------------------------------------------------- arg parsing
+
+
+def _parse_outpoint(value: str) -> tuple[str, int]:
+    """``TXID:VOUT`` → (txid, vout)."""
+    txid, sep, vout = value.partition(":")
+    if not sep or len(txid) != 64:
+        raise UserError(
+            f"invalid outpoint {sanitize_terminal(value, max_len=80)!r}",
+            cause="expected TXID:VOUT (64-hex txid, decimal vout)",
+            fix="e.g. --give 3f2a…9c:0",
+        )
+    try:
+        return str(Txid(txid)), int(vout)
+    except (ValueError, RxdSdkError) as exc:
+        raise UserError(f"invalid outpoint: {exc}") from exc
+
+
+def _parse_token(value: str) -> GlyphRef | None:
+    """``rxd`` | 72-hex contract ref | ``TXID:VOUT`` → GlyphRef (None = native RXD)."""
+    if value.lower() == "rxd":
+        return None
+    try:
+        if ":" in value:
+            txid, vout = _parse_outpoint(value)
+            return GlyphRef(txid=Txid(txid), vout=vout)
+        if len(value) == 72:
+            return GlyphRef.from_contract_hex(value)
+    except (RxdSdkError, UserError, ValueError):
+        pass
+    raise UserError(
+        f"invalid token {sanitize_terminal(value, max_len=80)!r}",
+        cause="expected 'rxd', a 72-hex contract ref, or TXID:VOUT",
+        fix="copy the token's contract id from an explorer, or pass its genesis outpoint",
+    )
+
+
+def _parse_asset_spec(value: str) -> Asset:
+    """``rxd:AMOUNT`` or ``TOKEN:AMOUNT`` (token as 72-hex ref or txid:vout) → Asset."""
+    token_part, sep, amount_part = value.rpartition(":")
+    if not sep:
+        raise UserError(
+            f"invalid asset spec {sanitize_terminal(value, max_len=80)!r}",
+            cause="expected ASSET:AMOUNT",
+            fix="e.g. --receive rxd:900000 or --receive <72-hex-ref>:50",
+        )
+    try:
+        amount = int(amount_part)
+    except ValueError as exc:
+        raise UserError(f"invalid amount {sanitize_terminal(amount_part, max_len=40)!r}") from exc
+    ref = _parse_token(token_part)
+    try:
+        return Asset(kind="rxd", amount=amount) if ref is None else Asset(kind="ft", amount=amount, ref=ref)
+    except RxdSdkError as exc:
+        raise UserError(f"invalid asset spec: {exc}") from exc
+
+
+def _describe_asset(asset: Asset) -> str:
+    if asset.kind == "rxd":
+        return f"{asset.amount} photons (RXD)"
+    return f"{asset.amount} units of FT {asset.ref.txid}:{asset.ref.vout}"
+
+
+def _estimate_fee(ctx: CliContext, n_inputs: int, n_outputs: int, override: int | None) -> int:
+    if override is not None:
+        if override < 0:
+            raise UserError("--fee must be non-negative")
+        return override
+    size = _TX_BASE_BYTES + n_inputs * _TX_PER_INPUT_BYTES + n_outputs * _TX_PER_OUTPUT_BYTES
+    return max(_MIN_FEE_PHOTONS, (ctx.fee_rate * size + 999) // 1000)
+
+
+# --------------------------------------------------------------------------- wallet plumbing
+
+
+@dataclass
+class _WalletFunds:
+    """Wallet UTXOs resolved for a build: funding inputs plus key lookup by owner pkh."""
+
+    triples: list  # (UtxoRecord, address, PrivateKey)
+
+    def key_for_pkh(self, pkh: bytes) -> PrivateKey:
+        for _utxo, _addr, key in self.triples:
+            if key.public_key().hash160() == pkh:
+                return key
+        raise UserError(
+            "the UTXO's owner key is not in this wallet",
+            cause="no wallet address matches the output's owner pubkey-hash",
+            fix="run `pyrxd balance --refresh` to discover used addresses, or check the outpoint",
+        )
+
+    def change_pkh(self) -> bytes:
+        if not self.triples:
+            raise UserError("wallet has no spendable UTXOs", fix="fund the wallet first")
+        return self.triples[0][2].public_key().hash160()
+
+
+async def _collect_funds(ctx: CliContext, client) -> _WalletFunds:
+    wallet = _load_wallet(ctx)
+    return _WalletFunds(triples=await wallet.collect_spendable(client))
+
+
+async def _rxd_funding(
+    client, funds: _WalletFunds, target_photons: int, *, exclude: tuple[str, int] | None = None
+) -> list[FundingInput]:
+    """Greedy plain-RXD funding selection totalling >= target (fetches each source tx)."""
+    picked: list[FundingInput] = []
+    total = 0
+    for utxo, _addr, key in sorted(funds.triples, key=lambda t: t[0].value, reverse=True):
+        if len(picked) >= _MAX_FUNDING_INPUTS:
+            break
+        if exclude is not None and (str(utxo.tx_hash), utxo.tx_pos) == exclude:
+            continue
+        source = await fetch_transaction(client, utxo.tx_hash)
+        out = source.outputs[utxo.tx_pos]
+        if _asset_of(out.satoshis, out.locking_script.serialize()).kind != "rxd":
+            continue  # never burn token UTXOs as plain funding
+        picked.append(FundingInput(source_tx=source, vout=utxo.tx_pos, key=key))
+        total += out.satoshis
+        if total >= target_photons:
+            return picked
+    raise UserError(
+        f"wallet cannot fund {target_photons} photons (found {total} across {len(picked)} plain UTXOs)",
+        fix="fund the wallet, consolidate UTXOs, or lower the amount/fee",
+    )
+
+
+# --------------------------------------------------------------------------- commands
+
+
+@click.command(name="orders")
+@click.argument("token")
+@click.option("--want", is_flag=True, default=False, help="Browse orders WANTING the token instead of offering it.")
+@click.option("--node-rpc", required=True, help="Radiant node JSON-RPC URL (node must run -swapindex=1 -txindex=1).")
+@click.option("--rpc-user", default=None, envvar="RADIANT_RPC_USER", help="Node RPC username (or $RADIANT_RPC_USER).")
+@click.option(
+    "--rpc-password", default=None, envvar="RADIANT_RPC_PASSWORD", help="Node RPC password (or $RADIANT_RPC_PASSWORD)."
+)
+@click.option("--limit", default=50, show_default=True, help="Maximum orders to fetch.")
+@click.pass_obj
+def swap_orders_cmd(ctx: CliContext, token: str, want: bool, node_rpc: str, rpc_user, rpc_password, limit: int) -> None:
+    """Browse + verify the on-chain book for TOKEN ('rxd', 72-hex ref, or TXID:VOUT).
+
+    READ-ONLY. Every row is re-verified against chain data (maker signature,
+    advertised token ids vs the real UTXO); rows that fail show the reason.
+    """
+    ref = _parse_token(token)
+    if want and ref is None:
+        raise UserError(
+            "the want-side book cannot be queried for native RXD",
+            cause="RXD-want orders omit want_tokenid on the wire, so the index has no key for them",
+            fix="browse the OFFER side of the token you would pay with instead",
+        )
+
+    async def _run() -> list[dict]:
+        async with NodeRpcSource(node_rpc, rpc_user=rpc_user, rpc_password=rpc_password) as source:
+            book = OrderbookClient(source)
+            entries = await (book.orders_wanting(ref, limit=limit) if want else book.orders_offering(ref, limit=limit))
+        rows = []
+        for e in entries:
+            demanded = e.order.demanded_outputs
+            rows.append(
+                {
+                    "offered_utxo": f"{e.order.offered_txid}:{e.order.offered_utxo_index}",
+                    "gives": _describe_asset(e.offer.terms.give) if e.offer else "(unverified)",
+                    "wants": _describe_asset(e.offer.terms.receive)
+                    if e.offer
+                    else (f"{demanded[0].value} photons?" if demanded else "(unparseable)"),
+                    "status": e.status,
+                    "fillable": e.fillable,
+                    "block_height": e.block_height,
+                    "problem": e.problem,
+                }
+            )
+        return rows
+
+    try:
+        rows = asyncio.run(_run())
+    except RxdSdkError as exc:
+        raise click.ClickException(f"orderbook read failed: {exc}") from exc
+
+    payload = {"token": token, "side": "want" if want else "offer", "count": len(rows), "orders": rows}
+    if ctx.output_mode in ("json", "quiet"):
+        click.echo(emit(payload, mode=ctx.output_mode, quiet_field="count"))
+        return
+    if not rows:
+        click.echo("no open orders")
+        return
+    for r in rows:
+        mark = "FILLABLE" if r["fillable"] else f"{r['status']} — {sanitize_terminal(r['problem'], max_len=100)}"
+        click.echo(f"{r['offered_utxo']}\n  gives {r['gives']}\n  wants {r['wants']}\n  [{mark}]")
+
+
+@click.command(name="post")
+@click.option("--give", "give_outpoint", required=True, help="Offered UTXO as TXID:VOUT (wallet-owned, given WHOLE).")
+@click.option("--receive", "receive_spec", required=True, help="Demanded asset as rxd:AMOUNT or TOKEN:AMOUNT.")
+@click.option(
+    "--fee", "fee_override", type=int, default=None, help="Advert-tx fee in photons (default: fee-rate estimate)."
+)
+@click.pass_obj
+def swap_post_cmd(ctx: CliContext, give_outpoint: str, receive_spec: str, fee_override: int | None) -> None:
+    """Post an order to the on-chain book: offer the --give UTXO for --receive.
+
+    The offered UTXO is given WHOLE and the signed price has NO expiry — it
+    stays fillable until you spend the UTXO (``pyrxd swap cancel``). Pre-split
+    an exact amount before posting.
+    """
+    give_txid, give_vout = _parse_outpoint(give_outpoint)
+    receive = _parse_asset_spec(receive_spec)
+
+    async def _run() -> dict:
+        async with ctx.make_client() as client:
+            give_source = await fetch_transaction(client, give_txid)
+            if not 0 <= give_vout < len(give_source.outputs):
+                raise UserError(f"vout {give_vout} does not exist in {give_txid}")
+            give_out = give_source.outputs[give_vout]
+            give_asset = _asset_of(give_out.satoshis, give_out.locking_script.serialize())
+
+            funds = await _collect_funds(ctx, client)
+            maker_key = funds.key_for_pkh(_owner_pkh_of(give_out.locking_script.serialize()))
+            post = create_rswp_order(
+                give_source_tx=give_source,
+                give_vout=give_vout,
+                maker_key=maker_key,
+                receive=receive,
+                maker_receive_pkh=maker_key.public_key().hash160(),
+            )
+            fee = _estimate_fee(ctx, 1, 2, fee_override)
+            funding = await _rxd_funding(client, funds, fee + _MIN_FEE_PHOTONS, exclude=(give_txid, give_vout))
+            advert_tx = build_advert_tx(
+                advert_script=post.advert_script, funding=funding, change_pkh=funds.change_pkh(), fee=fee
+            )
+            _confirm_or_abort(
+                ctx,
+                [
+                    _BroadcastSummary(
+                        title="POST public swap order (no expiry — cancel is the only revocation)",
+                        lines=[
+                            f"you give   : {_describe_asset(give_asset)}  ({give_txid}:{give_vout}, spent WHOLE)",
+                            f"you demand : {_describe_asset(receive)}",
+                            f"advert fee : {fee} photons",
+                        ],
+                    )
+                ],
+            )
+            advert_txid = await client.broadcast(advert_tx.serialize())
+            return {
+                "advert_txid": str(advert_txid),
+                "offered_utxo": f"{give_txid}:{give_vout}",
+                "gives": _describe_asset(give_asset),
+                "wants": _describe_asset(receive),
+            }
+
+    _finish(ctx, _run, quiet_field="advert_txid")
+
+
+@click.command(name="take")
+@click.option(
+    "--advert",
+    "advert_arg",
+    required=True,
+    help="The order's OP_RETURN script hex, a raw advert-tx hex, or @path to a file holding either.",
+)
+@click.option("--fee", "fee_override", type=int, default=None, help="Completion-tx fee in photons.")
+@click.pass_obj
+def swap_take_cmd(ctx: CliContext, advert_arg: str, fee_override: int | None) -> None:
+    """Verify and fill an on-chain order (the offered UTXO's source tx is fetched txid-verified).
+
+    Every advertised claim is checked against the chain before your funds are
+    committed; a lying or unfillable advert aborts with the reason.
+    """
+    order = _decode_advert_arg(advert_arg)
+    if order.demanded_outputs is None or len(order.demanded_outputs) != 1:
+        raise UserError("order does not have exactly one demanded output", cause="unenforceable demand (design D6)")
+    demand = order.demanded_outputs[0]
+    demand_asset = _asset_of(demand.value, demand.script)
+    if demand_asset.kind != "rxd":
+        raise UserError(
+            "this CLI can fund RXD-demand orders only (the maker wants an FT)",
+            fix="use the pyrxd.swap.rswp library take path with FT funding inputs",
+        )
+
+    async def _run() -> dict:
+        async with ctx.make_client() as client:
+            give_source = await fetch_transaction(client, order.offered_txid)
+            funds = await _collect_funds(ctx, client)
+            fee = _estimate_fee(ctx, 1 + 2, 4, fee_override)
+            funding = await _rxd_funding(client, funds, demand.value + fee)
+            taker_pkh = funds.change_pkh()
+            completion = take_rswp_order(
+                order,
+                give_source_tx=give_source,
+                funding=funding,
+                taker_receive_pkh=taker_pkh,
+                taker_change_pkh=taker_pkh,
+                fee=fee,
+            )
+            gives = _asset_of(
+                give_source.outputs[order.offered_utxo_index].satoshis,
+                give_source.outputs[order.offered_utxo_index].locking_script.serialize(),
+            )
+            _confirm_or_abort(
+                ctx,
+                [
+                    _BroadcastSummary(
+                        title="FILL swap order",
+                        lines=[
+                            f"you pay     : {demand.value} photons to the maker",
+                            f"you receive : {_describe_asset(gives)}",
+                            f"fee         : {fee} photons",
+                        ],
+                    )
+                ],
+            )
+            txid = await client.broadcast(completion.serialize())
+            return {
+                "completion_txid": str(txid),
+                "paid_photons": demand.value,
+                "received": _describe_asset(gives),
+            }
+
+    _finish(ctx, _run, quiet_field="completion_txid")
+
+
+@click.command(name="cancel")
+@click.option("--give", "give_outpoint", required=True, help="The posted order's offered UTXO as TXID:VOUT.")
+@click.option("--fee", "fee_override", type=int, default=None, help="Cancel-tx fee in photons.")
+@click.pass_obj
+def swap_cancel_cmd(ctx: CliContext, give_outpoint: str, fee_override: int | None) -> None:
+    """Cancel a posted order by self-spending its offered UTXO — the ONLY hard revocation.
+
+    Until this confirms, anyone holding the signed advert can still fill at
+    the original price.
+    """
+    give_txid, give_vout = _parse_outpoint(give_outpoint)
+
+    async def _run() -> dict:
+        async with ctx.make_client() as client:
+            give_source = await fetch_transaction(client, give_txid)
+            if not 0 <= give_vout < len(give_source.outputs):
+                raise UserError(f"vout {give_vout} does not exist in {give_txid}")
+            give_out = give_source.outputs[give_vout]
+            give_asset = _asset_of(give_out.satoshis, give_out.locking_script.serialize())
+            funds = await _collect_funds(ctx, client)
+            maker_key = funds.key_for_pkh(_owner_pkh_of(give_out.locking_script.serialize()))
+            fee = _estimate_fee(ctx, 2, 2, fee_override)
+            # FT cancels conserve the full token amount, so the fee needs plain-RXD funding.
+            funding = None
+            if give_asset.kind == "ft" or give_out.satoshis <= fee:
+                funding = await _rxd_funding(client, funds, fee, exclude=(give_txid, give_vout))
+            cancel = build_cancel_tx(
+                offered_source_tx=give_source,
+                offered_vout=give_vout,
+                maker_key=maker_key,
+                refund_pkh=maker_key.public_key().hash160(),
+                fee=fee,
+                funding=funding,
+            )
+            _confirm_or_abort(
+                ctx,
+                [
+                    _BroadcastSummary(
+                        title="CANCEL posted order (self-spend; kills every copy of the signed offer)",
+                        lines=[
+                            f"reclaims : {_describe_asset(give_asset)}  ({give_txid}:{give_vout})",
+                            f"fee      : {fee} photons",
+                        ],
+                    )
+                ],
+            )
+            txid = await client.broadcast(cancel.serialize())
+            return {"cancel_txid": str(txid), "reclaimed": _describe_asset(give_asset)}
+
+    _finish(ctx, _run, quiet_field="cancel_txid")
+
+
+# --------------------------------------------------------------------------- shared runners
+
+
+def _decode_advert_arg(advert_arg: str) -> RswpOrder:
+    """Accept the OP_RETURN script hex, a raw advert-tx hex, or @file of either."""
+    text = advert_arg
+    if text.startswith("@"):
+        from pathlib import Path
+
+        try:
+            text = Path(text[1:]).read_text().strip()
+        except OSError as exc:
+            raise UserError(f"cannot read advert file: {exc}") from exc
+    try:
+        blob = bytes.fromhex(text)
+    except ValueError as exc:
+        raise UserError("advert is not valid hex") from exc
+    try:
+        return decode_rswp_order(blob)
+    except ValidationError:
+        pass  # not a bare OP_RETURN script — try it as a whole transaction
+    tx = Transaction.from_hex(blob)
+    if tx is not None:
+        for out in tx.outputs:
+            try:
+                return decode_rswp_order(out.locking_script.serialize())
+            except ValidationError:
+                continue
+    raise UserError(
+        "no decodable RSWP order in the input",
+        cause="input is neither an RSWP OP_RETURN script nor a transaction containing one",
+        fix="pass the advert output's script hex, or the full advert transaction hex",
+    )
+
+
+def _finish(ctx: CliContext, run, *, quiet_field: str) -> None:
+    """Run an async command body; render its payload; map SDK errors to CLI errors."""
+    try:
+        payload = asyncio.run(run())
+    except (UserError, click.ClickException):
+        raise
+    except RxdSdkError as exc:
+        raise click.ClickException(str(exc)) from exc
+    click.echo(emit(payload, mode=ctx.output_mode, quiet_field=quiet_field))

--- a/src/pyrxd/cli/swap_cmds.py
+++ b/src/pyrxd/cli/swap_cmds.py
@@ -171,7 +171,12 @@ async def _read_covenant(ctx: CliContext, spk_hex: str) -> dict:
 
 @click.group(name="swap")
 def swap_group() -> None:
-    """Inspect Gravity cross-chain swaps (read-only — never broadcasts)."""
+    """Same-chain RSWP orderbook (orders/post/take/cancel) + cross-chain swap status.
+
+    ``status`` and ``orders`` are read-only. ``post``/``take``/``cancel``
+    broadcast AFTER an explicit value confirmation (``--json`` requires
+    ``--yes``) — see each command's help for what exactly is signed.
+    """
 
 
 @swap_group.command(name="status")

--- a/src/pyrxd/swap/rswp/__init__.py
+++ b/src/pyrxd/swap/rswp/__init__.py
@@ -44,6 +44,7 @@ from ...gravity.swap_order import (
     parse_price_terms_lenient,
 )
 from .book import BookEntry, OrderbookClient, OrderbookSource
+from .node_rpc import NodeRpcSource
 from .orders import (
     RswpOrderPost,
     build_advert_tx,
@@ -83,6 +84,7 @@ __all__ = [
     "RXD_TOKEN_ID",
     "BookEntry",
     "DemandedOutput",
+    "NodeRpcSource",
     "OrderbookClient",
     "OrderbookSource",
     "RswpOrder",

--- a/src/pyrxd/swap/rswp/node_rpc.py
+++ b/src/pyrxd/swap/rswp/node_rpc.py
@@ -1,0 +1,106 @@
+"""``OrderbookSource`` over a Radiant node's JSON-RPC — the production book transport.
+
+Talks directly to a node started with ``-swapindex=1`` (plus ``-txindex=1`` so
+offered-UTXO source transactions resolve). This is the same surface the hosted
+``swap.radiantcore.org`` endpoint proxies. Deliberately minimal: four calls,
+no session state beyond the aiohttp connection, and **fail-closed** — any
+transport error, HTTP error, or RPC error raises :class:`NetworkError` rather
+than returning an empty/None answer that would read as a healthy-but-empty
+book (see :class:`pyrxd.swap.rswp.book.OrderbookSource`).
+
+Credentials note: pass ``rpc_user``/``rpc_password`` explicitly rather than
+embedding them in the URL, so they never appear in logs or exception reprs.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from ...security.errors import NetworkError
+from ...security.types import Txid
+
+_DEFAULT_TIMEOUT_S = 15.0
+
+
+class NodeRpcSource:
+    """:class:`~pyrxd.swap.rswp.book.OrderbookSource` over Radiant node JSON-RPC.
+
+    Usage::
+
+        source = NodeRpcSource("http://127.0.0.1:7332", rpc_user="u", rpc_password="p")
+        async with source:
+            entries = await OrderbookClient(source).orders_offering(ref)
+    """
+
+    def __init__(
+        self,
+        url: str,
+        *,
+        rpc_user: str | None = None,
+        rpc_password: str | None = None,
+        timeout_s: float = _DEFAULT_TIMEOUT_S,
+    ) -> None:
+        self._url = url
+        self._auth = (rpc_user, rpc_password)
+        self._timeout_s = timeout_s
+        self._session: Any = None  # aiohttp.ClientSession, created lazily
+
+    async def __aenter__(self) -> NodeRpcSource:
+        return self
+
+    async def __aexit__(self, exc_type: object, exc: object, tb: object) -> None:
+        await self.close()
+
+    async def close(self) -> None:
+        if self._session is not None:
+            await self._session.close()
+            self._session = None
+
+    async def _call(self, method: str, params: list) -> Any:
+        import aiohttp  # deferred: `import pyrxd.swap.rswp` stays aiohttp-free
+
+        if self._session is None:
+            auth = None
+            if self._auth[0] is not None:
+                auth = aiohttp.BasicAuth(self._auth[0], self._auth[1] or "")
+            self._session = aiohttp.ClientSession(auth=auth, timeout=aiohttp.ClientTimeout(total=self._timeout_s))
+        payload = {"jsonrpc": "1.0", "id": "pyrxd", "method": method, "params": params}
+        try:
+            async with self._session.post(self._url, json=payload) as resp:
+                # Radiant nodes answer RPC-level errors with non-200 + a JSON body;
+                # read the body first so the error message survives.
+                body = await resp.json(content_type=None)
+                err = body.get("error") if isinstance(body, dict) else None
+                if err:
+                    raise NetworkError(f"node RPC {method} failed: {err.get('message', err)}")
+                if resp.status != 200:
+                    raise NetworkError(f"node RPC {method} failed: HTTP {resp.status}")
+                return body["result"] if isinstance(body, dict) else None
+        except NetworkError:
+            raise
+        except Exception as exc:  # aiohttp/transport/JSON errors — fail closed
+            raise NetworkError(f"node RPC {method} transport error: {exc!r}") from exc
+
+    async def get_open_orders(self, token_id_hex: str, *, limit: int = 100, offset: int = 0) -> list[dict]:
+        rows = await self._call("getopenorders", [token_id_hex, limit, offset])
+        if not isinstance(rows, list):
+            raise NetworkError("getopenorders returned a non-list result")
+        return rows
+
+    async def get_open_orders_by_want(self, want_token_id_hex: str, *, limit: int = 100, offset: int = 0) -> list[dict]:
+        rows = await self._call("getopenordersbywant", [want_token_id_hex, limit, offset])
+        if not isinstance(rows, list):
+            raise NetworkError("getopenordersbywant returned a non-list result")
+        return rows
+
+    async def get_transaction(self, txid: str | Txid) -> bytes:
+        raw = await self._call("getrawtransaction", [str(txid)])
+        if not isinstance(raw, str):
+            raise NetworkError("getrawtransaction returned a non-hex result")
+        return bytes.fromhex(raw)
+
+    async def is_unspent(self, txid: str, vout: int) -> bool:
+        # gettxout returns null for a spent/unknown outpoint — that IS the answer
+        # (not a transport failure), so a None result maps to False here.
+        out = await self._call("gettxout", [str(txid), int(vout), True])
+        return isinstance(out, dict)

--- a/tests/cli/test_swap_book_cmds.py
+++ b/tests/cli/test_swap_book_cmds.py
@@ -1,0 +1,225 @@
+"""``pyrxd swap orders/post/take/cancel`` — CLI seams.
+
+The value mechanics under these commands are the fully-tested
+:mod:`pyrxd.swap.rswp` builders; what the CLI adds — and what these tests
+cover — is argument parsing, the read-only ``orders`` pipeline against a fake
+node source, and the guard rails that fire BEFORE any wallet or network
+access (FT-demand refusal, undecodable adverts).
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+from click.testing import CliRunner
+
+from pyrxd.cli.errors import UserError
+from pyrxd.cli.main import cli
+from pyrxd.cli.swap_book_cmds import (
+    _decode_advert_arg,
+    _parse_asset_spec,
+    _parse_outpoint,
+    _parse_token,
+)
+from pyrxd.glyph.script import build_ft_locking_script
+from pyrxd.glyph.types import GlyphRef
+from pyrxd.keys import PrivateKey
+from pyrxd.script.script import Script
+from pyrxd.script.type import P2PKH
+from pyrxd.security.types import Hex20, Txid
+from pyrxd.swap import Asset
+from pyrxd.swap.rswp import create_rswp_order, decode_rswp_order, swap_token_id
+from pyrxd.transaction.transaction import Transaction
+from pyrxd.transaction.transaction_output import TransactionOutput
+
+_REF = GlyphRef(txid=Txid("cd" * 32), vout=0)
+
+
+# --------------------------------------------------------------------------- parsing
+
+
+class TestParsing:
+    def test_outpoint_round_trip(self) -> None:
+        assert _parse_outpoint("ab" * 32 + ":3") == ("ab" * 32, 3)
+
+    @pytest.mark.parametrize("bad", ["nope", "ab" * 32, "xyz:1", "ab" * 31 + ":0"])
+    def test_bad_outpoints_rejected(self, bad: str) -> None:
+        with pytest.raises(UserError):
+            _parse_outpoint(bad)
+
+    def test_token_forms(self) -> None:
+        assert _parse_token("rxd") is None
+        assert _parse_token("RXD") is None
+        assert _parse_token("cd" * 32 + ":7") == GlyphRef(txid=Txid("cd" * 32), vout=7)
+        contract = "cd" * 32 + "00000007"  # 72-hex display form
+        assert _parse_token(contract) == GlyphRef(txid=Txid("cd" * 32), vout=7)
+        with pytest.raises(UserError):
+            _parse_token("not-a-token")
+
+    def test_asset_specs(self) -> None:
+        assert _parse_asset_spec("rxd:900") == Asset(kind="rxd", amount=900)
+        assert _parse_asset_spec("cd" * 32 + ":0:50") == Asset(kind="ft", amount=50, ref=_REF)
+        with pytest.raises(UserError):
+            _parse_asset_spec("rxd")  # no amount
+        with pytest.raises(UserError):
+            _parse_asset_spec("rxd:-5")  # Asset rejects non-positive
+
+
+# --------------------------------------------------------------------------- advert decoding
+
+
+def _key() -> tuple[PrivateKey, bytes]:
+    k = PrivateKey()
+    return k, k.public_key().hash160()
+
+
+def _ft_src(pkh: bytes, ref: GlyphRef, value: int) -> Transaction:
+    tx = Transaction()
+    tx.add_output(TransactionOutput(Script(build_ft_locking_script(Hex20(pkh), ref)), value))
+    return tx
+
+
+def _rxd_src(pkh: bytes, value: int) -> Transaction:
+    tx = Transaction()
+    tx.add_output(TransactionOutput(P2PKH().lock(pkh), value))
+    return tx
+
+
+def _posted_order(receive: Asset):
+    mk, mk_pkh = _key()
+    src = _ft_src(mk_pkh, _REF, 500) if receive.kind == "rxd" else _rxd_src(mk_pkh, 1200)
+    post = create_rswp_order(give_source_tx=src, give_vout=0, maker_key=mk, receive=receive, maker_receive_pkh=mk_pkh)
+    return post, src
+
+
+class TestDecodeAdvertArg:
+    def test_accepts_bare_script_hex(self) -> None:
+        post, _ = _posted_order(Asset(kind="rxd", amount=900))
+        order = _decode_advert_arg(post.advert_script.hex())
+        assert order.offered_utxo_index == 0
+
+    def test_accepts_full_advert_tx_hex(self) -> None:
+        post, _ = _posted_order(Asset(kind="rxd", amount=900))
+        tx = Transaction()
+        tx.add_output(TransactionOutput(Script(post.advert_script), 0))
+        assert _decode_advert_arg(tx.serialize().hex()).signature == decode_rswp_order(post.advert_script).signature
+
+    def test_accepts_at_file(self, tmp_path) -> None:
+        post, _ = _posted_order(Asset(kind="rxd", amount=900))
+        f = tmp_path / "advert.hex"
+        f.write_text(post.advert_script.hex() + "\n")
+        assert _decode_advert_arg(f"@{f}").offered_txid == decode_rswp_order(post.advert_script).offered_txid
+
+    @pytest.mark.parametrize("garbage", ["zz", "00" * 40, ""])
+    def test_garbage_rejected(self, garbage: str) -> None:
+        with pytest.raises(UserError):
+            _decode_advert_arg(garbage)
+
+
+# --------------------------------------------------------------------------- take guard rails (pre-wallet)
+
+
+class TestTakeGuards:
+    def test_ft_demand_refused_before_any_network(self, runner: CliRunner) -> None:
+        post, _ = _posted_order(Asset(kind="ft", amount=50, ref=_REF))
+        result = runner.invoke(cli, ["swap", "take", "--advert", post.advert_script.hex()])
+        assert result.exit_code != 0
+        assert "RXD-demand orders only" in result.output
+
+    def test_undecodable_advert_refused(self, runner: CliRunner) -> None:
+        result = runner.invoke(cli, ["swap", "take", "--advert", "6a04beef"])
+        assert result.exit_code != 0
+        assert "no decodable RSWP order" in result.output
+
+
+# --------------------------------------------------------------------------- orders (fake node source)
+
+
+class _FakeNodeSource:
+    """Stands in for NodeRpcSource: same constructor + async-context surface."""
+
+    rows: list[dict] = []
+    txs: dict[str, bytes] = {}
+
+    def __init__(self, url: str, *, rpc_user=None, rpc_password=None, timeout_s: float = 0) -> None:
+        self.url = url
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *exc) -> None:
+        return None
+
+    async def get_open_orders(self, token_id_hex: str, *, limit: int = 100, offset: int = 0) -> list[dict]:
+        return [r for r in type(self).rows if r["tokenid"] == token_id_hex]
+
+    async def get_open_orders_by_want(self, want_token_id_hex: str, *, limit: int = 100, offset: int = 0) -> list[dict]:
+        return [r for r in type(self).rows if r.get("want_tokenid") == want_token_id_hex]
+
+    async def get_transaction(self, txid) -> bytes:
+        return type(self).txs[str(txid)]
+
+    async def is_unspent(self, txid: str, vout: int) -> bool:
+        return True
+
+
+@pytest.fixture
+def fake_book(monkeypatch):
+    post, src = _posted_order(Asset(kind="rxd", amount=900))
+    order = decode_rswp_order(post.advert_script)
+    row = {
+        "version": order.version,
+        "flags": order.flags,
+        "offered_type": order.offered_type,
+        "terms_type": order.terms_type,
+        "tokenid": order.token_id[::-1].hex(),
+        "utxo": {"txid": order.offered_txid, "vout": order.offered_utxo_index},
+        "price_terms": order.price_terms.hex(),
+        "signature": order.signature.hex(),
+        "block_height": 42,
+    }
+    _FakeNodeSource.rows = [row]
+    _FakeNodeSource.txs = {src.txid(): src.serialize()}
+    import pyrxd.cli.swap_book_cmds as mod
+
+    monkeypatch.setattr(mod, "NodeRpcSource", _FakeNodeSource)
+    return row
+
+
+class TestOrders:
+    def test_offer_side_lists_verified_order(self, runner: CliRunner, fake_book) -> None:
+        token = f"{_REF.txid}:{_REF.vout}"
+        result = runner.invoke(cli, ["swap", "orders", token, "--node-rpc", "http://x"])
+        assert result.exit_code == 0, result.output
+        assert "FILLABLE" in result.output
+        assert "500 units of FT" in result.output
+        assert "900 photons" in result.output
+
+    def test_json_mode_payload(self, runner: CliRunner, fake_book) -> None:
+        token = f"{_REF.txid}:{_REF.vout}"
+        result = runner.invoke(cli, ["--json", "swap", "orders", token, "--node-rpc", "http://x"])
+        assert result.exit_code == 0, result.output
+        payload = json.loads(result.output)
+        assert payload["count"] == 1
+        assert payload["orders"][0]["fillable"] is True
+        assert payload["orders"][0]["block_height"] == 42
+
+    def test_lying_index_row_shows_problem(self, runner: CliRunner, fake_book) -> None:
+        other = GlyphRef(txid=Txid("ef" * 32), vout=9)
+        fake_book["tokenid"] = swap_token_id(other).hex()  # index lies about the asset
+        result = runner.invoke(cli, ["swap", "orders", f"{other.txid}:{other.vout}", "--node-rpc", "http://x"])
+        assert result.exit_code == 0, result.output
+        assert "FILLABLE" not in result.output
+        assert "token_id does not match" in result.output
+
+    def test_want_side_rxd_is_a_clean_error(self, runner: CliRunner) -> None:
+        result = runner.invoke(cli, ["swap", "orders", "rxd", "--want", "--node-rpc", "http://x"])
+        assert result.exit_code != 0
+        assert "want-side book cannot be queried for native RXD" in result.output
+
+    def test_empty_book(self, runner: CliRunner, fake_book) -> None:
+        _FakeNodeSource.rows = []
+        result = runner.invoke(cli, ["swap", "orders", "rxd", "--node-rpc", "http://x"])
+        assert result.exit_code == 0, result.output
+        assert "no open orders" in result.output

--- a/tests/test_rswp_node_rpc.py
+++ b/tests/test_rswp_node_rpc.py
@@ -1,0 +1,92 @@
+"""NodeRpcSource against a real local HTTP server — fail-closed transport semantics.
+
+A tiny stdlib JSON-RPC stub stands in for a Radiant node: enough to prove the
+source passes results through, maps RPC errors and malformed results to
+``NetworkError`` (never a healthy-looking empty answer), and treats a null
+``gettxout`` as "spent" rather than as a failure.
+"""
+
+from __future__ import annotations
+
+import json
+import threading
+from http.server import BaseHTTPRequestHandler, HTTPServer
+
+import pytest
+
+from pyrxd.security.errors import NetworkError
+from pyrxd.swap.rswp import NodeRpcSource
+
+_RESPONSES: dict[str, object] = {}
+_ERRORS: dict[str, str] = {}
+
+
+class _StubRpc(BaseHTTPRequestHandler):
+    def do_POST(self):  # BaseHTTPRequestHandler API name
+        body = json.loads(self.rfile.read(int(self.headers["Content-Length"])))
+        method = body["method"]
+        if method in _ERRORS:
+            payload = {"result": None, "error": {"code": -1, "message": _ERRORS[method]}, "id": body["id"]}
+            status = 500
+        else:
+            payload = {"result": _RESPONSES.get(method), "error": None, "id": body["id"]}
+            status = 200
+        data = json.dumps(payload).encode()
+        self.send_response(status)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(data)))
+        self.end_headers()
+        self.wfile.write(data)
+
+    def log_message(self, *args):  # silence request logging
+        pass
+
+
+@pytest.fixture
+def stub_url():
+    _RESPONSES.clear()
+    _ERRORS.clear()
+    server = HTTPServer(("127.0.0.1", 0), _StubRpc)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        yield f"http://127.0.0.1:{server.server_address[1]}"
+    finally:
+        server.shutdown()
+        thread.join(timeout=5)
+
+
+async def test_results_pass_through(stub_url) -> None:
+    _RESPONSES["getopenorders"] = [{"version": 2}]
+    _RESPONSES["getrawtransaction"] = "beef"
+    _RESPONSES["gettxout"] = {"value": 1.0}
+    async with NodeRpcSource(stub_url) as src:
+        assert await src.get_open_orders("00" * 32) == [{"version": 2}]
+        assert await src.get_transaction("ab" * 32) == b"\xbe\xef"
+        assert await src.is_unspent("ab" * 32, 0) is True
+
+
+async def test_null_gettxout_means_spent_not_error(stub_url) -> None:
+    _RESPONSES["gettxout"] = None
+    async with NodeRpcSource(stub_url) as src:
+        assert await src.is_unspent("ab" * 32, 0) is False
+
+
+async def test_rpc_error_raises_network_error(stub_url) -> None:
+    _ERRORS["getopenorders"] = "Swap index not enabled. Use -swapindex=1 to enable."
+    async with NodeRpcSource(stub_url) as src:
+        with pytest.raises(NetworkError, match="Swap index not enabled"):
+            await src.get_open_orders("00" * 32)
+
+
+async def test_non_list_orders_result_fails_closed(stub_url) -> None:
+    _RESPONSES["getopenordersbywant"] = "surprise"
+    async with NodeRpcSource(stub_url) as src:
+        with pytest.raises(NetworkError, match="non-list"):
+            await src.get_open_orders_by_want("00" * 32)
+
+
+async def test_unreachable_endpoint_fails_closed() -> None:
+    async with NodeRpcSource("http://127.0.0.1:1", timeout_s=2) as src:
+        with pytest.raises(NetworkError, match="transport error"):
+            await src.get_open_orders("00" * 32)


### PR DESCRIPTION
Follow-up to #276 (deferred item D9 of the design note): the on-chain RSWP orderbook gets a CLI, as a thin layer over the proven `pyrxd.swap.rswp` library.

## Commands (all under the existing `pyrxd swap` group)

| Command | Posture |
|---|---|
| `swap orders TOKEN [--want] --node-rpc URL` | **Read-only.** Browses a `-swapindex=1` node and runs the full hostile-input pipeline per row — *FILLABLE* means the maker signature and every advertised claim verified against chain data; failing rows print the reason instead of vanishing. |
| `swap post --give TXID:VOUT --receive rxd:N\|TOKEN:N` | Signs `0xC3`, wraps the advert, **confirms before broadcast** — the summary explicitly states the offer has **no expiry** and that cancel is the only revocation. |
| `swap take --advert HEX\|@file` | Accepts the OP_RETURN script hex or a whole advert-tx hex; verifies everything against a txid-verified source fetch before wallet funds are committed. RXD-demand orders only (FT-demand → clean error pointing at the library path). |
| `swap cancel --give TXID:VOUT` | The self-spend hard revocation; FT cancels conserve the full token amount and fund the fee from plain RXD. |

Same broadcast gates as the glyph commands (`--json` requires `--yes`; y/N value summary otherwise).

## Library addition

`pyrxd.swap.rswp.NodeRpcSource` — production `OrderbookSource` over Radiant node JSON-RPC (aiohttp, import deferred so `import pyrxd.swap.rswp` stays aiohttp-free). **Fail-closed**: transport errors, RPC errors, and malformed results raise `NetworkError` rather than presenting a healthy-but-empty book; a `null` `gettxout` maps to *spent* (that's an answer, not a failure).

## Scope decisions

- Funding selection is greedy over wallet plain-RXD UTXOs (token UTXOs are never burned as fee funding); single-pass generous fee estimate with `--fee` override.
- `--give` key lookup works for RXD and FT offers via owner-PKH match against wallet keys.
- Want-side browse of native RXD is a clean error (RXD-want orders omit `want_tokenid` on the wire, so no index key exists).
- Quoting/price display deliberately left to the upcoming quoting-toolkit PR.

## Tests

- 20 CLI-seam tests: arg parsing, advert-input forms (`hex`, full tx, `@file`), pre-wallet guard rails, and the `orders` pipeline over a fake source — including a lying index row surfacing as a problem, not FILLABLE.
- 5 `NodeRpcSource` tests against a real local HTTP JSON-RPC stub (pass-through, null-gettxout, RPC-error, malformed-result, unreachable-endpoint — all fail-closed).
- `task ci` green locally: 4515 passed, coverage 87.72%, mypy/bandit/link-check clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)