### PR TITLE
feat(swap): FT-demand fills in the v3 covenant take (per-ref conservation, red-teamed)

### DIFF
--- a/src/pyrxd/swap/rswp/covenant.py
+++ b/src/pyrxd/swap/rswp/covenant.py
@@ -166,6 +166,12 @@ def _append_selector(tx: Transaction, index: int, selector: bytes) -> None:
     inp.unlocking_script = Script(inp.unlocking_script.serialize() + selector)
 
 
+def _build_ft_change(ref, amount: int, pkh: bytes) -> TransactionOutput:
+    from ...glyph.script import build_ft_locking_script
+
+    return TransactionOutput(Script(build_ft_locking_script(Hex20(pkh), ref)), amount)
+
+
 # --------------------------------------------------------------------------- maker: reserve + post
 
 
@@ -234,11 +240,10 @@ def create_covenant_order(
     the SWAP selector is appended by the TAKER at completion (Photonic
     convention), so v2 verifiers see the familiar two-push shape.
 
-    Asymmetry to know about (red-team L4): an FT *demand* is protocol-valid
-    and postable here (a covenant-aware external taker can fill it), but
-    :func:`take_covenant_order` in this slice completes RXD-demand orders
-    only — an FT-demand v3 order is not yet fillable by pyrxd itself. The
-    maker's covenant refund/cancel is unaffected either way.
+    Both demand kinds are fillable by pyrxd: RXD demands and FT demands
+    (:func:`take_covenant_order` enforces per-ref conservation for the
+    latter). The RESERVED side stays RXD-only — FT-in-covenant is blocked at
+    consensus by the FT codeScript epilogue.
     """
     if not 0 <= covenant_vout < len(covenant_source_tx.outputs):
         raise ValidationError("covenant_vout out of range for the source transaction")
@@ -313,10 +318,13 @@ def take_covenant_order(
     maker-signature verification over the reconstructed preimage (whose
     scriptCode is the covenant SPK).
 
-    RXD-only: the covenant's inner script must be P2PKH, and the demanded
-    output must be classifiable; taker funding must be plain RXD (there is no
-    token conservation in an all-RXD completion — the arithmetic is checked
-    explicitly instead).
+    The RESERVED side is RXD-only (covenant inner script must be P2PKH). The
+    DEMAND side may be RXD or a Glyph FT: for an FT demand the taker funds
+    with FT UTXOs of exactly the demanded ref (plus plain RXD for value/fee),
+    and per-ref conservation is enforced here — the demanded amount goes to
+    the maker, any FT surplus returns to ``taker_change_pkh``, and funding
+    carrying any OTHER token (different FT ref, or an NFT) is refused rather
+    than burned or stranded.
     """
     from ..partial import _asset_of, _parse_p2pkh_scriptsig
 
@@ -382,16 +390,26 @@ def take_covenant_order(
         # heuristic in security.errors and would print "<redacted>".
         raise ValidationError("maker signature does NOT validate over the covenant order")
 
-    # Complete: taker receives the reserved RXD; plain-RXD funding covers the
-    # demand + fee; explicit arithmetic replaces FT conservation (all-RXD tx).
+    # Complete: taker receives the reserved RXD; funding covers the demand + fee.
+    # Per-ref FT conservation is single-ref by construction (D6: exactly one
+    # demanded output), so it reduces to: FT-in(demanded ref) >= demanded amount,
+    # surplus returned as FT change, and NO other token may enter the funding.
     tx.add_output(TransactionOutput(P2PKH().lock(bytes(taker_receive_pkh)), cov_out.satoshis))
     total_funding = 0
+    ft_funded = 0
+    demanded_ref = receive.ref  # None for an RXD demand
     for f in funding:
         if not 0 <= f.vout < len(f.source_tx.outputs):
             raise ValidationError("funding input references a non-existent source output")
         f_out = f.source_tx.outputs[f.vout]
-        if _asset_of(f_out.satoshis, f_out.locking_script.serialize()).kind != "rxd":
-            raise ValidationError("v3 take funding must be plain RXD")
+        f_asset = _asset_of(f_out.satoshis, f_out.locking_script.serialize())
+        if f_asset.kind == "ft" and demanded_ref is not None and f_asset.ref == demanded_ref:
+            ft_funded += f_asset.amount
+        elif f_asset.kind != "rxd":
+            raise ValidationError(
+                "v3 take funding must be plain RXD, or FTs of exactly the demanded ref — "
+                "any other token here would be burned or stranded"
+            )
         total_funding += f_out.satoshis
         tx.add_input(
             TransactionInput(
@@ -401,9 +419,16 @@ def take_covenant_order(
                 sighash=SIGHASH.ALL_FORKID,
             )
         )
-    if receive.kind != "rxd":
-        raise ValidationError("v3 take supports RXD-demand orders only in this slice")
-    change = total_funding - demanded.value - fee
+    ft_surplus = 0
+    if demanded_ref is not None:
+        ft_surplus = ft_funded - receive.amount
+        if ft_surplus < 0:
+            raise ValidationError(
+                f"funding lacks {-ft_surplus} units of the demanded FT {demanded_ref.txid}:{demanded_ref.vout}"
+            )
+        if ft_surplus > 0:
+            tx.add_output(_build_ft_change(demanded_ref, ft_surplus, bytes(taker_change_pkh)))
+    change = total_funding - demanded.value - ft_surplus - fee
     if change < 0:
         raise ValidationError(f"funding is {-change} photons short of the demand plus fee")
     if change >= _DUST_PHOTONS:

--- a/tests/test_rswp_covenant_ft_demand.py
+++ b/tests/test_rswp_covenant_ft_demand.py
@@ -1,0 +1,205 @@
+"""FT-demand fills in the v3 covenant take — per-ref conservation, offline.
+
+The reserved side is RXD-only (consensus); the DEMAND side may be a Glyph FT.
+Conservation is single-ref by construction (D6: exactly one demanded output):
+FT-in of the demanded ref covers the demand, surplus returns as FT change,
+and any other token in the funding is refused rather than burned/stranded.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from pyrxd.glyph.script import build_ft_locking_script, build_nft_locking_script, is_ft_script
+from pyrxd.glyph.types import GlyphRef
+from pyrxd.keys import PrivateKey
+from pyrxd.script.script import Script
+from pyrxd.script.type import P2PKH
+from pyrxd.security.errors import ValidationError
+from pyrxd.security.types import Hex20, Txid
+from pyrxd.swap import Asset, FundingInput
+from pyrxd.swap.rswp import create_covenant_order, decode_rswp_order, prepare_covenant_offer, take_covenant_order
+from pyrxd.transaction.transaction import Transaction
+from pyrxd.transaction.transaction_output import TransactionOutput
+
+_EXPIRY = 840_000
+_FT_REF = GlyphRef(txid=Txid("dd" * 32), vout=0)
+_OTHER_REF = GlyphRef(txid=Txid("ee" * 32), vout=1)
+
+
+def _key() -> tuple[PrivateKey, bytes]:
+    k = PrivateKey()
+    return k, k.public_key().hash160()
+
+
+def _rxd_src(pkh: bytes, value: int) -> Transaction:
+    tx = Transaction()
+    tx.add_output(TransactionOutput(P2PKH().lock(pkh), value))
+    return tx
+
+
+def _ft_src(pkh: bytes, ref: GlyphRef, value: int) -> Transaction:
+    tx = Transaction()
+    tx.add_output(TransactionOutput(Script(build_ft_locking_script(Hex20(pkh), ref)), value))
+    return tx
+
+
+def _posted_ft_demand(maker: PrivateKey, *, reserved: int = 10_000, demand_ft: int = 50):
+    pkh = maker.public_key().hash160()
+    reservation = prepare_covenant_offer(
+        funding=[FundingInput(_rxd_src(pkh, reserved + 5_000), 0, maker)],
+        photons=reserved,
+        owner_pkh=pkh,
+        expiry_height=_EXPIRY,
+        change_pkh=pkh,
+        fee=1_000,
+    )
+    post = create_covenant_order(
+        covenant_source_tx=reservation,
+        covenant_vout=0,
+        maker_key=maker,
+        receive=Asset("ft", demand_ft, _FT_REF),
+        maker_receive_pkh=pkh,
+    )
+    return reservation, decode_rswp_order(post.advert_script)
+
+
+def _take(order, reservation, taker, funding, fee=1_000, tip=_EXPIRY - 10):
+    tk_pkh = taker.public_key().hash160()
+    return take_covenant_order(
+        order,
+        give_source_tx=reservation,
+        funding=funding,
+        taker_receive_pkh=tk_pkh,
+        taker_change_pkh=tk_pkh,
+        fee=fee,
+        current_height=tip,
+    )
+
+
+def test_ft_demand_fill_with_exact_funding() -> None:
+    maker, _ = _key()
+    taker, tk_pkh = _key()
+    reservation, order = _posted_ft_demand(maker)
+    assert order.version == 3 and order.want_token_id is not None
+
+    tx = _take(
+        order,
+        reservation,
+        taker,
+        [FundingInput(_ft_src(tk_pkh, _FT_REF, 50), 0, taker), FundingInput(_rxd_src(tk_pkh, 5_000), 0, taker)],
+    )
+    out0 = tx.outputs[0].locking_script.serialize()
+    assert is_ft_script(out0.hex()) and tx.outputs[0].satoshis == 50  # maker's FT demand at index 0
+    assert tx.outputs[1].satoshis == 10_000  # taker receives the reserved RXD
+    assert tx.inputs[0].unlocking_script.serialize().endswith(b"\x51")
+    # conservation: no FT change output for exact funding
+    assert sum(1 for o in tx.outputs if is_ft_script(o.locking_script.serialize().hex())) == 1
+
+
+def test_ft_demand_surplus_returns_as_ft_change() -> None:
+    maker, _ = _key()
+    taker, tk_pkh = _key()
+    reservation, order = _posted_ft_demand(maker)
+
+    tx = _take(
+        order,
+        reservation,
+        taker,
+        [FundingInput(_ft_src(tk_pkh, _FT_REF, 80), 0, taker), FundingInput(_rxd_src(tk_pkh, 5_000), 0, taker)],
+    )
+    ft_outs = [o for o in tx.outputs if is_ft_script(o.locking_script.serialize().hex())]
+    assert [o.satoshis for o in ft_outs] == [50, 30]  # demand + change, conserved exactly
+    total_in = 10_000 + 80 + 5_000
+    assert total_in - sum(o.satoshis for o in tx.outputs) == 1_000  # fee exact
+
+
+def test_ft_underfunding_refused() -> None:
+    maker, _ = _key()
+    taker, tk_pkh = _key()
+    reservation, order = _posted_ft_demand(maker)
+    with pytest.raises(ValidationError, match="lacks 20 units of the demanded FT"):
+        _take(
+            order,
+            reservation,
+            taker,
+            [FundingInput(_ft_src(tk_pkh, _FT_REF, 30), 0, taker), FundingInput(_rxd_src(tk_pkh, 5_000), 0, taker)],
+        )
+
+
+def test_wrong_ref_ft_funding_refused() -> None:
+    maker, _ = _key()
+    taker, tk_pkh = _key()
+    reservation, order = _posted_ft_demand(maker)
+    with pytest.raises(ValidationError, match="burned or stranded"):
+        _take(
+            order,
+            reservation,
+            taker,
+            [FundingInput(_ft_src(tk_pkh, _OTHER_REF, 80), 0, taker), FundingInput(_rxd_src(tk_pkh, 5_000), 0, taker)],
+        )
+
+
+def test_nft_funding_refused() -> None:
+    maker, _ = _key()
+    taker, tk_pkh = _key()
+    reservation, order = _posted_ft_demand(maker)
+    nft = Transaction()
+    nft.add_output(TransactionOutput(Script(build_nft_locking_script(Hex20(tk_pkh), _OTHER_REF)), 600))
+    # Pre-NFT-support main refuses via _asset_of ("unsupported asset"); once the
+    # NFT branch lands, the same input hits the explicit funding guard instead.
+    with pytest.raises(ValidationError, match="burned or stranded|unsupported asset"):
+        _take(
+            order,
+            reservation,
+            taker,
+            [
+                nft and FundingInput(nft, 0, taker),
+                FundingInput(_ft_src(tk_pkh, _FT_REF, 50), 0, taker),
+                FundingInput(_rxd_src(tk_pkh, 5_000), 0, taker),
+            ],
+        )
+
+
+def test_rxd_demand_path_unchanged() -> None:
+    """The original RXD-demand fill still works byte-for-byte semantics."""
+    maker, mk_pkh = _key()
+    taker, tk_pkh = _key()
+    reservation = prepare_covenant_offer(
+        funding=[FundingInput(_rxd_src(mk_pkh, 15_000), 0, maker)],
+        photons=10_000,
+        owner_pkh=mk_pkh,
+        expiry_height=_EXPIRY,
+        change_pkh=mk_pkh,
+        fee=1_000,
+    )
+    post = create_covenant_order(
+        covenant_source_tx=reservation,
+        covenant_vout=0,
+        maker_key=maker,
+        receive=Asset("rxd", 9_000),
+        maker_receive_pkh=mk_pkh,
+    )
+    tx = _take(
+        decode_rswp_order(post.advert_script), reservation, taker, [FundingInput(_rxd_src(tk_pkh, 20_000), 0, taker)]
+    )
+    assert tx.outputs[0].satoshis == 9_000 and tx.outputs[1].satoshis == 10_000
+
+
+def test_tampered_ft_demand_amount_breaks_signature() -> None:
+    from pyrxd.gravity.swap_order import DemandedOutput, RswpOrder
+    from pyrxd.swap.rswp import encode_price_terms
+
+    maker, _ = _key()
+    taker, tk_pkh = _key()
+    reservation, order = _posted_ft_demand(maker)
+    deflated = [DemandedOutput(value=1, script=order.demanded_outputs[0].script)]
+    fields = {f: getattr(order, f) for f in RswpOrder.__dataclass_fields__}
+    fields.update(price_terms=encode_price_terms(deflated), demanded_outputs=deflated)
+    with pytest.raises(ValidationError, match="signature does NOT validate"):
+        _take(
+            RswpOrder(**fields),
+            reservation,
+            taker,
+            [FundingInput(_ft_src(tk_pkh, _FT_REF, 50), 0, taker), FundingInput(_rxd_src(tk_pkh, 5_000), 0, taker)],
+        )

--- a/tests/test_rswp_covenant_ft_demand.py
+++ b/tests/test_rswp_covenant_ft_demand.py
@@ -203,3 +203,38 @@ def test_tampered_ft_demand_amount_breaks_signature() -> None:
             taker,
             [FundingInput(_ft_src(tk_pkh, _FT_REF, 50), 0, taker), FundingInput(_rxd_src(tk_pkh, 5_000), 0, taker)],
         )
+
+
+def test_tampered_ft_demand_script_breaks_signature() -> None:
+    """Red-team hunt 3 hardening: tamper the demanded SCRIPT (ref and owner),
+    keeping the advert metadata CONSISTENT so only the signature can object —
+    SINGLE's hash_outputs + Radiant's hashOutputHashes both bind the script."""
+    from pyrxd.gravity.swap_order import DemandedOutput, RswpOrder
+    from pyrxd.swap.rswp import encode_price_terms, swap_token_id
+
+    maker, _ = _key()
+    taker, tk_pkh = _key()
+    _, attacker_pkh = _key()
+    reservation, order = _posted_ft_demand(maker)
+
+    def _mutate_with(script: bytes, want_id: bytes | None) -> RswpOrder:
+        outs = [DemandedOutput(value=order.demanded_outputs[0].value, script=script)]
+        fields = {f: getattr(order, f) for f in RswpOrder.__dataclass_fields__}
+        fields.update(price_terms=encode_price_terms(outs), demanded_outputs=outs)
+        if want_id is not None:
+            fields["want_token_id"] = want_id
+        return RswpOrder(**fields)
+
+    funding = [FundingInput(_ft_src(tk_pkh, _OTHER_REF, 50), 0, taker), FundingInput(_rxd_src(tk_pkh, 5_000), 0, taker)]
+    # (a) different REF, want_token_id updated to match it (metadata coherent).
+    swapped_ref = build_ft_locking_script(Hex20(order.demanded_outputs[0].script[3:23]), _OTHER_REF)
+    with pytest.raises(ValidationError, match="signature does NOT validate"):
+        _take(_mutate_with(swapped_ref, swap_token_id(_OTHER_REF)[::-1]), reservation, taker, funding)
+    # (b) same ref, different OWNER pkh (metadata untouched and still coherent).
+    funding_same_ref = [
+        FundingInput(_ft_src(tk_pkh, _FT_REF, 50), 0, taker),
+        FundingInput(_rxd_src(tk_pkh, 5_000), 0, taker),
+    ]
+    swapped_owner = build_ft_locking_script(Hex20(attacker_pkh), _FT_REF)
+    with pytest.raises(ValidationError, match="signature does NOT validate"):
+        _take(_mutate_with(swapped_owner, None), reservation, taker, funding_same_ref)

--- a/tests/test_rswp_v3_ft_demand_regtest_e2e.py
+++ b/tests/test_rswp_v3_ft_demand_regtest_e2e.py
@@ -1,0 +1,85 @@
+"""FT-demand v3 covenant fill on a REAL radiant-core regtest node.
+
+The maker reserves RXD into the refund covenant and demands a Glyph FT; the
+taker funds with real FT UTXOs (ref-induction mint) and fills the SWAP branch.
+Consensus proves the per-ref conservation the offline suite asserts: the maker
+holds the demanded FT amount, the taker holds the FT change AND the reserved
+RXD, all in one atomic completion.
+
+Gating: ``@pytest.mark.integration`` + ``RSWP_REGTEST=1`` (reuses the v2 e2e
+node harness). Isolated container, no real value.
+
+Run it:  RSWP_REGTEST=1 pytest tests/test_rswp_v3_ft_demand_regtest_e2e.py -m integration -s
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from pyrxd.glyph.script import is_ft_script
+from pyrxd.keys import PrivateKey
+from pyrxd.swap import Asset, FundingInput
+from pyrxd.swap.rswp import create_covenant_order, decode_rswp_order, prepare_covenant_offer, take_covenant_order
+from tests.test_rswp_regtest_e2e import _FEE, _fund_key, _mint_ft, _Node
+from tests.test_rswp_regtest_e2e import node as node
+
+pytestmark = pytest.mark.integration
+
+
+def _tip(node: _Node) -> int:
+    return int(node.cli("getblockcount"))
+
+
+async def test_v3_ft_demand_fill_conserves_on_chain(node) -> None:
+    maker, taker = PrivateKey(), PrivateKey()
+    mk_pkh, tk_pkh = maker.public_key().hash160(), taker.public_key().hash160()
+
+    # Maker reserves 10M photons, demanding 60k units of the taker's FT.
+    taker_ft_tx, ref = _mint_ft(node, taker, units=100_000)
+    fund_tx, fund_vout = _fund_key(node, maker, 20_000_000)
+    reservation = prepare_covenant_offer(
+        funding=[FundingInput(fund_tx, fund_vout, maker)],
+        photons=10_000_000,
+        owner_pkh=mk_pkh,
+        expiry_height=_tip(node) + 60,
+        change_pkh=mk_pkh,
+        fee=_FEE,
+    )
+    node.send_and_mine(reservation)
+    post = create_covenant_order(
+        covenant_source_tx=reservation,
+        covenant_vout=0,
+        maker_key=maker,
+        receive=Asset("ft", 60_000, ref),
+        maker_receive_pkh=mk_pkh,
+    )
+    order = decode_rswp_order(post.advert_script)
+    assert order.version == 3 and order.want_token_id is not None
+
+    fee_fund, ff_vout = _fund_key(node, taker, 20_000_000)
+    completion = take_covenant_order(
+        order,
+        give_source_tx=reservation,
+        funding=[FundingInput(taker_ft_tx, 0, taker), FundingInput(fee_fund, ff_vout, taker)],
+        taker_receive_pkh=tk_pkh,
+        taker_change_pkh=tk_pkh,
+        fee=_FEE,
+        current_height=_tip(node),
+    )
+    verdict = node.accepts(completion.serialize().hex())
+    assert verdict.get("allowed") is True, verdict
+    txid = node.send_and_mine(completion)
+
+    # On-chain conservation: output 0 = maker's 60k FT; output 1 = taker's 10M RXD;
+    # an FT change output carries the remaining 40k back to the taker.
+    out0 = node.cli("gettxout", txid, "0", "true")
+    assert isinstance(out0, dict) and round(out0["value"] * 1e8) == 60_000
+    assert is_ft_script(out0["scriptPubKey"]["hex"])
+    out1 = node.cli("gettxout", txid, "1", "true")
+    assert isinstance(out1, dict) and round(out1["value"] * 1e8) == 10_000_000
+    change_vals = []
+    for i in range(2, len(completion.outputs)):
+        got = node.cli("gettxout", txid, str(i), "true")
+        if isinstance(got, dict) and is_ft_script(got["scriptPubKey"]["hex"]):
+            change_vals.append(round(got["value"] * 1e8))
+    assert change_vals == [40_000]  # exact per-ref conservation, proven by consensus


### PR DESCRIPTION
Closes the L4 asymmetry from #279: FT-demand v3 covenant orders are now fillable by pyrxd, not just postable.

## What changed

`take_covenant_order` accepts an FT demand: funding may include FT UTXOs of **exactly the demanded ref** (plus plain RXD for value/fee). Conservation is single-ref by construction (design D6 — exactly one demanded output), so it reduces to three enforced facts: FT-in covers the demand, surplus returns to the taker as FT change, and funding carrying any *other* token (different ref, or an NFT) is refused rather than burned or stranded. The reserved side stays RXD-only (FT-in-covenant remains consensus-blocked by the FT codeScript epilogue). The RXD-demand path is byte-for-byte unchanged (regression-tested).

## Red-team gate (pre-PR, adversarial pass on the diff)

**No fund-safety finding.** The conservation ledger was verified by hand — `change = rxd_funding − fee` exactly, with the reserved photons cancelling and FT value fully conserved; fee can never absorb token value or vice versa. Confirmed safe: `demanded.value ≡ receive.amount` by construction; `GlyphRef`/`Txid` equality is case-strict; a tampered demanded *script* (ref or owner) dies on the maker signature via two independent bindings (SINGLE `hash_outputs` + Radiant `hashOutputHashes`) — now locked in by a dedicated test with advert metadata kept coherent so only the signature can object; the new FT-change output at index ≥ 2 is provably invisible to the maker's SINGLE|ANYONECANPAY preimage while ref induction is satisfied; duplicate-outpoint funding double-count is taker-self-harm rejected at consensus, identical to the existing `accept_offer` contract.

## Verification

- 8 offline tests (exact / surplus / underfunded / wrong-ref / NFT-funding / RXD-path-unchanged / tampered-value / tampered-script); all 51 pre-existing covenant+orders tests unchanged and green.
- **Regtest consensus proof**: FT-demand fill accepted and mined on radiant-core v3.1.1; per-ref conservation verified via `gettxout` — 60k units to the maker, 40k FT change and the 10M reserved photons to the taker, one atomic completion.

Note for merge sequencing: #282 (CLI v3) refuses FT-demand takes at the CLI level — correct against today's main; after this merges, that guard can be relaxed in a follow-up. Pre-audit posture unchanged: regtest only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)