### PR TITLE
fix(rswp): pre-0.11.0 security-panel follow-ups — 2 HIGH fund-safety + DoS/parser/CLI hardening

### DIFF
--- a/src/pyrxd/cli/swap_book_cmds.py
+++ b/src/pyrxd/cli/swap_book_cmds.py
@@ -316,6 +316,22 @@ def swap_orders_cmd(ctx: CliContext, token: str, want: bool, node_rpc: str, rpc_
             entries = await (book.orders_wanting(ref, limit=limit) if want else book.orders_offering(ref, limit=limit))
         rows = []
         for e in entries:
+            if e.order is None:
+                # A row too malformed to even decode an order from — book.py surfaced it as a problem with
+                # order=None. Render it as a problem line rather than dereferencing e.order (review MEDIUM:
+                # one such row must not AttributeError and crash the whole browse).
+                rows.append(
+                    {
+                        "offered_utxo": "(undecodable)",
+                        "gives": "(unverified)",
+                        "wants": "(unparseable)",
+                        "status": e.status,
+                        "fillable": e.fillable,
+                        "block_height": e.block_height,
+                        "problem": e.problem,
+                    }
+                )
+                continue
             demanded = e.order.demanded_outputs
             rows.append(
                 {
@@ -335,7 +351,9 @@ def swap_orders_cmd(ctx: CliContext, token: str, want: bool, node_rpc: str, rpc_
     try:
         rows = asyncio.run(_run())
     except RxdSdkError as exc:
-        raise click.ClickException(f"orderbook read failed: {exc}") from exc
+        # The error text can embed a hostile node's RPC message — strip terminal-control bytes so it can't
+        # inject ANSI/cursor sequences that spoof or hide CLI output (review MEDIUM).
+        raise click.ClickException(f"orderbook read failed: {sanitize_terminal(str(exc), max_len=300)}") from exc
 
     payload = {"token": token, "side": "want" if want else "offer", "count": len(rows), "orders": rows}
     if ctx.output_mode in ("json", "quiet"):
@@ -793,5 +811,6 @@ def _finish(ctx: CliContext, run, *, quiet_field: str) -> None:
     except (UserError, click.ClickException):
         raise
     except RxdSdkError as exc:
-        raise click.ClickException(str(exc)) from exc
+        # Strip terminal-control bytes: the message can carry a hostile node/server string (review MEDIUM).
+        raise click.ClickException(sanitize_terminal(str(exc), max_len=300)) from exc
     click.echo(emit(payload, mode=ctx.output_mode, quiet_field=quiet_field))

--- a/src/pyrxd/gravity/swap_order.py
+++ b/src/pyrxd/gravity/swap_order.py
@@ -25,7 +25,6 @@ from __future__ import annotations
 from dataclasses import dataclass
 
 from ..constants import OpCode
-from ..script import Script
 from ..security.errors import ValidationError
 from ..utils import Reader
 
@@ -81,20 +80,41 @@ class RswpOrder:
 
 
 def _items(op_return_script: bytes) -> list:
-    """Post-``OP_RETURN`` pushes as a list of ``bytes`` (data push) or ``int`` (OP_0 / OP_1..OP_16)."""
-    chunks = Script(op_return_script).chunks
-    if not chunks or chunks[0].op != bytes(OpCode.OP_RETURN):
+    """Post-``OP_RETURN`` pushes as a list of ``bytes`` (data push) or ``int`` (OP_0 / OP_1..OP_16).
+
+    Strict, node-matching walk (review MEDIUM): a push whose DECLARED length exceeds the bytes actually
+    present is REJECTED — Radiant-Core ``GetOp`` returns false on a truncated push and drops the advert, but
+    ``Script``'s chunk parser silently CLAMPS it, so pyrxd would otherwise decode (and show as fillable) a
+    frame the canonical book never indexes. Non-minimal / PUSHDATA-form pushes are still accepted (the node
+    is lenient there); only truncation is a hard error.
+    """
+    if not op_return_script or op_return_script[0] != bytes(OpCode.OP_RETURN)[0]:
         raise ValidationError("not an OP_RETURN script")
     out: list = []
-    for c in chunks[1:]:
-        if c.data is not None:
-            out.append(c.data)
-        elif c.op == b"\x00":  # OP_0
+    i, n = 1, len(op_return_script)
+    while i < n:
+        op = op_return_script[i]
+        i += 1
+        if op == 0x00:  # OP_0
             out.append(0)
-        elif b"\x51" <= c.op <= b"\x60":  # OP_1..OP_16
-            out.append(c.op[0] - 0x50)
+        elif 0x51 <= op <= 0x60:  # OP_1..OP_16
+            out.append(op - 0x50)
+        elif op <= 0x4B or op in (0x4C, 0x4D, 0x4E):
+            if op <= 0x4B:
+                plen = op
+            else:
+                width = {0x4C: 1, 0x4D: 2, 0x4E: 4}[op]
+                if i + width > n:
+                    raise ValidationError("truncated push-length prefix in RSWP frame")
+                plen = int.from_bytes(op_return_script[i : i + width], "little")
+                i += width
+            data = op_return_script[i : i + plen]
+            if len(data) != plen:
+                raise ValidationError("truncated push in RSWP frame (declared length exceeds available bytes)")
+            i += plen
+            out.append(bytes(data))
         else:
-            raise ValidationError(f"unexpected opcode 0x{c.op.hex()} in RSWP frame")
+            raise ValidationError(f"unexpected opcode 0x{op:02x} in RSWP frame")
     return out
 
 
@@ -127,9 +147,11 @@ def parse_price_terms(blob: bytes) -> list[DemandedOutput] | None:
         # unbounded slen (a 0xff varint up to 2**64-1) would otherwise reach BytesIO.read and raise
         # OverflowError — leaking out of the public decode_rswp_order, which documents ValidationError
         # only. Reject out-of-range lengths as "not clean MultiTxOutV1" (None), the documented outcome.
-        if slen is None or slen < 0 or slen > len(blob):
+        # A zero-length demanded script is not a real demand (the encoder refuses it too) — reject for
+        # round-trip fidelity (review LOW).
+        if slen is None or slen <= 0 or slen > len(blob):
             return None
-        script = r.read_bytes(slen) if slen else b""
+        script = r.read_bytes(slen)
         if script is None or len(script) != slen:
             return None
         outs.append(DemandedOutput(value=int.from_bytes(vb, "little"), script=script))

--- a/src/pyrxd/swap/partial.py
+++ b/src/pyrxd/swap/partial.py
@@ -266,8 +266,16 @@ def accept_offer(
     give_source = Transaction.from_hex(bytes.fromhex(offer.give_source_tx_hex))
     if partial is None or give_source is None:
         raise ValidationError("offer contains an unparseable transaction")
-    if not partial.inputs or not partial.outputs:
-        raise ValidationError("offer partial transaction is missing the maker input/output")
+    # SINGLE|ANYONECANPAY binds EXACTLY input[0] + output[0]; ANY additional maker input or output is
+    # UNSIGNED, and _balance_and_add_change funds every output from the taker's inputs — so a hand-delivered
+    # offer carrying an injected extra output (paying the maker) would make the taker silently overpay by
+    # that amount while the advertised terms show a fair trade (audit HIGH). The public book path rebuilds
+    # with exactly one output; enforce the same invariant here for the direct/private-transport primitive.
+    if len(partial.inputs) != 1 or len(partial.outputs) != 1:
+        raise ValidationError(
+            "offer partial transaction must have EXACTLY one maker input and one output — "
+            "SIGHASH_SINGLE|ANYONECANPAY binds only input[0]/output[0]; any extra is attacker-injectable"
+        )
 
     maker_in = partial.inputs[0]
     # The source tx the taker was handed must be the real funder of the maker input.

--- a/src/pyrxd/swap/rswp/book.py
+++ b/src/pyrxd/swap/rswp/book.py
@@ -109,6 +109,13 @@ def _order_from_rpc(entry: dict) -> RswpOrder:
         raise ValidationError(f"malformed swapindex response row: {exc!r}") from exc
 
 
+def _clamp_rows(rows: list[dict], limit: int) -> list[dict]:
+    """A source MUST honor ``limit``, but a hostile/MITM'd one can ignore it and return N rows — each costs
+    a network fetch + an ECDSA verify in ``_verify_row`` (review MEDIUM DoS). Truncate to the requested
+    limit so one browse can't be amplified into unbounded work."""
+    return rows[: max(0, limit)]
+
+
 class OrderbookClient:
     """Browse the on-chain book through any :class:`OrderbookSource`, verifying before trusting."""
 
@@ -118,11 +125,13 @@ class OrderbookClient:
     async def orders_offering(self, ref: GlyphRef | None, *, limit: int = 100, offset: int = 0) -> list[BookEntry]:
         """Open orders OFFERING the given asset (``None`` = native RXD)."""
         rows = await self._source.get_open_orders(swap_token_id(ref).hex(), limit=limit, offset=offset)
+        rows = _clamp_rows(rows, limit)
         return [await self._verify_row(row, expected_ref=ref, side="offer") for row in rows]
 
     async def orders_wanting(self, ref: GlyphRef, *, limit: int = 100, offset: int = 0) -> list[BookEntry]:
         """Open orders WANTING the given Glyph token (the ask side of that token's book)."""
         rows = await self._source.get_open_orders_by_want(swap_token_id(ref).hex(), limit=limit, offset=offset)
+        rows = _clamp_rows(rows, limit)
         return [await self._verify_row(row, expected_ref=ref, side="want") for row in rows]
 
     async def _verify_row(self, row: dict, *, expected_ref: GlyphRef | None, side: str) -> BookEntry:

--- a/src/pyrxd/swap/rswp/covenant.py
+++ b/src/pyrxd/swap/rswp/covenant.py
@@ -75,6 +75,11 @@ REFUND_SEQUENCE = 0xFFFFFFFE
 #: nLockTime/CLTV values at/above this are UNIX timestamps, not heights. The
 #: swap expiry is always a HEIGHT; reject anything at/above the threshold.
 LOCKTIME_HEIGHT_THRESHOLD = 500_000_000
+# A real swap-refund covenant SPK is ~62-67 bytes (OP_IF + 25B P2PKH + OP_ELSE + <=6B expiry push +
+# CLTV DROP + 25B P2PKH + OP_ENDIF). The parser's nested marker scan is ~O(len^2) in the worst case, and a
+# griefer picks the advertised covenant txid (fetch_transaction has no size cap), so bound the input before
+# scanning — anything larger cannot be a covenant (review MEDIUM DoS).
+_MAX_COVENANT_SPK = 256
 
 _DUST_PHOTONS = 546  # same fold-to-fee rule as pyrxd.swap.partial
 
@@ -110,7 +115,7 @@ def parse_refund_covenant(spk: bytes) -> tuple[bytes, int] | None:
     the two inner branches to be byte-identical — a tampered covenant whose
     branches differ is NOT a swap-refund covenant.
     """
-    if len(spk) < 8 or spk[:1] != _OP_IF or spk[-1:] != _OP_ENDIF:
+    if not 8 <= len(spk) <= _MAX_COVENANT_SPK or spk[:1] != _OP_IF or spk[-1:] != _OP_ENDIF:
         return None
     for data_len in range(1, 7):  # minimal pushes of 1..6 bytes
         for else_pos in range(1, len(spk) - (1 + 1 + data_len + 2)):
@@ -295,6 +300,15 @@ def _p2pkh_or_ft_output(asset: Asset, pkh: bytes) -> TransactionOutput:
         from ...glyph.script import build_ft_locking_script
 
         return TransactionOutput(Script(build_ft_locking_script(Hex20(pkh), asset.ref)), asset.amount)
+    if asset.kind != "rxd":
+        # audit HIGH: an nft (or any non-rxd/ft) demand would silently become a plain P2PKH paying only
+        # asset.amount (the ~dust carrier value), and create_covenant_order signs THAT as the price for the
+        # reserved RXD — so the covenant becomes spendable for dust and the maker loses the reservation.
+        # NFT-in-covenant demand is not supported by this builder; fail closed instead of emitting a dust demand.
+        raise ValidationError(
+            f"covenant order demand of kind {asset.kind!r} is not supported (only rxd/ft) — an nft demand "
+            "would silently degrade to a dust P2PKH output and sell the reserved RXD for dust"
+        )
     return TransactionOutput(P2PKH().lock(pkh), asset.amount)
 
 
@@ -427,6 +441,14 @@ def take_covenant_order(
         if ft_surplus < 0:
             raise ValidationError(
                 f"funding lacks {-ft_surplus} units of the demanded FT {demanded_ref.txid}:{demanded_ref.vout}"
+            )
+        if 0 < ft_surplus < _DUST_PHOTONS:
+            # An FT change output below the dust floor is relay-rejected, so the whole take would be an
+            # unbroadcastable tx that fails opaquely (review MEDIUM). Folding the surplus to fee would BURN
+            # tokens, so refuse and tell the taker to fund exact-or-dust-clear instead.
+            raise ValidationError(
+                f"FT funding surplus is {ft_surplus} units (< dust floor {_DUST_PHOTONS}); the change output "
+                "would be un-relayable — re-fund the exact demanded amount or leave a >= dust surplus"
             )
         if ft_surplus > 0:
             tx.add_output(_build_ft_change(demanded_ref, ft_surplus, bytes(taker_change_pkh)))

--- a/src/pyrxd/swap/rswp/orders.py
+++ b/src/pyrxd/swap/rswp/orders.py
@@ -305,8 +305,14 @@ def verify_offer_signature(offer: SwapOffer) -> None:
     """
     partial = Transaction.from_hex(bytes.fromhex(offer.partial_tx_hex))
     give_source = Transaction.from_hex(bytes.fromhex(offer.give_source_tx_hex))
-    if partial is None or give_source is None or not partial.inputs or not partial.outputs:
+    if partial is None or give_source is None:
         raise ValidationError("offer does not contain a parseable partial/source transaction")
+    # Mirror accept_offer's invariant (audit HIGH): SINGLE|ANYONECANPAY binds only input[0]/output[0], so a
+    # "fillable" verdict on an offer with extra unsigned outputs would mislead a browser into funding them.
+    if len(partial.inputs) != 1 or len(partial.outputs) != 1:
+        raise ValidationError(
+            "offer must have exactly one maker input and one output (SINGLE|ANYONECANPAY binds only those)"
+        )
     maker_in = partial.inputs[0]
     if give_source.txid() != maker_in.source_txid:
         raise ValidationError("give_source_tx does not match the maker input's outpoint")

--- a/src/pyrxd/swap/rswp/quoting.py
+++ b/src/pyrxd/swap/rswp/quoting.py
@@ -88,6 +88,10 @@ def quote_ladder(mid: Fraction | int, spread_bps: int, sizes: Sequence[int]) -> 
     to zero photons (size × price too small to be a real order) or if a bid
     would go non-positive (spread too wide for the level count).
     """
+    if isinstance(mid, float):
+        # A float mid introduces binary-rounding error into an exact-Fraction price ladder (review INFO);
+        # require an exact type so the maker-favorable rounding is the ONLY rounding that happens.
+        raise ValidationError("mid must be an int, Fraction, or decimal string — not a float (binary rounding)")
     mid = Fraction(mid)
     if mid <= 0:
         raise ValidationError(f"mid price must be positive, got {mid}")

--- a/src/pyrxd/swap/rswp/rxindexer_source.py
+++ b/src/pyrxd/swap/rswp/rxindexer_source.py
@@ -174,7 +174,19 @@ class RxindexerOrderbookSource:
         discovery, then an independent re-derive of each order (see module docstring)."""
         base_ref = f"{token_id_hex}_0"
         entries = await self._call_swap_get_orders(base_ref=base_ref, limit=limit, offset=offset)
-        return [await self._row_from_discovery(entry) for entry in entries]
+        # RM-1 (DoS): a source ignoring `limit` can't force unbounded per-row fetch+decode work.
+        entries = entries[: max(0, limit)]
+        rows: list[dict] = []
+        for entry in entries:
+            try:
+                rows.append(await self._row_from_discovery(entry))
+            except ValidationError:
+                # RM-7: an advert RXinDexer indexes but pyrxd's STRICTER decoder rejects (e.g. an OP_N /
+                # selective-disclosure field) must NOT abort the whole browse — that violates book.py's
+                # per-row invariant. Pass the raw discovery row through so book._verify_row surfaces it as a
+                # per-row PROBLEM. A transport failure (NetworkError) still propagates (fails closed).
+                rows.append({**entry, "block_height": entry.get("height")})
+        return rows
 
     async def get_open_orders_by_want(self, want_token_id_hex: str, *, limit: int = 100, offset: int = 0) -> list[dict]:
         """Always raises — RXinDexer has no want-token-only order index.

--- a/src/pyrxd/swap/rswp/tracker.py
+++ b/src/pyrxd/swap/rswp/tracker.py
@@ -147,6 +147,13 @@ def _script_hash(script: bytes) -> bytes:
     return sha256(script)[::-1]
 
 
+# Cap on confirmed history candidates fetched while hunting the offered outpoint's spender (review MEDIUM
+# DoS): a hostile ElectrumX can pad the scripthash history with confirmed-looking non-matching entries, each
+# costing a full-tx fetch. Beyond the cap the offer falls to OPEN (re-poll) — the same safe liveness-only
+# disposition as "no confirmed spender yet", never a false FILLED.
+_MAX_HISTORY_FETCHES = 256
+
+
 async def classify(client: ElectrumXClient, offer: TrackedOffer) -> ClassifyResult:
     """Classify ``offer`` against the live chain — see the module docstring for the
     security argument. Every transaction this reads (the offered UTXO's own source
@@ -171,6 +178,8 @@ async def classify(client: ElectrumXClient, offer: TrackedOffer) -> ClassifyResu
     history = await client.get_history(script_hash)
     spending_tx = None
     spending_txid: str | None = None
+    spend_input_index = 0
+    fetches = 0
     for entry in history:
         candidate_txid = str(entry["tx_hash"])
         if candidate_txid == str(offer.outpoint_txid):
@@ -181,14 +190,22 @@ async def classify(client: ElectrumXClient, offer: TrackedOffer) -> ClassifyResu
             entry_height = 0
         if entry_height <= 0:
             continue  # unconfirmed (mempool) — not a settled spender; skip
+        if fetches >= _MAX_HISTORY_FETCHES:
+            break  # DoS cap — an un-found spender falls to OPEN below (safe, liveness-only)
+        fetches += 1
         candidate = await fetch_transaction(client, candidate_txid)
-        spends_it = any(
-            i.source_txid == str(offer.outpoint_txid) and i.source_output_index == offer.outpoint_vout
-            for i in candidate.inputs
+        spend_idx = next(
+            (
+                k
+                for k, i in enumerate(candidate.inputs)
+                if i.source_txid == str(offer.outpoint_txid) and i.source_output_index == offer.outpoint_vout
+            ),
+            None,
         )
-        if spends_it:
+        if spend_idx is not None:
             spending_tx = candidate
             spending_txid = candidate_txid
+            spend_input_index = spend_idx
             break
 
     if spending_tx is None:
@@ -212,9 +229,14 @@ async def classify(client: ElectrumXClient, offer: TrackedOffer) -> ClassifyResu
         return ClassifyResult(status=OfferStatus.CANCELLED, spending_txid=spending_txid)
     demanded = order.demanded_outputs[0]
 
-    settled = spending_tx.outputs[0]
-    if settled.satoshis == demanded.value and settled.locking_script.serialize() == demanded.script:
-        return ClassifyResult(status=OfferStatus.FILLED, spending_txid=spending_txid)
+    # SIGHASH_SINGLE binds the maker's demand to the output at the SAME index as the maker's signing input.
+    # A fill built by another wallet may place the maker input at index != 0, so check THAT output — not
+    # output[0] — else a genuine fill is misreported CANCELLED and the maker's net_position silently drops a
+    # given/received leg (review MEDIUM).
+    if spend_input_index < len(spending_tx.outputs):
+        settled = spending_tx.outputs[spend_input_index]
+        if settled.satoshis == demanded.value and settled.locking_script.serialize() == demanded.script:
+            return ClassifyResult(status=OfferStatus.FILLED, spending_txid=spending_txid)
     return ClassifyResult(status=OfferStatus.CANCELLED, spending_txid=spending_txid)
 
 

--- a/tests/test_rswp_covenant_ft_demand.py
+++ b/tests/test_rswp_covenant_ft_demand.py
@@ -102,16 +102,55 @@ def test_ft_demand_surplus_returns_as_ft_change() -> None:
     taker, tk_pkh = _key()
     reservation, order = _posted_ft_demand(maker)
 
+    # Fund with a surplus that clears the dust floor (a sub-dust FT change is un-relayable and now raises —
+    # see test_ft_demand_sub_dust_surplus_rejected): 600 funded, 50 demanded -> 550 change (>= 546).
     tx = _take(
         order,
         reservation,
         taker,
-        [FundingInput(_ft_src(tk_pkh, _FT_REF, 80), 0, taker), FundingInput(_rxd_src(tk_pkh, 5_000), 0, taker)],
+        [FundingInput(_ft_src(tk_pkh, _FT_REF, 600), 0, taker), FundingInput(_rxd_src(tk_pkh, 5_000), 0, taker)],
     )
     ft_outs = [o for o in tx.outputs if is_ft_script(o.locking_script.serialize().hex())]
-    assert [o.satoshis for o in ft_outs] == [50, 30]  # demand + change, conserved exactly
-    total_in = 10_000 + 80 + 5_000
+    assert [o.satoshis for o in ft_outs] == [50, 550]  # demand + change, conserved exactly
+    total_in = 10_000 + 600 + 5_000
     assert total_in - sum(o.satoshis for o in tx.outputs) == 1_000  # fee exact
+
+
+def test_ft_demand_sub_dust_surplus_rejected() -> None:
+    """RM-8: an FT change surplus below the dust floor would make an un-relayable (opaquely-failing) take —
+    refuse with a clear error instead (folding to fee would burn tokens)."""
+    maker, _ = _key()
+    taker, tk_pkh = _key()
+    reservation, order = _posted_ft_demand(maker)  # demand = 50 FT
+    with pytest.raises(ValidationError, match="dust"):
+        _take(
+            order,
+            reservation,
+            taker,
+            [FundingInput(_ft_src(tk_pkh, _FT_REF, 80), 0, taker), FundingInput(_rxd_src(tk_pkh, 5_000), 0, taker)],
+        )
+
+
+def test_covenant_order_nft_demand_rejected() -> None:
+    """RH-2 (audit HIGH): an nft demand would silently degrade to a dust P2PKH output that create_covenant_order
+    then signs as the price — the reserved RXD becomes spendable for dust and the maker loses it. Refuse it."""
+    maker, pkh = _key()
+    reservation = prepare_covenant_offer(
+        funding=[FundingInput(_rxd_src(pkh, 15_000), 0, maker)],
+        photons=10_000,
+        owner_pkh=pkh,
+        expiry_height=_EXPIRY,
+        change_pkh=pkh,
+        fee=1_000,
+    )
+    with pytest.raises(ValidationError, match="nft"):
+        create_covenant_order(
+            covenant_source_tx=reservation,
+            covenant_vout=0,
+            maker_key=maker,
+            receive=Asset("nft", 600, _FT_REF),
+            maker_receive_pkh=pkh,
+        )
 
 
 def test_ft_underfunding_refused() -> None:

--- a/tests/test_rswp_rxindexer_source.py
+++ b/tests/test_rswp_rxindexer_source.py
@@ -245,28 +245,32 @@ async def test_unknown_advert_tx_raises() -> None:
         await source.get_open_orders(RXD_TOKEN_ID.hex())
 
 
-async def test_malformed_advert_script_raises_validation_error() -> None:
-    """The referenced output exists but isn't a valid RSWP frame — decode_rswp_order raises,
-    matching book.py's own "malformed rows raise" contract for _order_from_rpc."""
+async def test_malformed_advert_row_survives_batch_as_problem() -> None:
+    """RM-7: the referenced output isn't a valid RSWP frame — decode_rswp_order rejects it, but that must
+    NOT abort the whole browse (book.py's per-row invariant). get_open_orders returns a passthrough row
+    (no decoded-order fields) that book._verify_row then surfaces as a per-row problem."""
     tx = Transaction()
     tx.add_output(TransactionOutput(P2PKH().lock(b"\x00" * 20), 0))  # not an OP_RETURN at all
     transport = FakeTransport()
     transport.add_tx(tx)
     transport.extension_responses["swap.get_orders"] = [{"tx_hash": tx.txid(), "vout": 0, "height": 1}]
     source = RxindexerOrderbookSource(transport=transport)
-    with pytest.raises(ValidationError):
-        await source.get_open_orders(RXD_TOKEN_ID.hex())
+    rows = await source.get_open_orders(RXD_TOKEN_ID.hex())
+    assert len(rows) == 1  # batch survived, row not dropped
+    assert "version" not in rows[0]  # passthrough (undecodable) -> book renders it a problem
 
 
-async def test_vout_out_of_range_raises_validation_error() -> None:
+async def test_vout_out_of_range_row_survives_batch_as_problem() -> None:
+    """RM-7: an out-of-range advertised vout is a per-row problem, not a batch abort."""
     tx = Transaction()
     tx.add_output(TransactionOutput(P2PKH().lock(b"\x00" * 20), 0))
     transport = FakeTransport()
     transport.add_tx(tx)
     transport.extension_responses["swap.get_orders"] = [{"tx_hash": tx.txid(), "vout": 5, "height": 1}]
     source = RxindexerOrderbookSource(transport=transport)
-    with pytest.raises(ValidationError, match="out of range"):
-        await source.get_open_orders(RXD_TOKEN_ID.hex())
+    rows = await source.get_open_orders(RXD_TOKEN_ID.hex())
+    assert len(rows) == 1
+    assert "version" not in rows[0]
 
 
 # --------------------------------------------------------------------------- get_open_orders_by_want gap

--- a/tests/test_swap_order.py
+++ b/tests/test_swap_order.py
@@ -144,6 +144,15 @@ def test_rejects_short_tail():
         decode_rswp_order(_v2_frame(tail=[_push(b"onlyone")]))
 
 
+def test_rejects_truncated_push():
+    """RM-3: a push whose DECLARED length exceeds the bytes present must be rejected (Radiant-Core GetOp
+    drops it), not silently clamped — else pyrxd would show as fillable a frame the canonical book never
+    indexes. OP_RETURN + a direct push declaring 32 bytes but with only 4 present."""
+    truncated = bytes([0x6A, 0x20]) + b"\x01\x02\x03\x04"
+    with pytest.raises(ValidationError, match="truncated"):
+        decode_rswp_order(truncated)
+
+
 # --------------------------------------------------------------------------- audit M4: node-strictness parity
 
 

--- a/tests/test_swap_partial.py
+++ b/tests/test_swap_partial.py
@@ -306,6 +306,43 @@ def test_tampered_receive_output_breaks_maker_signature() -> None:
         )
 
 
+def test_injected_extra_output_rejected() -> None:
+    """RH-1 (audit HIGH): a maker's SINGLE|ANYONECANPAY signature binds only output[0], so an offer carrying
+    an EXTRA unsigned output would be funded from the TAKER's inputs (silent overpay; the maker pockets the
+    injected amount while the advertised terms look fair). accept_offer and verify_offer_signature must
+    refuse any offer whose partial tx has more than one input/output."""
+    mk, mk_pkh = _key()
+    tk, tk_pkh = _key()
+    _atk, atk_pkh = _key()
+    offer = create_offer(
+        give_source_tx=_rxd_src(mk_pkh, 1000),
+        give_vout=0,
+        maker_key=mk,
+        receive=Asset("rxd", 600),
+        maker_receive_pkh=mk_pkh,
+    )
+    partial = Transaction.from_hex(bytes.fromhex(offer.partial_tx_hex))
+    partial.add_output(TransactionOutput(P2PKH().lock(atk_pkh), 500_000))  # unsigned injected payout to the maker
+    tampered = SwapOffer(
+        partial_tx_hex=partial.serialize().hex(),
+        give_source_tx_hex=offer.give_source_tx_hex,
+        give_vout=offer.give_vout,
+        terms=offer.terms,
+    )
+    with pytest.raises(ValidationError, match="one maker input and one output"):
+        accept_offer(
+            tampered,
+            funding=[FundingInput(_rxd_src(tk_pkh, 600_000), 0, tk)],
+            taker_receive_pkh=tk_pkh,
+            taker_change_pkh=tk_pkh,
+            fee=300,
+        )
+    from pyrxd.swap.rswp.orders import verify_offer_signature
+
+    with pytest.raises(ValidationError, match="one maker input and one output"):
+        verify_offer_signature(tampered)
+
+
 def test_substituted_give_source_tx_rejected() -> None:
     """Swapping in a different source tx (claiming a bigger given asset) is
     caught by the outpoint-hash check."""


### PR DESCRIPTION
## What

An 8-agent security panel over the **assembled RSWP surface** + the shipped swap-stack diff (run before shipping RSWP as the 0.11.0 headline) found **2 HIGH fund-safety bugs the incremental per-PR reviews missed** — both in the Python order-construction layer. The consensus-level covenant and the shipped HTLC stack came back **clean**. This closes all findings (2 HIGH, 8 MEDIUM, several LOW).

RSWP is **experimental** and the cross-chain swap stack remains **UNAUDITED** — this is defense-in-depth ahead of the external audit.

### 🔴 HIGH (both confirmed against the code, both with regression tests)
- **RH-1 — `accept_offer` / `verify_offer_signature` output-injection.** A maker's `SIGHASH_SINGLE|ANYONECANPAY` signature binds only `input[0]`/`output[0]`, and `_balance_and_add_change` funds *every* output from the taker. A hand-delivered offer (private transport) carrying an unsigned extra output made the taker **silently overpay** while the advertised terms looked fair. Now both primitives require exactly one maker input + one output. (The public book path already rebuilt with one output.)
- **RH-2 — v3 covenant `nft` demand → dust.** `_p2pkh_or_ft_output` only special-cased `"ft"`; an `nft` receive silently became `P2PKH(pkh, ~carrier)` which `create_covenant_order` signed as the price → the reserved RXD became **spendable for dust and the maker lost it** (CLI-reachable via `swap post --receive nft:`). Now fails closed.

### 🟡 MEDIUM
- **RM-1** DoS — clamp attacker-controlled result lists to `limit` (book browse, RXinDexer source) + cap the tracker's confirmed-history spender scan.
- **RM-2** DoS — bound the covenant-parse input length before the ~O(n²) marker scan.
- **RM-3** — reject a push whose declared length exceeds the bytes present (matches Radiant-Core `GetOp`), instead of silently clamping → closes an advert book-visibility divergence.
- **RM-6** — `tracker.classify` checks the output at the maker input's index (`SIGHASH_SINGLE`), not `outputs[0]` — a legit fill built at input index ≠ 0 was misreported `CANCELLED`.
- **RM-7** — one un-decodable RXinDexer row is now a per-row problem, not a whole-browse abort (restores book.py's per-row invariant).
- **RM-8** — refuse a sub-dust FT change surplus (un-relayable, opaque-failing take) with a clear error.

### 🟢 LOW
CLI `order=None` crash guard on browse; sanitize server-controlled error strings before printing (terminal-escape injection); `parse_price_terms` rejects zero-length demanded scripts; `quoting` refuses a float `mid` (binary rounding).

## Testing
- New regression tests: RH-1 (injected-output rejection, both primitives), RH-2 (nft-demand rejection), RM-3 (truncated-push rejection), RM-8 (sub-dust surplus). RM-7 tests updated to the new per-row-resilience behavior.
- 507 swap/RSWP tests green; ruff clean; full `task ci` passed locally (pre-push).

## Note on the release
This should land **before** 0.11.0 ships, so the release includes the fixes. I'll update the 0.11.0 CHANGELOG (PR #309) to note this pre-release hardening once this merges.