### PR TITLE
fix(swap): taker RXD-funding depth gate + harness secret-guard + stall-refund retry semantics (audit M3 + follow-ups)

### DIFF
--- a/scripts/btc_swap_two_host.py
+++ b/scripts/btc_swap_two_host.py
@@ -110,7 +110,24 @@ _BTC_REGTEST = "bcrt"
 # File exchange (the cross-host surface — all public, never the preimage p)
 # ---------------------------------------------------------------------------
 
-_SECRET_FORBIDDEN_KEYS = ("preimage", "preimage_p", "preimage_p_hex", "p_hex", "wif", "secret", "privkey")
+_SECRET_FORBIDDEN_KEYS = (
+    "preimage",
+    "preimage_p",
+    "preimage_p_hex",
+    "p_hex",
+    "wif",
+    "secret",
+    "privkey",
+    # review MEDIUM: the original list missed several secret-carrying key names. Substring match, so
+    # "private_key" is NOT caught by "privkey" and "eth_key" covers "eth_key_hex".
+    "private_key",
+    "signing_key",
+    "eth_key",
+    "seed",
+    "mnemonic",
+    "xprv",
+    "xpriv",
+)
 
 
 def _assert_public_only(doc: dict, *, what: str) -> None:
@@ -481,7 +498,23 @@ async def taker_phase_fund(args) -> None:
                 "REFUSING to fund BTC: the agreed RXD covenant SPK is NOT funded on-chain with the agreed "
                 f"amount ({exc}). A hostile maker may not have locked RXD; aborting before our BTC is at risk."
             ) from None
-        print(f"  -> RXD covenant confirmed funded on-chain at {fop} ({fval} photons)")
+        # DEPTH GATE (review MEDIUM): "funded" is not enough — the funding must be BURIED. find_covenant_utxo
+        # can return a 0-conf/mempool UTXO (ElectrumX listunspent includes unconfirmed), and a hostile maker
+        # who funds RXD with a replaceable/reorgable tx, waits for our BTC lock, then double-spends the RXD
+        # funding away strands our BTC (the maker still claims BTC with p; the vanished covenant is no longer
+        # claimable by us -> one-sided taker loss). Require a confirmation floor; fail closed below it.
+        fop_txid = fop.split(":")[0]
+        try:
+            confs = await rxd_leg.chain_io.confirmations(fop_txid)
+        except Exception as exc:
+            raise SystemExit(f"REFUSING to fund BTC: could not read RXD covenant confirmation depth ({exc}).") from None
+        if confs < args.taker_min_rxd_confs:
+            raise SystemExit(
+                f"REFUSING to fund BTC: the RXD covenant funding {fop_txid} has {confs} confirmation(s) "
+                f"(< required {args.taker_min_rxd_confs}) — a shallow/mempool funding is reorgable/replaceable "
+                "and could be double-spent after we lock. Wait for it to bury, then retry."
+            )
+        print(f"  -> RXD covenant confirmed funded on-chain at {fop} ({fval} photons), buried {confs} conf(s)")
 
         confirm(
             "taker_funds_btc: fund the BTC HTLC (taker's UTXO; claim pays the maker, refund pays the taker)",
@@ -886,6 +919,14 @@ def _build_parser() -> argparse.ArgumentParser:
     p.add_argument("--t-rxd-blocks", type=int, default=20, help="(maker) the RXD covenant CSV")
     p.add_argument("--t-btc-blocks", type=int, default=60, help="(maker) the BTC HTLC CSV (must exceed t_rxd + margin)")
     p.add_argument("--margin-blocks", type=int, default=36)
+    p.add_argument(
+        "--taker-min-rxd-confs",
+        type=int,
+        default=1,
+        help="(taker) min confirmations the maker's RXD covenant funding must have before we lock BTC "
+        "(default 1 = MINED-only, fine for regtest). REAL VALUE must set this DEEP: a shallow/mempool RXD "
+        "funding is reorgable/replaceable, and a maker who double-spends it after we lock strands our BTC.",
+    )
 
     # Taker BTC funding UTXO + payout (taker)
     p.add_argument("--btc-funding-txid", default="")

--- a/scripts/eth_swap_two_host.py
+++ b/scripts/eth_swap_two_host.py
@@ -113,7 +113,24 @@ _ALLOWED_ETH_NETWORKS = frozenset({"anvil", "sepolia"})
 # Every writer asserts that no secret material is present before serialising, and every reader is
 # read-only. These four files are the ENTIRE communication channel between the two hosts.
 
-_SECRET_FORBIDDEN_KEYS = ("preimage", "preimage_p", "preimage_p_hex", "p_hex", "wif", "secret", "privkey")
+_SECRET_FORBIDDEN_KEYS = (
+    "preimage",
+    "preimage_p",
+    "preimage_p_hex",
+    "p_hex",
+    "wif",
+    "secret",
+    "privkey",
+    # review MEDIUM: the original list missed several secret-carrying key names. Substring match, so
+    # "private_key" is NOT caught by "privkey" and "eth_key" covers "eth_key_hex".
+    "private_key",
+    "signing_key",
+    "eth_key",
+    "seed",
+    "mnemonic",
+    "xprv",
+    "xpriv",
+)
 
 
 def _assert_public_only(doc: dict, *, what: str) -> None:
@@ -436,7 +453,23 @@ async def taker_phase_fund(args: argparse.Namespace) -> None:
                 "REFUSING to fund ETH: the agreed RXD covenant SPK is NOT funded on-chain with the agreed "
                 f"amount ({exc}). A hostile maker may not have locked RXD; aborting before our ETH is at risk."
             ) from None
-        print(f"  -> RXD covenant confirmed funded on-chain at {fop} ({fval} photons)")
+        # DEPTH GATE (review MEDIUM): "funded" is not enough — the funding must be BURIED. find_covenant_utxo
+        # can return a 0-conf/mempool UTXO, and a hostile maker who funds RXD with a replaceable/reorgable tx,
+        # waits for our ETH lock, then double-spends the RXD funding away strands our ETH (the maker still
+        # claims ETH with p; the vanished covenant is no longer claimable by us -> one-sided taker loss).
+        # Require a confirmation floor; fail closed below it.
+        fop_txid = fop.split(":")[0]
+        try:
+            confs = await rxd_leg.chain_io.confirmations(fop_txid)
+        except Exception as exc:
+            raise SystemExit(f"REFUSING to fund ETH: could not read RXD covenant confirmation depth ({exc}).") from None
+        if confs < args.taker_min_rxd_confs:
+            raise SystemExit(
+                f"REFUSING to fund ETH: the RXD covenant funding {fop_txid} has {confs} confirmation(s) "
+                f"(< required {args.taker_min_rxd_confs}) — a shallow/mempool funding is reorgable/replaceable "
+                "and could be double-spent after we lock. Wait for it to bury, then retry."
+            )
+        print(f"  -> RXD covenant confirmed funded on-chain at {fop} ({fval} photons), buried {confs} conf(s)")
 
         confirm("taker_funds_btc: deploy+fund the ETH HTLC (taker pays gas; claim pays the maker)", auto_yes=args.yes)
         rec = await coord.taker_funds_btc(terms, now_unix_s=int(time.time()))
@@ -933,6 +966,14 @@ def _args() -> argparse.Namespace:
     ap.add_argument("--fee-wif", default="")
     # margin / cross-clock
     ap.add_argument("--margin-blocks", type=int, default=36)
+    ap.add_argument(
+        "--taker-min-rxd-confs",
+        type=int,
+        default=1,
+        help="(taker) min confirmations the maker's RXD covenant funding must have before we lock ETH "
+        "(default 1 = MINED-only, fine for regtest). REAL VALUE must set this DEEP: a shallow/mempool RXD "
+        "funding is reorgable/replaceable, and a maker who double-spends it after we lock strands our ETH.",
+    )
     ap.add_argument("--btc-block-interval-s", type=float, default=600.0)
     ap.add_argument("--rxd-block-interval-s", type=float, default=300.0)
     ap.add_argument("--eth-finalization-window-s", type=int, default=None)

--- a/src/pyrxd/gravity/swap_coordinator.py
+++ b/src/pyrxd/gravity/swap_coordinator.py
@@ -52,7 +52,7 @@ from pyrxd.btc_wallet.taproot import (
 from pyrxd.eth_wallet.locator import EthHtlcLocator
 from pyrxd.glyph.credential_binding import CredentialBindingError, assert_soulbound_credential
 from pyrxd.gravity.htlc_covenant import holder_hash
-from pyrxd.security.errors import ValidationError
+from pyrxd.security.errors import NetworkError, ValidationError
 from pyrxd.security.secrets import SecretBytes
 
 from .eth_rxd_timelock import CrossClockMargin, assert_covenant_confirms_before_eth_deadline
@@ -1938,7 +1938,12 @@ class SwapCoordinator:
         ).value
         maturity_height = asset_locked_at_height + rxd_blocks
         if now_block_height < maturity_height:
-            raise ValidationError(
+            # NetworkError (not ValidationError): "not yet mature" is a TRANSIENT, retryable condition — the
+            # same convention the RadiantLeg/BtcLeg refund maturity self-checks use. A block-based poller
+            # keys on NetworkError to retry at maturity; raising ValidationError here (a permanent/input
+            # error) would make that poller give up on a swap that only needs to wait, risking a missed
+            # proactive refund.
+            raise NetworkError(
                 f"covenant CSV refund is not yet mature: it matures at height {maturity_height}, now "
                 f"{now_block_height} ({maturity_height - now_block_height} block(s) to go). Refusing to "
                 "broadcast a non-final refund (P3 maturity pre-check) — poll and retry at maturity "

--- a/src/pyrxd/network/bitcoin.py
+++ b/src/pyrxd/network/bitcoin.py
@@ -576,7 +576,10 @@ class BitcoinCoreRpcSource(BtcDataSource):
                 if resp.status not in (200, 500):
                     raise NetworkError(f"RPC HTTP error: {resp.status}")
                 try:
-                    data = json.loads(body)
+                    # parse_float=Decimal (review MEDIUM): Bitcoin Core reports BTC amounts as JSON numbers.
+                    # The default float parser is lossy, so downstream sat conversion could round-trip a
+                    # wrong value. Decimal keeps the node's decimal exact all the way into _btc_to_sats.
+                    data = json.loads(body, parse_float=Decimal)
                 except json.JSONDecodeError:
                     raise NetworkError("Bitcoin Core returned non-JSON response")
                 if data.get("error") is not None:
@@ -1112,6 +1115,10 @@ class BitcoinCoreFundingReader:
         return data
 
     async def confirmations(self, txid: str) -> int:
+        # NB (review MEDIUM, source-trust): this is the node's SELF-REPORTED depth — a single hostile/buggy
+        # node could OVER-report it, defeating a reorg-depth gate that trusts one source. The txid pin can't
+        # catch this (depth isn't in the tx). For real value use MultiSourceBtcFundingReader (quorum) so no
+        # single source's depth is load-bearing.
         data = await self._verbose_tx(txid)
         confs = data.get("confirmations")
         if confs is None:

--- a/tests/test_swap_coordinator.py
+++ b/tests/test_swap_coordinator.py
@@ -887,7 +887,9 @@ async def test_maker_stall_refuses_premature_refund():
 
     # locked at 1000; maturity = 1072; trigger fires at 1066 but the covenant is 6 blocks short of
     # CSV maturity — refuse to broadcast.
-    with pytest.raises(ValidationError, match="not yet mature.*matures at height 1072, now 1066"):
+    # NetworkError (not ValidationError): "not yet mature" is a TRANSIENT/retryable condition, the same
+    # convention the RadiantLeg/BtcLeg refund maturity self-checks use — a block poller keys on it to retry.
+    with pytest.raises(NetworkError, match="not yet mature.*matures at height 1072, now 1066"):
         await coord.maybe_refund_asset_on_maker_stall(
             now_block_height=1066, asset_locked_at_height=1000, maker_has_claimed_btc=False
         )


### PR DESCRIPTION
## What

Red-team panel follow-ups on the two-host swap harnesses, the coordinator, and the Bitcoin Core funding reader. (pyrxd swaps remain honestly labelled UNAUDITED; the external audit + a live two-party run are the hard gate — this is defense-in-depth ahead of it.)

### M3 — taker RXD-funding confirmation-depth gate (both harnesses)
Before the taker locks its BTC/ETH it verifies the maker funded the RXD covenant, but the existing gate accepted a **0-conf / mempool** covenant UTXO. A hostile maker could fund RXD with a replaceable/reorgable tx, wait for the taker's lock, then double-spend the RXD funding away — the maker still claims the counter leg with `p`, while the vanished covenant is no longer claimable by the taker (**one-sided taker loss**).

Both `taker_phase_fund` paths now read the covenant funding's confirmation depth via `chain_io.confirmations()` and refuse below `--taker-min-rxd-confs` (default `1` = MINED-only for regtest; real value must set it DEEP).

### Harness secret-guard key alignment (both harnesses)
`_SECRET_FORBIDDEN_KEYS` does a substring match but missed `private_key` (NOT caught by `privkey`), `signing_key`, `eth_key(_hex)`, `seed`, `mnemonic`, `xprv`/`xpriv`. Added them; verified no legit public-doc field collides.

### Coordinator stall-refund retry semantics
`maybe_refund_asset_on_maker_stall`'s P3 maturity pre-check raised `ValidationError` for "not yet mature" — but the `RadiantLeg`/`BtcLeg` refund maturity self-checks (and the `BtcLeg`'s own comment) establish `NetworkError` as the convention for that **transient/retryable** condition. A block poller keying on `NetworkError`-to-retry would have given up on a swap that only needed to wait, risking a missed proactive refund. Switched to `NetworkError`; the existing test (whose own comment says "retryable") updated to match.

### BitcoinCoreRpcSource lossless amount parse
`json.loads` now uses `parse_float=Decimal` so a node's BTC amount stays exact into `_btc_to_sats` (the Bitcoin-standard pattern). Added a source-trust note to `BitcoinCoreFundingReader.confirmations`: the depth is the node's self-report; a single node could over-report it — use `MultiSourceBtcFundingReader` (quorum) for real value.

## Testing
- 108 coordinator + 123 bitcoin/btc-network + 83 harness-self-check tests green.
- Parser (`--taker-min-rxd-confs`), expanded secret-guard, and `_btc_to_sats` Decimal/float parity smoke-checked for both harnesses.
- Full `task ci` passed locally (pre-push hook).