### PR TITLE
feat(swap): first-class taker_observed_reveal transition (removes the resume seam)

### DIFF
--- a/scripts/eth_swap_two_host.py
+++ b/scripts/eth_swap_two_host.py
@@ -461,13 +461,20 @@ async def taker_phase_claim(args: argparse.Namespace) -> None:
     if fee_source is None:
         raise SystemExit("taker claim needs a regtest fee UTXO (see --fee-* flags)")
     rxd_leg = _radiant_leg(args, taker_pkh=taker_pkh, maker_pkh=maker_pkh, fee_source=fee_source)
-    # Rebuild the coordinator with the funded counter-leg locator attached (so the FSM is at
-    # BOTH_LOCKED/SECRET_REVEALED — the resume seam mirrors dust_swap_resume.py).
+    # Rebuild the coordinator with the funded counter-leg locator attached (resume at BOTH_LOCKED —
+    # the resume seam mirrors dust_swap_resume.py). We advance to SECRET_REVEALED below via the
+    # first-class taker_observed_reveal, which VERIFIES the maker's on-chain reveal before advancing.
     loc = EthHtlcLocator.from_dict(_read_public(io_dir, "taker_funding.json")["eth_locator"])
-    record = SwapRecord(state=SwapState.SECRET_REVEALED, terms=terms).with_counter_lock(loc)
+    record = SwapRecord(state=SwapState.BOTH_LOCKED, terms=terms).with_counter_lock(loc)
     coord = _coordinator(args, terms=terms, eth_leg=eth_leg, rxd_leg=rxd_leg, keys_out=args.local_out, record=record)
 
     try:
+        # First-class observe-reveal (replaces the old fabricated-SECRET_REVEALED seam): verify the
+        # maker's on-chain ETH claim genuinely reveals THIS swap's p — sha256(p)==H + the R6 provenance
+        # gate, all read FROM CHAIN — and advance BOTH_LOCKED -> SECRET_REVEALED. A fabricated or
+        # cross-swap "reveal" fails closed here rather than entering the claim flow.
+        confirm("taker_observed_reveal: verify the maker's on-chain reveal before claiming", auto_yes=args.yes)
+        await coord.taker_observed_reveal(eth_claim_tx)
         deadline = time.monotonic() + args.resume_deadline_s
         print(
             f"  scraping p from the maker's ETH claim {eth_claim_tx} + reorg-gated RXD claim (deadline {args.resume_deadline_s:.0f}s)"
@@ -625,9 +632,7 @@ async def maker_phase_lock_claim(args: argparse.Namespace) -> None:
         # 2. Lock the RXD covenant: the operator funds the SPK out-of-band, then we re-validate.
         print(f"\n  Fund the RXD covenant SPK on regtest now (>= 1 conf):\n    {covenant_spk_hex}")
         confirm("you have funded the RXD covenant SPK on regtest and it has >= 1 conf", auto_yes=args.yes)
-        rec = await coord.post_asset_lock_revalidate(
-            bytes.fromhex(covenant_spk_hex), now_unix_s=int(time.time())
-        )
+        rec = await coord.post_asset_lock_revalidate(bytes.fromhex(covenant_spk_hex), now_unix_s=int(time.time()))
         if rec.state is not SwapState.BOTH_LOCKED:
             raise SystemExit(f"covenant/timing mismatch -> {rec.state.value}; refund the ETH HTLC after its timeout")
         print(f"  -> {rec.state.value}")

--- a/src/pyrxd/gravity/swap_coordinator.py
+++ b/src/pyrxd/gravity/swap_coordinator.py
@@ -1611,6 +1611,52 @@ class SwapCoordinator:
                 "refusing to scrape p (wrong or cross-swap claim tx)"
             )
 
+    # -- taker OBSERVES the maker's on-chain reveal (two-party step 4.5) ----
+    @_serialized_step
+    async def taker_observed_reveal(self, maker_claim_ref) -> SwapRecord:
+        """Advance BOTH_LOCKED -> SECRET_REVEALED on OBSERVING the maker's on-chain claim.
+
+        The honest TAKER never executes the maker's claim (that is the maker's key/action, on a
+        different host); it OBSERVES the reveal on-chain and must then enter the claim flow. The only
+        other path to SECRET_REVEALED is :meth:`maker_claims_btc` — a MAKER action — so two-party
+        callers previously FABRICATED a SECRET_REVEALED record as a resume seam
+        (``scripts/eth_swap_two_host.py``) or advanced the FSM directly in tests. This is the
+        first-class taker-side transition that replaces both seams.
+
+        It VERIFIES the observed claim is a genuine reveal of THIS swap's ``p`` before advancing —
+        ``sha256(p) == H`` scraped from the claim AND the per-swap provenance gate (BTC: the claim
+        spends OUR funding outpoint; ETH: it targets OUR HTLC contract and emits ``Claimed(p)``). A
+        fabricated or cross-swap "reveal" fails closed and does NOT move the FSM.
+
+        It deliberately does NOT claim the asset and does NOT run the reorg/finality gate — those stay
+        in :meth:`taker_scrape_and_claim_asset`, which the caller invokes NEXT (that gate decides
+        SAFE/WAIT/SQUEEZED off the same reveal). ``maker_claim_ref`` is the ETH claim tx HASH (str) or
+        the raw BTC claim tx bytes — exactly what :meth:`taker_scrape_and_claim_asset` takes.
+        """
+        if self.record.state is not SwapState.BOTH_LOCKED:
+            raise ValidationError(f"taker_observed_reveal only valid from BOTH_LOCKED, not {self.record.state.value}")
+        # Prove the observed claim genuinely reveals THIS swap's p (fail-closed) BEFORE advancing —
+        # the SAME scrape + provenance the claim step re-runs, minus the finality gate + broadcast.
+        if self.record.terms.counter_chain == "btc":
+            p = self.counter_leg.scrape_secret(maker_claim_ref, self.record.terms.hashlock)
+            if hashlib.sha256(bytes(p)).digest() != self.record.terms.hashlock:
+                raise ValidationError("observed claim does not reveal a p that opens H; refusing to advance")
+            self._assert_claim_tx_spends_our_htlc(maker_claim_ref)
+        else:
+            locator = self.record.counterchain_locator
+            if not isinstance(locator, EthHtlcLocator):
+                raise ValidationError("ETH reveal-observation requires an EthHtlcLocator on the record")
+            artifacts = await self.counter_leg.fetch_claim_artifacts(maker_claim_ref)
+            p = self.counter_leg.scrape_secret(artifacts, self.record.terms.hashlock)
+            if hashlib.sha256(bytes(p)).digest() != self.record.terms.hashlock:
+                raise ValidationError("observed claim does not reveal a p that opens H; refusing to advance")
+            await self.counter_leg.assert_claim_provenance(
+                maker_claim_ref, contract_address=locator.contract_address, preimage=bytes(p)
+            )
+        self._advance(SwapEvent.MAKER_CLAIMS_BTC_REVEALS_P)
+        await self._persist_record(self.record, shield=True)
+        return self.record
+
     # -- taker scrapes p from the claim tx and claims the asset (step 5) ----
     @_serialized_step
     async def taker_scrape_and_claim_asset(

--- a/tests/test_swap_coordinator.py
+++ b/tests/test_swap_coordinator.py
@@ -729,6 +729,70 @@ async def test_e2e_happy_path_completed():
 
 
 # ---------------------------------------------------------------------------
+# Two-party: the taker OBSERVES the maker's on-chain reveal (never executes it)
+# ---------------------------------------------------------------------------
+
+
+async def test_taker_observed_reveal_advances_then_claims():
+    """Two-party seam replacement: the honest taker OBSERVES the maker's on-chain claim (it never runs
+    maker_claims_btc — that is the maker's key/action on another host) and advances BOTH_LOCKED ->
+    SECRET_REVEALED via taker_observed_reveal, which verifies sha256(p)==H + the provenance gate from
+    the tx. The claim step then completes the swap."""
+    p_secret, h = generate_secret()
+    terms = _terms(hashlock=h)
+    btc = FakeBtcLeg()
+    rxd = FakeRadiantLeg()
+    coord = _coordinator(terms=terms, btc_leg=btc, radiant_leg=rxd, role=SwapRole.TAKER)
+
+    await coord.taker_funds_btc(terms)
+    await coord.post_asset_lock_revalidate(await rxd.expected_covenant_scriptpubkey(terms))
+    assert coord.record.state is SwapState.BOTH_LOCKED
+
+    # The maker claimed BTC on another host, publishing p on-chain. The honest taker only ever sees
+    # the claim tx (built here from the public locator + the now-public p); it never called claim.
+    claim_tx = _real_maker_claim_tx(coord.record.btc_locator, p_secret.unsafe_raw_bytes())
+    rec = await coord.taker_observed_reveal(claim_tx)
+    assert rec.state is SwapState.SECRET_REVEALED
+    assert "claim" not in btc.calls, "the honest taker must NOT have executed the maker's claim"
+
+    rec = await coord.taker_scrape_and_claim_asset(claim_tx, now_rxd_height=1000, asset_locked_at_height=1000)
+    assert rec.state is SwapState.COMPLETED
+    assert rxd.claimed_with is not None and hashlib.sha256(rxd.claimed_with).digest() == h
+
+
+async def test_taker_observed_reveal_rejects_foreign_reveal():
+    """A syntactically-valid claim tx from a DIFFERENT swap (it reveals p2, which opens H2 not our H)
+    must fail closed and leave the FSM at BOTH_LOCKED — a foreign/cross-swap "reveal" cannot push the
+    taker into the claim flow."""
+    _p1, h1 = generate_secret()
+    coord = _coordinator(terms=_terms(hashlock=h1), role=SwapRole.TAKER)
+    await coord.taker_funds_btc(coord.record.terms)
+    await coord.post_asset_lock_revalidate(await coord.radiant_leg.expected_covenant_scriptpubkey(coord.record.terms))
+    assert coord.record.state is SwapState.BOTH_LOCKED
+
+    # A REAL claim tx from a different swap (its own H2/p2) — reveals p2, which does not open our H1.
+    p2, h2 = generate_secret()
+    other = _coordinator(terms=_terms(hashlock=h2))
+    await other.taker_funds_btc(other.record.terms)
+    foreign_claim = _real_maker_claim_tx(other.record.btc_locator, p2.unsafe_raw_bytes())
+    with pytest.raises((ValidationError, Exception)):
+        await coord.taker_observed_reveal(foreign_claim)
+    assert coord.record.state is SwapState.BOTH_LOCKED, "a foreign reveal must not advance the FSM"
+
+
+async def test_taker_observed_reveal_only_from_both_locked():
+    """taker_observed_reveal is only valid from BOTH_LOCKED (both legs locked; the reveal is what
+    arms the claim flow)."""
+    p_secret, h = generate_secret()
+    terms = _terms(hashlock=h)
+    coord = _coordinator(terms=terms, role=SwapRole.TAKER)
+    await coord.taker_funds_btc(terms)  # BTC_LOCKED, not yet BOTH_LOCKED
+    claim_tx = _real_maker_claim_tx(coord.record.btc_locator, p_secret.unsafe_raw_bytes())
+    with pytest.raises(ValidationError, match="only valid from BOTH_LOCKED"):
+        await coord.taker_observed_reveal(claim_tx)
+
+
+# ---------------------------------------------------------------------------
 # SIMULATED: MUTUAL_REFUND (maker never claims)
 # ---------------------------------------------------------------------------
 

--- a/tests/test_xchain_eth_active_adversary_e2e.py
+++ b/tests/test_xchain_eth_active_adversary_e2e.py
@@ -16,12 +16,11 @@ SwapState.
 What this proves / what it does NOT: separation is at the OBJECT + secret level (the honest
 coordinator never receives `p` and never broadcasts the reveal — asserted). Fully separate OS
 processes / hosts / independent chain access are P4 (two-host networked regtest); this runs both sides
-in one process against one shared regtest node + anvil. Recovering off the *observed* reveal still
-requires advancing the taker FSM to SECRET_REVEALED — for which there is no first-class coordinator
-method; the production two-host harness fabricates that state as a resume seam
-(`eth_swap_two_host.py:467`). We use the same FSM event `maker_claims_btc` uses, WITHOUT the honest
-side ever holding/broadcasting `p`. **P2 finding:** a first-class `taker_observed_reveal()` transition
-would remove the need for either seam.
+in one process against one shared regtest node + anvil. The honest taker enters the claim flow off the
+*observed* reveal via the first-class `SwapCoordinator.taker_observed_reveal()` transition, which
+verifies the reveal FROM CHAIN (`sha256(p)==H` + the R6 provenance gate) before advancing
+BOTH_LOCKED -> SECRET_REVEALED — replacing the resume-seam that fabricated that state
+(`eth_swap_two_host.py`). The honest side never holds or broadcasts `p`.
 
 Run it:  XCHAIN_ETH_REGTEST=1 pytest tests/test_xchain_eth_active_adversary_e2e.py -m integration -s
 """
@@ -43,7 +42,7 @@ sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 from pyrxd.eth_wallet.htlc_leg import EthHtlcContractLeg
 from pyrxd.eth_wallet.rpc import EthRpc
 from pyrxd.gravity.eth_leg import EthLeg
-from pyrxd.gravity.swap_state import SwapEvent, SwapRole, SwapState
+from pyrxd.gravity.swap_state import SwapRole, SwapState
 from pyrxd.security.secrets import PrivateKeyMaterial
 
 # Reuse the real chain harness from the happy-path e2e (one source of truth for node/anvil/legs).
@@ -143,13 +142,12 @@ class TestEthActiveAdversary:
             claim_hash = await adv.claim_eth_revealing_p(locator)
             _anvil_mine(url, 3)  # finalize the ETH claim (anvil --slots-in-an-epoch 1 → finalized=latest-2)
 
-            # 4. The honest taker OBSERVES the reveal on-chain and advances to SECRET_REVEALED. There
-            #    is no first-class "observe reveal" coordinator method (see the module docstring / P2
-            #    finding); we advance the FSM via the SAME event maker_claims_btc uses — WITHOUT the
-            #    honest side holding or broadcasting p.
+            # 4. The honest taker OBSERVES the reveal on-chain: taker_observed_reveal fetches the claim
+            #    by its PUBLIC hash, verifies sha256(p)==H + the R6 provenance gate FROM CHAIN, and
+            #    advances BOTH_LOCKED -> SECRET_REVEALED. The honest side never holds/broadcasts p.
             assert coord.record.state is SwapState.BOTH_LOCKED
-            coord._advance(SwapEvent.MAKER_CLAIMS_BTC_REVEALS_P)
-            assert coord.record.state is SwapState.SECRET_REVEALED
+            rec = await coord.taker_observed_reveal(claim_hash)
+            assert rec.state is SwapState.SECRET_REVEALED
 
             # 5. Honest taker recovers p FROM THE CHAIN (fetch calldata+logs by the public claim hash),
             #    runs the R6 provenance + finalized-checkpoint reorg gate, then claims the covenant
@@ -209,8 +207,8 @@ class TestEthActiveAdversary:
             # Active reveal — anvil auto-mines the claim (1 block) so it is MINED but NOT finalized
             # (finalized = latest-2). We do NOT mine 3 more, so the finality gate sees a non-final claim.
             claim_hash = await adv.claim_eth_revealing_p(locator)
-            coord._advance(SwapEvent.MAKER_CLAIMS_BTC_REVEALS_P)
-            assert coord.record.state is SwapState.SECRET_REVEALED
+            rec = await coord.taker_observed_reveal(claim_hash)
+            assert rec.state is SwapState.SECRET_REVEALED
 
             # Drive RXD to the edge of t_rxd maturity while the ETH claim stays non-final → the gate
             # has no room left to WAIT for finality → SQUEEZED → ASSET_VULNERABLE (deliberate, not silent).


### PR DESCRIPTION
Follow-up from the P2 harness (#293), resolving the finding it surfaced.

## The gap
The honest taker never executes the maker's claim (the maker's key/action on another host) — it **observes** the reveal on-chain and must then enter the claim flow. But the only transition to `SECRET_REVEALED` was `maker_claims_btc` (a *maker* action), so two-party callers either **fabricated** a `SECRET_REVEALED` record as a resume seam (`eth_swap_two_host.py`) or advanced the FSM directly in tests — advancing **without verifying the reveal was real**.

## The change
`SwapCoordinator.taker_observed_reveal(maker_claim_ref)` — from `BOTH_LOCKED` it **verifies** the observed claim is a genuine reveal of *this* swap's `p`:
- `sha256(p) == H` scraped from the claim, **and**
- the per-swap provenance gate (BTC: the claim spends **our** funding outpoint; ETH: it targets **our** HTLC contract and emits `Claimed(p)`),

all read **from chain** — then advances to `SECRET_REVEALED`. A fabricated or cross-swap "reveal" **fails closed** and does not move the FSM. It deliberately does **not** claim and does **not** run the reorg/finality gate — those stay in `taker_scrape_and_claim_asset`, invoked next.

## Wiring + tests
- `eth_swap_two_host.py`: the taker step now resumes at `BOTH_LOCKED` and calls `taker_observed_reveal(eth_claim_tx)` — replacing the fabricated-`SECRET_REVEALED` seam (which advanced the FSM without verifying the reveal).
- `test_xchain_eth_active_adversary_e2e.py` (A1/A2): now drive the real method instead of a raw `_advance`; both consensus-proven on regtest + anvil (2 passed).
- `test_swap_coordinator.py`: 3 BTC unit tests — observe→advance→claim; foreign/cross-swap reveal rejected (stays `BOTH_LOCKED`); only-valid-from-`BOTH_LOCKED`.

Additive — existing S1–S7 / `maker_claims_btc` paths unchanged. Coordinator+state suites green (144); harness `py_compile` + ruff clean; `task ci` green (pre-push gate).