### PR TITLE
test(fuzz): RSWP wire-format fuzz coverage — decoder robustness + encoder round trip

### DIFF
--- a/scripts/fuzz_atheris/harness_decode_rswp_order.py
+++ b/scripts/fuzz_atheris/harness_decode_rswp_order.py
@@ -1,0 +1,60 @@
+"""Atheris harness for the RSWP order-advertisement decoder.
+
+Targets the two attacker-facing entry points that walk a raw ``OP_RETURN``
+byte string pulled straight off an ElectrumX/RXinDexer response
+(``pyrxd.gravity.swap_order``, re-exported from ``pyrxd.swap.rswp``):
+
+  - ``decode_rswp_order`` — the full advertisement decoder (magic, version,
+    flags, token ids, outpoint, price_terms/signature tail-rule split).
+    Contract: raise ``ValidationError`` on anything malformed, never a
+    deeper exception type.
+  - ``parse_price_terms_lenient`` — the ``price_terms`` blob reader
+    (``MultiTxOutV1``, else Photonic's bare value/script fallback, else
+    ``None``). Contract: NEVER raises — always returns a list or ``None``.
+
+Complements the structured Hypothesis round-trip property in
+``tests/test_rswp_wire.py::test_encode_decode_round_trip`` (which only
+feeds the decoder bytes the encoder itself produced) and the arbitrary-
+bytes robustness properties in ``tests/test_fuzz_parsers.py`` (Stage 1);
+this harness is the coverage-guided Stage 2 complement over fully
+adversarial, non-encoder-shaped byte strings.
+
+Run:
+    python3 scripts/fuzz_atheris/harness_decode_rswp_order.py \\
+        -atheris_runs=0 -max_total_time=3600 \\
+        -artifact_prefix=logs/atheris-decode_rswp_order-
+"""
+
+from __future__ import annotations
+
+import sys
+
+import atheris
+
+with atheris.instrument_imports(include=["pyrxd.gravity", "pyrxd.swap"]):
+    from pyrxd.gravity.swap_order import decode_rswp_order, parse_price_terms_lenient
+    from pyrxd.security.errors import ValidationError
+
+
+def TestOneInput(data: bytes) -> None:
+    fdp = atheris.FuzzedDataProvider(data)
+    choice = fdp.ConsumeIntInRange(0, 1)
+    blob = fdp.ConsumeBytes(fdp.remaining_bytes())
+    if choice == 0:
+        try:
+            decode_rswp_order(blob)
+        except ValidationError:
+            pass  # expected: decoder rejected a malformed/non-RSWP frame cleanly
+    else:
+        # No try/except: parse_price_terms_lenient's documented contract is
+        # "never raises" (MultiTxOutV1, else bare value/script, else None).
+        parse_price_terms_lenient(blob)
+
+
+def main() -> None:
+    atheris.Setup(sys.argv, TestOneInput)
+    atheris.Fuzz()
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/fuzz_atheris/harness_rswp_round_trip.py
+++ b/scripts/fuzz_atheris/harness_rswp_round_trip.py
@@ -1,0 +1,117 @@
+"""Atheris harness for the RSWP encoder <-> decoder round trip.
+
+Structured fuzz (via ``atheris.FuzzedDataProvider``) of ``encode_rswp_order``
+immediately followed by ``decode_rswp_order``: asserts the exact field-for-
+field equality that ``tests/test_rswp_wire.py::test_encode_decode_round_trip``
+checks with Hypothesis strategies, but driven by atheris's coverage feedback
+(byte-level mutation toward PUSHDATA1 boundaries, the scriptnum sign-pad
+boundary, offeredType 0/255, v2/v3 flag-bit edges, etc.) rather than random
+sampling.
+
+A mismatch here is a real interop bug: it would mean whatever pyrxd itself
+encodes, pyrxd's own decoder — the canonical, Radiant-Core-following
+implementation — cannot read back byte-for-byte.
+
+Run:
+    python3 scripts/fuzz_atheris/harness_rswp_round_trip.py \\
+        -atheris_runs=0 -max_total_time=3600 \\
+        -artifact_prefix=logs/atheris-rswp_round_trip-
+"""
+
+from __future__ import annotations
+
+import sys
+
+import atheris
+
+with atheris.instrument_imports(include=["pyrxd.gravity", "pyrxd.swap", "pyrxd.glyph"]):
+    from pyrxd.glyph.types import GlyphRef
+    from pyrxd.gravity.swap_order import DemandedOutput, decode_rswp_order
+    from pyrxd.security.types import Txid
+    from pyrxd.swap.rswp import RXD_TOKEN_ID, encode_price_terms, encode_rswp_order, swap_token_id
+
+# The node reads offeredUTXOIndex with a 4-byte CScriptNum — see
+# encode_rswp_order's _MAX_ADVERTISABLE_VOUT (not re-exported, so pinned here
+# too; a drift between the two would just make this harness under-fuzz, not
+# false-fail, since encode_rswp_order re-checks the same bound).
+_MAX_ADVERTISABLE_VOUT = 0x7FFFFFFF
+
+
+def _consume_ref(fdp: atheris.FuzzedDataProvider) -> GlyphRef | None:
+    if not fdp.ConsumeBool():
+        return None
+    txid_hex = fdp.ConsumeBytes(32).hex()
+    if len(txid_hex) != 64:
+        return None  # starved provider — not a case that can build a ref
+    vout = fdp.ConsumeIntInRange(0, 0xFFFFFFFF)
+    return GlyphRef(txid=Txid(txid_hex), vout=vout)
+
+
+def _consume_outputs(fdp: atheris.FuzzedDataProvider) -> list[DemandedOutput]:
+    n = fdp.ConsumeIntInRange(1, 5)
+    outs = []
+    for _ in range(n):
+        value = fdp.ConsumeIntInRange(0, 0xFFFFFFFFFFFFFFFF)
+        script = fdp.ConsumeBytes(fdp.ConsumeIntInRange(1, 200))
+        if not script:
+            script = b"\x51"  # keep the "non-empty script" invariant on a starved provider
+        outs.append(DemandedOutput(value=value, script=script))
+    return outs
+
+
+def TestOneInput(data: bytes) -> None:
+    fdp = atheris.FuzzedDataProvider(data)
+
+    offered_ref = _consume_ref(fdp)
+    want_ref = _consume_ref(fdp)
+    offered_type = fdp.ConsumeIntInRange(0, 255)
+    offered_txid = fdp.ConsumeBytes(32).hex()
+    if len(offered_txid) != 64:
+        return  # starved provider — not a case that can build a valid frame
+    offered_vout = fdp.ConsumeIntInRange(0, _MAX_ADVERTISABLE_VOUT)
+    outputs = _consume_outputs(fdp)
+    signature = fdp.ConsumeBytes(fdp.ConsumeIntInRange(1, 120))
+    if not signature:
+        signature = b"\x01"  # keep the "non-empty signature" invariant on a starved provider
+    expiry_height = fdp.ConsumeIntInRange(1, 0xFFFFFFFF) if fdp.ConsumeBool() else None
+
+    token_id = swap_token_id(offered_ref)
+    want_token_id = None if want_ref is None else swap_token_id(want_ref)
+    price_terms = encode_price_terms(outputs)
+
+    script = encode_rswp_order(
+        offered_type=offered_type,
+        token_id=token_id,
+        want_token_id=want_token_id,
+        offered_txid=offered_txid,
+        offered_vout=offered_vout,
+        price_terms=price_terms,
+        signature=signature,
+        expiry_height=expiry_height,
+    )
+    order = decode_rswp_order(script)
+
+    assert order.version == (3 if expiry_height is not None else 2)
+    assert order.expiry_height == expiry_height
+    assert order.offered_type == offered_type
+    assert order.terms_type == 1
+    # 32-byte ids travel byte-reversed on chain (display digest <-> pushed form).
+    assert order.token_id == (token_id if token_id == RXD_TOKEN_ID else token_id[::-1])
+    if want_token_id is None:
+        assert order.want_token_id is None
+    else:
+        assert order.want_token_id == want_token_id[::-1]
+    assert order.offered_txid == offered_txid
+    assert order.offered_utxo_index == offered_vout
+    assert order.price_terms == price_terms
+    assert order.demanded_outputs == outputs
+    assert order.signature == signature
+
+
+def main() -> None:
+    atheris.Setup(sys.argv, TestOneInput)
+    atheris.Fuzz()
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_fuzz_parsers.py
+++ b/tests/test_fuzz_parsers.py
@@ -47,6 +47,12 @@ Targets:
        suppresses all internal failures, so the contract is "returns
        ``None`` or a ``Transaction`` whose ``.serialize()`` round-trips,
        never raises".
+   12. ``decode_rswp_order(arbitrary bytes)`` / ``parse_price_terms_lenient``
+       — the RSWP swap-order ``OP_RETURN`` decoder (``pyrxd.gravity.swap_order``);
+       consumes bytes pulled straight off an ElectrumX/RXinDexer output.
+       ``decode_rswp_order`` must raise ``ValidationError`` or return an
+       ``RswpOrder``; ``parse_price_terms_lenient`` is documented to never
+       raise at all.
 """
 
 from __future__ import annotations
@@ -80,6 +86,7 @@ from pyrxd.glyph.script import (
     parse_mutable_nft_script,
 )
 from pyrxd.glyph.types import GlyphRef
+from pyrxd.gravity.swap_order import RswpOrder, decode_rswp_order, parse_price_terms_lenient
 from pyrxd.security.errors import ValidationError
 from pyrxd.transaction.transaction import Transaction
 
@@ -667,3 +674,49 @@ def test_transaction_from_hex_never_raises(stream):
             tx.serialize()
         except Exception as exc:
             _fail_unexpected("Transaction.from_hex(...).serialize()", exc, stream)
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# 12. decode_rswp_order / parse_price_terms_lenient — RSWP swap-order decoder
+# ═══════════════════════════════════════════════════════════════════════════════
+#
+# ``decode_rswp_order`` consumes an OP_RETURN script pulled straight off an
+# ElectrumX/RXinDexer response — the same attacker-supplied-bytes trust
+# boundary as ``decode_payload`` (target 1) and ``DmintState.from_script``
+# (target 2). Complements the structured round-trip property in
+# ``tests/test_rswp_wire.py`` (encoder-shaped bytes only) and the
+# coverage-guided ``scripts/fuzz_atheris/harness_decode_rswp_order.py``.
+
+
+@given(data=st.binary(min_size=0, max_size=2_048))
+@settings(max_examples=_budget(400), suppress_health_check=[HealthCheck.too_slow])
+def test_decode_rswp_order_only_validation_error(data):
+    """``decode_rswp_order`` walks the OP_RETURN chunk stream, then a fixed
+    field sequence, then the greedy price_terms/signature tail. Every
+    truncation, wrong-opcode, or malformed-tail case must surface as
+    ``ValidationError`` — never an ``IndexError`` or other internal
+    exception leaking past the trust boundary."""
+    try:
+        order = decode_rswp_order(data)
+    except ValidationError:
+        # expected: decoder rejected a malformed/non-RSWP frame cleanly
+        return
+    except Exception as exc:
+        _fail_unexpected("decode_rswp_order", exc, data)
+        return
+    assert isinstance(order, RswpOrder)
+
+
+@given(data=st.binary(min_size=0, max_size=1_024))
+@settings(max_examples=_budget(400), suppress_health_check=[HealthCheck.too_slow])
+def test_parse_price_terms_lenient_never_raises(data):
+    """``parse_price_terms_lenient`` is documented to never raise: clean
+    ``MultiTxOutV1``, else Photonic's bare ``value(8 LE) || script`` fallback,
+    else ``None``. No try/except for an expected exception type here — the
+    contract is total, so *any* exception is a bug."""
+    try:
+        result = parse_price_terms_lenient(data)
+    except Exception as exc:
+        _fail_unexpected("parse_price_terms_lenient", exc, data)
+        return
+    assert result is None or isinstance(result, list)


### PR DESCRIPTION
## Summary

Adds RSWP swap-order wire-format coverage to the fuzz lane added in #275, which shipped the fuzz infrastructure (`.github/workflows/fuzz.yml`, `scripts/fuzz_deep.sh`, 7 atheris harnesses) but predates the RSWP encoder (#276) and had no RSWP-specific coverage at all.

- **Two new atheris harnesses** under `scripts/fuzz_atheris/` (picked up automatically by the existing `harness_*.py` glob in the fuzz workflow and `scripts/fuzz_overnight.sh` — no wiring changes needed):
  - `harness_decode_rswp_order.py` — `decode_rswp_order` / `parse_price_terms_lenient` on fully adversarial bytes pulled off an `OP_RETURN` output. Contract: `ValidationError` or a clean return, never a deeper exception, never a hang.
  - `harness_rswp_round_trip.py` — structured fuzz (via `atheris.FuzzedDataProvider`) of `encode_rswp_order` → `decode_rswp_order`, asserting the same field-for-field equality as `tests/test_rswp_wire.py::test_encode_decode_round_trip`.
- **Closed a Stage-1 gap** in `tests/test_fuzz_parsers.py`: `decode_rswp_order` had no arbitrary-bytes Hypothesis property (only structured, encoder-shaped input via `test_rswp_wire.py`). Added `test_decode_rswp_order_only_validation_error` and `test_parse_price_terms_lenient_never_raises`, mirroring the existing `decode_payload` / `DmintState.from_script` two-engine pattern (fast Hypothesis property + coverage-guided atheris harness) from `docs/solutions/design-decisions/fuzzing-strategy-graduated-approach.md`.

No committed atheris seed corpus was added — none of the 7 pre-existing harnesses have one (the lane relies on the shared `tests/.hypothesis-corpus` regression corpus plus the GitHub Actions-cached `.atheris-corpus`), so a new per-harness corpus dir would be a one-off departure from house convention.

## Verification

- `ruff format` + `ruff check --fix` clean on all touched files.
- `.venv/bin/pytest tests/test_fuzz_parsers.py tests/test_rswp_wire.py tests/test_rswp_conformance_vectors.py tests/test_swap_order.py` — 78 passed.
- Bounded local atheris runs (`-max_total_time=45`, non-CI smoke test):
  - `harness_decode_rswp_order.py`: ~710k executions, 0 crashes (independently rediscovered the `RSWP` magic bytes via coverage feedback).
  - `harness_rswp_round_trip.py`: ~738k executions, 0 crashes — the round-trip invariant held on every generated input.

## Test plan

- [x] `ruff format` + `ruff check --fix` on touched files
- [x] Targeted pytest run green (78 passed)
- [x] Both atheris harnesses run clean for a bounded local smoke test (no crash, no hang)
- [ ] Weekly scheduled fuzz lane (`.github/workflows/fuzz.yml`) will pick up both harnesses automatically on its next run