### PR TITLE
fix(swap): BTC counter-leg CSV refund maturity self-check (P3-rest)

### DIFF
--- a/src/pyrxd/btc_wallet/htlc_leg.py
+++ b/src/pyrxd/btc_wallet/htlc_leg.py
@@ -495,11 +495,27 @@ class BitcoinTaprootLeg:
 
         The refund leaf spends via the taker's refund key (held by this leg) after
         the relative timelock matures. Idempotent broadcast tolerates a retry.
+
+        P3 maturity self-check: the refund spends the CSV leaf (BIP68/112 relative-block
+        timelock), final only once the FUNDING utxo is buried ``timeout`` deep (mature at
+        ``funding confirmations >= timeout``). Refuse a non-final refund HERE with an exact
+        "needs N confirmations, has M" message a block-based poller retries on — rather than
+        emitting a tx a node rejects (under a deadline-pinning mempool "rely on node rejection"
+        is fragile). The twin of RadiantCovenantLeg.refund_asset's covenant-CSV check. Only the
+        block-CSV case is confs-checkable; a (non-default) time-based CSV is left to the node.
         """
         if not isinstance(locator, t.BtcHtlcLocator):
             raise ValidationError("locator must be a BtcHtlcLocator")
         if not isinstance(timeout, t.Timelock):
             raise ValidationError("timeout must be a Timelock")
+        if timeout.unit is t.TimeUnit.BLOCKS:
+            confs = await self.funding_reader.confirmations(locator.funding_outpoint.txid)
+            if confs < timeout.value:
+                raise ValidationError(
+                    f"BTC CSV refund is not yet mature: needs {timeout.value} confirmations, has {confs} "
+                    f"({timeout.value - confs} block(s) to go) — refusing to broadcast a non-final refund "
+                    "(P3 maturity self-check); poll and retry at maturity rather than relying on node rejection."
+                )
         raw = t.build_refund_tx(
             locator=locator,
             refund_privkey=self.taker_keypair._privkey.unsafe_raw_bytes(),

--- a/tests/test_btc_htlc_leg.py
+++ b/tests/test_btc_htlc_leg.py
@@ -487,13 +487,29 @@ async def test_claim_broadcasts_with_maker_key_and_reveals_preimage():
 
 async def test_refund_signs_with_taker_key_and_broadcasts():
     taker, maker = generate_keypair("bcrt"), generate_keypair("bcrt")
-    terms = _terms(maker_kp=maker, taker_kp=taker)
+    terms = _terms(maker_kp=maker, taker_kp=taker)  # t_btc = 144 blocks
     bc = FakeBroadcaster()
-    leg = _leg(taker_kp=taker, maker_kp=maker, broadcaster=bc)
+    # Mature: the funding utxo is buried >= t_btc (144) deep, so the CSV refund is final.
+    leg = _leg(taker_kp=taker, maker_kp=maker, broadcaster=bc, reader=FakeFundingReader(claim_confs=144))
     htlc = leg._htlc(terms)
     locator = htlc.with_funding(t.BtcOutpoint("cd" * 32, 0), terms.btc_sats)
     await leg.refund(locator, terms.t_btc)
     assert len(bc.raw_seen) == 1  # broadcast the CSV refund
+
+
+async def test_refund_rejects_premature_csv():
+    """P3 maturity self-check: a BTC CSV refund one block short of t_btc maturity must fail closed with
+    a clear "needs N, has M" message and NOT broadcast — the leg refuses a non-final refund rather than
+    relying on node rejection under deadline pressure."""
+    taker, maker = generate_keypair("bcrt"), generate_keypair("bcrt")
+    terms = _terms(maker_kp=maker, taker_kp=taker)  # t_btc = 144 → mature at funding confs >= 144
+    bc = FakeBroadcaster()
+    leg = _leg(taker_kp=taker, maker_kp=maker, broadcaster=bc, reader=FakeFundingReader(claim_confs=143))
+    htlc = leg._htlc(terms)
+    locator = htlc.with_funding(t.BtcOutpoint("cd" * 32, 0), terms.btc_sats)
+    with pytest.raises(ValidationError, match="not yet mature: needs 144 confirmations, has 143"):
+        await leg.refund(locator, terms.t_btc)
+    assert bc.raw_seen == [], "no non-final refund may be broadcast before CSV maturity"
 
 
 # --------------------------------------------------------------------------- broadcaster idempotency


### PR DESCRIPTION
The twin of the covenant check (#295), completing the relative-CSV half of P3-rest.

## The check
`BitcoinTaprootLeg.refund` spends the CSV leaf (BIP68/112 `<timeout> OP_CSV`), final only once the funding UTXO is buried `t_btc` deep. It now reads funding depth (`self.funding_reader.confirmations`, already present for the reorg gate) and refuses a non-final refund with an exact **"needs N confirmations, has M"** message a poller retries on — rather than emitting a tx a node rejects. Guards **every** counter-leg refund caller (`taker_refund_btc`, `mutual_refund`) with **no** signature change. Block-CSV only; a non-default time-based CSV is left to the node.

## Boundary
`confs >= timeout.value` is the shared BIP68 rule already calibrated against real consensus for the **identical** Radiant covenant CSV in #295 (`TestCovenantRefundCsvMaturity`), and bracketed for BTC by the pre-existing node-level `test_premature_refund_rejected_matured_accepted` (which builds the raw tx and checks the node directly — unaffected by this leg check). Unit tests: mature broadcasts, premature (`t_btc-1`) fails closed with no tx emitted. A pre-existing unit test broadcast at `confs=100` with a 144-block CSV (the fake reader's depth was unread) — corrected to a mature depth.

## ETH intentionally not gated
ETH's `refund()` is self-enforced by the contract's immutable timeout — a premature call **reverts on-chain** (a deterministic, observable failure), not the silent-strand risk BTC/RXD mempool rejection carries under deadline pressure. A gas-saving ETH pre-check is a possible low-priority follow-up.

## P3-rest status
With this + #295, both relative-CSV refund legs (covenant + BTC counter-leg) self-check; ETH self-enforces. That closes the meaningful P3-rest scope.

Regression: BTC↔RXD `mutual_refund` + the node BIP68 boundary test stay green; `task ci` green (pre-push gate).