### PR TITLE
feat(cli): RSWP v3 covenant flows — swap reserve/post/take/cancel/refund

### DIFF
--- a/src/pyrxd/cli/main.py
+++ b/src/pyrxd/cli/main.py
@@ -204,9 +204,11 @@ cli.add_command(wallet_cmds.wallet_group)
 # RSWP orderbook commands live in their own module but share the `swap` group
 # (same no-import-cycle rule as above: swap_book_cmds does not import swap_cmds).
 swap_cmds.swap_group.add_command(swap_book_cmds.swap_orders_cmd)
+swap_cmds.swap_group.add_command(swap_book_cmds.swap_reserve_cmd)
 swap_cmds.swap_group.add_command(swap_book_cmds.swap_post_cmd)
 swap_cmds.swap_group.add_command(swap_book_cmds.swap_take_cmd)
 swap_cmds.swap_group.add_command(swap_book_cmds.swap_cancel_cmd)
+swap_cmds.swap_group.add_command(swap_book_cmds.swap_refund_cmd)
 
 
 if __name__ == "__main__":

--- a/src/pyrxd/cli/swap_book_cmds.py
+++ b/src/pyrxd/cli/swap_book_cmds.py
@@ -1,4 +1,4 @@
-"""``pyrxd swap orders/post/take/cancel`` — the on-chain RSWP orderbook commands.
+"""``pyrxd swap orders/post/take/cancel/reserve/refund`` — the on-chain RSWP orderbook commands.
 
 Thin CLI over the proven :mod:`pyrxd.swap.rswp` library (design:
 docs/plans/2026-07-05-rswp-orderbook-design.md). Same safety posture as the
@@ -8,15 +8,40 @@ glyph commands:
   Radiant node running ``-swapindex=1`` and re-verifies every row against
   chain data — *fillable* means the maker signature and every advertised
   claim checked out, not that the index said so.
-* **Write side** (``post`` / ``take`` / ``cancel``) shows a full value summary
-  and asks for confirmation before ANY broadcast (``--json`` requires
-  ``--yes``, same gate as the glyph commands). Funding comes from the local
-  HD wallet; the offered/give UTXO must be owned by a wallet key.
+* **Write side** (``post`` / ``take`` / ``cancel`` / ``reserve`` / ``refund``)
+  shows a full value summary and asks for confirmation before ANY broadcast
+  (``--json`` requires ``--yes``, same gate as the glyph commands). Funding
+  comes from the local HD wallet; the offered/give UTXO must be owned by a
+  wallet key. Every transaction is built exclusively with
+  :mod:`pyrxd.swap.rswp` builders — this module never hand-assembles a
+  script or transaction.
 
 Wire/format authority: the maker's offer is signed
 ``SIGHASH_SINGLE|ANYONECANPAY|FORKID`` — posting publishes a price that stays
 fillable until the offered UTXO is spent. ``cancel`` (a self-spend) is the
-ONLY hard revocation; the confirmation text says so.
+ONLY hard revocation for a v2 order; the confirmation text says so.
+
+v3 timelocked-refund covenant flows (:mod:`pyrxd.swap.rswp.covenant`)
+----------------------------------------------------------------------
+``reserve`` puts RXD into a v3 refund covenant; ``post`` auto-detects a
+covenant-held ``--give`` (via ``is_refund_covenant``) and posts a v3 advert
+instead of a v2 one; ``take`` auto-detects a v3 advert (``expiry_height`` set)
+and fills it through the CLTV-aware builder; ``refund`` and ``cancel`` route a
+covenant-held ``--give`` to the covenant builders (before-expiry self-spend
+for ``cancel``, at/after-expiry CLTV reclaim for ``refund``). Two operator
+warnings are MANDATORY reading (both repeated in every relevant confirmation
+summary below — see :mod:`pyrxd.swap.rswp.covenant`'s module docstring for
+the full detail):
+
+* **Refund txids are third-party malleable.** Track a refund by the
+  covenant OUTPOINT it spent, never by the txid the CLI prints.
+* **Expiry does not stop fills.** At/after the covenant's expiry, the
+  maker's refund RACES any late taker still holding a signed v3 advert —
+  "expired" alone does not make the reservation safe; act promptly.
+
+v3 adverts are DROPPED by the deployed Radiant-Core ``-swapindex`` (design
+note D1) — ``post``'s v3 path is rollout/testing only until every consumer
+that matters parses v3.
 """
 
 from __future__ import annotations
@@ -39,10 +64,18 @@ from ..swap.rswp import (
     RswpOrder,
     build_advert_tx,
     build_cancel_tx,
+    build_covenant_cancel_tx,
+    build_covenant_refund_tx,
+    create_covenant_order,
     create_rswp_order,
     decode_rswp_order,
+    is_refund_covenant,
+    parse_refund_covenant,
+    prepare_covenant_offer,
+    take_covenant_order,
     take_rswp_order,
 )
+from ..swap.rswp.covenant import _inner_p2pkh_pkh
 from ..transaction.transaction import Transaction
 from .context import CliContext
 from .errors import UserError
@@ -253,6 +286,72 @@ def swap_orders_cmd(ctx: CliContext, token: str, want: bool, node_rpc: str, rpc_
         click.echo(f"{r['offered_utxo']}\n  gives {r['gives']}\n  wants {r['wants']}\n  [{mark}]")
 
 
+@click.command(name="reserve")
+@click.option("--amount", "amount", required=True, type=int, help="Photons of RXD to reserve into the v3 covenant.")
+@click.option(
+    "--expiry", "expiry_height", required=True, type=int, help="Block height the CLTV refund branch opens at."
+)
+@click.option("--fee", "fee_override", type=int, default=None, help="Reservation-tx fee in photons.")
+@click.pass_obj
+def swap_reserve_cmd(ctx: CliContext, amount: int, expiry_height: int, fee_override: int | None) -> None:
+    """Reserve RXD into a v3 timelocked-refund covenant (RXD ONLY — no FT/NFT).
+
+    ``pyrxd swap post --give <the reservation outpoint>`` can then advertise
+    it as a v3 order. Two things every operator MUST understand before
+    running this:
+
+    \b
+    * Reclaim at --expiry is GUARANTEED — `pyrxd swap refund` always works
+      at/after that height (barring a lost key).
+    * That guarantee does NOT stop a fill: at/after --expiry the refund
+      RACES any late taker still holding a signed v3 advert. Cancel with
+      `pyrxd swap cancel` before --expiry if you no longer want it live.
+    """
+    if amount <= 0:
+        raise UserError("--amount must be Positive")
+    if expiry_height <= 0:
+        raise UserError("--expiry must be a Positive block height")
+
+    async def _run() -> dict:
+        async with ctx.make_client() as client:
+            funds = await _collect_funds(ctx, client)
+            owner_pkh = funds.change_pkh()
+            fee = _estimate_fee(ctx, 2, 2, fee_override)
+            funding = await _rxd_funding(client, funds, amount + fee)
+            reserve_tx = prepare_covenant_offer(
+                funding=funding,
+                photons=amount,
+                owner_pkh=owner_pkh,
+                expiry_height=expiry_height,
+                change_pkh=owner_pkh,
+                fee=fee,
+            )
+            _confirm_or_abort(
+                ctx,
+                [
+                    _BroadcastSummary(
+                        title="RESERVE into v3 refund covenant (RXD only)",
+                        lines=[
+                            f"reserve  : {amount} photons — RXD only, no FT/NFT",
+                            f"guaranteed reclaim at height {expiry_height} via `pyrxd swap refund`",
+                            "WARNING  : refund races late fills at/after expiry — expiry does Not itself "
+                            "invalidate a fill; act promptly.",
+                            f"fee      : {fee} photons",
+                        ],
+                    )
+                ],
+            )
+            txid = await client.broadcast(reserve_tx.serialize())
+            return {
+                "reservation_txid": str(txid),
+                "covenant_outpoint": f"{txid}:0",
+                "reserved_photons": amount,
+                "expiry_height": expiry_height,
+            }
+
+    _finish(ctx, _run, quiet_field="reservation_txid")
+
+
 @click.command(name="post")
 @click.option("--give", "give_outpoint", required=True, help="Offered UTXO as TXID:VOUT (wallet-owned, given WHOLE).")
 @click.option("--receive", "receive_spec", required=True, help="Demanded asset as rxd:AMOUNT or TOKEN:AMOUNT.")
@@ -263,9 +362,15 @@ def swap_orders_cmd(ctx: CliContext, token: str, want: bool, node_rpc: str, rpc_
 def swap_post_cmd(ctx: CliContext, give_outpoint: str, receive_spec: str, fee_override: int | None) -> None:
     """Post an order to the on-chain book: offer the --give UTXO for --receive.
 
-    The offered UTXO is given WHOLE and the signed price has NO expiry — it
-    stays fillable until you spend the UTXO (``pyrxd swap cancel``). Pre-split
-    an exact amount before posting.
+    A plain P2PKH/FT --give is posted as a v2 order: it is given WHOLE and the
+    signed price has NO expiry — it stays fillable until you spend the UTXO
+    (``pyrxd swap cancel``). Pre-split an exact amount before posting.
+
+    A --give that rests in a v3 refund covenant (``pyrxd swap reserve``) is
+    posted as a v3 order instead (the reservation's expiry rides on the
+    advert). WARNING: the deployed Radiant-Core ``-swapindex`` DROPS v3
+    adverts — this path is rollout/testing only until every consumer you
+    care about parses v3.
     """
     give_txid, give_vout = _parse_outpoint(give_outpoint)
     receive = _parse_asset_spec(receive_spec)
@@ -276,17 +381,39 @@ def swap_post_cmd(ctx: CliContext, give_outpoint: str, receive_spec: str, fee_ov
             if not 0 <= give_vout < len(give_source.outputs):
                 raise UserError(f"vout {give_vout} does not exist in {give_txid}")
             give_out = give_source.outputs[give_vout]
-            give_asset = _asset_of(give_out.satoshis, give_out.locking_script.serialize())
-
+            give_spk = give_out.locking_script.serialize()
             funds = await _collect_funds(ctx, client)
-            maker_key = funds.key_for_pkh(_owner_pkh_of(give_out.locking_script.serialize()))
-            post = create_rswp_order(
-                give_source_tx=give_source,
-                give_vout=give_vout,
-                maker_key=maker_key,
-                receive=receive,
-                maker_receive_pkh=maker_key.public_key().hash160(),
-            )
+
+            extra_lines: list[str] = []
+            if is_refund_covenant(give_spk):
+                owner_pkh, expiry = _inner_p2pkh_pkh(give_spk)
+                maker_key = funds.key_for_pkh(owner_pkh)
+                give_asset = Asset(kind="rxd", amount=give_out.satoshis)
+                post = create_covenant_order(
+                    covenant_source_tx=give_source,
+                    covenant_vout=give_vout,
+                    maker_key=maker_key,
+                    receive=receive,
+                    maker_receive_pkh=maker_key.public_key().hash160(),
+                )
+                title = "POST v3 covenant swap order (ROLLOUT/TESTING ONLY)"
+                extra_lines = [
+                    f"expiry     : height {expiry} (v3 refund covenant)",
+                    "WARNING    : the deployed swapindex Drops v3 adverts — rollout/testing only, "
+                    "not yet indexed by production nodes.",
+                ]
+            else:
+                give_asset = _asset_of(give_out.satoshis, give_spk)
+                maker_key = funds.key_for_pkh(_owner_pkh_of(give_spk))
+                post = create_rswp_order(
+                    give_source_tx=give_source,
+                    give_vout=give_vout,
+                    maker_key=maker_key,
+                    receive=receive,
+                    maker_receive_pkh=maker_key.public_key().hash160(),
+                )
+                title = "POST public swap order (no expiry — cancel is the only revocation)"
+
             fee = _estimate_fee(ctx, 1, 2, fee_override)
             funding = await _rxd_funding(client, funds, fee + _MIN_FEE_PHOTONS, exclude=(give_txid, give_vout))
             advert_tx = build_advert_tx(
@@ -296,11 +423,12 @@ def swap_post_cmd(ctx: CliContext, give_outpoint: str, receive_spec: str, fee_ov
                 ctx,
                 [
                     _BroadcastSummary(
-                        title="POST public swap order (no expiry — cancel is the only revocation)",
+                        title=title,
                         lines=[
                             f"you give   : {_describe_asset(give_asset)}  ({give_txid}:{give_vout}, spent WHOLE)",
                             f"you demand : {_describe_asset(receive)}",
                             f"advert fee : {fee} photons",
+                            *extra_lines,
                         ],
                     )
                 ],
@@ -329,7 +457,11 @@ def swap_take_cmd(ctx: CliContext, advert_arg: str, fee_override: int | None) ->
     """Verify and fill an on-chain order (the offered UTXO's source tx is fetched txid-verified).
 
     Every advertised claim is checked against the chain before your funds are
-    committed; a lying or unfillable advert aborts with the reason.
+    committed; a lying or unfillable advert aborts with the reason. An order
+    carrying an ``expiry_height`` (v3, covenant-held) is filled through the
+    CLTV-aware builder, which refuses to fill at/after expiry — the chain tip
+    is fetched fresh (via ElectrumX) and checked BEFORE the wallet is even
+    opened, so an unreachable node fails closed with no funds at risk.
     """
     order = _decode_advert_arg(advert_arg)
     if order.demanded_outputs is None or len(order.demanded_outputs) != 1:
@@ -345,22 +477,41 @@ def swap_take_cmd(ctx: CliContext, advert_arg: str, fee_override: int | None) ->
     async def _run() -> dict:
         async with ctx.make_client() as client:
             give_source = await fetch_transaction(client, order.offered_txid)
+            tip_height = None
+            if order.expiry_height is not None:
+                # Fetched — and the order's freshness checked — BEFORE any wallet
+                # access: a dead node fails closed without ever prompting for the
+                # mnemonic. See take_covenant_order's docstring: filling at/after
+                # expiry races the maker's live refund.
+                tip_height = int(await client.get_tip_height())
             funds = await _collect_funds(ctx, client)
             fee = _estimate_fee(ctx, 1 + 2, 4, fee_override)
             funding = await _rxd_funding(client, funds, demand.value + fee)
             taker_pkh = funds.change_pkh()
-            completion = take_rswp_order(
-                order,
-                give_source_tx=give_source,
-                funding=funding,
-                taker_receive_pkh=taker_pkh,
-                taker_change_pkh=taker_pkh,
-                fee=fee,
-            )
-            gives = _asset_of(
-                give_source.outputs[order.offered_utxo_index].satoshis,
-                give_source.outputs[order.offered_utxo_index].locking_script.serialize(),
-            )
+            if order.expiry_height is not None:
+                completion = take_covenant_order(
+                    order,
+                    give_source_tx=give_source,
+                    funding=funding,
+                    taker_receive_pkh=taker_pkh,
+                    taker_change_pkh=taker_pkh,
+                    fee=fee,
+                    current_height=tip_height,
+                )
+                gives = Asset(kind="rxd", amount=give_source.outputs[order.offered_utxo_index].satoshis)
+            else:
+                completion = take_rswp_order(
+                    order,
+                    give_source_tx=give_source,
+                    funding=funding,
+                    taker_receive_pkh=taker_pkh,
+                    taker_change_pkh=taker_pkh,
+                    fee=fee,
+                )
+                gives = _asset_of(
+                    give_source.outputs[order.offered_utxo_index].satoshis,
+                    give_source.outputs[order.offered_utxo_index].locking_script.serialize(),
+                )
             _confirm_or_abort(
                 ctx,
                 [
@@ -392,7 +543,9 @@ def swap_cancel_cmd(ctx: CliContext, give_outpoint: str, fee_override: int | Non
     """Cancel a posted order by self-spending its offered UTXO — the ONLY hard revocation.
 
     Until this confirms, anyone holding the signed advert can still fill at
-    the original price.
+    the original price. A --give held in a v3 refund covenant is cancelled
+    via its SWAP-branch self-spend (works at ANY height, before or after
+    expiry); a plain P2PKH/FT --give keeps the v2 self-spend path.
     """
     give_txid, give_vout = _parse_outpoint(give_outpoint)
 
@@ -402,30 +555,51 @@ def swap_cancel_cmd(ctx: CliContext, give_outpoint: str, fee_override: int | Non
             if not 0 <= give_vout < len(give_source.outputs):
                 raise UserError(f"vout {give_vout} does not exist in {give_txid}")
             give_out = give_source.outputs[give_vout]
-            give_asset = _asset_of(give_out.satoshis, give_out.locking_script.serialize())
+            give_spk = give_out.locking_script.serialize()
             funds = await _collect_funds(ctx, client)
-            maker_key = funds.key_for_pkh(_owner_pkh_of(give_out.locking_script.serialize()))
-            fee = _estimate_fee(ctx, 2, 2, fee_override)
-            # FT cancels conserve the full token amount, so the fee needs plain-RXD funding.
-            funding = None
-            if give_asset.kind == "ft" or give_out.satoshis <= fee:
-                funding = await _rxd_funding(client, funds, fee, exclude=(give_txid, give_vout))
-            cancel = build_cancel_tx(
-                offered_source_tx=give_source,
-                offered_vout=give_vout,
-                maker_key=maker_key,
-                refund_pkh=maker_key.public_key().hash160(),
-                fee=fee,
-                funding=funding,
-            )
+
+            extra_lines: list[str] = []
+            if is_refund_covenant(give_spk):
+                owner_pkh, expiry = _inner_p2pkh_pkh(give_spk)
+                maker_key = funds.key_for_pkh(owner_pkh)
+                give_asset = Asset(kind="rxd", amount=give_out.satoshis)
+                fee = _estimate_fee(ctx, 1, 1, fee_override)
+                cancel = build_covenant_cancel_tx(
+                    covenant_source_tx=give_source,
+                    covenant_vout=give_vout,
+                    maker_key=maker_key,
+                    refund_pkh=owner_pkh,
+                    fee=fee,
+                )
+                title = "CANCEL v3 covenant reservation (SWAP-branch self-spend, before OR after expiry)"
+                extra_lines = [f"covenant expiry: height {expiry} (informational — cancel works at Any height)"]
+            else:
+                give_asset = _asset_of(give_out.satoshis, give_spk)
+                maker_key = funds.key_for_pkh(_owner_pkh_of(give_spk))
+                fee = _estimate_fee(ctx, 2, 2, fee_override)
+                # FT cancels conserve the full token amount, so the fee needs plain-RXD funding.
+                funding = None
+                if give_asset.kind == "ft" or give_out.satoshis <= fee:
+                    funding = await _rxd_funding(client, funds, fee, exclude=(give_txid, give_vout))
+                cancel = build_cancel_tx(
+                    offered_source_tx=give_source,
+                    offered_vout=give_vout,
+                    maker_key=maker_key,
+                    refund_pkh=maker_key.public_key().hash160(),
+                    fee=fee,
+                    funding=funding,
+                )
+                title = "CANCEL posted order (self-spend; kills every copy of the signed offer)"
+
             _confirm_or_abort(
                 ctx,
                 [
                     _BroadcastSummary(
-                        title="CANCEL posted order (self-spend; kills every copy of the signed offer)",
+                        title=title,
                         lines=[
                             f"reclaims : {_describe_asset(give_asset)}  ({give_txid}:{give_vout})",
                             f"fee      : {fee} photons",
+                            *extra_lines,
                         ],
                     )
                 ],
@@ -434,6 +608,76 @@ def swap_cancel_cmd(ctx: CliContext, give_outpoint: str, fee_override: int | Non
             return {"cancel_txid": str(txid), "reclaimed": _describe_asset(give_asset)}
 
     _finish(ctx, _run, quiet_field="cancel_txid")
+
+
+@click.command(name="refund")
+@click.option("--give", "give_outpoint", required=True, help="The v3 covenant UTXO to reclaim, as TXID:VOUT.")
+@click.option("--fee", "fee_override", type=int, default=None, help="Refund-tx fee in photons.")
+@click.pass_obj
+def swap_refund_cmd(ctx: CliContext, give_outpoint: str, fee_override: int | None) -> None:
+    """Reclaim a v3 covenant reservation via its CLTV refund branch.
+
+    Only mineable AT or AFTER the covenant's expiry height — a node will
+    reject this transaction as non-final if broadcast earlier. Two things to
+    remember (see :mod:`pyrxd.swap.rswp.covenant`):
+
+    \b
+    * The resulting txid is third-party MALLEABLE (the branch selector is
+      unsigned scriptSig data) — track this reservation by the covenant
+      OUTPOINT you reclaimed, never by the txid this command prints.
+    * Filing at/after expiry RACES any late taker still holding a signed
+      v3 advert for this same outpoint — cancel first if the order was
+      never advertised, or you no longer want it live.
+    """
+    give_txid, give_vout = _parse_outpoint(give_outpoint)
+
+    async def _run() -> dict:
+        async with ctx.make_client() as client:
+            give_source = await fetch_transaction(client, give_txid)
+            if not 0 <= give_vout < len(give_source.outputs):
+                raise UserError(f"vout {give_vout} does not exist in {give_txid}")
+            give_out = give_source.outputs[give_vout]
+            give_spk = give_out.locking_script.serialize()
+            if parse_refund_covenant(give_spk) is None:
+                raise UserError(
+                    "the --give UTXO is Not a v3 refund covenant",
+                    cause="`pyrxd swap refund` only reclaims v3 covenant reservations",
+                    fix="use `pyrxd swap cancel` for a plain v2 posted order instead",
+                )
+            owner_pkh, expiry = _inner_p2pkh_pkh(give_spk)
+            funds = await _collect_funds(ctx, client)
+            maker_key = funds.key_for_pkh(owner_pkh)
+            fee = _estimate_fee(ctx, 1, 1, fee_override)
+            refund_tx = build_covenant_refund_tx(
+                covenant_source_tx=give_source,
+                covenant_vout=give_vout,
+                maker_key=maker_key,
+                refund_pkh=owner_pkh,
+                fee=fee,
+            )
+            _confirm_or_abort(
+                ctx,
+                [
+                    _BroadcastSummary(
+                        title="REFUND v3 covenant reservation (CLTV branch)",
+                        lines=[
+                            f"reclaims : {give_out.satoshis} photons — RXD only  ({give_txid}:{give_vout})",
+                            f"mineable : only at/after height {expiry}",
+                            "WARNING  : the refund txid is Malleable — track the OUTPOINT above, never this txid.",
+                            f"fee      : {fee} photons",
+                        ],
+                    )
+                ],
+            )
+            txid = await client.broadcast(refund_tx.serialize())
+            return {
+                "refund_txid": str(txid),
+                "reclaimed_outpoint": f"{give_txid}:{give_vout}",
+                "reclaimed_photons": give_out.satoshis,
+                "expiry_height": expiry,
+            }
+
+    _finish(ctx, _run, quiet_field="refund_txid")
 
 
 # --------------------------------------------------------------------------- shared runners

--- a/src/pyrxd/cli/swap_cmds.py
+++ b/src/pyrxd/cli/swap_cmds.py
@@ -171,11 +171,14 @@ async def _read_covenant(ctx: CliContext, spk_hex: str) -> dict:
 
 @click.group(name="swap")
 def swap_group() -> None:
-    """Same-chain RSWP orderbook (orders/post/take/cancel) + cross-chain swap status.
+    """Same-chain RSWP orderbook (orders/reserve/post/take/cancel/refund) + cross-chain swap status.
 
-    ``status`` and ``orders`` are read-only. ``post``/``take``/``cancel``
-    broadcast AFTER an explicit value confirmation (``--json`` requires
-    ``--yes``) — see each command's help for what exactly is signed.
+    ``status`` and ``orders`` are read-only. ``reserve``/``post``/``take``/
+    ``cancel``/``refund`` broadcast AFTER an explicit value confirmation
+    (``--json`` requires ``--yes``) — see each command's help for what
+    exactly is signed. ``reserve``/``refund`` are the v3 timelocked-refund
+    covenant flows; ``post``/``take``/``cancel`` auto-detect a covenant-held
+    UTXO and route to the matching v3 builder.
     """
 
 

--- a/tests/cli/test_swap_covenant_cmds.py
+++ b/tests/cli/test_swap_covenant_cmds.py
@@ -1,0 +1,305 @@
+"""``pyrxd swap reserve/post/take/cancel/refund`` v3 covenant CLI seams.
+
+The covenant value mechanics are the fully-tested
+:mod:`pyrxd.swap.rswp.covenant` builders (see ``test_swap_rswp_covenant.py``
+in the library test suite); what these tests cover is the CLI's ROUTING and
+fail-closed guard rails:
+
+* ``take`` fetches the chain tip and checks a v3 order's expiry BEFORE the
+  wallet is even opened — an unreachable node must fail closed with no
+  wallet prompt and no broadcast.
+* ``reserve`` funds exclusively from plain-RXD wallet UTXOs
+  (:func:`pyrxd.cli.swap_book_cmds._rxd_funding`); a wallet holding only an
+  FT UTXO must be refused cleanly, not silently spend the token.
+* ``cancel`` and ``refund`` decide v2-vs-v3 routing purely from
+  ``is_refund_covenant`` on the fetched give UTXO's script — never from a
+  flag the caller passes.
+
+No real wallet file or node is used anywhere here: the wallet is replaced by
+a tiny ``_FakeWallet`` (monkeypatching ``swap_book_cmds._load_wallet``, same
+spirit as ``test_swap_book_cmds.py``'s ``_FakeNodeSource``), and the network
+is a ``MagicMock`` ElectrumXClient injected via ``CliContext.client_factory``
+(the same seam ``test_wallet_sweep.py`` uses).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from click.testing import CliRunner
+
+import pyrxd.cli.swap_book_cmds as swap_book_cmds
+from pyrxd.cli.config import Config
+from pyrxd.cli.context import CliContext
+
+# Importing pyrxd.cli.main wires the reserve/post/take/cancel/refund commands
+# onto pyrxd.cli.swap_cmds.swap_group (see main.py's add_command calls) —
+# required before invoking swap_group directly below.
+from pyrxd.cli.main import cli
+from pyrxd.cli.swap_cmds import swap_group
+from pyrxd.glyph.script import build_ft_locking_script
+from pyrxd.glyph.types import GlyphRef
+from pyrxd.keys import PrivateKey
+from pyrxd.network.electrumx import UtxoRecord
+from pyrxd.script.script import Script
+from pyrxd.script.type import P2PKH
+from pyrxd.security.errors import NetworkError
+from pyrxd.security.types import Hex20, Txid
+from pyrxd.swap import Asset
+from pyrxd.swap.rswp import build_refund_covenant_script, create_covenant_order, decode_rswp_order
+from pyrxd.transaction.transaction import Transaction
+from pyrxd.transaction.transaction_output import TransactionOutput
+
+_REF = GlyphRef(txid=Txid("cd" * 32), vout=0)
+_EXPIRY = 900_000
+
+
+@pytest.fixture
+def runner() -> CliRunner:
+    return CliRunner()
+
+
+def _key() -> tuple[PrivateKey, bytes]:
+    k = PrivateKey()
+    return k, k.public_key().hash160()
+
+
+def _covenant_src(owner_pkh: bytes, expiry: int, value: int = 900) -> Transaction:
+    tx = Transaction()
+    tx.add_output(TransactionOutput(Script(build_refund_covenant_script(owner_pkh, expiry)), value))
+    return tx
+
+
+def _rxd_src(pkh: bytes, value: int) -> Transaction:
+    tx = Transaction()
+    tx.add_output(TransactionOutput(P2PKH().lock(pkh), value))
+    return tx
+
+
+def _ft_src(pkh: bytes, value: int) -> Transaction:
+    tx = Transaction()
+    tx.add_output(TransactionOutput(Script(build_ft_locking_script(Hex20(pkh), _REF)), value))
+    return tx
+
+
+def _unreachable_wallet(ctx, **kw):
+    raise AssertionError("wallet must Not be opened for this guard-rail path")
+
+
+class _FakeWallet:
+    """Stands in for HdWallet: only the ``collect_spendable`` surface the CLI needs."""
+
+    def __init__(self, triples: list) -> None:
+        self._triples = triples
+
+    async def collect_spendable(self, client) -> list:
+        return self._triples
+
+
+def _fake_client(*, get_transaction=None, get_tip_height=None) -> MagicMock:
+    client = MagicMock()
+    client.__aenter__ = AsyncMock(return_value=client)
+    client.__aexit__ = AsyncMock(return_value=None)
+    client.broadcast = AsyncMock(return_value="cd" * 32)
+    client.get_transaction = get_transaction or AsyncMock()
+    if get_tip_height is not None:
+        client.get_tip_height = get_tip_height
+    return client
+
+
+def _ctx(client, *, yes: bool = True, output_mode: str = "human") -> CliContext:
+    wallet_path = Path("/tmp/_pyrxd_covenant_cli_test")
+    return CliContext(
+        config=Config(network="mainnet", electrumx="wss://test/", fee_rate=10_000, wallet_path=wallet_path),
+        network="mainnet",
+        electrumx_url="wss://test/",
+        fee_rate=10_000,
+        wallet_path=wallet_path,
+        output_mode=output_mode,
+        yes=yes,
+        client_factory=lambda: client,
+    )
+
+
+def _invoke(runner: CliRunner, ctx: CliContext, args: list[str], *, confirm: str = "y"):
+    return runner.invoke(swap_group, args, obj=ctx, input="" if ctx.yes else f"{confirm}\n")
+
+
+# --------------------------------------------------------------------------- reserve: pure parsing
+
+
+class TestReserveParsing:
+    def test_non_positive_amount_rejected_before_network(self, runner: CliRunner) -> None:
+        result = runner.invoke(cli, ["swap", "reserve", "--amount", "0", "--expiry", str(_EXPIRY)])
+        assert result.exit_code != 0
+        assert "--amount must be Positive" in result.output
+
+    def test_non_positive_expiry_rejected_before_network(self, runner: CliRunner) -> None:
+        result = runner.invoke(cli, ["swap", "reserve", "--amount", "1000", "--expiry", "0"])
+        assert result.exit_code != 0
+        assert "--expiry must be a Positive" in result.output
+
+
+# --------------------------------------------------------------------------- reserve: FT-only wallet refused
+
+
+class TestReserveFundingGuard:
+    def test_ft_only_wallet_refused_without_broadcast(self, runner: CliRunner, monkeypatch) -> None:
+        mk, mk_pkh = _key()
+        ft_src = _ft_src(mk_pkh, 500)
+        client = _fake_client(get_transaction=AsyncMock(return_value=ft_src.serialize()))
+        triples = [(UtxoRecord(tx_hash=ft_src.txid(), tx_pos=0, value=500, height=800_000), "addr", mk)]
+        monkeypatch.setattr(swap_book_cmds, "_load_wallet", lambda ctx, **kw: _FakeWallet(triples))
+
+        ctx = _ctx(client)
+        result = _invoke(runner, ctx, ["reserve", "--amount", "100000", "--expiry", str(_EXPIRY)])
+
+        assert result.exit_code != 0, result.output
+        assert "cannot fund" in result.output
+        client.broadcast.assert_not_awaited()
+
+
+# --------------------------------------------------------------------------- take: v3 expiry / tip guard
+
+
+class TestTakeCovenantTipGuard:
+    def test_v3_take_without_reachable_tip_fails_closed(self, runner: CliRunner, monkeypatch) -> None:
+        mk, mk_pkh = _key()
+        cov_src = _covenant_src(mk_pkh, _EXPIRY, value=900)
+        post = create_covenant_order(
+            covenant_source_tx=cov_src,
+            covenant_vout=0,
+            maker_key=mk,
+            receive=Asset(kind="rxd", amount=500),
+            maker_receive_pkh=mk_pkh,
+        )
+        order = decode_rswp_order(post.advert_script)
+        assert order.expiry_height == _EXPIRY  # sanity: this really is a v3 order
+
+        client = _fake_client(
+            get_transaction=AsyncMock(return_value=cov_src.serialize()),
+            get_tip_height=AsyncMock(side_effect=NetworkError("Node Unreachable")),
+        )
+        # `_load_wallet` is intentionally left as the REAL implementation — a
+        # dead tip must fail before the wallet is ever touched, so no wallet
+        # file or mnemonic input is provided at all.
+        ctx = _ctx(client)
+
+        result = _invoke(runner, ctx, ["take", "--advert", post.advert_script.hex()])
+
+        assert result.exit_code != 0, result.output
+        assert "Node Unreachable" in result.output
+        client.get_tip_height.assert_awaited_once()
+        client.broadcast.assert_not_awaited()
+
+    def test_v2_take_never_calls_get_tip_height(self, runner: CliRunner, monkeypatch) -> None:
+        # Guard against a regression that fetches the tip unconditionally —
+        # a v2 (no-expiry) order must not pay that network round trip.
+        from pyrxd.swap.rswp import create_rswp_order
+
+        mk, mk_pkh = _key()
+        give_src = _rxd_src(mk_pkh, 900)
+        post = create_rswp_order(
+            give_source_tx=give_src,
+            give_vout=0,
+            maker_key=mk,
+            receive=Asset(kind="rxd", amount=500),
+            maker_receive_pkh=mk_pkh,
+        )
+        order = decode_rswp_order(post.advert_script)
+        assert order.expiry_height is None
+
+        taker_key, taker_pkh = _key()
+        funding_src = _rxd_src(taker_pkh, 10_000_000)
+        triples = [(UtxoRecord(tx_hash=funding_src.txid(), tx_pos=0, value=10_000_000, height=1), "addr", taker_key)]
+        monkeypatch.setattr(swap_book_cmds, "_load_wallet", lambda ctx, **kw: _FakeWallet(triples))
+
+        async def _get_transaction(txid):
+            wanted = str(txid)
+            if wanted == give_src.txid():
+                return give_src.serialize()
+            return funding_src.serialize()
+
+        client = _fake_client(get_tip_height=AsyncMock(side_effect=AssertionError("must not be called for v2")))
+        client.get_transaction = _get_transaction
+
+        ctx = _ctx(client)
+        result = _invoke(runner, ctx, ["take", "--advert", post.advert_script.hex()])
+
+        assert result.exit_code == 0, result.output
+        client.get_tip_height.assert_not_awaited()
+        client.broadcast.assert_awaited_once()
+
+
+# --------------------------------------------------------------------------- cancel/refund: is_refund_covenant routing
+
+
+class TestCancelRoutesOnCovenantDetection:
+    def test_covenant_give_routes_to_v3_cancel(self, runner: CliRunner, monkeypatch) -> None:
+        mk, mk_pkh = _key()
+        # Comfortably above the estimated fee + dust floor so the covenant
+        # builder's post-fee dust check doesn't fire — this test is about
+        # ROUTING, not fee-edge behavior.
+        cov_src = _covenant_src(mk_pkh, _EXPIRY, value=10_000_000)
+        client = _fake_client(get_transaction=AsyncMock(return_value=cov_src.serialize()))
+        triples = [(UtxoRecord(tx_hash="00" * 32, tx_pos=0, value=0, height=0), "addr", mk)]
+        monkeypatch.setattr(swap_book_cmds, "_load_wallet", lambda ctx, **kw: _FakeWallet(triples))
+
+        # ctx.yes=False so the confirmation summary (where the routing text
+        # lives) actually gets echoed — `--yes` skips printing it entirely.
+        ctx = _ctx(client, yes=False)
+        result = _invoke(runner, ctx, ["cancel", "--give", f"{cov_src.txid()}:0"], confirm="y")
+
+        assert result.exit_code == 0, result.output
+        assert "CANCEL v3 covenant reservation" in result.output
+        assert "before OR after expiry" in result.output
+        client.broadcast.assert_awaited_once()
+
+    def test_plain_give_routes_to_v2_cancel(self, runner: CliRunner, monkeypatch) -> None:
+        mk, mk_pkh = _key()
+        give_src = _rxd_src(mk_pkh, 1_000_000)  # well above the estimated fee — no extra funding needed
+        client = _fake_client(get_transaction=AsyncMock(return_value=give_src.serialize()))
+        triples = [(UtxoRecord(tx_hash="00" * 32, tx_pos=0, value=0, height=0), "addr", mk)]
+        monkeypatch.setattr(swap_book_cmds, "_load_wallet", lambda ctx, **kw: _FakeWallet(triples))
+
+        ctx = _ctx(client, yes=False)
+        result = _invoke(runner, ctx, ["cancel", "--give", f"{give_src.txid()}:0"], confirm="y")
+
+        assert result.exit_code == 0, result.output
+        assert "CANCEL posted order" in result.output
+        assert "v3 covenant" not in result.output.lower()
+        client.broadcast.assert_awaited_once()
+
+
+class TestRefundRoutesOnCovenantDetection:
+    def test_covenant_give_refund_succeeds(self, runner: CliRunner, monkeypatch) -> None:
+        mk, mk_pkh = _key()
+        cov_src = _covenant_src(mk_pkh, _EXPIRY, value=10_000_000)
+        client = _fake_client(get_transaction=AsyncMock(return_value=cov_src.serialize()))
+        triples = [(UtxoRecord(tx_hash="00" * 32, tx_pos=0, value=0, height=0), "addr", mk)]
+        monkeypatch.setattr(swap_book_cmds, "_load_wallet", lambda ctx, **kw: _FakeWallet(triples))
+
+        ctx = _ctx(client, yes=False)
+        result = _invoke(runner, ctx, ["refund", "--give", f"{cov_src.txid()}:0"], confirm="y")
+
+        assert result.exit_code == 0, result.output
+        assert "REFUND v3 covenant reservation" in result.output
+        assert "Malleable" in result.output
+        assert f"height {_EXPIRY}" in result.output
+        client.broadcast.assert_awaited_once()
+
+    def test_plain_give_refund_refused_cleanly(self, runner: CliRunner, monkeypatch) -> None:
+        _mk, mk_pkh = _key()
+        give_src = _rxd_src(mk_pkh, 1_000_000)
+        client = _fake_client(get_transaction=AsyncMock(return_value=give_src.serialize()))
+        # Never reached: the covenant check fails before any wallet access.
+        monkeypatch.setattr(swap_book_cmds, "_load_wallet", _unreachable_wallet)
+
+        ctx = _ctx(client)
+        result = _invoke(runner, ctx, ["refund", "--give", f"{give_src.txid()}:0"])
+
+        assert result.exit_code != 0, result.output
+        assert "Not a v3 refund covenant" in result.output
+        client.broadcast.assert_not_awaited()


### PR DESCRIPTION
## Summary

Wires the red-teamed v3 timelocked-refund covenant library (`pyrxd.swap.rswp.covenant`, merged today) into the `pyrxd swap` CLI:

- `pyrxd swap reserve --amount PHOTONS --expiry HEIGHT [--fee N]` — new. Reserves RXD into a v3 refund covenant via `prepare_covenant_offer`, funded from the wallet.
- `pyrxd swap post --give TXID:VOUT ...` — extended. Auto-detects a covenant-held `--give` (`is_refund_covenant`) and posts a v3 advert via `create_covenant_order`; a plain P2PKH/FT give is unchanged (still `create_rswp_order`, the v2 path).
- `pyrxd swap take --advert ...` — extended. An order carrying `expiry_height` is routed to `take_covenant_order`; the ElectrumX chain tip is fetched and the order's expiry checked *before* the wallet is opened, so an unreachable node fails closed with no funds at risk. RXD-demand only, same refusal message style as the existing FT-demand guard.
- `pyrxd swap refund --give TXID:VOUT [--fee N]` — new. Reclaims a covenant reservation via `build_covenant_refund_tx` (the CLTV branch).
- `pyrxd swap cancel --give TXID:VOUT` — extended. A covenant-held give routes to `build_covenant_cancel_tx` (before/after-expiry self-spend via the SWAP branch); a plain give keeps the existing v2 self-spend path unchanged.

**No new consensus logic.** Every transaction the CLI produces on the v3 path is built exclusively with the existing, already-reviewed `pyrxd.swap.rswp.covenant` builders (`prepare_covenant_offer`, `create_covenant_order`, `take_covenant_order`, `build_covenant_refund_tx`, `build_covenant_cancel_tx`) — this PR adds routing/argument-parsing/confirmation-text around them, not script or transaction construction.

Two operator warnings from the covenant library are repeated in every relevant confirmation summary (`reserve`, `post`, `refund`, `cancel`) and in the command docstrings:

- **Refund txids are third-party malleable** — the branch selector is unsigned scriptSig data, so track a reservation by the covenant *outpoint*, never by the txid the CLI prints.
- **Expiry does not stop a fill** — CLTV is valid-*from*, so at/after the covenant's expiry the maker's refund races any late taker still holding a signed v3 advert; "expired" alone does not make the reservation safe.

`post`'s v3 path also carries its own warning: the currently deployed Radiant-Core `-swapindex` drops v3 adverts, so this is rollout/testing only until every consumer that matters parses v3.

## Test plan

- [x] New `tests/cli/test_swap_covenant_cmds.py`: pure-parsing guard rails (reserve `--amount`/`--expiry` validation before any network call), an FT-only wallet cleanly refused as reserve funding, a v3 `take` failing closed when the ElectrumX tip is unreachable (checked *before* the wallet is opened), a v2 `take` never calling `get_tip_height`, and `cancel`/`refund` routing to the v3 vs v2 builder purely from `is_refund_covenant` on a fake-fetched SPK (no real wallet file or node — `HdWallet`/`ElectrumXClient` are replaced with monkeypatched fakes, same style as the existing `test_swap_book_cmds.py`).
- [x] `.venv/bin/pytest tests/cli/ -o "addopts="` — 330 passed.
- [x] `ruff format` + `ruff check --fix` on all touched files — clean.