### PR TITLE
fix(swap): recovery role guard + covenant CSV maturity pre-check (P3)

### DIFF
--- a/src/pyrxd/gravity/swap_coordinator.py
+++ b/src/pyrxd/gravity/swap_coordinator.py
@@ -62,6 +62,7 @@ from .swap_state import (
     NegotiatedTerms,
     SwapEvent,
     SwapRecord,
+    SwapRole,
     SwapState,
     advance,
 )
@@ -914,6 +915,12 @@ class CoordinatorConfig:
     # Min confirmations a gating credential's live UTXO must have (reorg safety),
     # when a swap sets terms.credential_ref. Mirrors min_ref_confirmations.
     min_credential_confirmations: int = 6
+    # Which side this coordinator drives (P3 role guard). ``None`` = the legacy
+    # single-operator flow where one coordinator drives both legs; a genuine
+    # two-party deployment sets the honest party's role so role-scoped recovery
+    # guards (e.g. the taker-stranding asset-only refund) fail closed in code, not
+    # merely in a docstring.
+    role: SwapRole | None = None
 
     def __post_init__(self) -> None:
         if not isinstance(self.margin_policy, MarginPolicy):
@@ -931,6 +938,8 @@ class CoordinatorConfig:
             raise ValidationError("accept_nondurable_seen must be a bool")
         if not isinstance(self.accept_estimated_eth_margins, bool):
             raise ValidationError("accept_estimated_eth_margins must be a bool")
+        if self.role is not None and not isinstance(self.role, SwapRole):
+            raise ValidationError("role must be a SwapRole or None")
 
 
 def _serialized_step(method):
@@ -1846,6 +1855,18 @@ class SwapCoordinator:
         and ETH runbooks is :meth:`mutual_refund` (refunds BOTH legs after both timeouts). The
         watchtower (gravity.watch.decide) routes neither counter-chain's taker here.
         """
+        # ROLE GUARD (P3): this primitive's CSV refund pays the MAKER in BOTH directions, so a TAKER
+        # that runs it gifts the asset back AND destroys its only recourse (the claimable covenant)
+        # while its own counter-leg stays locked — the maker, still holding p, then takes both legs
+        # (proven by tests/test_xchain_swap_regtest_e2e.py::TestMakerStallAssetOnlyRefundIsTakerLoss).
+        # The docstring has always said "MAKER-side only"; a TAKER-role coordinator now cannot call it
+        # at all. The taker's stall recovery is mutual_refund (both legs unwind, no one-sided loss).
+        if self.config.role is SwapRole.TAKER:
+            raise ValidationError(
+                "maybe_refund_asset_on_maker_stall is a MAKER-side primitive and is forbidden for a "
+                "TAKER-role coordinator: its CSV refund pays the MAKER, so a taker that runs it strands "
+                "itself. The taker's maker-stall recovery is mutual_refund (P3 role guard)."
+            )
         if self.record.state is not SwapState.BOTH_LOCKED:
             raise ValidationError(
                 f"maybe_refund_asset_on_maker_stall only valid from BOTH_LOCKED, not {self.record.state.value}"
@@ -1860,6 +1881,23 @@ class SwapCoordinator:
         )
         if not trigger:
             return self.record
+        # MATURITY PRE-CHECK (P3): the trigger fires N blocks BEFORE t_rxd maturity ("stop waiting"),
+        # but the covenant's CSV refund cannot be MINED until it is buried t_rxd deep. Broadcasting at
+        # trigger time (t_rxd - N) is non-final — a real node rejects it, and under deadline pressure a
+        # hostile mempool (deadline-pinning) makes "rely on node rejection" fragile. Refuse to broadcast
+        # before maturity with an exact "matures at height N, now M" message; a block-based poller
+        # retries at maturity. (Uses the SAME normalize_to(BLOCKS) as the trigger so the two agree.)
+        rxd_blocks = self.record.terms.t_rxd.normalize_to(
+            TimeUnit.BLOCKS, block_interval_s=self.config.margin_policy.block_interval_s
+        ).value
+        maturity_height = asset_locked_at_height + rxd_blocks
+        if now_block_height < maturity_height:
+            raise ValidationError(
+                f"covenant CSV refund is not yet mature: it matures at height {maturity_height}, now "
+                f"{now_block_height} ({maturity_height - now_block_height} block(s) to go). Refusing to "
+                "broadcast a non-final refund (P3 maturity pre-check) — poll and retry at maturity "
+                "rather than relying on node rejection under deadline pressure."
+            )
         # BROADCAST-THEN-ADVANCE (red-team LOW): advancing to MAKER_STALLS before the on-chain
         # refund broadcast wedges the swap there (maybe_refund is only valid from BOTH_LOCKED) if
         # the broadcast transiently fails. Broadcast FIRST — a raising refund leaves the record at

--- a/src/pyrxd/gravity/swap_state.py
+++ b/src/pyrxd/gravity/swap_state.py
@@ -83,6 +83,21 @@ class SwapState(Enum):
     # ABORTED terminal (no asset, no BTC was ever locked → nothing to recover).
 
 
+class SwapRole(Enum):
+    """Which side of the swap a coordinator instance is driving.
+
+    Used for role-scoped safety guards: a recovery primitive that is safe for one
+    role can be self-destructive for the other (e.g. the asset-only CSV refund pays
+    the MAKER, so a TAKER that runs it strands itself). ``None`` (role unset)
+    preserves the legacy single-operator flows where one coordinator drives BOTH
+    legs; a genuine two-party deployment sets the honest party's role so the guard
+    can fail closed instead of relying on a docstring warning.
+    """
+
+    MAKER = "maker"
+    TAKER = "taker"
+
+
 # The diagram's ``--> [*]`` sinks. No transition may leave a terminal state.
 TERMINAL_STATES: frozenset[SwapState] = frozenset(
     {

--- a/tests/test_swap_coordinator.py
+++ b/tests/test_swap_coordinator.py
@@ -47,6 +47,7 @@ from pyrxd.gravity.swap_coordinator import (
 from pyrxd.gravity.swap_state import (
     NegotiatedTerms,
     SwapRecord,
+    SwapRole,
     SwapState,
 )
 from pyrxd.security.errors import NetworkError, ValidationError
@@ -260,7 +261,9 @@ def _terms(*, variant: str = "ft", t_btc_blocks: int = 144, t_rxd_blocks: int = 
     )
 
 
-def _coordinator(*, terms, btc_leg=None, radiant_leg=None, indexer=None, seen_store=None, policy=None, window=6):
+def _coordinator(
+    *, terms, btc_leg=None, radiant_leg=None, indexer=None, seen_store=None, policy=None, window=6, role=None
+):
     rec = SwapRecord(state=SwapState.NEGOTIATED, terms=terms)
     return SwapCoordinator(
         record=rec,
@@ -271,6 +274,7 @@ def _coordinator(*, terms, btc_leg=None, radiant_leg=None, indexer=None, seen_st
         config=CoordinatorConfig(
             margin_policy=policy or MarginPolicy.estimated(),
             maker_stall_safety_window_blocks=window,
+            role=role,
         ),
     )
 
@@ -790,16 +794,62 @@ async def test_e2e_maker_stalls_taker_refunds_asset():
     await coord.post_asset_lock_revalidate(await rxd.expected_covenant_scriptpubkey(terms))
     assert coord.record.state is SwapState.BOTH_LOCKED
 
-    # Maker stalls: hasn't claimed and we are within N of t_RXD maturity.
-    # locked at 1000; maturity = 1072; act at >= 1066.
+    # Maker stalls: hasn't claimed and the covenant's CSV refund is now MATURE.
+    # locked at 1000; maturity = 1072; the CSV refund can only be MINED at >= 1072
+    # (the trigger fires N earlier at 1066, but the P3 maturity pre-check refuses to
+    # broadcast a non-final refund — see test_maker_stall_refuses_premature_refund).
     rec = await coord.maybe_refund_asset_on_maker_stall(
-        now_block_height=1066, asset_locked_at_height=1000, maker_has_claimed_btc=False
+        now_block_height=1072, asset_locked_at_height=1000, maker_has_claimed_btc=False
     )
     assert rec.state is SwapState.ASSET_REFUNDED_TAKER_ACTS
     assert rxd.refunded  # the covenant CSV refund was broadcast — it pays the MAKER, not the taker.
     # NOTE: this exercises the helper's mechanics only. The CSV refund pays the maker (maker owns the
     # covenant), so this is NOT a taker recovery — the watchtower routes a taker to mutual_refund
     # instead (FSM finding #2, 2026-06-09). See test_xchain_swap_regtest_e2e for the taker-loss proof.
+
+
+async def test_maker_stall_refuses_premature_refund():
+    """P3 maturity pre-check: the trigger fires at t_rxd-N ("stop waiting"), but the CSV refund can
+    only be mined at maturity. Between trigger-fire and maturity the method must REFUSE to broadcast a
+    non-final refund (rather than emit a tx a real node rejects), with an exact "matures at N, now M"
+    message a block-based poller can act on — and it must NOT broadcast or advance the FSM."""
+    _p, h = generate_secret()
+    terms = _terms(hashlock=h, t_rxd_blocks=72)
+    rxd = FakeRadiantLeg()
+    coord = _coordinator(terms=terms, radiant_leg=rxd, window=6)
+    await coord.taker_funds_btc(terms)
+    await coord.post_asset_lock_revalidate(await rxd.expected_covenant_scriptpubkey(terms))
+    assert coord.record.state is SwapState.BOTH_LOCKED
+
+    # locked at 1000; maturity = 1072; trigger fires at 1066 but the covenant is 6 blocks short of
+    # CSV maturity — refuse to broadcast.
+    with pytest.raises(ValidationError, match="not yet mature.*matures at height 1072, now 1066"):
+        await coord.maybe_refund_asset_on_maker_stall(
+            now_block_height=1066, asset_locked_at_height=1000, maker_has_claimed_btc=False
+        )
+    assert not rxd.refunded, "no non-final refund may be broadcast before CSV maturity"
+    assert coord.record.state is SwapState.BOTH_LOCKED, "the FSM must stay BOTH_LOCKED (retryable)"
+
+
+async def test_maker_stall_forbidden_for_taker_role():
+    """P3 role guard: the asset-only CSV refund pays the MAKER, so a TAKER that runs it strands itself.
+    A TAKER-role coordinator must be PHYSICALLY unable to call it (fail closed in code, not merely in a
+    docstring) — even at a mature height where a role-less coordinator would broadcast."""
+    _p, h = generate_secret()
+    terms = _terms(hashlock=h, t_rxd_blocks=72)
+    rxd = FakeRadiantLeg()
+    coord = _coordinator(terms=terms, radiant_leg=rxd, window=6, role=SwapRole.TAKER)
+    await coord.taker_funds_btc(terms)
+    await coord.post_asset_lock_revalidate(await rxd.expected_covenant_scriptpubkey(terms))
+    assert coord.record.state is SwapState.BOTH_LOCKED
+
+    # Mature height (1072) — a role-less coordinator would broadcast here; the taker role must not.
+    with pytest.raises(ValidationError, match="forbidden for a TAKER-role coordinator"):
+        await coord.maybe_refund_asset_on_maker_stall(
+            now_block_height=1072, asset_locked_at_height=1000, maker_has_claimed_btc=False
+        )
+    assert not rxd.refunded, "a taker-role coordinator must never broadcast the asset-only refund"
+    assert coord.record.state is SwapState.BOTH_LOCKED
 
 
 async def test_maker_stall_noop_before_window():


### PR DESCRIPTION
Advances the two-party adversarial-run plan's **P3 (wired recovery phase)**. Both fixes below were previously enforced only by docstring / node behaviour, not by code. Scoped to the one recovery primitive whose heights are in-signature and fully unit-verifiable.

## Role guard (P3c)
`maybe_refund_asset_on_maker_stall`'s CSV refund pays the **MAKER** in both covenant directions, so a **TAKER** that runs it gifts the asset back *and* destroys its only recourse while its own counter-leg stays locked — the maker, still holding `p`, then takes both legs (already proven by `test_xchain_swap_regtest_e2e::TestMakerStallAssetOnlyRefundIsTakerLoss`). The docstring has always said "MAKER-side only"; a new `SwapRole` on `CoordinatorConfig` now makes a TAKER-role coordinator **physically unable** to call it. `role=None` (default) preserves the legacy single-operator flows; a genuine two-party deployment sets the honest party's role so the guard fails closed.

## Maturity pre-check (P3a/b)
The C1 trigger fires `N` blocks **before** `t_rxd` maturity ("stop waiting"), but the covenant CSV refund cannot be mined until buried `t_rxd` deep. The method broadcast at trigger time (`t_rxd - N`) — a non-final tx a real node rejects; under a deadline-pinning mempool, "rely on node rejection" is fragile. It now refuses to broadcast before maturity with an exact **"matures at height N, now M"** message a block-based poller retries on, using the *same* `normalize_to(BLOCKS)` computation as the trigger.

A pre-existing unit test (`test_e2e_maker_stalls_taker_refunds_asset`) had encoded the premature broadcast at height 1066 (maturity 1072) — it only passed because `FakeRadiantLeg` doesn't enforce CSV maturity. Corrected to call at maturity, with two new tests: premature-call-refused and taker-role-forbidden.

## Scope / next slice
Only this primitive. Extending the same maturity gate to `mutual_refund` / `taker_refund_btc` (counter-leg `t_btc` CSV + covenant `t_rxd`) needs chain-height plumbing and regtest verification — tracked as the next P3 slice. Both regtest callers already mine to maturity before calling, so they are unaffected.

## Verification
`task ci` green locally (4779 passed, 88.81% coverage, mypy clean, private-links clean). New/updated unit tests: `test_maker_stall_refuses_premature_refund`, `test_maker_stall_forbidden_for_taker_role`, `test_e2e_maker_stalls_taker_refunds_asset`.