### PR TITLE
fix(swap): covenant CSV refund maturity self-check in the leg (P3-rest)

### DIFF
--- a/src/pyrxd/gravity/radiant_leg.py
+++ b/src/pyrxd/gravity/radiant_leg.py
@@ -513,10 +513,29 @@ class RadiantCovenantLeg:
         return await self._broadcast(tx)
 
     async def refund_asset(self, record: SwapRecord) -> str:
-        """Build + broadcast the MAKER's CSV refund spend. Returns the txid."""
+        """Build + broadcast the MAKER's CSV refund spend. Returns the txid.
+
+        P3 maturity self-check: the covenant's CSV refund leaf is only spendable once the covenant UTXO
+        is buried ``t_rxd`` deep (the BIP68 relative-block timelock the covenant was built with:
+        ``refund_csv=t_rxd.value``, mature at ``confirmations >= t_rxd.value``). Refuse a non-final
+        refund HERE rather than emit a tx a node rejects — under a deadline-pinning mempool "rely on
+        node rejection" is fragile — with an exact "needs N confirmations, has M" message a block-based
+        poller retries on. This guards EVERY ``refund_asset`` caller (``mutual_refund``,
+        ``maybe_refund_asset_on_maker_stall``) at the leg, complementing the coordinator-side height
+        check in ``maybe_refund_asset_on_maker_stall``. (The CLAIM branch has no CSV, so ``claim_asset``
+        is intentionally NOT gated this way.)
+        """
         if not isinstance(record, SwapRecord):
             raise ValidationError("record must be a SwapRecord")
         cov, outpoint, carrier = await self._resolve_covenant(record)
+        required_csv = record.terms.t_rxd.value
+        confs = await self.chain_io.confirmations(outpoint.split(":")[0])
+        if confs < required_csv:
+            raise NetworkError(
+                f"covenant CSV refund is not yet mature: needs {required_csv} confirmations, has {confs} "
+                f"({required_csv - confs} block(s) to go) — refusing to broadcast a non-final refund "
+                "(P3 maturity self-check); poll and retry at maturity rather than relying on node rejection."
+            )
         tx = build_htlc_refund_tx(
             covenant=cov,
             covenant_outpoint=outpoint,

--- a/tests/test_radiant_leg.py
+++ b/tests/test_radiant_leg.py
@@ -334,13 +334,38 @@ async def test_claim_asset_builds_and_broadcasts():
 
 
 async def test_refund_asset_builds_and_broadcasts():
-    terms = _rxd_terms(amount=100_000)
-    client = FakeClient(utxo_value=100_000, confirmations=3)
+    terms = _rxd_terms(amount=100_000)  # csv=6
+    # Mature: the covenant UTXO is buried >= t_rxd (6) deep, so the CSV refund is final.
+    client = FakeClient(utxo_value=100_000, confirmations=6)
     leg = _leg(client=client)
     rec = SwapRecord(state=SwapState.MAKER_STALLS, terms=terms, radiant_covenant_outpoint="cd" * 32 + ":0")
     txid = await leg.refund_asset(rec)
     assert txid == "ab" * 32
     assert len(client.broadcast_raw) == 1
+
+
+async def test_refund_asset_rejects_premature_csv():
+    """P3 maturity self-check: a CSV refund one block short of t_rxd maturity must fail closed with a
+    clear "needs N, has M" message and NOT broadcast — the leg refuses a non-final refund rather than
+    relying on node rejection under deadline pressure."""
+    terms = _rxd_terms(amount=100_000)  # csv=6 → mature at confirmations >= 6
+    client = FakeClient(utxo_value=100_000, confirmations=5)
+    leg = _leg(client=client)
+    rec = SwapRecord(state=SwapState.MAKER_STALLS, terms=terms, radiant_covenant_outpoint="cd" * 32 + ":0")
+    with pytest.raises(NetworkError, match="not yet mature: needs 6 confirmations, has 5"):
+        await leg.refund_asset(rec)
+    assert client.broadcast_raw == [], "no non-final refund may be broadcast before CSV maturity"
+
+
+async def test_claim_asset_not_gated_by_csv_maturity():
+    """The CLAIM branch has no CSV — claim_asset must remain spendable at shallow depth (only the
+    reorg min_confirmations gate applies), unaffected by the refund-side maturity check."""
+    terms = _rxd_terms(amount=100_000)  # csv=6
+    client = FakeClient(utxo_value=100_000, confirmations=1)  # far below csv, but >= min_confirmations
+    leg = _leg(client=client, min_confirmations=1)
+    rec = SwapRecord(state=SwapState.SECRET_REVEALED, terms=terms, radiant_covenant_outpoint="cd" * 32 + ":0")
+    txid = await leg.claim_asset(rec, _P)
+    assert txid == "ab" * 32
 
 
 async def test_spend_conf_gated():

--- a/tests/test_xchain_swap_regtest_e2e.py
+++ b/tests/test_xchain_swap_regtest_e2e.py
@@ -646,6 +646,39 @@ def _scan_value_for_spk(nodes: _Nodes, spk: bytes) -> int:
     return round(sum(u["amount"] for u in res.get("unspents", [])) * 1e8)
 
 
+class TestCovenantRefundCsvMaturity:
+    """P3 leg-level maturity self-check calibrated against REAL consensus: RadiantCovenantLeg.refund_asset
+    must refuse a non-final CSV refund below t_rxd maturity (a real node would reject it) and succeed at
+    exactly t_rxd confirmations. Proves the leg's `confs >= t_rxd.value` boundary is neither too strict
+    (would waste a block) nor too lax (would emit a tx the node rejects — the failure mode P3 exists to
+    avoid). Drives the leg directly to isolate the leg check from the coordinator-side height gate."""
+
+    async def test_refund_asset_boundary_matches_consensus(self, nodes):
+        s = await _setup_locked_swap(nodes, t_rxd_blocks=5)
+        leg = s.coord.radiant_leg
+        rec = s.coord.record
+        cov_txid = rec.radiant_covenant_outpoint.split(":")[0]
+
+        async def _confs() -> int:
+            return await leg.chain_io.confirmations(cov_txid)
+
+        # Mine to exactly t_rxd - 1 confirmations (one short of CSV maturity).
+        while await _confs() < s.t_rxd.value - 1:
+            nodes.rxd_mine(1)
+        assert await _confs() == s.t_rxd.value - 1
+        # The leg refuses to broadcast a non-final refund — fail-closed, no tx emitted.
+        with pytest.raises(NetworkError, match=f"needs {s.t_rxd.value} confirmations, has {s.t_rxd.value - 1}"):
+            await leg.refund_asset(rec)
+
+        # One more block → exactly t_rxd confirmations → the CSV refund is final; the node accepts it.
+        nodes.rxd_mine(1)
+        assert await _confs() == s.t_rxd.value
+        txid = await leg.refund_asset(rec)  # broadcasts; a too-lax boundary would raise here (node reject)
+        assert len(txid) == 64
+        nodes.rxd_mine(1)
+        assert nodes.rxd("gettxout", cov_txid, "0") in (None, ""), "the mature CSV refund spent the covenant"
+
+
 class TestMakerStallAssetOnlyRefundIsTakerLoss:
     """ADVERSARIAL (FSM finding #2, 2026-06-09): on the BTC<->RXD runbook the asset-only
     proactive refund (:meth:`maybe_refund_asset_on_maker_stall`) is NOT a taker defense — its


### PR DESCRIPTION
Extends the P3 maturity gate (started in #292 for the coordinator-side `maybe_refund_asset_on_maker_stall`) down into `RadiantCovenantLeg.refund_asset`, where chain access + timelock knowledge already live.

## Why the leg, not the coordinator
`mutual_refund` / `taker_refund_btc` have ~108 call-sites across the codebase — adding height params there would ripple everywhere. Putting the check in `refund_asset` covers **every** caller (`mutual_refund` **and** `maybe_refund_asset_on_maker_stall`) with **zero** signature change, and the leg already reads `chain_io.confirmations()` for the reorg gate.

## The check
The covenant's CSV refund leaf is only spendable once the UTXO is buried `t_rxd` deep (BIP68 relative-block timelock, built as `refund_csv=t_rxd.value`; mature at `confirmations >= t_rxd.value`). `refund_asset` now refuses a non-final refund with an exact **"needs N confirmations, has M"** message a block-based poller retries on — rather than emitting a tx a node rejects (under a deadline-pinning mempool, "rely on node rejection" is fragile). The CLAIM branch has no CSV, so `claim_asset` is intentionally **not** gated.

## Boundary calibrated against real consensus
`TestCovenantRefundCsvMaturity` (regtest): refund **refused** at `t_rxd-1` confirmations, node **accepts** at exactly `t_rxd` — proving `confs >= t_rxd.value` is neither too strict (wastes a block) nor **too lax** (emits a tx the node rejects — the exact failure P3 exists to avoid). Unit tests: mature broadcasts, premature (`t_rxd-1`) fails closed with no tx emitted, `claim_asset` unaffected. A pre-existing unit test had broadcast at `confs=3` with a 6-block CSV — it only passed because the fake client ignores maturity; corrected to a mature depth.

## Scope / next
The **covenant** leg. The **counter-leg** refund maturity remains: BTC (funding-depth CSV in `BitcoinTaprootLeg.refund`) is the twin of this; ETH is already self-enforced (a premature `refund()` reverts on-chain against the contract's immutable timeout). Tracked as the remaining P3-rest slice.

Existing `mutual_refund` / `maybe_refund` regtest paths (which mine to `t_rxd`) + ETH S1 stay green; watchtower refund uses a pre-signed BTC tx, unaffected. `task ci` green (pre-push gate).