### PR TITLE
docs: promote dMint V2 to "Working on mainnet today" (closes #219)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,12 @@ real value.**
   retryable condition) consistently across the coordinator and all legs (#301, #306, #308).
 - `BitcoinCoreRpcSource` parses node BTC amounts with `parse_float=Decimal`, keeping the
   amount exact all the way into sat conversion (#308).
+- **dMint V2 promoted from "Experimental" to "Working on mainnet today"** (closes #219). The
+  implementation, a real mainnet deploy + PoW mint, and an on-chain adaptive-difficulty retarget
+  were all proven and merged; the label now matches V1 — the same evidence class (node-consensus-
+  validated + mainnet-proven), under the same blanket "unaudited primitives" caveat. The stale
+  `allow_v2_deploy` opt-in note is dropped (that gate was removed in 0.9.0). *The cross-chain **swap**
+  stack stays Experimental/unaudited — a different bar, gated on an external audit, not this cleanup.*
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -57,6 +57,10 @@ mainnet. If you find a bug that affects funds, report it via the
 - **dMint permissionless PoW tokens (V1)** — deploy (byte-equal to the live Glyph-protocol deploy,
   node-consensus-validated) and mine/claim from live mainnet contracts
   (`pyrxd glyph deploy-dmint` / `claim-dmint`)
+- **dMint permissionless PoW tokens (V2)** — the canonical Photonic redesign with adaptive difficulty
+  (FIXED / ASERT / LWMA / EPOCH / SCHEDULE), byte-matched to upstream Photonic and node-consensus-validated
+  on regtest and Radiant mainnet: the first V2 deploy + PoW mint and an on-chain difficulty retarget were
+  confirmed on mainnet (`pyrxd glyph deploy-dmint --v2` / `claim-dmint`)
 - List your Glyph tokens (`pyrxd glyph list`)
 - `pyrxd agent` — a per-spend-confirmed signing daemon that keeps the key out of the short-lived CLI process
 - ElectrumX async client with reconnect, balance, UTXOs, history, broadcast
@@ -68,11 +72,6 @@ mainnet. If you find a bug that affects funds, report it via the
   small real-value dust runs), against BTC, ETH, and EVM L2s (Base / Optimism / Arbitrum /
   Linea). This cross-chain swap stack is **unaudited — verify it yourself before moving
   real value.**
-- dMint **V2** (canonical Photonic redesign — FIXED plus ASERT / LWMA adaptive difficulty) —
-  byte-matched to upstream Photonic and consensus-validated on `radiant-core` v3.1.1 regtest
-  AND Radiant mainnet (3.1.2): the first V2 dMint deploy + PoW mint confirmed on mainnet, plus an
-  LWMA mint that advanced difficulty on-chain — adaptive difficulty proven on mainnet (#219).
-  V2 deploys are gated behind `allow_v2_deploy=True` as a deliberate opt-in for the newer format.
 
 ## Upgrading
 

--- a/src/pyrxd/glyph/dmint/types.py
+++ b/src/pyrxd/glyph/dmint/types.py
@@ -25,20 +25,15 @@ from pyrxd.security.errors import ValidationError
 from ..types import GlyphRef  # ..types resolves to pyrxd.glyph.types
 
 # ---------------------------------------------------------------------------
-# V2 quarantine marker
+# V2 warning category (retired)
 # ---------------------------------------------------------------------------
 #
-# V2 dMint is implemented per spec but **has never been validated against
-# on-chain bytes** — no V2 contract exists on Radiant mainnet as of pyrxd
-# 0.5.1. Every protocol-level claim in the V2 path is byte-derived from
-# the V1 covenant (where the two share bytecode, e.g. ``_PART_C``) or
-# from the V2 design doc; nothing is cross-validated against live
-# transactions. This is the same anti-pattern that produced the M1
-# mint-shape bug (docs/solutions/logic-errors/dmint-v1-mint-shape-mismatch.md)
-# and the V2 reward-shape bug caught by the 0.5.0 red-team audit. The
-# quarantine warning below is the smallest reversible signal we can put
-# on every V2 entry point to make the "this path has never run on chain"
-# status visible at runtime.
+# V2 dMint was once quarantined behind a per-call warning because it had never
+# run against live consensus. That is no longer true (see the class docstring):
+# the canonical-Photonic V2 redesign is byte-matched to upstream and mainnet-
+# proven, so the warning is retained as an importable category but is no longer
+# emitted. V2 now sits alongside V1 in the README's "Working on mainnet today"
+# list under the same blanket "unaudited primitives" caveat.
 
 
 class V2UnvalidatedWarning(UserWarning):


### PR DESCRIPTION
Closes #219.

dMint V2 is a consensus primitive (permissionless PoW mint), node-consensus-validated on regtest **and mainnet-proven** (real deploy + PoW mint + an on-chain adaptive-difficulty retarget) — the **same evidence class as V1**, which is already "Working on mainnet today." Its "Experimental" label and the `allow_v2_deploy` opt-in were artifacts of the pre-0.9.0 audit-gate posture: 0.9.0 made those gates advisory, and V1 already ships mainnet under the same blanket *"cryptographic primitives have not been independently audited"* caveat. This reconciles the label.

### Changes
- **README** — moved the V2 bullet into "Working on mainnet today" alongside V1; dropped the stale `allow_v2_deploy=True` gating note (that gate was removed in 0.9.0).
- **`types.py`** — replaced the stale "V2 quarantine marker" comment, which still claimed V2 *"has never been validated against on-chain bytes … no V2 contract exists on mainnet as of 0.5.1"* — directly contradicting the accurate class docstring right below it.
- **CHANGELOG [0.11.0]** — noted the promotion.

### What this does NOT touch
The cross-chain **swap** stack stays **Experimental / unaudited** — a genuinely different bar. Unlike V2 (a mainnet-proven consensus primitive), the swaps are a multi-party adversarial protocol that is not externally audited (this session's panel found 2 HIGH fund-safety bugs in the swap surface, fixed pre-0.11.0). The external audit remains its hard gate.

Docs + one stale comment; `task ci` passed (pre-push).