### PR TITLE
fix(swap): leg exception consistency + taker RXD-funded gate (review LOW + F2)

### DIFF
--- a/scripts/btc_swap_two_host.py
+++ b/scripts/btc_swap_two_host.py
@@ -467,6 +467,22 @@ async def taker_phase_fund(args) -> None:
     coord = _coordinator(args, terms=terms, btc_leg=btc_leg, rxd_leg=rxd_leg, keys_out=args.local_out)
 
     try:
+        # HARDENING (review F2): confirm the maker ACTUALLY funded the RXD covenant on-chain (with the
+        # agreed amount) BEFORE we lock any BTC. Otherwise a hostile maker who never locks RXD can wait
+        # for our BTC HTLC and claim it with p -> one-sided taker loss. The maker funds RXD in its
+        # envelope step (runbook); we verify it programmatically here and fail closed.
+        confirm("verify the maker funded the RXD covenant on-chain before funding BTC", auto_yes=args.yes)
+        try:
+            fop, fval, _fh = await rxd_leg.chain_io.find_covenant_utxo(
+                cov.funded_spk, expected_value=terms.radiant_amount
+            )
+        except Exception as exc:
+            raise SystemExit(
+                "REFUSING to fund BTC: the agreed RXD covenant SPK is NOT funded on-chain with the agreed "
+                f"amount ({exc}). A hostile maker may not have locked RXD; aborting before our BTC is at risk."
+            ) from None
+        print(f"  -> RXD covenant confirmed funded on-chain at {fop} ({fval} photons)")
+
         confirm(
             "taker_funds_btc: fund the BTC HTLC (taker's UTXO; claim pays the maker, refund pays the taker)",
             auto_yes=args.yes,

--- a/scripts/eth_swap_two_host.py
+++ b/scripts/eth_swap_two_host.py
@@ -423,6 +423,21 @@ async def taker_phase_fund(args: argparse.Namespace) -> None:
     coord = _coordinator(args, terms=terms, eth_leg=eth_leg, rxd_leg=rxd_leg, keys_out=args.local_out)
 
     try:
+        # HARDENING (review F2): confirm the maker ACTUALLY funded the RXD covenant on-chain (with the
+        # agreed amount) BEFORE we lock any ETH. Otherwise a hostile maker who never locks RXD can wait
+        # for our ETH HTLC and claim it with p -> one-sided taker loss. We verify it fail-closed.
+        confirm("verify the maker funded the RXD covenant on-chain before funding ETH", auto_yes=args.yes)
+        try:
+            fop, fval, _fh = await rxd_leg.chain_io.find_covenant_utxo(
+                cov.funded_spk, expected_value=terms.radiant_amount
+            )
+        except Exception as exc:
+            raise SystemExit(
+                "REFUSING to fund ETH: the agreed RXD covenant SPK is NOT funded on-chain with the agreed "
+                f"amount ({exc}). A hostile maker may not have locked RXD; aborting before our ETH is at risk."
+            ) from None
+        print(f"  -> RXD covenant confirmed funded on-chain at {fop} ({fval} photons)")
+
         confirm("taker_funds_btc: deploy+fund the ETH HTLC (taker pays gas; claim pays the maker)", auto_yes=args.yes)
         rec = await coord.taker_funds_btc(terms, now_unix_s=int(time.time()))
         if rec.state is not SwapState.BTC_LOCKED:

--- a/src/pyrxd/btc_wallet/htlc_leg.py
+++ b/src/pyrxd/btc_wallet/htlc_leg.py
@@ -511,7 +511,10 @@ class BitcoinTaprootLeg:
         if timeout.unit is t.TimeUnit.BLOCKS:
             confs = await self.funding_reader.confirmations(locator.funding_outpoint.txid)
             if confs < timeout.value:
-                raise ValidationError(
+                # NetworkError (not ValidationError): "not yet mature" is a TRANSIENT, retryable condition
+                # (poll and re-broadcast at maturity), not a permanent input error — consistent with the
+                # covenant leg's premature-refund raise (review LOW: unify the retryable exception family).
+                raise NetworkError(
                     f"BTC CSV refund is not yet mature: needs {timeout.value} confirmations, has {confs} "
                     f"({timeout.value - confs} block(s) to go) — refusing to broadcast a non-final refund "
                     "(P3 maturity self-check); poll and retry at maturity rather than relying on node rejection."

--- a/src/pyrxd/eth_wallet/htlc_leg.py
+++ b/src/pyrxd/eth_wallet/htlc_leg.py
@@ -376,7 +376,10 @@ class EthHtlcContractLeg:
         await self._rpc.assert_chain()
         now_ts = int((await self._rpc.w3.eth.get_block("latest"))["timestamp"])
         if now_ts < int(locator.timeout):
-            raise ValidationError(
+            # NetworkError (not ValidationError): "not yet mature" is a TRANSIENT, retryable condition
+            # (wait for the timeout, then refund), not a permanent input error — consistent with the
+            # BTC/covenant premature-refund raises (review LOW: unify the retryable exception family).
+            raise NetworkError(
                 f"ETH HTLC refund is not yet mature: matures at unix {int(locator.timeout)}, now {now_ts} "
                 f"({int(locator.timeout) - now_ts}s to go) — refusing to submit a refund the contract "
                 "would revert (gas/clarity guard; the contract enforces the deadline regardless)."

--- a/tests/test_btc_htlc_leg.py
+++ b/tests/test_btc_htlc_leg.py
@@ -507,7 +507,8 @@ async def test_refund_rejects_premature_csv():
     leg = _leg(taker_kp=taker, maker_kp=maker, broadcaster=bc, reader=FakeFundingReader(claim_confs=143))
     htlc = leg._htlc(terms)
     locator = htlc.with_funding(t.BtcOutpoint("cd" * 32, 0), terms.btc_sats)
-    with pytest.raises(ValidationError, match="not yet mature: needs 144 confirmations, has 143"):
+    # NetworkError (transient/retryable), consistent with the covenant leg — not a fatal ValidationError.
+    with pytest.raises(NetworkError, match="not yet mature: needs 144 confirmations, has 143"):
         await leg.refund(locator, terms.t_btc)
     assert bc.raw_seen == [], "no non-final refund may be broadcast before CSV maturity"
 

--- a/tests/test_eth_leg_anvil_integration.py
+++ b/tests/test_eth_leg_anvil_integration.py
@@ -34,7 +34,7 @@ if shutil.which("anvil") is None:  # pragma: no cover - environment gate
 
 from pyrxd.eth_wallet.htlc_leg import EthHtlcContractLeg
 from pyrxd.eth_wallet.rpc import EthRpc
-from pyrxd.security.errors import ValidationError
+from pyrxd.security.errors import NetworkError, ValidationError
 from pyrxd.security.secrets import PrivateKeyMaterial
 
 pytestmark = pytest.mark.integration
@@ -208,8 +208,9 @@ async def test_refund_after_timeout_and_claim_blocked_when_expired(anvil_url):
             hashlock=h, claimant=_ADDR_MAKER, refundee=_ADDR_TAKER, timeout=timeout, amount_wei=_AMOUNT_WEI
         )
         # P3 gas pre-check: a refund BEFORE the timeout is refused (the contract would revert anyway),
-        # so no gas is burned on a guaranteed-revert tx.
-        with pytest.raises(ValidationError, match="not yet mature"):
+        # so no gas is burned on a guaranteed-revert tx. NetworkError = transient/retryable (wait for the
+        # timeout), consistent with the BTC/covenant legs — not a fatal ValidationError.
+        with pytest.raises(NetworkError, match="not yet mature"):
             await taker.refund(locator)
         # Fast-forward past the timeout.
         await _advance_time(rpc, 200)


### PR DESCRIPTION
The last two security-review follow-ups.

- **Leg exception consistency (LOW):** the three legs raised inconsistent exception types for the identical *not-yet-mature, retry* refund condition (covenant `NetworkError`, BTC/ETH `ValidationError`). A poller treating `ValidationError` as permanent-fatal would abort a retryable premature refund. Unified on `NetworkError` (the transient/retryable family the covenant leg already uses), same messages; tests updated.
- **Taker RXD-funded gate (F2, both harnesses):** the taker funded the counter leg without first confirming the maker actually funded the RXD covenant on-chain — a hostile maker who never locks RXD can wait for the taker's counter HTLC and claim it with p (one-sided taker loss). Both two-host harnesses now verify the agreed covenant SPK is funded on-chain with the agreed amount before locking any counter value, failing closed. (Live-path; self-check unaffected + green.)

`task ci` green (pre-push gate).