### PR TITLE
feat(swap): NFT singleton support in same-chain swaps + RSWP orderbook (red-teamed)

### DIFF
--- a/src/pyrxd/cli/swap_book_cmds.py
+++ b/src/pyrxd/cli/swap_book_cmds.py
@@ -98,21 +98,31 @@ def _parse_token(value: str) -> GlyphRef | None:
 
 
 def _parse_asset_spec(value: str) -> Asset:
-    """``rxd:AMOUNT`` or ``TOKEN:AMOUNT`` (token as 72-hex ref or txid:vout) → Asset."""
+    """``rxd:AMOUNT`` | ``TOKEN:AMOUNT`` (FT) | ``nft:TOKEN:CARRIER_PHOTONS`` → Asset.
+
+    A bare token ref means FT (the common case); an NFT must be explicit via
+    the ``nft:`` prefix because the ref alone cannot distinguish the two.
+    """
+    kind = "ft"
+    if value.lower().startswith("nft:"):
+        kind = "nft"
+        value = value[4:]
     token_part, sep, amount_part = value.rpartition(":")
     if not sep:
         raise UserError(
             f"invalid asset spec {sanitize_terminal(value, max_len=80)!r}",
             cause="expected ASSET:AMOUNT",
-            fix="e.g. --receive rxd:900000 or --receive <72-hex-ref>:50",
+            fix="e.g. --receive rxd:900000, --receive <72-hex-ref>:50, or --receive nft:<72-hex-ref>:600",
         )
     try:
         amount = int(amount_part)
     except ValueError as exc:
         raise UserError(f"invalid amount {sanitize_terminal(amount_part, max_len=40)!r}") from exc
     ref = _parse_token(token_part)
+    if ref is None and kind == "nft":
+        raise UserError("nft: prefix requires a token ref, not 'rxd'")
     try:
-        return Asset(kind="rxd", amount=amount) if ref is None else Asset(kind="ft", amount=amount, ref=ref)
+        return Asset(kind="rxd", amount=amount) if ref is None else Asset(kind=kind, amount=amount, ref=ref)
     except RxdSdkError as exc:
         raise UserError(f"invalid asset spec: {exc}") from exc
 
@@ -120,6 +130,8 @@ def _parse_asset_spec(value: str) -> Asset:
 def _describe_asset(asset: Asset) -> str:
     if asset.kind == "rxd":
         return f"{asset.amount} photons (RXD)"
+    if asset.kind == "nft":
+        return f"the NFT {asset.ref.txid}:{asset.ref.vout} (carrier {asset.amount} photons)"
     return f"{asset.amount} units of FT {asset.ref.txid}:{asset.ref.vout}"
 
 

--- a/src/pyrxd/cli/swap_book_cmds.py
+++ b/src/pyrxd/cli/swap_book_cmds.py
@@ -144,6 +144,19 @@ def _estimate_fee(ctx: CliContext, n_inputs: int, n_outputs: int, override: int 
     return max(_MIN_FEE_PHOTONS, (ctx.fee_rate * size + 999) // 1000)
 
 
+def _cancel_needs_fee_funding(give_kind: str, give_value: int, fee: int) -> bool:
+    """Whether a cancel self-spend needs separate plain-RXD fee funding.
+
+    Token cancels ALWAYS do: an FT cancel conserves the full token amount and
+    an NFT cancel returns the full carrier (a singleton has no change path), so
+    neither leaves photons for the fee. (Red-team MEDIUM on the NFT slice: the
+    original FT-only condition made `swap cancel` — the advertised hard
+    revocation — abort for every non-dust NFT.) An RXD cancel funds the fee
+    from its own value unless that value cannot cover it.
+    """
+    return give_kind in ("ft", "nft") or give_value <= fee
+
+
 # --------------------------------------------------------------------------- wallet plumbing
 
 
@@ -418,9 +431,8 @@ def swap_cancel_cmd(ctx: CliContext, give_outpoint: str, fee_override: int | Non
             funds = await _collect_funds(ctx, client)
             maker_key = funds.key_for_pkh(_owner_pkh_of(give_out.locking_script.serialize()))
             fee = _estimate_fee(ctx, 2, 2, fee_override)
-            # FT cancels conserve the full token amount, so the fee needs plain-RXD funding.
             funding = None
-            if give_asset.kind == "ft" or give_out.satoshis <= fee:
+            if _cancel_needs_fee_funding(give_asset.kind, give_out.satoshis, fee):
                 funding = await _rxd_funding(client, funds, fee, exclude=(give_txid, give_vout))
             cancel = build_cancel_tx(
                 offered_source_tx=give_source,

--- a/src/pyrxd/swap/partial.py
+++ b/src/pyrxd/swap/partial.py
@@ -21,10 +21,11 @@ freely, but cannot alter what the maker gives or receives without
 invalidating the maker's signature — which :func:`accept_offer` checks
 before returning.
 
-Scope (v1): plain RXD and Glyph FT assets, on the same chain. The maker
-spends their entire given UTXO (SINGLE protects only output[0], so a
-maker-side change output would be unprotected — pre-split the UTXO to
-sell a partial amount). NFTs are out of scope.
+Scope: plain RXD, Glyph FT, and Glyph NFT singleton assets, on the same
+chain. The maker spends their entire given UTXO (SINGLE protects only
+output[0], so a maker-side change output would be unprotected — pre-split
+the UTXO to sell a partial amount). An NFT moves whole (the singleton ref
+must appear exactly once on each side; there is no NFT change).
 
 This module is pure (no network). To fetch the source/funding
 transactions an offer references, see :mod:`pyrxd.swap.resolve`.
@@ -35,7 +36,15 @@ from __future__ import annotations
 from dataclasses import dataclass
 
 from ..constants import SIGHASH
-from ..glyph.script import build_ft_locking_script, extract_ref_from_ft_script, is_ft_script
+from ..glyph.script import (
+    build_ft_locking_script,
+    build_nft_locking_script,
+    extract_owner_pkh_from_nft_script,
+    extract_ref_from_ft_script,
+    extract_ref_from_nft_script,
+    is_ft_script,
+    is_nft_script,
+)
 from ..glyph.types import GlyphRef
 from ..keys import PrivateKey, PublicKey
 from ..script.script import Script
@@ -63,27 +72,33 @@ def _is_p2pkh(script: bytes) -> bool:
 
 
 def _owner_pkh_of(script: bytes) -> bytes:
-    """Owner PKH of a spendable output (plain P2PKH or an FT lock — both embed it at [3:23])."""
+    """Owner PKH of a spendable output (P2PKH / FT embed it at [3:23]; the NFT singleton at [41:61])."""
     if _is_p2pkh(script) or is_ft_script(script.hex()):
         return script[3:23]
-    raise ValidationError("output is not a spendable P2PKH or FT script")
+    if is_nft_script(script.hex()):
+        return bytes(extract_owner_pkh_from_nft_script(script))
+    raise ValidationError("output is not a spendable P2PKH, FT, or NFT script")
 
 
 def _asset_of(satoshis: int, script: bytes) -> Asset:
-    """Classify an output's spendable asset. Rejects anything but RXD / FT."""
+    """Classify an output's spendable asset. Rejects anything but RXD / FT / NFT."""
     if is_ft_script(script.hex()):
         return Asset(kind="ft", amount=satoshis, ref=extract_ref_from_ft_script(script))
+    if is_nft_script(script.hex()):
+        return Asset(kind="nft", amount=satoshis, ref=extract_ref_from_nft_script(script))
     if _is_p2pkh(script):
         return Asset(kind="rxd", amount=satoshis, ref=None)
-    raise ValidationError("unsupported asset: output is neither plain RXD (P2PKH) nor a Glyph FT")
+    raise ValidationError("unsupported asset: output is not plain RXD (P2PKH), a Glyph FT, or a Glyph NFT")
 
 
 def _build_asset_output(asset: Asset, pkh: bytes) -> TransactionOutput:
     """Build the output that pays *asset* to the holder of *pkh*."""
+    if asset.ref is None and asset.kind != "rxd":  # guaranteed by Asset.__post_init__; keeps types + bandit happy
+        raise ValidationError(f"{asset.kind.upper()} asset is missing its ref")
     if asset.kind == "ft":
-        if asset.ref is None:  # guaranteed by Asset.__post_init__; guard keeps types + bandit happy
-            raise ValidationError("FT asset is missing its ref")
         return TransactionOutput(Script(build_ft_locking_script(Hex20(pkh), asset.ref)), asset.amount)
+    if asset.kind == "nft":
+        return TransactionOutput(Script(build_nft_locking_script(Hex20(pkh), asset.ref)), asset.amount)
     return TransactionOutput(P2PKH().lock(pkh), asset.amount)
 
 
@@ -311,17 +326,23 @@ def accept_offer(
 
 
 def _balance_and_add_change(tx: Transaction, taker_change_pkh: bytes, fee: int) -> None:
-    """Enforce per-FT-ref conservation and append FT/RXD change outputs.
+    """Enforce per-FT-ref conservation + NFT singleton discipline; append FT/RXD change.
 
     Each FT ref must conserve (sum of input photons of that ref == sum of
     output photons); any surplus becomes an FT change output to the taker.
-    The remaining (non-FT) photon surplus, less ``fee``, becomes an RXD
-    change output. Raises if the taker under-funded any leg.
+    Each NFT singleton ref present anywhere must appear EXACTLY once on each
+    side — an NFT in the inputs with no output would be silently BURNED
+    (consensus permits burning; only this builder stands in the way), and an
+    NFT in the outputs with no input is an unbacked ref the chain rejects.
+    There is no NFT change (a singleton is indivisible). The remaining photon
+    surplus, less ``fee``, becomes an RXD change output. Raises if the taker
+    under-funded any leg.
     """
     if fee < 0:
         raise ValidationError("fee must be non-negative")
 
     ft_in: dict[GlyphRef, int] = {}
+    nft_in: dict[GlyphRef, int] = {}
     total_in = 0
     for inp in tx.inputs:
         if inp.satoshis is None or inp.locking_script is None:
@@ -330,14 +351,31 @@ def _balance_and_add_change(tx: Transaction, taker_change_pkh: bytes, fee: int) 
         asset = _asset_of(inp.satoshis, inp.locking_script.serialize())
         if asset.kind == "ft":
             ft_in[asset.ref] = ft_in.get(asset.ref, 0) + asset.amount  # type: ignore[index]
+        elif asset.kind == "nft":
+            nft_in[asset.ref] = nft_in.get(asset.ref, 0) + 1  # type: ignore[index]
 
     ft_out: dict[GlyphRef, int] = {}
+    nft_out: dict[GlyphRef, int] = {}
     total_out = 0
     for out in tx.outputs:
         total_out += out.satoshis
         asset = _asset_of(out.satoshis, out.locking_script.serialize())
         if asset.kind == "ft":
             ft_out[asset.ref] = ft_out.get(asset.ref, 0) + asset.amount  # type: ignore[index]
+        elif asset.kind == "nft":
+            nft_out[asset.ref] = nft_out.get(asset.ref, 0) + 1  # type: ignore[index]
+
+    # NFT singleton discipline: exactly one in, exactly one out, per ref.
+    for ref in set(nft_in) | set(nft_out):
+        in_c, out_c = nft_in.get(ref, 0), nft_out.get(ref, 0)
+        if in_c == 0:
+            raise ValidationError(f"funding lacks the NFT singleton {ref.txid}:{ref.vout}")
+        if out_c == 0:
+            raise ValidationError(
+                f"transaction would BURN the NFT singleton {ref.txid}:{ref.vout} (no output carries it)"
+            )
+        if in_c > 1 or out_c > 1:
+            raise ValidationError(f"the NFT singleton {ref.txid}:{ref.vout} appears more than once on a side")
 
     # FT change: per ref, emit the surplus back to the taker; a deficit is
     # under-funding (and the chain would reject the unbacked output ref).

--- a/src/pyrxd/swap/rswp/orders.py
+++ b/src/pyrxd/swap/rswp/orders.py
@@ -68,7 +68,13 @@ def _contract_type_of(asset: Asset) -> int:
 
 
 def _pushed_token_id(asset: Asset) -> bytes:
-    """The 32 token-id bytes as they appear ON CHAIN (display digest reversed; zeros for RXD)."""
+    """The 32 token-id bytes as they appear ON CHAIN (display digest reversed; zeros for RXD).
+
+    NB: the id is REF-ONLY — an FT and an NFT sharing a genesis ref would hash
+    identically (unreachable on chain: one genesis commits to one refType).
+    Kind is therefore discriminated by the bridge's offered_type-vs-reality
+    check, never by token_id; do not lean on token_id as a kind signal.
+    """
     tid = swap_token_id(asset.ref)
     return tid if tid == RXD_TOKEN_ID else tid[::-1]
 

--- a/src/pyrxd/swap/rswp/orders.py
+++ b/src/pyrxd/swap/rswp/orders.py
@@ -45,6 +45,7 @@ from ..partial import (
 from ..types import Asset, SwapOffer, SwapTerms
 from .wire import (
     CONTRACT_TYPE_FT,
+    CONTRACT_TYPE_NFT,
     CONTRACT_TYPE_RXD,
     RXD_TOKEN_ID,
     encode_price_terms,
@@ -58,8 +59,12 @@ _MAX_PHOTONS = 21_000_000_000 * 100_000_000
 
 
 def _contract_type_of(asset: Asset) -> int:
-    """Photonic ``ContractType`` byte for an asset this module supports (RXD=0, FT=2)."""
-    return CONTRACT_TYPE_FT if asset.kind == "ft" else CONTRACT_TYPE_RXD
+    """Photonic ``ContractType`` byte (RXD=0, NFT=1, FT=2 — verified from Photonic source)."""
+    if asset.kind == "ft":
+        return CONTRACT_TYPE_FT
+    if asset.kind == "nft":
+        return CONTRACT_TYPE_NFT
+    return CONTRACT_TYPE_RXD
 
 
 def _pushed_token_id(asset: Asset) -> bytes:
@@ -372,7 +377,13 @@ def build_cancel_tx(
                 sighash=SIGHASH.ALL_FORKID,
             )
         )
-    # No explicit outputs: conservation emits the FT amount (if any) and the
+    offered = offered_source_tx.outputs[offered_vout]
+    offered_asset = _asset_of(offered.satoshis, offered.locking_script.serialize())
+    if offered_asset.kind == "nft":
+        # A singleton has no change path — send it back explicitly, or the
+        # conservation check would (correctly) refuse the burn.
+        tx.add_output(_build_asset_output(offered_asset, bytes(refund_pkh)))
+    # Remaining value: conservation emits the FT amount (if any) and the
     # remaining RXD, less fee, as "change" to the maker's refund key.
     _balance_and_add_change(tx, bytes(refund_pkh), fee)
     if not tx.outputs:

--- a/src/pyrxd/swap/types.py
+++ b/src/pyrxd/swap/types.py
@@ -16,17 +16,19 @@ from ..glyph.types import GlyphRef
 from ..security.errors import ValidationError
 from ..security.types import Txid
 
-AssetKind = Literal["rxd", "ft"]
+AssetKind = Literal["rxd", "ft", "nft"]
 
 
 @dataclass(frozen=True)
 class Asset:
-    """One side of a trade: plain RXD, or a Glyph fungible token.
+    """One side of a trade: plain RXD, a Glyph fungible token, or a Glyph NFT singleton.
 
     ``amount`` is in photons. For an FT this is also the token-unit count
-    (Radiant convention: 1 photon = 1 FT unit). ``ref`` is the FT's
-    genesis/commit outpoint (the permanent token identity) and is required
-    for — and only for — ``kind == "ft"``.
+    (Radiant convention: 1 photon = 1 FT unit). For an NFT it is the
+    singleton's CARRIER value (the photons riding on the one UTXO that holds
+    the singleton ref — the NFT itself is the ref, indivisible). ``ref`` is
+    the token's genesis/commit outpoint (the permanent identity) and is
+    required for — and only for — ``kind in ("ft", "nft")``.
     """
 
     kind: AssetKind
@@ -36,8 +38,8 @@ class Asset:
     def __post_init__(self) -> None:
         if self.amount <= 0:
             raise ValidationError(f"asset amount must be positive, got {self.amount}")
-        if self.kind == "ft" and self.ref is None:
-            raise ValidationError("an FT asset requires a genesis ref")
+        if self.kind in ("ft", "nft") and self.ref is None:
+            raise ValidationError(f"a {self.kind.upper()} asset requires a genesis ref")
         if self.kind == "rxd" and self.ref is not None:
             raise ValidationError("a plain RXD asset must not carry a ref")
 

--- a/tests/cli/test_swap_book_cmds.py
+++ b/tests/cli/test_swap_book_cmds.py
@@ -223,3 +223,23 @@ class TestOrders:
         result = runner.invoke(cli, ["swap", "orders", "rxd", "--node-rpc", "http://x"])
         assert result.exit_code == 0, result.output
         assert "no open orders" in result.output
+
+
+class TestCancelFeeFunding:
+    """Red-team MEDIUM (NFT slice): token cancels always need separate fee funding —
+    an NFT cancel returns the FULL carrier (no singleton change path), so the
+    FT-only condition made the advertised hard revocation abort for every
+    non-dust NFT."""
+
+    def test_token_cancels_always_need_funding(self) -> None:
+        from pyrxd.cli.swap_book_cmds import _cancel_needs_fee_funding
+
+        assert _cancel_needs_fee_funding("ft", 1_000_000, 1_000)
+        assert _cancel_needs_fee_funding("nft", 1_000_000, 1_000)  # the fixed case
+        assert _cancel_needs_fee_funding("nft", 500, 1_000)
+
+    def test_rxd_cancel_funds_fee_from_its_own_value(self) -> None:
+        from pyrxd.cli.swap_book_cmds import _cancel_needs_fee_funding
+
+        assert not _cancel_needs_fee_funding("rxd", 1_000_000, 1_000)
+        assert _cancel_needs_fee_funding("rxd", 900, 1_000)  # value cannot cover the fee

--- a/tests/test_rswp_nft_regtest_e2e.py
+++ b/tests/test_rswp_nft_regtest_e2e.py
@@ -1,0 +1,110 @@
+"""NFT singleton RSWP order on a REAL radiant-core regtest node — the consensus proof.
+
+One end-to-end case: mint a consensus-valid NFT singleton (ref-induction — the
+0xD8 OP_PUSHINPUTREFSINGLETON analogue of the FT trick; consensus enforces ref
+uniqueness, not mint provenance), post an NFT→RXD v2 order, see it in the real
+swapindex book, verify it fillable through the OrderbookClient, take it, and
+confirm the TAKER owns the singleton afterwards with the carrier intact.
+
+Gating: ``@pytest.mark.integration`` + ``RSWP_REGTEST=1`` (reuses the v2 e2e
+node harness). Isolated container, no real value.
+
+Run it:  RSWP_REGTEST=1 pytest tests/test_rswp_nft_regtest_e2e.py -m integration -s
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from pyrxd.glyph.script import build_nft_locking_script, extract_owner_pkh_from_nft_script, is_nft_script
+from pyrxd.glyph.types import GlyphRef
+from pyrxd.keys import PrivateKey
+from pyrxd.script.script import Script
+from pyrxd.script.type import P2PKH
+from pyrxd.security.types import Hex20, Txid
+from pyrxd.swap import Asset, FundingInput
+from pyrxd.swap.rswp import (
+    OrderbookClient,
+    build_advert_tx,
+    create_rswp_order,
+    decode_rswp_order,
+    swap_token_id,
+    take_rswp_order,
+)
+from pyrxd.transaction.transaction import Transaction
+from pyrxd.transaction.transaction_input import TransactionInput
+from pyrxd.transaction.transaction_output import TransactionOutput
+from tests.test_rswp_regtest_e2e import _FEE, _CliSource, _fund_key, _Node
+from tests.test_rswp_regtest_e2e import node as node
+
+pytestmark = pytest.mark.integration
+
+
+def _mint_nft(node: _Node, owner: PrivateKey, carrier: int) -> tuple[Transaction, GlyphRef]:
+    """Create a consensus-valid NFT singleton UTXO at vout 0 (ref = the spent outpoint)."""
+    fund_tx, fund_vout = _fund_key(node, owner, carrier + 10_000_000)
+    ref = GlyphRef(txid=Txid(fund_tx.txid()), vout=fund_vout)
+    pkh = owner.public_key().hash160()
+    tx = Transaction()
+    tx.add_input(
+        TransactionInput(
+            source_transaction=fund_tx,
+            source_output_index=fund_vout,
+            unlocking_script_template=P2PKH().unlock(owner),
+        )
+    )
+    tx.add_output(TransactionOutput(Script(build_nft_locking_script(Hex20(pkh), ref)), carrier))
+    change = fund_tx.outputs[fund_vout].satoshis - carrier - _FEE
+    tx.add_output(TransactionOutput(P2PKH().lock(pkh), change))
+    tx.sign(bypass=True)
+    node.send_and_mine(tx)
+    return tx, ref
+
+
+async def test_nft_order_post_browse_take_settle(node) -> None:
+    maker, taker = PrivateKey(), PrivateKey()
+    mk_pkh, tk_pkh = maker.public_key().hash160(), taker.public_key().hash160()
+
+    nft_tx, ref = _mint_nft(node, maker, carrier=1_000_000)
+    post = create_rswp_order(
+        give_source_tx=nft_tx, give_vout=0, maker_key=maker, receive=Asset("rxd", 9_000_000), maker_receive_pkh=mk_pkh
+    )
+    order = decode_rswp_order(post.advert_script)
+    assert order.offered_type == 1  # ContractType.NFT
+
+    advert_fund, af_vout = _fund_key(node, maker, 20_000_000)
+    node.send_and_mine(
+        build_advert_tx(
+            advert_script=post.advert_script,
+            funding=[FundingInput(advert_fund, af_vout, maker)],
+            change_pkh=mk_pkh,
+            fee=_FEE,
+        )
+    )
+
+    # The REAL swapindex lists the NFT order under sha256 of its ref (v2 frame).
+    rows = node.cli("getopenorders", swap_token_id(ref).hex())
+    assert isinstance(rows, list) and len(rows) == 1 and rows[0]["offered_type"] == 1
+
+    entries = await OrderbookClient(_CliSource(node)).orders_offering(ref)
+    assert len(entries) == 1 and entries[0].fillable, entries[0].problem
+
+    fund_tx, fund_vout = _fund_key(node, taker, 20_000_000)
+    completion = take_rswp_order(
+        order,
+        give_source_tx=nft_tx,
+        funding=[FundingInput(fund_tx, fund_vout, taker)],
+        taker_receive_pkh=tk_pkh,
+        taker_change_pkh=tk_pkh,
+        fee=_FEE,
+    )
+    verdict = node.accepts(completion.serialize().hex())
+    assert verdict.get("allowed") is True, verdict
+    txid = node.send_and_mine(completion)
+
+    # Settlement: the taker holds the singleton at completion:1 with the carrier intact.
+    got = node.cli("gettxout", txid, "1", "true")
+    assert isinstance(got, dict) and round(got["value"] * 1e8) == 1_000_000
+    spk = bytes.fromhex(got["scriptPubKey"]["hex"])
+    assert is_nft_script(spk.hex()) and bytes(extract_owner_pkh_from_nft_script(spk)) == tk_pkh
+    assert node.cli("getopenorders", swap_token_id(ref).hex()) == []  # book settled

--- a/tests/test_swap_partial_nft.py
+++ b/tests/test_swap_partial_nft.py
@@ -1,0 +1,283 @@
+"""NFT singleton support in the same-chain swap (``pyrxd.swap``) + RSWP integration.
+
+The singleton discipline is the point: an NFT ref present anywhere in a swap
+must appear EXACTLY once on each side — consensus permits burning a singleton
+(no backstop; see the deployed-covenant finding), so the builder is the only
+thing standing between a buggy completion and a destroyed NFT.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from pyrxd.glyph.script import build_nft_locking_script, extract_owner_pkh_from_nft_script, is_nft_script
+from pyrxd.glyph.types import GlyphRef
+from pyrxd.keys import PrivateKey
+from pyrxd.script.script import Script
+from pyrxd.script.type import P2PKH
+from pyrxd.security.errors import ValidationError
+from pyrxd.security.types import Hex20, Txid
+from pyrxd.swap import Asset, FundingInput, SwapOffer, accept_offer, create_offer
+from pyrxd.swap.rswp import build_cancel_tx, create_rswp_order, decode_rswp_order, take_rswp_order
+from pyrxd.transaction.transaction import Transaction
+from pyrxd.transaction.transaction_output import TransactionOutput
+
+_NFT_REF = GlyphRef(txid=Txid("aa" * 32), vout=0)
+_NFT_REF2 = GlyphRef(txid=Txid("bb" * 32), vout=1)
+_FT_REF = GlyphRef(txid=Txid("cc" * 32), vout=0)
+
+
+def _key() -> tuple[PrivateKey, bytes]:
+    k = PrivateKey()
+    return k, k.public_key().hash160()
+
+
+def _rxd_src(pkh: bytes, value: int) -> Transaction:
+    tx = Transaction()
+    tx.add_output(TransactionOutput(P2PKH().lock(pkh), value))
+    return tx
+
+
+def _nft_src(pkh: bytes, ref: GlyphRef, carrier: int) -> Transaction:
+    tx = Transaction()
+    tx.add_output(TransactionOutput(Script(build_nft_locking_script(Hex20(pkh), ref)), carrier))
+    return tx
+
+
+def _out_kinds(tx: Transaction) -> list[str]:
+    return ["nft" if is_nft_script(o.locking_script.serialize().hex()) else "other" for o in tx.outputs]
+
+
+# ─────────────────────────────── happy paths ─────────────────────────────────
+
+
+def test_nft_for_rxd() -> None:
+    """Maker sells an NFT for RXD; the taker receives the singleton whole."""
+    mk, mk_pkh = _key()
+    tk, tk_pkh = _key()
+    offer = create_offer(
+        give_source_tx=_nft_src(mk_pkh, _NFT_REF, 600),
+        give_vout=0,
+        maker_key=mk,
+        receive=Asset("rxd", 5_000),
+        maker_receive_pkh=mk_pkh,
+    )
+    assert offer.terms.give == Asset("nft", 600, _NFT_REF)
+    tx = accept_offer(
+        SwapOffer.from_dict(offer.to_dict()),
+        funding=[FundingInput(_rxd_src(tk_pkh, 9_000), 0, tk)],
+        taker_receive_pkh=tk_pkh,
+        taker_change_pkh=tk_pkh,
+        fee=300,
+    )
+    assert tx.outputs[0].satoshis == 5_000  # maker's RXD demand
+    nft_out = tx.outputs[1].locking_script.serialize()
+    assert is_nft_script(nft_out.hex()) and tx.outputs[1].satoshis == 600
+    assert bytes(extract_owner_pkh_from_nft_script(nft_out)) == tk_pkh  # taker owns it now
+    assert _out_kinds(tx).count("nft") == 1  # exactly-one singleton output
+
+
+def test_rxd_for_nft() -> None:
+    """Maker buys a specific NFT with RXD; taker funds with the singleton + fee RXD."""
+    mk, mk_pkh = _key()
+    tk, tk_pkh = _key()
+    offer = create_offer(
+        give_source_tx=_rxd_src(mk_pkh, 5_000),
+        give_vout=0,
+        maker_key=mk,
+        receive=Asset("nft", 600, _NFT_REF),
+        maker_receive_pkh=mk_pkh,
+    )
+    tx = accept_offer(
+        SwapOffer.from_dict(offer.to_dict()),
+        funding=[FundingInput(_nft_src(tk_pkh, _NFT_REF, 600), 0, tk), FundingInput(_rxd_src(tk_pkh, 2_000), 0, tk)],
+        taker_receive_pkh=tk_pkh,
+        taker_change_pkh=tk_pkh,
+        fee=300,
+    )
+    out0 = tx.outputs[0].locking_script.serialize()
+    assert is_nft_script(out0.hex()) and bytes(extract_owner_pkh_from_nft_script(out0)) == mk_pkh
+    assert tx.outputs[1].satoshis == 5_000  # taker receives the maker's RXD
+    assert _out_kinds(tx).count("nft") == 1
+
+
+def test_nft_for_ft() -> None:
+    mk, mk_pkh = _key()
+    tk, tk_pkh = _key()
+    from pyrxd.glyph.script import build_ft_locking_script
+
+    ft_src = Transaction()
+    ft_src.add_output(TransactionOutput(Script(build_ft_locking_script(Hex20(tk_pkh), _FT_REF)), 80))
+    offer = create_offer(
+        give_source_tx=_nft_src(mk_pkh, _NFT_REF, 600),
+        give_vout=0,
+        maker_key=mk,
+        receive=Asset("ft", 50, _FT_REF),
+        maker_receive_pkh=mk_pkh,
+    )
+    tx = accept_offer(
+        SwapOffer.from_dict(offer.to_dict()),
+        funding=[FundingInput(ft_src, 0, tk), FundingInput(_rxd_src(tk_pkh, 3_000), 0, tk)],
+        taker_receive_pkh=tk_pkh,
+        taker_change_pkh=tk_pkh,
+        fee=300,
+    )
+    assert _out_kinds(tx).count("nft") == 1  # the singleton moved, exactly once
+
+
+# ─────────────────────────────── singleton discipline ────────────────────────
+
+
+def test_taker_missing_demanded_nft_rejected() -> None:
+    mk, mk_pkh = _key()
+    tk, tk_pkh = _key()
+    offer = create_offer(
+        give_source_tx=_rxd_src(mk_pkh, 5_000),
+        give_vout=0,
+        maker_key=mk,
+        receive=Asset("nft", 600, _NFT_REF),
+        maker_receive_pkh=mk_pkh,
+    )
+    with pytest.raises(ValidationError, match="funding lacks the NFT singleton"):
+        accept_offer(
+            SwapOffer.from_dict(offer.to_dict()),
+            funding=[FundingInput(_rxd_src(tk_pkh, 9_000), 0, tk)],  # no NFT
+            taker_receive_pkh=tk_pkh,
+            taker_change_pkh=tk_pkh,
+            fee=300,
+        )
+
+
+def test_wrong_nft_rejected() -> None:
+    """Funding with a DIFFERENT singleton than demanded fails both directions
+    (the demanded ref is missing AND the provided one would burn)."""
+    mk, mk_pkh = _key()
+    tk, tk_pkh = _key()
+    offer = create_offer(
+        give_source_tx=_rxd_src(mk_pkh, 5_000),
+        give_vout=0,
+        maker_key=mk,
+        receive=Asset("nft", 600, _NFT_REF),
+        maker_receive_pkh=mk_pkh,
+    )
+    with pytest.raises(ValidationError, match="NFT singleton"):
+        accept_offer(
+            SwapOffer.from_dict(offer.to_dict()),
+            funding=[
+                FundingInput(_nft_src(tk_pkh, _NFT_REF2, 600), 0, tk),
+                FundingInput(_rxd_src(tk_pkh, 9_000), 0, tk),
+            ],
+            taker_receive_pkh=tk_pkh,
+            taker_change_pkh=tk_pkh,
+            fee=300,
+        )
+
+
+def test_stray_nft_funding_would_burn_rejected() -> None:
+    """An extra singleton slipped into funding with no matching output = a burn —
+    the builder must refuse rather than destroy it."""
+    mk, mk_pkh = _key()
+    tk, tk_pkh = _key()
+    offer = create_offer(
+        give_source_tx=_rxd_src(mk_pkh, 5_000),
+        give_vout=0,
+        maker_key=mk,
+        receive=Asset("rxd", 3_000),
+        maker_receive_pkh=mk_pkh,
+    )
+    with pytest.raises(ValidationError, match="would BURN the NFT singleton"):
+        accept_offer(
+            SwapOffer.from_dict(offer.to_dict()),
+            funding=[
+                FundingInput(_nft_src(tk_pkh, _NFT_REF, 600), 0, tk),
+                FundingInput(_rxd_src(tk_pkh, 9_000), 0, tk),
+            ],
+            taker_receive_pkh=tk_pkh,
+            taker_change_pkh=tk_pkh,
+            fee=300,
+        )
+
+
+def test_nft_carrier_value_mismatch_is_not_the_singleton() -> None:
+    """The demanded output's carrier value is signature-bound; a taker's singleton
+    with a different carrier still satisfies the ref (value flows via change)."""
+    mk, mk_pkh = _key()
+    tk, tk_pkh = _key()
+    offer = create_offer(
+        give_source_tx=_rxd_src(mk_pkh, 5_000),
+        give_vout=0,
+        maker_key=mk,
+        receive=Asset("nft", 600, _NFT_REF),  # maker wants carrier 600
+        maker_receive_pkh=mk_pkh,
+    )
+    tx = accept_offer(
+        SwapOffer.from_dict(offer.to_dict()),
+        funding=[FundingInput(_nft_src(tk_pkh, _NFT_REF, 550), 0, tk), FundingInput(_rxd_src(tk_pkh, 2_000), 0, tk)],
+        taker_receive_pkh=tk_pkh,
+        taker_change_pkh=tk_pkh,
+        fee=300,
+    )
+    assert tx.outputs[0].satoshis == 600  # signature-bound demand honored
+    total_in = 5_000 + 550 + 2_000
+    assert total_in - sum(o.satoshis for o in tx.outputs) == 300
+
+
+# ─────────────────────────────── RSWP integration ────────────────────────────
+
+
+def test_rswp_nft_order_full_loop() -> None:
+    """Post an NFT→RXD order to the book format and take it from the advert bytes."""
+    from pyrxd.swap.rswp import swap_token_id
+
+    mk, mk_pkh = _key()
+    tk, tk_pkh = _key()
+    src = _nft_src(mk_pkh, _NFT_REF, 600)
+    post = create_rswp_order(
+        give_source_tx=src, give_vout=0, maker_key=mk, receive=Asset("rxd", 5_000), maker_receive_pkh=mk_pkh
+    )
+    order = decode_rswp_order(post.advert_script)
+    assert order.offered_type == 1  # ContractType.NFT (verified from Photonic source)
+    assert order.token_id == swap_token_id(_NFT_REF)[::-1]
+
+    tx = take_rswp_order(
+        order,
+        give_source_tx=src,
+        funding=[FundingInput(_rxd_src(tk_pkh, 9_000), 0, tk)],
+        taker_receive_pkh=tk_pkh,
+        taker_change_pkh=tk_pkh,
+        fee=300,
+    )
+    assert _out_kinds(tx).count("nft") == 1
+
+
+def test_rswp_nft_cancel_returns_singleton() -> None:
+    mk, mk_pkh = _key()
+    src = _nft_src(mk_pkh, _NFT_REF, 600)
+    tx = build_cancel_tx(
+        offered_source_tx=src,
+        offered_vout=0,
+        maker_key=mk,
+        refund_pkh=mk_pkh,
+        fee=300,
+        funding=[FundingInput(_rxd_src(mk_pkh, 1_000), 0, mk)],
+    )
+    out0 = tx.outputs[0].locking_script.serialize()
+    assert is_nft_script(out0.hex()) and tx.outputs[0].satoshis == 600
+    assert bytes(extract_owner_pkh_from_nft_script(out0)) == mk_pkh
+
+
+def test_rswp_lying_nft_offered_type_rejected() -> None:
+    """Advert claims FT (2) for a UTXO that really holds an NFT — refused at the bridge."""
+    from pyrxd.gravity.swap_order import RswpOrder
+    from pyrxd.swap.rswp import rswp_order_to_swap_offer
+
+    mk, mk_pkh = _key()
+    src = _nft_src(mk_pkh, _NFT_REF, 600)
+    post = create_rswp_order(
+        give_source_tx=src, give_vout=0, maker_key=mk, receive=Asset("rxd", 5_000), maker_receive_pkh=mk_pkh
+    )
+    order = decode_rswp_order(post.advert_script)
+    fields = {f: getattr(order, f) for f in RswpOrder.__dataclass_fields__}
+    fields["offered_type"] = 2
+    with pytest.raises(ValidationError, match="offeredType does not match"):
+        rswp_order_to_swap_offer(RswpOrder(**fields), give_source_tx=src)


### PR DESCRIPTION
The second consensus item from the deferred list: `AssetKind` gains `"nft"` across `pyrxd.swap` and the RSWP book — the brainstorm's "Same-chain NFT support in partial swap" (reusing ~90% of the proven offer/accept logic, as it predicted).

## What ships

- **`pyrxd.swap`**: NFT classification (63-byte `0xD8` singleton script; owner pkh via the proper extractor at [41:61], *not* the P2PKH/FT offset) and **singleton discipline** in conservation: every NFT ref present anywhere in a swap must appear exactly once on each side. Consensus permits *burning* a singleton — there is no backstop — so the builder refuses would-be burns, unbacked demands, and duplicates outright. No NFT change ever exists (a singleton is indivisible; carrier value flows through RXD change).
- **RSWP book**: NFT orders post/take through the existing verified bridge with `offeredType` NFT=1 (verified from Photonic source earlier in this line of work); cancel explicitly returns the singleton. NFT orders are v2 frames — **visible in the live swapindex book**.
- **CLI**: `nft:REF:CARRIER` asset specs, NFT-aware descriptions, and the red-team fix below.

## Red-team gate (pre-PR, adversarial pass on the diff)

**No fund-safety blocker.** Confirmed safe: the FT/NFT/P2PKH classifiers are provably disjoint (anchored full-match regexes, different lengths *and* lead bytes — branch order unexploitable); conservation counts the maker's give input and taker funding alike and fails closed on burn/forge/duplicate; the taker always receives the on-chain-truth singleton (built from `real_give`, never from declared terms); the v3 covenant paths still refuse NFT inner scripts everywhere; no existing test was modified.

Two findings, both applied:
- **MEDIUM (fixed)**: `pyrxd swap cancel` — the advertised hard revocation — didn't provision fee funding for NFT offers, so it aborted (fail-closed, no fund loss) for any NFT with carrier > fee, because an NFT cancel returns the *full* carrier. The decision is now a tested helper covering FT, NFT, and low-value-RXD cases.
- **INFO (documented in code)**: swap token ids are ref-only, so kind discrimination rests entirely on the bridge's `offered_type`-vs-reality check — now stated at the helper so a future refactor can't silently lean on token_id as a kind signal.

## Verification

- Equivalence: all 144 pre-existing swap/rswp/cli tests pass unchanged.
- 10 new offline NFT tests: all trade directions (NFT↔RXD, RXD↔NFT, NFT↔FT), burn/missing/wrong-singleton refusals, carrier-vs-ref semantics, lying `offeredType` rejected.
- **Regtest consensus proof**: real singleton minted (ref-induction), posted as a v2 order, listed in the REAL swapindex book, verified fillable by the OrderbookClient, taken — taker ownership and intact carrier verified via `gettxout`, order dropped from the book on settlement.

Merge-sequencing note: independent of #284 (FT-demand); whichever lands second will need the usual small `__init__`/test-message reconciliation. Pre-audit posture unchanged: regtest only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)