### PR TITLE
feat(swap): RSWP market-maker quoting toolkit (pure helpers)

### DIFF
--- a/src/pyrxd/swap/rswp/__init__.py
+++ b/src/pyrxd/swap/rswp/__init__.py
@@ -54,6 +54,7 @@ from .orders import (
     take_rswp_order,
     verify_offer_signature,
 )
+from .quoting import LadderQuote, PriceFeed, implied_price, quote_ladder, quote_legs
 from .wire import (
     CONTRACT_TYPE_FT,
     CONTRACT_TYPE_NFT,
@@ -83,8 +84,10 @@ __all__ = [
     "RXD_TOKEN_ID",
     "BookEntry",
     "DemandedOutput",
+    "LadderQuote",
     "OrderbookClient",
     "OrderbookSource",
+    "PriceFeed",
     "RswpOrder",
     "RswpOrderPost",
     "build_advert_tx",
@@ -93,9 +96,12 @@ __all__ = [
     "decode_rswp_order",
     "encode_price_terms",
     "encode_rswp_order",
+    "implied_price",
     "parse_price_terms",
     "parse_price_terms_lenient",
     "prepare_offered_utxo",
+    "quote_ladder",
+    "quote_legs",
     "rswp_order_to_swap_offer",
     "swap_token_id",
     "take_rswp_order",

--- a/src/pyrxd/swap/rswp/quoting.py
+++ b/src/pyrxd/swap/rswp/quoting.py
@@ -1,0 +1,138 @@
+"""Market-maker quoting helpers for the RSWP orderbook — pure math, no price source.
+
+pyrxd NEVER fabricates a price: the operator supplies the mid (their own
+oracle behind the :class:`PriceFeed` protocol), and these helpers turn it into
+exact integer order legs. All prices are :class:`fractions.Fraction` in
+**photons per token unit** — floats never touch money here, and every rounding
+step is explicit and maker-favorable (a posted order can round FOR the maker,
+never against, because the ``0xC3`` signature freezes whatever was posted).
+
+Composition with the order flows::
+
+    give, receive = quote_legs(quote, ref)
+    utxo_tx = prepare_offered_utxo(funding=…, asset=give, …)     # exact-amount UTXO
+    post    = create_rswp_order(give_source_tx=utxo_tx, give_vout=0,
+                                receive=receive, …)
+"""
+
+from __future__ import annotations
+
+import math
+from collections.abc import Sequence
+from dataclasses import dataclass
+from fractions import Fraction
+from typing import Literal, Protocol, runtime_checkable
+
+from ...glyph.types import GlyphRef
+from ...security.errors import ValidationError
+from ..types import Asset, SwapTerms
+
+_BPS = 10_000
+
+
+@runtime_checkable
+class PriceFeed(Protocol):
+    """Operator-supplied mid-price oracle (pyrxd ships no implementation).
+
+    Implementations MUST raise when a fresh price is unavailable — returning a
+    stale or guessed mid would silently misprice every quote built from it.
+    """
+
+    async def mid_price(self, ref: GlyphRef) -> Fraction:
+        """Current mid for the token, in photons per token unit."""
+        ...  # pragma: no cover
+
+
+def implied_price(terms: SwapTerms) -> Fraction:
+    """The maker's demanded price implied by an order's terms, in photons per token unit.
+
+    Reads either direction of a token/RXD order: for *sell* orders (give FT,
+    want RXD) this is ``receive / give``; for *buy* orders (give RXD, want FT)
+    it is ``give / receive``. Raises for RXD/RXD or FT/FT terms — "photons per
+    unit" is not defined there (compare those with plain ``Fraction`` math on
+    the amounts).
+    """
+    give, receive = terms.give, terms.receive
+    if give.kind == "ft" and receive.kind == "rxd":
+        return Fraction(receive.amount, give.amount)
+    if give.kind == "rxd" and receive.kind == "ft":
+        return Fraction(give.amount, receive.amount)
+    raise ValidationError(f"implied_price needs a token/RXD pair, got {give.kind}/{receive.kind}")
+
+
+@dataclass(frozen=True)
+class LadderQuote:
+    """One priced level of a two-sided ladder, with exact integer order legs.
+
+    ``sell``: the maker gives ``size`` token units and demands
+    ``receive_photons`` (= ``ceil(size × price)`` — the ceil is the
+    maker-favorable direction). ``buy``: the maker gives ``give_photons``
+    (= ``floor(size × price)``) and demands ``size`` token units.
+    """
+
+    side: Literal["sell", "buy"]
+    level: int  # 0-based distance from mid
+    size: int  # token units
+    price: Fraction  # photons per token unit, as quoted
+    give_photons: int | None  # buy side only
+    receive_photons: int | None  # sell side only
+
+
+def quote_ladder(mid: Fraction | int, spread_bps: int, sizes: Sequence[int]) -> list[LadderQuote]:
+    """Build a two-sided quote ladder around *mid*.
+
+    Level *i* (one per entry of *sizes*, both sides) is priced
+    ``mid × (1 ± half_spread × (i+1))`` with ``half_spread = spread_bps/2``
+    — deeper levels back away from mid linearly. Rounding is maker-favorable
+    and explicit (see :class:`LadderQuote`). Raises if any buy level rounds
+    to zero photons (size × price too small to be a real order) or if a bid
+    would go non-positive (spread too wide for the level count).
+    """
+    mid = Fraction(mid)
+    if mid <= 0:
+        raise ValidationError(f"mid price must be positive, got {mid}")
+    if spread_bps < 0:
+        raise ValidationError("spread_bps must be non-negative")
+    if not sizes:
+        raise ValidationError("quote_ladder needs at least 1 size")
+    half = Fraction(spread_bps, 2 * _BPS)
+
+    quotes: list[LadderQuote] = []
+    for level, size in enumerate(sizes):
+        if size <= 0:
+            raise ValidationError(f"ladder sizes must be positive, got {size}")
+        ask = mid * (1 + half * (level + 1))
+        bid = mid * (1 - half * (level + 1))
+        if bid <= 0:
+            raise ValidationError(
+                f"level {level} bid is non-positive (spread {spread_bps} bps too wide for {len(sizes)} levels)"
+            )
+        receive = math.ceil(size * ask)
+        give = math.floor(size * bid)
+        if give <= 0:
+            raise ValidationError(f"level {level} buy gives 0 photons for size {size} — size × price too small")
+        quotes.append(
+            LadderQuote(side="sell", level=level, size=size, price=ask, give_photons=None, receive_photons=receive)
+        )
+        quotes.append(
+            LadderQuote(side="buy", level=level, size=size, price=bid, give_photons=give, receive_photons=None)
+        )
+    return quotes
+
+
+def quote_legs(quote: LadderQuote, ref: GlyphRef) -> tuple[Asset, Asset]:
+    """The ``(give, receive)`` assets an order for *quote* must post.
+
+    ``give`` is exactly what :func:`~pyrxd.swap.rswp.orders.prepare_offered_utxo`
+    should mint; ``receive`` goes straight into
+    :func:`~pyrxd.swap.rswp.orders.create_rswp_order`.
+    """
+    if quote.side == "sell":
+        return (
+            Asset(kind="ft", amount=quote.size, ref=ref),
+            Asset(kind="rxd", amount=quote.receive_photons),
+        )
+    return (
+        Asset(kind="rxd", amount=quote.give_photons),
+        Asset(kind="ft", amount=quote.size, ref=ref),
+    )

--- a/tests/test_rswp_quoting.py
+++ b/tests/test_rswp_quoting.py
@@ -1,0 +1,129 @@
+"""Quoting toolkit: exact-Fraction prices, maker-favorable rounding invariants."""
+
+from __future__ import annotations
+
+from fractions import Fraction
+
+import pytest
+from hypothesis import given
+from hypothesis import strategies as st
+
+from pyrxd.glyph.types import GlyphRef
+from pyrxd.security.errors import ValidationError
+from pyrxd.security.types import Txid
+from pyrxd.swap import Asset, SwapTerms
+from pyrxd.swap.rswp.quoting import PriceFeed, implied_price, quote_ladder, quote_legs
+
+_REF = GlyphRef(txid=Txid("ab" * 32), vout=0)
+
+
+# --------------------------------------------------------------------------- implied price
+
+
+def test_implied_price_sell_and_buy_read_the_same_market() -> None:
+    sell = SwapTerms(give=Asset("ft", 400, _REF), receive=Asset("rxd", 900))
+    buy = SwapTerms(give=Asset("rxd", 900), receive=Asset("ft", 400, _REF))
+    assert implied_price(sell) == implied_price(buy) == Fraction(900, 400)
+
+
+def test_implied_price_is_exact_not_float() -> None:
+    terms = SwapTerms(give=Asset("ft", 3, _REF), receive=Asset("rxd", 1))
+    assert implied_price(terms) == Fraction(1, 3)  # a float would have lied here
+
+
+@pytest.mark.parametrize(
+    "terms",
+    [
+        SwapTerms(give=Asset("rxd", 10), receive=Asset("rxd", 20)),
+        SwapTerms(give=Asset("ft", 10, _REF), receive=Asset("ft", 20, GlyphRef(txid=Txid("cd" * 32), vout=1))),
+    ],
+)
+def test_implied_price_rejects_non_token_rxd_pairs(terms) -> None:
+    with pytest.raises(ValidationError, match="token/RXD pair"):
+        implied_price(terms)
+
+
+# --------------------------------------------------------------------------- ladder
+
+
+def test_ladder_shape_and_monotonicity() -> None:
+    quotes = quote_ladder(Fraction(100), 200, [10, 20, 30])  # 2% spread
+    sells = [q for q in quotes if q.side == "sell"]
+    buys = [q for q in quotes if q.side == "buy"]
+    assert len(sells) == len(buys) == 3
+    assert [s.price for s in sells] == sorted(s.price for s in sells)  # asks rise with depth
+    assert [b.price for b in buys] == sorted((b.price for b in buys), reverse=True)  # bids fall
+    assert all(s.price > Fraction(100) > b.price for s, b in zip(sells, buys, strict=True))
+
+
+@given(
+    mid_num=st.integers(min_value=1, max_value=10**9),
+    mid_den=st.integers(min_value=1, max_value=10**4),
+    spread_bps=st.integers(min_value=0, max_value=2000),
+    size=st.integers(min_value=1, max_value=10**9),
+)
+def test_rounding_is_always_maker_favorable(mid_num, mid_den, spread_bps, size) -> None:
+    """sell: demanded photons >= exact size×ask; buy: given photons <= exact size×bid."""
+    mid = Fraction(mid_num, mid_den)
+    try:
+        quotes = quote_ladder(mid, spread_bps, [size])
+    except ValidationError:
+        return  # zero-rounding / non-positive-bid guards are allowed to fire
+    (sell,) = (q for q in quotes if q.side == "sell")
+    (buy,) = (q for q in quotes if q.side == "buy")
+    assert sell.receive_photons >= size * sell.price
+    assert buy.give_photons <= size * buy.price
+    assert buy.give_photons >= 1
+
+
+def test_zero_rounding_buy_is_refused() -> None:
+    with pytest.raises(ValidationError, match="0 photons"):
+        quote_ladder(Fraction(1, 1000), 100, [10])  # 10 units at ~0.001 photon/unit
+
+
+def test_too_wide_spread_refused() -> None:
+    with pytest.raises(ValidationError, match="non-positive"):
+        quote_ladder(Fraction(100), 10_000, [1, 1, 1, 1])  # level 4 bid would cross zero
+
+
+@pytest.mark.parametrize(
+    ("kwargs", "match"),
+    [
+        (dict(mid=0, spread_bps=10, sizes=[1]), "positive"),
+        (dict(mid=100, spread_bps=-1, sizes=[1]), "non-negative"),
+        (dict(mid=100, spread_bps=10, sizes=[]), "at least 1"),
+        (dict(mid=100, spread_bps=10, sizes=[0]), "positive"),
+    ],
+)
+def test_ladder_input_validation(kwargs, match) -> None:
+    with pytest.raises(ValidationError, match=match):
+        quote_ladder(kwargs["mid"], kwargs["spread_bps"], kwargs["sizes"])
+
+
+# --------------------------------------------------------------------------- order-leg composition
+
+
+def test_quote_legs_compose_into_valid_assets_and_round_trip_the_price() -> None:
+    quotes = quote_ladder(Fraction(150), 100, [40])
+    for q in quotes:
+        give, receive = quote_legs(q, _REF)
+        terms = SwapTerms(give=give, receive=receive)  # Asset validation runs here
+        got = implied_price(terms)
+        # Maker-favorable: an order built from a sell quote implies >= the quoted
+        # ask; from a buy quote it implies <= the quoted bid.
+        assert got >= q.price if q.side == "sell" else got <= q.price
+
+
+# --------------------------------------------------------------------------- price feed protocol
+
+
+def test_price_feed_is_runtime_checkable() -> None:
+    class StaticFeed:
+        def __init__(self, price: Fraction) -> None:
+            self._price = price
+
+        async def mid_price(self, ref: GlyphRef) -> Fraction:
+            return self._price
+
+    assert isinstance(StaticFeed(Fraction(1)), PriceFeed)
+    assert not isinstance(object(), PriceFeed)


### PR DESCRIPTION
Second deferred item from the #276 design note: the quoting toolkit for makers on the RSWP book. Pure math, no network, and **pyrxd never fabricates a price** — the mid comes from an operator-supplied `PriceFeed` protocol implementation.

- `implied_price(terms) -> Fraction` — photons per token unit, exact (no float money), reads both sell (FT→RXD) and buy (RXD→FT) order directions; refuses RXD/RXD and FT/FT pairs where the unit price is undefined.
- `quote_ladder(mid, spread_bps, sizes)` — two-sided ladder, level *i* priced `mid × (1 ± half_spread × (i+1))`, with **explicit maker-favorable rounding** (ceil the demanded photons, floor the given photons). Rationale: the `0xC3` signature freezes the posted price, so any rounding error must land on the maker's side of the trade. Guards: zero-rounding buys and crossed/non-positive bids are refused, not silently emitted.
- `quote_legs(quote, ref) -> (give, receive)` — composes directly into the proven flow: `give` is exactly what `prepare_offered_utxo` mints, `receive` goes straight into `create_rswp_order`.
- `PriceFeed` — `@runtime_checkable` async protocol; implementations must raise when a fresh price is unavailable (a stale mid silently misprices every quote).

Tests (14): Fraction exactness, ladder monotonicity, a Hypothesis property proving the maker-favorable rounding invariants across random mids/spreads/sizes, guard-rail cases, and the legs→`SwapTerms`→`implied_price` round trip. `task ci` green locally: 4504 passed, coverage 88.14%.

Independent of #277 (branched from main).

🤖 Generated with [Claude Code](https://claude.com/claude-code)