### PR TITLE
fix(swap-verify): asset-leg provenance + txid pin + value gating (audit C1 CRITICAL)

### DIFF
--- a/scripts/swap_run_verify.py
+++ b/scripts/swap_run_verify.py
@@ -59,7 +59,30 @@ from pyrxd.gravity.htlc_covenant import build_htlc_covenant_rxd
 from pyrxd.transaction.transaction import Transaction
 
 # Secret substrings forbidden in any cross-host / journal file (mirrors eth_swap_two_host._assert_public_only).
-_SECRET_FORBIDDEN_KEYS = ("preimage", "p_hex", "wif", "secret", "privkey", "mnemonic", "seed")
+# NB: "priv" (not "privkey") so `private_key` / `priv_key` / `privatekey` all match despite the separator;
+# "key" is deliberately broad (an audit journal names things like txid/height/state/address, never a bare
+# "key"), and "xprv"/"entropy" cover BIP32 extended-private-keys and raw seed entropy.
+_SECRET_FORBIDDEN_KEYS = (
+    "preimage",
+    "p_hex",
+    "wif",
+    "secret",
+    "priv",
+    "key",
+    "mnemonic",
+    "seed",
+    "xprv",
+    "entropy",
+)
+
+
+def _looks_like_wif(s: str) -> bool:
+    """A base58 WIF-shaped VALUE (51-52 chars, 5/K/L lead). Distinguishable from a 64-hex txid — so scanning
+    values for this can't false-positive on the txids that legitimately fill every journal. (A raw 32-byte
+    preimage is 64-hex, SHAPE-identical to a txid, so it is caught by key name, not by value scan.)"""
+    if not (51 <= len(s) <= 52) or s[0] not in "5KL":
+        return False
+    return all(c in "123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz" for c in s)
 
 
 def _sha256(b: bytes) -> bytes:
@@ -228,10 +251,21 @@ def assert_no_secrets(doc: object, *, what: str) -> None:
     elif isinstance(doc, list):
         for v in doc:
             assert_no_secrets(v, what=what)
+    elif isinstance(doc, str) and _looks_like_wif(doc):
+        # Value-level catch for a WIF stored under an innocuous key ({"note": "L5..."}). Limited to the
+        # WIF shape on purpose — a raw preimage/txid is 64-hex and indistinguishable, so those are guarded
+        # by key name above rather than by a value scan that would reject every legitimate txid.
+        raise ValueError(f"{what}: a WIF-shaped secret value is present in a public file")
 
 
 def assert_independent_endpoints(verifier_urls: list[str], party_endpoints: tuple[str, ...]) -> None:
-    """The verifier's corroboration sources MUST be hosts neither party ran (else it's not independent)."""
+    """The verifier's corroboration sources MUST be hosts neither party ran (else it's not independent).
+
+    NB: `party_endpoints` is manifest-supplied (party-declared), so an adversary who runs the "third-party"
+    source can simply omit it here and this hostname check passes. This guard is therefore ADVISORY — the
+    auditor should still pass endpoints they trust out-of-band. The load-bearing anti-substitution defenses
+    are the per-tx txid pins (BTC/RXD: bytes hash to the cited txid) plus the covenant-outpoint provenance
+    checks, which hold even against a source that lies about which txid is which."""
     party_hosts = {(urlparse(e).hostname or e).lower() for e in party_endpoints}
     for u in verifier_urls:
         host = (urlparse(u).hostname or u).lower()
@@ -269,6 +303,22 @@ def _output(raw_tx: bytes, vout: int) -> tuple[bytes, int]:
     return out.locking_script.serialize(), int(out.satoshis)
 
 
+def _rxd_input_prevouts(raw_tx: bytes) -> set[bytes]:
+    """The set of prevout-le-bytes (reversed txid || vout LE) consumed by a NON-segwit RXD tx.
+
+    Parallels ``btc_input_outpoints_from_raw`` for the asset leg so ``verify_asset_leg`` can prove a
+    cited spend actually consumes the covenant funding outpoint (provenance) — not merely that some tx
+    happens to pay a party's holder address. Matches ``Outpoint.prevout_le_bytes`` exactly.
+    """
+    tx = Transaction.from_hex(raw_tx)
+    if tx is None:
+        raise ValueError("could not parse RXD transaction bytes")
+    out: set[bytes] = set()
+    for inp in tx.inputs:
+        out.add(bytes.fromhex(inp.source_txid)[::-1] + int(inp.source_output_index).to_bytes(4, "little"))
+    return out
+
+
 def _output_spk(raw_tx: bytes, vout: int) -> bytes:
     return _output(raw_tx, vout)[0]
 
@@ -279,43 +329,56 @@ def verify_asset_leg(
     """Re-derive the RXD asset-leg disposition from the funding + spending tx bytes.
 
     1. The funding output MUST pay the re-derived covenant SPK (the asset was locked to the legit covenant).
-    2. The spend's output[0] decides who got the asset: taker_holder => taker claimed; maker_holder => refund.
+    2. The spend MUST consume the covenant funding outpoint (provenance) — the cited spend txid is
+       journal-supplied, so a party cannot pass off an unrelated tx that merely pays a holder address.
+    3. The spend's output[0] decides who got the asset: taker_holder => taker claimed; maker_holder => refund.
+
+    Because the funding SPK is proven to be the real hashlock covenant (check 1) and the confirmed spend
+    is proven to consume it (check 2), a confirmed spend to the taker holder necessarily satisfied the
+    hashlock branch at consensus (revealing p) — so re-scraping p here would be redundant, and is
+    unreliable anyway (RXD is non-segwit; p rides in the scriptSig, not a witness). Provenance + value
+    conservation (checks 2 & 4) are the load-bearing gates.
     """
     notes: list[str] = []
     funded_spk, taker_holder, maker_holder = rxd_expected_scripts(m)
     observed_funding_spk, observed_funding_value = _output(covenant_funding_tx, m.covenant_funding.vout)
-    # Independent value-integrity: the covenant must carry the agreed amount (catches an under-funded asset —
-    # a partial-fill / short-change attack the SPK check alone would miss).
-    if observed_funding_value != m.rxd_amount:
-        notes.append(
-            f"WARNING: covenant funded with {observed_funding_value} photons, agreed {m.rxd_amount} "
-            f"(value mismatch — asset under/over-funded)"
-        )
     if observed_funding_spk != funded_spk:
         return AssetLeg.ANOMALOUS, [
             "covenant funding output SPK does NOT match the covenant re-derived from public terms — "
             "the asset was not locked to the agreed covenant (PARAMS_MISMATCH territory)"
         ]
-    notes.append("covenant funding SPK == re-derived covenant (asset locked to the agreed covenant)")
+    # Independent value-integrity: the covenant must carry the agreed amount (catches an under-funded asset —
+    # a partial-fill / short-change attack the SPK check alone would miss). Verdict-affecting: a genuine run
+    # conserves value, so a mismatch is ANOMALOUS, never a note-only warning that a PASS could sail past.
+    if observed_funding_value != m.rxd_amount:
+        return AssetLeg.ANOMALOUS, [
+            f"covenant funded with {observed_funding_value} photons, agreed {m.rxd_amount} "
+            f"(value mismatch — asset under/over-funded)"
+        ]
+    notes.append("covenant funding SPK == re-derived covenant, carrying the agreed amount")
     if covenant_spend_tx is None:
         return AssetLeg.PENDING, [*notes, "covenant outpoint still unspent"]
+    # PROVENANCE (the fix for the false-PASS free-option attack): the cited spend must actually consume the
+    # covenant funding outpoint. Mirrors verify_counter_leg_btc's prevout check, which the asset leg lacked.
+    if m.covenant_funding.prevout_le_bytes() not in _rxd_input_prevouts(covenant_spend_tx):
+        return AssetLeg.ANOMALOUS, [
+            *notes,
+            "the cited covenant-spend does NOT consume the covenant funding outpoint "
+            "(wrong/decoy tx — provenance fail)",
+        ]
+    notes.append("covenant-spend consumes the covenant funding outpoint")
     spent_to, paid_value = _output(covenant_spend_tx, 0)
-    # Independent made-whole (asset side): the covenant pays its full carrier amount to the holder (the miner
-    # fee comes from a separate fee input, never the carrier), so the payout must equal the funded amount.
+    # Made-whole (asset side): the covenant pays its full carrier amount to the holder (the miner fee comes
+    # from a separate fee input, never the carrier), so a short-changed payout is a value-integrity failure,
+    # not a cosmetic note — ANOMALOUS.
     if paid_value != observed_funding_value:
-        notes.append(
-            f"WARNING: covenant spend paid {paid_value} photons, carrier was {observed_funding_value} "
-            f"(value not conserved — short-changed payout)"
-        )
+        return AssetLeg.ANOMALOUS, [
+            *notes,
+            f"covenant spend paid {paid_value} photons, carrier was {observed_funding_value} "
+            f"(value not conserved — short-changed payout)",
+        ]
     if spent_to == taker_holder:
-        # claim path: the covenant claim scriptSig reveals p; confirm it hashes to H.
-        try:
-            p = scrape_secret(covenant_spend_tx, bytes.fromhex(m.h_hex))
-            if _sha256(p) == bytes.fromhex(m.h_hex):
-                notes.append("asset claim reveals a 32-byte p with sha256(p)==H")
-        except Exception:
-            notes.append("WARNING: asset paid the taker holder but p was not scrapeable from the spend")
-        return AssetLeg.TAKER_CLAIMED, notes
+        return AssetLeg.TAKER_CLAIMED, [*notes, "covenant spent to the taker holder (hashlock claim)"]
     if spent_to == maker_holder:
         return AssetLeg.MAKER_REFUNDED, [*notes, "covenant spent to the maker holder (CSV refund)"]
     return AssetLeg.ANOMALOUS, [*notes, "covenant spent to NEITHER the taker nor maker holder script"]
@@ -546,7 +609,14 @@ class _RxdFetcher:
 
     async def raw_tx(self, txid: str) -> bytes:
         async with self._client as c:
-            return bytes(await c.get_transaction(txid))
+            raw = bytes(await c.get_transaction(txid))
+        # Pin the returned bytes to the requested txid (txid == hash(tx) for RXD). Without this a hostile
+        # or MITM'd ElectrumX could substitute arbitrary bytes and steer the asset-leg verdict — the sibling
+        # BTC/resolve fetchers already do this; the RXD path was the lone outlier.
+        parsed = Transaction.from_hex(raw)
+        if parsed is None or parsed.txid() != str(txid):
+            raise ValueError(f"RXD endpoint returned bytes whose hash != requested txid ({txid})")
+        return raw
 
     async def confirm_height(self, txid: str) -> int | None:
         """The block height a tx confirmed at (tip - confirmations + 1), or None if unconfirmed/unknown."""
@@ -589,8 +659,17 @@ async def _fetch_for_live(m: RunManifest, cited: dict, btc_url: str, rxd_url: st
         cov_fund = await rxd.raw_tx(m.covenant_funding.txid)
         spend_txid = cited.get("covenant_spend_txid")
         cov_spend = await rxd.raw_tx(spend_txid) if spend_txid else None
-        if spend_txid:  # for the lucky-pass margin grade
+        if spend_txid:
             asset_claim_height = await rxd.confirm_height(spend_txid)
+            # Confirmation gate: a cited spend must be MINED. An unconfirmed (or unknown) tx was never
+            # validated by consensus, so its scriptSig could be junk that doesn't actually satisfy the
+            # covenant — treating it as a settled disposition would let a fabricated tx that merely names
+            # the covenant outpoint pass the provenance check. Mirrors the BTC leg's min_confirmations=1.
+            if asset_claim_height is None:
+                raise ValueError(
+                    f"cited covenant-spend {spend_txid} is not confirmed on the independent RXD source — "
+                    "refusing to score an unconfirmed disposition"
+                )
     finally:
         await rxd.close()
 
@@ -629,8 +708,11 @@ def run_verify(
     else:
         tx, rcpt = counter_obj if counter_obj else (None, None)
         counter, counter_p_sha256, counter_notes = verify_counter_leg_eth(m, tx, rcpt)
-    # Leg verifiers return sha256(p) (== manifest H, proven in-leg), never raw p; the
-    # asset leg additionally reports no digest at all (its H-match is note-level only).
+    # Leg verifiers return sha256(p) (== manifest H, proven in-leg), never raw p. The asset-side digest is
+    # INTENTIONALLY None: both legs are already bound to the single manifest H (the covenant SPK is rebuilt
+    # from H, and the counter claim is checked sha256(p)==H), so equal-H both-complete ⟺ same preimage by
+    # collision resistance — the asset_p_sha256 arg is a redundant belt-and-suspenders slot. Do NOT wire a
+    # raw scraped preimage back in here (it re-introduces the CodeQL clear-text-secret taint of PR #273).
     res = atomicity_verdict(m, asset, counter, None, counter_p_sha256)
     grade, slack, margin_note = margin_grade(m, asset, counter, asset_claim_height)
     res.checks = {
@@ -716,9 +798,13 @@ def _self_check() -> int:
     # 4) RXD asset-leg disposition against a synthetic covenant funding + claim tx.
     funded_spk, taker_holder, maker_holder = rxd_expected_scripts(m)
 
-    def _rxd_tx(out_spk: bytes, value: int = 1000) -> bytes:
+    # All self-check manifests lock the asset at this covenant outpoint; a genuine claim/refund CONSUMES it
+    # (provenance). `spend_covenant=False` builds a "decoy" that pays a holder address without spending the
+    # covenant — the exact free-option forgery the provenance gate now rejects.
+    def _rxd_tx(out_spk: bytes, value: int = 1000, *, spend_covenant: bool = True) -> bytes:
+        src_txid = "ab" * 32 if spend_covenant else "00" * 32
         tx = _Tx()
-        tx.add_input(TransactionInput(source_txid="00" * 32, source_output_index=0, unlocking_script=Script(b"")))
+        tx.add_input(TransactionInput(source_txid=src_txid, source_output_index=0, unlocking_script=Script(b"")))
         tx.add_output(TransactionOutput(locking_script=Script(out_spk), satoshis=value))
         return tx.serialize()
 
@@ -737,11 +823,15 @@ def _self_check() -> int:
     check("RXD spent to neither holder -> ANOMALOUS", a4 is AssetLeg.ANOMALOUS)
     a5, _ = verify_asset_leg(m, _rxd_tx(b"\x00\x14" + b"\xff" * 20), claim)  # funding to a wrong SPK
     check("RXD wrong funding SPK -> ANOMALOUS", a5 is AssetLeg.ANOMALOUS)
-    # value integrity: under-funded covenant + short-changed payout each raise a warning note.
-    _, a6_notes = verify_asset_leg(m, _rxd_tx(funded_spk, value=500), claim)
-    check("RXD under-funded covenant -> value warning", any("under/over-funded" in n for n in a6_notes))
-    _, a7_notes = verify_asset_leg(m, _rxd_tx(funded_spk, 1000), _rxd_tx(taker_holder, 900))
-    check("RXD short-changed payout -> value warning", any("value not conserved" in n for n in a7_notes))
+    # PROVENANCE regression (the free-option false-PASS): a decoy paying the taker holder that does NOT
+    # spend the covenant must be ANOMALOUS, not TAKER_CLAIMED.
+    a_decoy, _ = verify_asset_leg(m, funding, _rxd_tx(taker_holder, spend_covenant=False))
+    check("RXD decoy (pays taker, doesn't spend covenant) -> ANOMALOUS", a_decoy is AssetLeg.ANOMALOUS)
+    # value integrity is verdict-affecting: under-funded covenant + short-changed payout each ANOMALOUS.
+    a6, _ = verify_asset_leg(m, _rxd_tx(funded_spk, value=500), claim)
+    check("RXD under-funded covenant -> ANOMALOUS", a6 is AssetLeg.ANOMALOUS)
+    a7, _ = verify_asset_leg(m, _rxd_tx(funded_spk, 1000), _rxd_tx(taker_holder, 900))
+    check("RXD short-changed payout -> ANOMALOUS", a7 is AssetLeg.ANOMALOUS)
 
     # 5) full happy-path through verify_from_bytes — manifest H must equal sha256(stub p) so the BTC claim
     #    actually reveals a matching preimage (counter -> MAKER_CLAIMED) and the asset goes to the taker.

--- a/tests/test_swap_run_verify.py
+++ b/tests/test_swap_run_verify.py
@@ -75,3 +75,86 @@ def test_independence_guard_rejects_shared_endpoint():
 
     with pytest.raises(ValueError):
         v.assert_independent_endpoints(["https://x.example/api"], ("https://x.example/api",))
+
+
+# ─────────────────── audit follow-ups: asset-leg provenance + value gates ───────────────────
+
+from pyrxd.script.script import Script
+from pyrxd.transaction.transaction import Transaction
+from pyrxd.transaction.transaction_input import TransactionInput
+from pyrxd.transaction.transaction_output import TransactionOutput
+
+
+def _rxd_tx(out_spk: bytes, value: int = 1000, spend_txid: str = "ab" * 32) -> bytes:
+    """A synthetic RXD tx whose single input spends spend_txid:0 and whose output[0] is out_spk."""
+    tx = Transaction()
+    tx.add_input(TransactionInput(source_txid=spend_txid, source_output_index=0, unlocking_script=Script(b"")))
+    tx.add_output(TransactionOutput(locking_script=Script(out_spk), satoshis=value))
+    return tx.serialize()
+
+
+def test_asset_leg_rejects_decoy_that_does_not_spend_the_covenant():
+    """Audit C1 (CRITICAL): the free-option false-PASS. A spend paying the taker holder but NOT consuming
+    the covenant outpoint must be ANOMALOUS, not TAKER_CLAIMED — otherwise a genuine one-sided loss (maker
+    refunds the asset AND claims the counter) scores PASS by citing a decoy txid."""
+    m = _m()  # covenant_funding = ab*32:0
+    funded, taker_holder, _maker_holder = v.rxd_expected_scripts(m)
+    funding = _rxd_tx(funded)
+    honest_claim = _rxd_tx(taker_holder, spend_txid="ab" * 32)  # spends the covenant
+    decoy = _rxd_tx(taker_holder, spend_txid="00" * 32)  # pays taker, does NOT spend the covenant
+
+    assert v.verify_asset_leg(m, funding, honest_claim)[0] is v.AssetLeg.TAKER_CLAIMED
+    assert v.verify_asset_leg(m, funding, decoy)[0] is v.AssetLeg.ANOMALOUS
+
+    # End-to-end: the decoy can no longer flip a real one-sided loss to PASS.
+    p = b"\xab" * 32
+    m2 = v.RunManifest(
+        swap_id="t2",
+        asset_variant="rxd",
+        counter_chain="btc",
+        honest_party="taker",
+        h_hex=v._sha256(p).hex(),
+        taker_pkh_hex="22" * 20,
+        maker_pkh_hex="33" * 20,
+        rxd_amount=1000,
+        refund_csv=48,
+        covenant_funding=v.Outpoint("ab" * 32, 0),
+        counter_funding=v.Outpoint("cd" * 32, 0),
+    )
+    f2, t2_holder, m2_holder = v.rxd_expected_scripts(m2)
+    btc_claim = v._btc_claim_stub(m2, p)  # maker claimed the counter (revealed p)
+    real_refund = _rxd_tx(m2_holder, spend_txid="ab" * 32)  # asset really refunded to the maker
+    assert v.run_verify(m2, _rxd_tx(f2), real_refund, btc_claim).verdict is v.Verdict.FAIL_ONE_SIDED
+    decoy_claim = _rxd_tx(t2_holder, spend_txid="00" * 32)  # decoy paying the taker
+    assert v.run_verify(m2, _rxd_tx(f2), decoy_claim, btc_claim).verdict is not v.Verdict.PASS
+
+
+def test_asset_leg_value_integrity_is_verdict_affecting():
+    """Audit F-B3: under-funded covenant and short-changed payout are ANOMALOUS, not note-only warnings."""
+    m = _m()
+    funded, taker_holder, _ = v.rxd_expected_scripts(m)  # m.rxd_amount == 1000
+    claim = _rxd_tx(taker_holder, spend_txid="ab" * 32)
+    assert v.verify_asset_leg(m, _rxd_tx(funded, value=500), claim)[0] is v.AssetLeg.ANOMALOUS  # under-funded
+    short = _rxd_tx(taker_holder, value=900, spend_txid="ab" * 32)
+    assert v.verify_asset_leg(m, _rxd_tx(funded, 1000), short)[0] is v.AssetLeg.ANOMALOUS  # short-changed
+
+
+def test_assert_no_secrets_hardening():
+    """Audit MED-2: named private-key fields and WIF-shaped values are caught; a clean journal full of
+    64-hex txids is NOT a false positive (a raw preimage is shape-identical to a txid, so it is guarded by
+    key name, never by a hex value scan)."""
+    import pytest
+
+    for doc in (
+        {"maker_private_key": "x"},
+        {"xprv": "x"},
+        {"account_priv_key": "x"},
+        {"note": "5Kb8kLf9zgWQnogidDA76MzPL6TsZZY36hWXMssSzNydYXYB9KF"},
+    ):
+        with pytest.raises(ValueError):
+            v.assert_no_secrets(doc, what="journal")
+    # clean journal: 64-hex txids everywhere must pass.
+    v.assert_no_secrets(
+        {"steps": [{"txid": "cd" * 32, "spend_txid": "ab" * 32, "state": "COMPLETED", "height": 444076}]},
+        what="journal",
+    )


### PR DESCRIPTION
First of two PRs from the post-0.10.0 security audit (11-agent review + red team). This one closes the single **CRITICAL** finding, in the two-party-run verifier `scripts/swap_run_verify.py`.

## The bug (audit C1)

`verify_asset_leg` classified the RXD asset disposition from the cited spend's `output[0]` script alone — **it never checked the spend consumes the covenant funding outpoint**. The sibling `verify_counter_leg_btc` does exactly this prevout check; the asset leg lacked it. Since holder scripts are plain P2PKH (the party's ordinary address), *any* confirmed tx paying that address scored as a "claim." So a genuine one-sided loss — maker CSV-refunds the asset **and** claims the counter leg revealing `p` — could be scored **PASS** by citing a decoy txid (even a 1-photon dust payment to the taker's address). The `--self-check` baked the gap in (synthetic claims used `source_txid="00"*32`, never spending the covenant, yet asserted `TAKER_CLAIMED`).

**Confirmed with a repro** (from the red team, re-run by me): honest citation → `FAIL_ONE_SIDED`; decoy txid → `PASS`. After the fix: decoy → `ANOMALOUS` ("does not consume the covenant funding outpoint — provenance fail"), honest run unchanged.

Context: this verifier is the P1 audit tool (the "live half" of the hard gate before real-value swaps). It has **not yet been used to gate any real run**, so there was no live exposure — but the tool exists precisely to catch this free-option attack, and it didn't. It must be sound before it's relied on.

## Fix

- **Provenance (C1):** `verify_asset_leg` now requires `m.covenant_funding.prevout ∈ inputs(spend)` via a new `_rxd_input_prevouts` (mirrors `btc_input_outpoints_from_raw`). A confirmed spend of the *real* covenant to the taker holder necessarily satisfied the hashlock at consensus, so re-scraping `p` (unreliable for non-segwit RXD — `p` is in the scriptSig, not a witness) is redundant.
- **Value integrity (F-B3):** under-funded covenant and short-changed payout are now `ANOMALOUS`, not note-only WARNINGs a PASS could sail past.
- **Txid pin (C1c):** `_RxdFetcher.raw_tx` now pins returned bytes to the requested txid — it was the lone fetcher trusting server bytes; `resolve.fetch_transaction` and `MempoolSpaceSource` already pin.
- **Confirmation gate:** a cited covenant-spend must be confirmed (mirrors the BTC leg's `min_confirmations=1`) so a fabricated unconfirmed tx can't satisfy provenance with a junk scriptSig.
- **Secret guard (MED-2):** broadened the forbidden-key set (`private_key`/`priv`/`key`/`xprv`/`entropy`) and added a WIF-shaped value scan — deliberately limited to the WIF shape, because a raw preimage is 64-hex and indistinguishable from a txid, so it's guarded by key name to avoid false-positiving every legitimate journal txid.
- Documented the intentionally-dead `asset_p_sha256` slot (don't rewire raw `p` — reintroduces the #273 CodeQL taint) and the advisory nature of the independence guard.

## Verification

`--self-check` green; 8 tests green including new regressions: decoy-rejection, the end-to-end no-longer-false-PASS, value-integrity gating, and secret-guard hardening (incl. the txid non-false-positive). No behavioral change to honest runs.

*Audit note:* one agent-reported MEDIUM (high-S signature malleability) was **refuted** during verification — libsecp256k1 enforces low-S on verify (8/8 high-S rejected in my test); not included. PR 2 (RSWP library/CLI follow-ups: tracker forge, book-browse DoS, query correspondence, FT-demand consent display) is separate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)