### PR TITLE
feat(swap): ETH refund maturity pre-check (P3-rest gas guard)

### DIFF
--- a/src/pyrxd/eth_wallet/htlc_leg.py
+++ b/src/pyrxd/eth_wallet/htlc_leg.py
@@ -364,8 +364,23 @@ class EthHtlcContractLeg:
 
     async def refund(self, locator: EthHtlcLocator) -> str:
         """Taker: call refund() after timeout; returns the tx hash. Taker-unilateral
-        (no maker signature; the contract pays the immutable refundee)."""
+        (no maker signature; the contract pays the immutable refundee).
+
+        P3 maturity pre-check: the contract's ``refund()`` reverts until
+        ``block.timestamp >= timeout``. We read the latest block timestamp and refuse a premature
+        refund with a clear "matures at unix T, now S" message rather than burning gas on a guaranteed
+        revert. Unlike the BTC/RXD CSV legs, a premature ETH refund is a deterministic on-chain revert
+        (never a silent mempool strand), so this is a gas/clarity guard — the contract stays the source
+        of truth for the deadline.
+        """
         await self._rpc.assert_chain()
+        now_ts = int((await self._rpc.w3.eth.get_block("latest"))["timestamp"])
+        if now_ts < int(locator.timeout):
+            raise ValidationError(
+                f"ETH HTLC refund is not yet mature: matures at unix {int(locator.timeout)}, now {now_ts} "
+                f"({int(locator.timeout) - now_ts}s to go) — refusing to submit a refund the contract "
+                "would revert (gas/clarity guard; the contract enforces the deadline regardless)."
+            )
         c = self._rpc.w3.eth.contract(address=locator.contract_address, abi=self._artifact["abi"])
         built = await c.functions.refund().build_transaction(await self._base_tx(gas=100_000))
         return await self._sign_and_send(built)

--- a/tests/test_eth_leg_anvil_integration.py
+++ b/tests/test_eth_leg_anvil_integration.py
@@ -207,6 +207,10 @@ async def test_refund_after_timeout_and_claim_blocked_when_expired(anvil_url):
         locator = await taker.fund(
             hashlock=h, claimant=_ADDR_MAKER, refundee=_ADDR_TAKER, timeout=timeout, amount_wei=_AMOUNT_WEI
         )
+        # P3 gas pre-check: a refund BEFORE the timeout is refused (the contract would revert anyway),
+        # so no gas is burned on a guaranteed-revert tx.
+        with pytest.raises(ValidationError, match="not yet mature"):
+            await taker.refund(locator)
         # Fast-forward past the timeout.
         await _advance_time(rpc, 200)
         # A claim is now expired — the contract reverts; the leg's eth_call preflight catches it.


### PR DESCRIPTION
Completes P3-rest refund-maturity coverage across all three legs. The ETH HTLC's `refund()` reverts on-chain until `block.timestamp >= timeout`; `EthHtlcContractLeg.refund` now reads the latest block timestamp and refuses a premature refund with an exact **"matures at unix T, now S"** message rather than burning gas on a guaranteed revert.

Unlike the BTC/RXD CSV legs (#295, #296), a premature ETH refund is a **deterministic on-chain revert**, never a silent mempool strand — so this is a gas/clarity guard, not a new safety property; the contract stays the source of truth for the deadline. With this, every refund path pre-checks maturity: covenant + BTC via BIP68 funding depth, ETH via block timestamp.

Verified on anvil (`test_refund_after_timeout_and_claim_blocked_when_expired`): a pre-timeout refund now raises "not yet mature"; the post-timeout refund still succeeds and pays the refundee. `task ci` green (pre-push gate).