### PR TITLE
feat(swap-verify): ETH counter-leg finality gate + spender discovery (cross-chain symmetry)

### DIFF
--- a/scripts/swap_run_verify.py
+++ b/scripts/swap_run_verify.py
@@ -763,6 +763,31 @@ class _EthFetcher:
         rcpt = await self._rpc.get_transaction_receipt(tx_hash)
         return dict(tx), (dict(rcpt) if rcpt is not None else None)
 
+    async def finalized_height(self) -> int | None:
+        """The post-Merge ``finalized`` checkpoint block number (the ETH reorg-safety oracle), or None
+        if the endpoint can't report it (fail closed at the caller)."""
+        try:
+            return int(await self._rpc.finalized_block_number())
+        except Exception:
+            return None
+
+    async def spend_of(self, contract: str) -> str | None:
+        """Independent discovery of an OMITTED ETH claim/refund (review — the ETH analog of BTC/RXD spend
+        discovery): ``eth_getLogs`` for OUR per-swap contract's ``Claimed``/``Refunded`` events. Returns
+        the spending tx hash; None if no such event (genuinely PENDING) or the source can't say
+        (fail-soft — a missed discovery degrades to PENDING, never a false PASS)."""
+        try:
+            logs = await self._rpc.get_logs(address=contract, topics=[[_ETH_CLAIMED_TOPIC, _ETH_REFUNDED_TOPIC]])
+            for lg in logs:
+                th = lg.get("transactionHash")
+                if th is not None:
+                    b = _hb(th)  # HexBytes / '0x..' / bytes -> bytes
+                    if len(b) == 32:
+                        return "0x" + b.hex()
+        except Exception:
+            return None
+        return None
+
     async def close(self) -> None:
         await self._rpc.close()
 
@@ -821,15 +846,30 @@ async def _fetch_for_live(
         finally:
             await btc.close()
     else:  # eth
-        if spend_id or m.eth_funding_tx:
-            eth = _EthFetcher(eth_url, m.eth_chain_id)  # type: ignore[arg-type]
-            try:
+        eth = _EthFetcher(eth_url, m.eth_chain_id)  # type: ignore[arg-type]
+        try:
+            if not spend_id and m.eth_contract is not None:
+                spend_id = await eth.spend_of(m.eth_contract)  # DISCOVER an omitted ETH claim/refund
                 if spend_id:
-                    counter_obj = await eth.tx_and_receipt(spend_id)
-                if m.eth_funding_tx:
-                    counter_funding = await eth.tx_and_receipt(m.eth_funding_tx)  # deploy tx: value == funded wei
-            finally:
-                await eth.close()
+                    print(f"  discovered counter (ETH) spend {spend_id} independently (was not cited)", file=sys.stderr)
+            if spend_id:
+                counter_obj = await eth.tx_and_receipt(spend_id)
+                # FINALITY gate (review): the ETH claim/refund must be at/under the `finalized` checkpoint
+                # — a mined-but-non-final (reorgable) disposition must NOT be scored as settled. This is
+                # the ETH analog of the BTC/RXD confirmation-depth gate (ETH reorg-safety is checkpoint-
+                # based, not depth-based), matching swap_coordinator's finalized-checkpoint verdict.
+                _tx, rcpt = counter_obj
+                claim_block = _as_int((rcpt or {}).get("blockNumber", 0)) if rcpt else 0
+                finalized = await eth.finalized_height()
+                if finalized is None or claim_block <= 0 or claim_block > finalized:
+                    raise ValueError(
+                        f"cited/discovered ETH counter-spend {spend_id} is NOT finalized (block {claim_block}, "
+                        f"finalized {finalized}) on the independent source — refusing to score a reorgable disposition"
+                    )
+            if m.eth_funding_tx:
+                counter_funding = await eth.tx_and_receipt(m.eth_funding_tx)  # deploy tx: value == funded wei
+        finally:
+            await eth.close()
     return cov_fund, cov_spend, counter_obj, counter_funding, asset_claim_height
 
 


### PR DESCRIPTION
Closes the last two ETH asymmetries so **all** cross-chain arms enforce the same checks (before: the ETH counter leg had value + provenance but, unlike BTC/RXD, no reorg-safety gate and no independent spender discovery).

- **Finality gate:** `verify_counter_leg_eth` only checked `status==1`, so a mined-but-non-final (reorgable) ETH claim scored as settled. `_fetch_for_live` now refuses an ETH counter-spend whose block is not at/under the `finalized` checkpoint — the ETH analog of the BTC/RXD confirmation-depth gate (ETH reorg-safety is checkpoint-based). Uses the **same** predicate as the live coordinator (`tx_block <= finalized_block_number`).
- **Spender discovery:** like BTC (Esplora `/outspend`) and RXD (scripthash `get_history`), `_EthFetcher.spend_of` discovers an *omitted* ETH claim/refund via `eth_getLogs` for our contract's `Claimed`/`Refunded` events, so a party can't park the ETH leg at PENDING. Fail-soft (miss → PENDING, never a false PASS).

Cross-chain scorecard is now symmetric across all three legs — provenance, value, reorg-safety gate, spender discovery. Reuses proven `EthRpc` primitives; network-exercised (live), fail-closed (finality) / fail-soft (discovery). Self-check + 8 unit tests green. `task ci` green (pre-push).